### PR TITLE
Prevent type error in `BatchProcessingController`

### DIFF
--- a/plugins/woocommerce/changelog/fix-prevent-type-erorr-in-batch-processing
+++ b/plugins/woocommerce/changelog/fix-prevent-type-erorr-in-batch-processing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible type error in BatchProcessingController.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -220,17 +220,20 @@ class BatchProcessingController {
 	 * @return array Current state for the processor, or a "blank" state if none exists yet.
 	 */
 	private function get_process_details( BatchProcessorInterface $batch_processor ): array {
-		return get_option(
-			$this->get_processor_state_option_name( $batch_processor ),
-			array(
-				'total_time_spent'    => 0,
-				'current_batch_size'  => $batch_processor->get_default_batch_size(),
-				'last_error'          => null,
-				'recent_failures'     => 0,
-				'batch_first_failure' => null,
-				'batch_last_failure'  => null,
-			)
+		$defaults        = array(
+			'total_time_spent'    => 0,
+			'current_batch_size'  => $batch_processor->get_default_batch_size(),
+			'last_error'          => null,
+			'recent_failures'     => 0,
+			'batch_first_failure' => null,
+			'batch_last_failure'  => null,
 		);
+		$process_details = get_option( $this->get_processor_state_option_name( $batch_processor ), $defaults );
+		if ( ! is_array( $process_details ) ) {
+			$process_details = $defaults;
+		}
+
+		return $process_details;
 	}
 
 	/**
@@ -349,7 +352,12 @@ class BatchProcessingController {
 	 * @return array List (of string) of the class names of the enqueued processors.
 	 */
 	public function get_enqueued_processors(): array {
-		return get_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, array() );
+		$enqueued_processors = get_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, array() );
+		if ( ! is_array( $enqueued_processors ) ) {
+			$enqueued_processors = array();
+		}
+
+		return $enqueued_processors;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -220,7 +220,7 @@ class BatchProcessingController {
 	 * @return array Current state for the processor, or a "blank" state if none exists yet.
 	 */
 	private function get_process_details( BatchProcessorInterface $batch_processor ): array {
-		$defaults        = array(
+		$defaults = array(
 			'total_time_spent'    => 0,
 			'current_batch_size'  => $batch_processor->get_default_batch_size(),
 			'last_error'          => null,
@@ -228,10 +228,9 @@ class BatchProcessingController {
 			'batch_first_failure' => null,
 			'batch_last_failure'  => null,
 		);
-		$process_details = get_option( $this->get_processor_state_option_name( $batch_processor ), $defaults );
-		if ( ! is_array( $process_details ) ) {
-			$process_details = $defaults;
-		}
+
+		$process_details = get_option( $this->get_processor_state_option_name( $batch_processor ) );
+		$process_details = wp_parse_args( is_array( $process_details ) ? $process_details : array(), $defaults );
 
 		return $process_details;
 	}

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -353,7 +353,10 @@ class BatchProcessingController {
 	 */
 	public function get_enqueued_processors(): array {
 		$enqueued_processors = get_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, array() );
+
 		if ( ! is_array( $enqueued_processors ) ) {
+			$this->logger->error( 'Could not fetch list of processors. Clearing up queue.', array( 'source' => 'batch-processing' ) );
+			delete_option( self::ENQUEUED_PROCESSORS_OPTION_NAME );
 			$enqueued_processors = array();
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR introduces some type checking around the value of options involved in batch processing, particularly the one controlling which processors are enqueued.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `wp option set wc_pending_batch_processes 'string'` to simulate an incorrect value for the option controlling enqueued batch processors.
1. Your site should continue to operate normally with no fatal errors being logged.
1. Go to **WC > Status > Logs > batch-processing** and confirm that you have an entry like this:
   >  Could not fetch list of processors. Clearing up queue.
1. Running `wp option get wc_pending_batch_processes` should indicate that the option doesn't exist.
1. (Optional) Change branch to `trunk` and repeat the previous steps. Notice that the following fatal error being triggered on every page load (and the site is possibly broken):

   > PHP Fatal error:  Uncaught TypeError: Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController::get_enqueued_processors(): Return value must be of type array, string returned in [...]woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php:352

1. Delete the option to continue via `wp delete set wc_pending_batch_processes`.
1. Back on this PR branch, go to **WC > Settings > Advanced > Features** and make sure HPOS is enabled and compatibility mode *disabled*.
1. Create a few new orders or make changes to existing orders.
1. Go back to **WC > Settings > Advanced > Features** and enable compatibility mode.
1. Wait for a little bit for the process to finish or go to **Tools > Scheduled Actions** and manually run the `wc_schedule_pending_batch_processes` and subsequent `wc_run_batch_process`  actions manually.
1. Confirm that the process finishes correctly, with all changed/added orders synced.



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
