### PR TITLE
CYS - Schedule fetching patterns only once an hour

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
@@ -46,10 +46,7 @@ import { useEditorBlocks } from '../../hooks/use-editor-blocks';
 import { isTrackingAllowed } from '../../utils/is-tracking-allowed';
 import clsx from 'clsx';
 import './style.scss';
-import {
-	usePatterns,
-	usePatternsByCategory,
-} from '~/customize-store/assembler-hub/hooks/use-patterns';
+import { usePatterns } from '~/customize-store/assembler-hub/hooks/use-patterns';
 import { THEME_SLUG } from '~/customize-store/data/constants';
 
 const isActiveElement = ( path: string | undefined, category: string ) => {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
@@ -136,7 +136,7 @@ export const SidebarNavigationScreenHomepagePTK = ( {
 		);
 	} else if ( ! isLoadingPatterns && patternsFromPTK.length === 0 ) {
 		notice = __(
-			"Unfortunately, we're experiencing some technical issues getting the patterns — please <FetchPatterns>try again.</FetchPatterns>",
+			'Unfortunately, a technical issue is preventing more patterns from being displayed. Please <FetchPatterns>try again</FetchPatterns> later.',
 			'woocommerce'
 		);
 	}

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
@@ -46,6 +46,11 @@ import { useEditorBlocks } from '../../hooks/use-editor-blocks';
 import { isTrackingAllowed } from '../../utils/is-tracking-allowed';
 import clsx from 'clsx';
 import './style.scss';
+import {
+	usePatterns,
+	usePatternsByCategory,
+} from '~/customize-store/assembler-hub/hooks/use-patterns';
+import { THEME_SLUG } from '~/customize-store/data/constants';
 
 const isActiveElement = ( path: string | undefined, category: string ) => {
 	if ( path?.includes( category ) ) {
@@ -105,6 +110,17 @@ export const SidebarNavigationScreenHomepagePTK = ( {
 		}, initialAccumulator );
 	}, [ blocks ] );
 
+	const { blockPatterns, isLoading: isLoadingPatterns } = usePatterns();
+	const patternsFromPTK = blockPatterns.filter(
+		( pattern ) =>
+			! pattern.name.includes( THEME_SLUG ) &&
+			! pattern.name.includes( 'woocommerce' ) &&
+			pattern.source !== 'core' &&
+			pattern.source !== 'pattern-directory/featured' &&
+			pattern.source !== 'pattern-directory/theme' &&
+			pattern.source !== 'pattern-directory/core'
+	);
+
 	let notice;
 	if ( isNetworkOffline ) {
 		notice = __(
@@ -119,6 +135,11 @@ export const SidebarNavigationScreenHomepagePTK = ( {
 	} else if ( ! isTrackingAllowed() ) {
 		notice = __(
 			'Opt in to <OptInModal>usage tracking</OptInModal> to get access to more patterns.',
+			'woocommerce'
+		);
+	} else if ( ! isLoadingPatterns && patternsFromPTK.length === 0 ) {
+		notice = __(
+			"Unfortunately, we're experiencing some technical issues getting the patterns — please <FetchPatterns>try again.</FetchPatterns>",
 			'woocommerce'
 		);
 	}
@@ -241,6 +262,22 @@ export const SidebarNavigationScreenHomepagePTK = ( {
 											<Button
 												onClick={ () => {
 													openModal();
+												} }
+												variant="link"
+											/>
+										),
+										FetchPatterns: (
+											<Button
+												onClick={ () => {
+													if ( isIframe( window ) ) {
+														sendMessageToParent( {
+															type: 'INSTALL_PATTERNS',
+														} );
+													} else {
+														sendEvent(
+															'INSTALL_PATTERNS'
+														);
+													}
 												} }
 												variant="link"
 											/>

--- a/plugins/woocommerce/changelog/49754-fix-ptk-registration
+++ b/plugins/woocommerce/changelog/49754-fix-ptk-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Schedule the `fetch_patterns` actions only once every hour.

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -91,11 +91,13 @@ class PTKPatternsStore {
 	 * @return void
 	 */
 	private function schedule_action_if_not_pending( $action ) {
-		if ( as_has_scheduled_action( $action ) ) {
+		$last_request = get_transient( 'last_fetch_patterns_request' );
+		if ( as_has_scheduled_action( $action ) || false !== $last_request ) {
 			return;
 		}
 
 		as_schedule_single_action( time(), $action );
+		set_transient( 'last_fetch_patterns_request', time(), HOUR_IN_SECONDS );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR avoids continuously scheduling the fetch patterns action when it returns no patterns. Instead, it sets a transient with 1 hour expiration time, so it won't try again until it's gone.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

⚠️ To test by devs only ⚠️
1. Install the `Transients Manager` plugin.
2. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and ensure `Allow usage of WooCommerce to be tracked` is enabled.
3. Go to [this line](https://github.com/woocommerce/woocommerce/blob/b41bf38a3f78f969da34ce29f2a177461f278866/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php#L100) and change the `HOUR_IN_SECONDS` to 30.
4. Go to [this line](https://github.com/woocommerce/woocommerce/blob/b41bf38a3f78f969da34ce29f2a177461f278866/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php#L220) and comment it out (this is to simulate the transients are not set after the request).
5. Go to `wp-admin/tools.php?page=transients-manager&s=ptk` and delete the `ptk_patterns` transient.
6. Go to `wp-admin/tools.php?page=transients-manager&s=last_fetch_patterns_request` and delete the `last_fetch_patterns_request` transient.
7. Go to `wp-admin/tools.php?page=action-scheduler&orderby=schedule&order=desc&s=fetch_patterns&paged=1` and ensure the `fetch_patterns` action is scheduled.
8. Run it, and check that no other `fetch_patterns` action is scheduled immediately.
9. Wait for the `last_fetch_patterns_request` transient to expire (30s).
10. Refresh the Scheduled Actions page and check a new `fetch_patterns` action is scheduled.
11. Bring back the `HOUR_IN_SECONDS` in the `PTKPatternsStore.php` file.
12. Delete the `ptk_patterns` and the `last_fetch_patterns_request` transients.
13. The `fetch_patterns` action will be scheduled again, wait for it to finish or run it.
14. Delete the `ptk_patterns`.
15. Go to `wp-admin/admin.php?page=wc-admin&customizing=true&path=%2Fcustomize-store%2Fassembler-hub%2Fhomepage` and make sure you see this message:
<img width="368" alt="Screenshot 2024-07-22 at 14 49 13" src="https://github.com/user-attachments/assets/650a15da-1cac-4edf-b440-b8445fdedca3">

16. Click `try again` and wait for the assembler to load again.
17. Make sure you see the PTK patterns are loaded.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Schedule the `fetch_patterns` actions only once every hour.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
