### PR TITLE
Make the address 2 line visible when a value is autofilled

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
@@ -66,8 +66,8 @@ const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 						tabIndex={ -1 }
 						className="wc-block-components-address-form__address_2-hidden-input"
 						aria-hidden="true"
-						aria-label={ props?.label }
-						autoComplete="address-line2"
+						aria-label={ field.label }
+						autoComplete={ field.autocomplete }
 						id={ props?.id }
 						value={ value }
 						onChange={ ( event ) =>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
@@ -3,7 +3,7 @@
  */
 import { ValidatedTextInput } from '@woocommerce/blocks-components';
 import { AddressFormValues, ContactFormValues } from '@woocommerce/settings';
-import { useState, Fragment } from '@wordpress/element';
+import { useState, Fragment, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -24,6 +24,14 @@ const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 		() => Boolean( value ) || isFieldRequired
 	);
 
+	const handleHiddenInputChange = useCallback(
+		( newValue: string ) => {
+			onChange( field.key as keyof T, newValue );
+			setIsFieldVisible( true );
+		},
+		[ field.key, onChange ]
+	);
+
 	return (
 		<Fragment>
 			{ isFieldVisible ? (
@@ -40,18 +48,33 @@ const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 					}
 				/>
 			) : (
-				<button
-					className={
-						'wc-block-components-address-form__address_2-toggle'
-					}
+				<>
+					<button
+						className={
+							'wc-block-components-address-form__address_2-toggle'
+						}
 						onClick={ () => setIsFieldVisible( true ) }
-				>
-					{ sprintf(
-						// translators: %s: address 2 field label.
-						__( '+ Add %s', 'woocommerce' ),
-						field.label.toLowerCase()
-					) }
-				</button>
+					>
+						{ sprintf(
+							// translators: %s: address 2 field label.
+							__( '+ Add %s', 'woocommerce' ),
+							field.label.toLowerCase()
+						) }
+					</button>
+					<input
+						type="text"
+						tabIndex={ -1 }
+						className="wc-block-components-address-form__address_2-hidden-input"
+						aria-hidden="true"
+						aria-label={ props?.label }
+						autoComplete="address-line2"
+						id={ props?.id }
+						value={ value }
+						onChange={ ( event ) =>
+							handleHiddenInputChange( event.target.value )
+						}
+					/>
+				</>
 			) }
 		</Fragment>
 	);

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
@@ -10,6 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { AddressLineFieldProps } from './types';
+import './style.scss';
 
 const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 	field,

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
@@ -20,7 +20,7 @@ const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 	const isFieldRequired = field?.required ?? false;
 
 	// Display the input field if it has a value or if it is required.
-	const [ isFieldVisible, setFieldVisible ] = useState(
+	const [ isFieldVisible, setIsFieldVisible ] = useState(
 		() => Boolean( value ) || isFieldRequired
 	);
 
@@ -44,7 +44,7 @@ const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 					className={
 						'wc-block-components-address-form__address_2-toggle'
 					}
-					onClick={ () => setFieldVisible( true ) }
+						onClick={ () => setIsFieldVisible( true ) }
 				>
 					{ sprintf(
 						// translators: %s: address 2 field label.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/style.scss
@@ -1,0 +1,4 @@
+.wc-block-components-address-form__address_2-hidden-input {
+	position: absolute;
+	left: -20000px;
+}

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/test/address-line-2-field.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/test/address-line-2-field.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import AddressLine2Field from '@woocommerce/base-components/cart-checkout/form/address-line-2-field';
+import { useState } from '@wordpress/element';
+
+describe( 'Address Line 2 Component', () => {
+	it( 'Renders a hidden field which disappears as soon as text is entered (autofill functionality)', async () => {
+		// Render in a wrapper so we can track the value is sent correctly from hidden to visible input.
+		const FieldWrapper = () => {
+			const [ value, setValue ] = useState( '' );
+			return (
+				<AddressLine2Field
+					field={ {
+						index: 0,
+						key: 'address_2',
+						required: false,
+						label: 'Address 2',
+						optionalLabel: 'Optional Address 2',
+						type: 'text',
+						hidden: false,
+						autocomplete: 'address-line2',
+					} }
+					value={ value }
+					onChange={ ( _: string, newValue: string ) => {
+						setValue( newValue );
+					} }
+				/>
+			);
+		};
+		render( <FieldWrapper /> );
+		const hiddenInput = screen.getByLabelText( 'Address 2' );
+		expect( hiddenInput ).toBeInTheDocument();
+		expect( hiddenInput ).toHaveAttribute( 'aria-hidden', 'true' );
+		fireEvent.change( hiddenInput, { target: { value: '123' } } );
+		expect( hiddenInput ).not.toBeInTheDocument();
+		const visibleInput = screen.getByLabelText( 'Optional Address 2' );
+		expect( visibleInput ).toBeInTheDocument();
+		expect( visibleInput ).toHaveValue( '123' );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -487,7 +487,7 @@ test.describe( 'Merchant → Checkout', () => {
 				await expect( shippingApartmentLink ).toBeVisible();
 
 				// Verify that the apartment field is hidden by default and the field is optional.
-				await expect( shippingApartmentInput ).toBeHidden();
+				await expect( shippingApartmentInput ).not.toBeInViewport();
 				await expect( shippingApartmentOptionalToggle ).toBeChecked();
 
 				// Make the apartment number required.
@@ -504,7 +504,7 @@ test.describe( 'Merchant → Checkout', () => {
 
 				// Verify that the apartment link and the apartment field are hidden.
 				await expect( shippingApartmentLink ).toBeHidden();
-				await expect( shippingApartmentInput ).toBeHidden();
+				await expect( shippingApartmentInput ).not.toBeInViewport();
 
 				// Display the billing address form.
 				await editor.canvas
@@ -568,7 +568,7 @@ test.describe( 'Merchant → Checkout', () => {
 				await expect( billingApartmentLink ).toBeVisible();
 
 				// Verify that the apartment field is hidden and optional.
-				await expect( billingApartmentInput ).toBeHidden();
+				await expect( billingApartmentInput ).not.toBeInViewport();
 				await expect( billingApartmentOptionalToggle ).toBeChecked();
 
 				// Disable the apartment field.
@@ -576,7 +576,7 @@ test.describe( 'Merchant → Checkout', () => {
 
 				// Verify that the apartment link and the apartment field are hidden.
 				await expect( billingApartmentLink ).toBeHidden();
-				await expect( billingApartmentInput ).toBeHidden();
+				await expect( billingApartmentInput ).not.toBeInViewport();
 			} );
 
 			test( 'Phone input visibility and optional and required can be toggled', async ( {

--- a/plugins/woocommerce/changelog/fix-address-autocomplete
+++ b/plugins/woocommerce/changelog/fix-address-autocomplete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the second address line input appears when using autofill


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a hidden (hidden by CSS, not actually hidden) field to the `AddressLine2Field` component to capture autofill events.
Before this change, the field did not exist in the DOM so autofill programmes could not enter text.

The reason it is hidden by CSS and not just a `type="hidden"` field is because while testing, the hidden field was ignored by autofill.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #47586

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Have a saved address set up in your browser. Make sure this saved address contains an entry for address 2. (A tip to get this working is to fill in the checkout form with the data and check out on the site, then your browser should offer to save the address info for you).
2. In a new session (or incognito window) add an item to your cart and go to the Checkout block.
3. Ensure address 2 is not visible, but the link to add it is. Do not click it.
4. Use autofill to enter the address.
5. Ensure the address line 2 is autofilled correctly and is visible.
6. Check out and then check the order details to ensure address line 2 was recorded correctly.
7. Try removing address line 2 from your saved address and repeat these steps. The field should *not* become visible if address 2 is not in the autofill data.
8. Try in different browsers and on mobile.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
