### PR TITLE
[Enhancement] Create new filter `wc_lock_sku_query` for SKU lock query.

### DIFF
--- a/plugins/woocommerce/changelog/49755-fix-49660-new-filter-sku-lock
+++ b/plugins/woocommerce/changelog/49755-fix-49660-new-filter-sku-lock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add a filter to override the SKU database lock.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -133,15 +133,17 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		);
 
 		/**
-		 * Filters the query to lock SKU on product creation.
-		 * Expects a prepared SQL query.
+		 * Filter to bail early on the SKU lock query.
 		 *
-		 * @since 9.2.0
+		 * @since 9.3.0
 		 *
-		 * @param $query   The query to lock SKU.
-		 * @param $product The product being created.
+		 * @param bool|null  $locked  Set to a boolean value to short-circuit the SKU lock query.
+		 * @param WC_Product $product The product being created.
 		 */
-		$query = apply_filters( 'wc_lock_sku_query', $query, $product );
+		$locked = apply_filters( 'wc_product_pre_lock_on_sku', null, $product );
+		if ( ! is_null( $locked ) ) {
+			return boolval( $locked );
+		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( $query );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -131,6 +131,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$sku,
 			$sku
 		);
+
+		/**
+		 * Filters the query to lock SKU on product creation.
+		 * Expects a prepared SQL query.
+		 *
+		 * @since 9.2.0
+		 *
+		 * @param $query   The query to lock SKU.
+		 * @param $product The product being created.
+		 */
+		$query = apply_filters( 'wc_lock_sku_query', $query, $product );
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( $query );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Create a new filter `wc_lock_sku_query` to allow third party to filter the SKU lock query.

Closes #49660.

### How to test the changes in this Pull Request:

- Copy the following script to a file on your local machine.
    - Modify the script and enter your credentials, you can get them from woocommerce>settings>advanced>REST API
    - Create new API keys if you don't have one already.
    - Add the CK and CS in the respective placeholders.
    - Replace the URL to the endpoint
    - Change the initial product SKU to something which is already not present on the table
- Now run the script via bash, and check the  log_error_counts.txt file. The total for each round should be 1.
- Check the products page in WC admin, you'll see only one product created with the same SKU.
- Now add this PHP snippet somewhere in your test site, such as in a file in mu-plugins:
    - `add_filter( 'wc_product_pre_lock_on_sku', '__return_true' );`
    - This overrides the SKU lock so that multiple products with the same SKU can be created.
- Run the script again, check the  log_error_counts.txt file. The total for each round should be 10.
- Check the products page in WC admin, you'll see multiple products created with the same SKU.

Test bash script:

```bash
!/bin/bash

# Define the URL and authentication
URL="https://d.w.test/wp-json/wc/v3/products/batch"
CK="ck_7b87bfb00d141081ea0b2be4c443b939ac60677e"
CS="cs_0fbab889a09db5d83af5f2096ec553cf011c47c0"
CONTENT_TYPE="Content-Type: application/json"

INITIAL_SKU=4048

ROUNDS=5

CONCURRENT_REQUESTS=10

echo "Sending $ROUNDS rounds of $CONCURRENT_REQUESTS concurrent requests..."

count_errors() {
    local round=$1
    local error_count=0

    for i in $(seq 1 $CONCURRENT_REQUESTS); do
        if grep -q "error" "log_${round}_${i}.txt"; then
            error_count=$((error_count + 1))
        fi
    done

    echo $((CONCURRENT_REQUESTS - $error_count))
}

for j in $(seq 1 $ROUNDS); do
    SKU=$(($INITIAL_SKU + $j - 1)) 
    echo "Round $j with SKU $SKU..."

    for i in $(seq 1 $CONCURRENT_REQUESTS); do
        JSON_DATA=$(cat <<EOF
{
    "create": [
        {
            "name": "${j}-${i} New Test Product",
            "type": "simple",
            "sku": "${SKU}"
        }
    ]
}
EOF
)
        curl -X POST $URL \
            -u "$CK:$CS" \
            -H "$CONTENT_TYPE" \
            -d "$JSON_DATA" -k > "log_${j}_${i}.txt" 2>&1 &
    done

    wait
    echo "Completed round $j."

    error_count=$(count_errors $j)
    echo "Total products created in round $j with sku $SKU: $error_count" >> log_error_counts.txt
done

echo "All requests sent. Check log files for output."
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a filter to override the SKU database lock.

</details>
