### PR TITLE
Fix extensionCartUpdates not surfacing errors to cart and checkout

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
@@ -30,8 +30,8 @@ const createNoticesFromErrors = ( errors: ApiErrorResponse[] ) => {
 /**
  * This function is used to dismiss old errors from the store.
  */
-const dismissNoticesFromErrors = ( oldErrors: ApiErrorResponse[] ) => {
-	oldErrors.forEach( ( error ) => {
+const dismissNoticesFromErrors = ( errors: ApiErrorResponse[] ) => {
+	errors.forEach( ( error ) => {
 		dispatch( 'core/notices' ).removeNotice(
 			error.code,
 			error?.data?.context || 'wc/cart'

--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
@@ -7,26 +7,49 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { dispatch } from '@wordpress/data';
 
 /**
- * This function is used to notify the user of cart item errors/conflicts
+ * This function is used to notify the user of errors/conflicts from an API error response object.
  */
-export const notifyCartErrors = (
-	errors: ApiErrorResponse[] | null = null,
-	oldErrors: ApiErrorResponse[] | null = null
-) => {
-	if ( oldErrors ) {
-		oldErrors.forEach( ( error ) => {
-			dispatch( 'core/notices' ).removeNotice( error.code, 'wc/cart' );
+const createNotices = ( errors: ApiErrorResponse[] ) => {
+	errors.forEach( ( error ) => {
+		createNotice( 'error', decodeEntities( error.message ), {
+			id: error.code,
+			context: error?.data?.context || 'wc/cart',
 		} );
-	}
+	} );
+};
 
+/**
+ * This function is used to dismiss old errors from the store.
+ */
+const dismissNotices = ( oldErrors: ApiErrorResponse[] ) => {
+	oldErrors.forEach( ( error ) => {
+		dispatch( 'core/notices' ).removeNotice(
+			error.code,
+			error?.data?.context || 'wc/cart'
+		);
+	} );
+};
+
+/**
+ * This function is used to normalize errors into an array of ApiErrorResponse objects.
+ */
+const normalizeErrors = ( errors: ApiErrorResponse | ApiErrorResponse[] ) => {
+	return isApiErrorResponse( errors )
+		? [ errors ]
+		: errors.filter( isApiErrorResponse );
+};
+
+/**
+ * This function is used to notify the user of cart errors/conflicts.
+ */
+export const notifyErrors = (
+	errors: ApiErrorResponse | ApiErrorResponse[] | null = null,
+	oldErrors: ApiErrorResponse | ApiErrorResponse[] | null = null
+) => {
+	if ( oldErrors !== null ) {
+		dismissNotices( normalizeErrors( oldErrors ) );
+	}
 	if ( errors !== null ) {
-		errors.forEach( ( error ) => {
-			if ( isApiErrorResponse( error ) ) {
-				createNotice( 'error', decodeEntities( error.message ), {
-					id: error.code,
-					context: 'wc/cart',
-				} );
-			}
-		} );
+		createNotices( normalizeErrors( errors ) );
 	}
 };

--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
@@ -7,9 +7,18 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { dispatch } from '@wordpress/data';
 
 /**
+ * This function is used to normalize errors into an array of ApiErrorResponse objects.
+ */
+const filterValidErrors = ( errors: ApiErrorResponse | ApiErrorResponse[] ) => {
+	return isApiErrorResponse( errors )
+		? [ errors ]
+		: errors.filter( isApiErrorResponse );
+};
+
+/**
  * This function is used to notify the user of errors/conflicts from an API error response object.
  */
-const createNotices = ( errors: ApiErrorResponse[] ) => {
+const createNoticesFromErrors = ( errors: ApiErrorResponse[] ) => {
 	errors.forEach( ( error ) => {
 		createNotice( 'error', decodeEntities( error.message ), {
 			id: error.code,
@@ -21,7 +30,7 @@ const createNotices = ( errors: ApiErrorResponse[] ) => {
 /**
  * This function is used to dismiss old errors from the store.
  */
-const dismissNotices = ( oldErrors: ApiErrorResponse[] ) => {
+const dismissNoticesFromErrors = ( oldErrors: ApiErrorResponse[] ) => {
 	oldErrors.forEach( ( error ) => {
 		dispatch( 'core/notices' ).removeNotice(
 			error.code,
@@ -31,25 +40,16 @@ const dismissNotices = ( oldErrors: ApiErrorResponse[] ) => {
 };
 
 /**
- * This function is used to normalize errors into an array of ApiErrorResponse objects.
- */
-const normalizeErrors = ( errors: ApiErrorResponse | ApiErrorResponse[] ) => {
-	return isApiErrorResponse( errors )
-		? [ errors ]
-		: errors.filter( isApiErrorResponse );
-};
-
-/**
  * This function is used to notify the user of cart errors/conflicts.
  */
-export const notifyErrors = (
+export const notifyCartErrors = (
 	errors: ApiErrorResponse | ApiErrorResponse[] | null = null,
 	oldErrors: ApiErrorResponse | ApiErrorResponse[] | null = null
 ) => {
 	if ( oldErrors !== null ) {
-		dismissNotices( normalizeErrors( oldErrors ) );
+		dismissNoticesFromErrors( filterValidErrors( oldErrors ) );
 	}
 	if ( errors !== null ) {
-		createNotices( normalizeErrors( errors ) );
+		createNoticesFromErrors( filterValidErrors( errors ) );
 	}
 };

--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
@@ -7,12 +7,10 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { dispatch } from '@wordpress/data';
 
 /**
- * This function is used to normalize errors into an array of ApiErrorResponse objects.
+ * This function is used to normalize errors into an array of valid ApiErrorResponse objects.
  */
-const filterValidErrors = ( errors: ApiErrorResponse | ApiErrorResponse[] ) => {
-	return isApiErrorResponse( errors )
-		? [ errors ]
-		: errors.filter( isApiErrorResponse );
+const filterValidErrors = ( errors: ApiErrorResponse[] ) => {
+	return errors.filter( isApiErrorResponse );
 };
 
 /**
@@ -43,8 +41,8 @@ const dismissNoticesFromErrors = ( errors: ApiErrorResponse[] ) => {
  * This function is used to notify the user of cart errors/conflicts.
  */
 export const notifyCartErrors = (
-	errors: ApiErrorResponse | ApiErrorResponse[] | null = null,
-	oldErrors: ApiErrorResponse | ApiErrorResponse[] | null = null
+	errors: ApiErrorResponse[] | null = null,
+	oldErrors: ApiErrorResponse[] | null = null
 ) => {
 	if ( oldErrors !== null ) {
 		dismissNoticesFromErrors( filterValidErrors( oldErrors ) );

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -52,7 +52,7 @@ const reducer: Reducer< CartState > = (
 			if ( action.error ) {
 				state = {
 					...state,
-					errors: [ action.error ],
+					errors: [ ...state.errors, action.error ],
 				};
 			}
 			break;

--- a/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/reducers.ts
@@ -52,7 +52,7 @@ const reducer: Reducer< CartState > = (
 			if ( action.error ) {
 				state = {
 					...state,
-					errors: [ ...state.errors, action.error ],
+					errors: [ action.error ],
 				};
 			}
 			break;

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -23,7 +23,7 @@ import { CartDispatchFromMap, CartSelectFromMap } from './index';
  * @param {CartResponse} response
  */
 export const receiveCart =
-	( response: Partial< CartResponse >, onSuccess = true ) =>
+	( response: Partial< CartResponse > ) =>
 	( {
 		dispatch,
 		select,
@@ -41,12 +41,7 @@ export const receiveCart =
 			cartItemsPendingDelete: select.getItemsPendingDelete(),
 		} );
 		dispatch.setCartData( newCart );
-
-		// If this was a successful update, clear top level errors.
-		if ( onSuccess ) {
-			notifyErrors( null, select.getCartErrors() );
-			dispatch.setErrorData( null );
-		}
+		dispatch.setErrorData( null );
 	};
 
 /**
@@ -74,11 +69,9 @@ export const receiveError =
 		if ( ! isApiErrorResponse( response ) ) {
 			return;
 		}
-
 		if ( response.data?.cart ) {
-			dispatch.receiveCart( response?.data?.cart, false );
+			dispatch.receiveCart( response?.data?.cart );
 		}
-
 		dispatch.setErrorData( response );
 	};
 

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -13,7 +13,7 @@ import { camelCaseKeys } from '@woocommerce/base-utils';
  * Internal dependencies
  */
 import { notifyQuantityChanges } from './notify-quantity-changes';
-import { notifyErrors } from './notify-errors';
+import { notifyCartErrors } from './notify-errors';
 import { CartDispatchFromMap, CartSelectFromMap } from './index';
 
 /**
@@ -33,7 +33,7 @@ export const receiveCart =
 	} ) => {
 		const newCart = camelCaseKeys( response ) as unknown as Cart;
 		const oldCart = select.getCartData();
-		notifyErrors( newCart.errors, oldCart.errors );
+		notifyCartErrors( newCart.errors, oldCart.errors );
 		notifyQuantityChanges( {
 			oldCart,
 			newCart,

--- a/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/utils/process-error-response.ts
@@ -209,6 +209,9 @@ export const processErrorResponse = (
 
 	createNotice( 'error', errorMessage, {
 		id: response.code,
-		context: context || getErrorContextFromCode( response.code ),
+		context:
+			context ||
+			response?.data?.context ||
+			getErrorContextFromCode( response.code ),
 	} );
 };

--- a/plugins/woocommerce-blocks/assets/js/types/type-defs/api-error-response.ts
+++ b/plugins/woocommerce-blocks/assets/js/types/type-defs/api-error-response.ts
@@ -15,6 +15,7 @@ export type ApiErrorResponseData = {
 	status: number;
 	params: Record< string, string >;
 	details: Record< string, ApiErrorResponseDataDetails >;
+	context?: string;
 	// Some endpoints return cart data to update the client.
 	cart?: CartResponse | undefined;
 } | null;

--- a/plugins/woocommerce-blocks/assets/js/types/type-defs/cart.ts
+++ b/plugins/woocommerce-blocks/assets/js/types/type-defs/cart.ts
@@ -11,7 +11,7 @@ import {
 	ShippingRateItem,
 	ExtensionsData,
 } from './cart-response';
-
+import { ApiErrorResponse } from './api-error-response';
 import {
 	ProductResponseItemData,
 	ProductResponseItem,
@@ -182,11 +182,6 @@ export interface CartTotals extends CurrencyInfo {
 	tax_lines: Array< CartTotalsTaxLineItem >;
 }
 
-export interface CartErrorItem {
-	code: string;
-	message: string;
-}
-
 export interface Cart extends Record< string, unknown > {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRate >;
@@ -201,7 +196,7 @@ export interface Cart extends Record< string, unknown > {
 	hasCalculatedShipping: boolean;
 	fees: Array< CartFeeItem >;
 	totals: CartTotals;
-	errors: Array< CartErrorItem >;
+	errors: Array< ApiErrorResponse >;
 	paymentMethods: Array< string >;
 	paymentRequirements: Array< string >;
 	extensions: ExtensionsData;

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md
@@ -48,6 +48,7 @@ and on the client side:
 
 ```ts
 const { extensionCartUpdate } = wc.blocksCheckout;
+const { processErrorResponse } = wc.wcBlocksData;
 
 extensionCartUpdate( {
 	namespace: 'extension-unique-namespace',
@@ -58,6 +59,11 @@ extensionCartUpdate( {
 			fourth_key: true,
 		},
 	},
+} ).then( () => {
+	// Cart has been updated.
+} ).catch( ( error ) => {
+	// Handle error.
+	processErrorResponse(error);
 } );
 ```
 

--- a/plugins/woocommerce-blocks/packages/checkout/utils/README.md
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/README.md
@@ -2,15 +2,15 @@
 
 ## Table of Contents <!-- omit in toc -->
 
--   [`extensionCartUpdate`](#extensioncartupdate)
-    -   [Usage](#usage)
-    -   [Options](#options)
-        -   [`args (object, required)`](#args-object-required)
--   [`mustContain`](#mustcontain)
-    -   [Usage](#usage-1)
-    -   [Options](#options-1)
-        -   [`value (string, required)`](#value-string-required)
-        -   [`requiredValue (string, required)`](#requiredvalue-string-required)
+- [`extensionCartUpdate`](#extensioncartupdate)
+   	- [`extensionCartUpdate` Usage](#extensioncartupdate-usage)
+   	- [`extensionCartUpdate` Options](#extensioncartupdate-options)
+      		- [`args (object, required)`](#args-object-required)
+- [`mustContain`](#mustcontain)
+   	- [`mustContain` Usage](#mustcontain-usage)
+   	- [`mustContain` Options](#mustcontain-options)
+      		- [`value (string, required)`](#value-string-required)
+      		- [`requiredValue (string, required)`](#requiredvalue-string-required)
 
 Miscellaneous utility functions for dealing with checkout functionality.
 

--- a/plugins/woocommerce-blocks/packages/checkout/utils/README.md
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/README.md
@@ -16,7 +16,7 @@ Miscellaneous utility functions for dealing with checkout functionality.
 
 ## `extensionCartUpdate`
 
-When executed, this will call the cart/extensions REST API endpoint. The new cart is then received into the client-side store.
+When executed, this will call the cart/extensions REST API endpoint. The new cart is then received into the client-side store. `extensionCartUpdate` returns a promise that resolves when the cart is updated which should also be used for error handling.
 
 ### Usage
 
@@ -32,6 +32,10 @@ extensionCartUpdate( {
 	data: {
 		key: 'value',
 	},
+} ).then( () => {
+	// Cart has been updated.
+} ).catch( ( error ) => {
+	// Handle error.
 } );
 ```
 

--- a/plugins/woocommerce-blocks/packages/checkout/utils/README.md
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/README.md
@@ -18,7 +18,7 @@ Miscellaneous utility functions for dealing with checkout functionality.
 
 When executed, this will call the cart/extensions REST API endpoint. The new cart is then received into the client-side store. `extensionCartUpdate` returns a promise that resolves when the cart is updated which should also be used for error handling.
 
-### Usage
+### `extensionCartUpdate` Usage
 
 ```ts
 // Aliased import
@@ -39,7 +39,7 @@ extensionCartUpdate( {
 } );
 ```
 
-### Options
+### `extensionCartUpdate` Options
 
 The following options are available:
 
@@ -51,7 +51,7 @@ Args to pass to the Rest API endpoint. This can contain data and a namespace to 
 
 Ensures that a given value contains a string, or throws an error.
 
-### Usage
+### `mustContain` Usage
 
 ```js
 // Aliased import
@@ -64,7 +64,7 @@ mustContain( 'This is a string containing a <price />', '<price />' ); // This w
 mustContain( 'This is a string', '<price />' ); // This will throw an error
 ```
 
-### Options
+### `mustContain` Options
 
 The following options are available:
 

--- a/plugins/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts
@@ -21,7 +21,9 @@ export const extensionCartUpdate = (
 ): Promise< CartResponse > => {
 	const { applyExtensionCartUpdate } = dispatch( STORE_KEY );
 	return applyExtensionCartUpdate( args ).catch( ( error ) => {
-		processErrorResponse( error );
+		if ( error?.code === 'woocommerce_rest_cart_extensions_error' ) {
+			processErrorResponse( error );
+		}
 		return Promise.resolve( false );
 	} );
 };

--- a/plugins/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts
@@ -3,6 +3,7 @@
  */
 import { dispatch } from '@wordpress/data';
 import { CartResponse, ExtensionCartUpdateArgs } from '@woocommerce/types';
+import { processErrorResponse } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -19,5 +20,8 @@ export const extensionCartUpdate = (
 	args: ExtensionCartUpdateArgs
 ): Promise< CartResponse > => {
 	const { applyExtensionCartUpdate } = dispatch( STORE_KEY );
-	return applyExtensionCartUpdate( args );
+	return applyExtensionCartUpdate( args ).catch( ( error ) => {
+		processErrorResponse( error );
+		return Promise.resolve( false );
+	} );
 };

--- a/plugins/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts
@@ -24,6 +24,6 @@ export const extensionCartUpdate = (
 		if ( error?.code === 'woocommerce_rest_cart_extensions_error' ) {
 			processErrorResponse( error );
 		}
-		return Promise.resolve( false );
+		return Promise.reject( error );
 	} );
 };

--- a/plugins/woocommerce-blocks/tests/e2e/plugins/cart-extensions-test-helper.php
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/cart-extensions-test-helper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Blocks Test Cart Extensions
+ * Description: Adds callbacks for cart extensions.
+ * Plugin URI: https://github.com/woocommerce/woocommerce
+ * Author: WooCommerce
+ *
+ * @package woocommerce-blocks-test-cart-extensions
+ */
+
+class Cart_Extensions_Test_Helper {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_blocks_loaded', array( $this, 'register_update_callbacks' ) );
+	}
+
+	/**
+	 * Register callbacks.
+	 */
+	public function register_update_callbacks() {
+		woocommerce_store_api_register_update_callback(
+			array(
+				'namespace' => 'cart-extensions-test-helper',
+				'callback'  => function () {
+					throw new Automattic\WooCommerce\StoreApi\Exceptions\RouteException( 'test_error', 'This is an error with cart context.', 400, array( 'context' => 'wc/cart' ) );
+				},
+			)
+		);
+		woocommerce_store_api_register_update_callback(
+			array(
+				'namespace' => 'cart-extensions-test-helper-2',
+				'callback'  => function () {
+					throw new Automattic\WooCommerce\StoreApi\Exceptions\RouteException( 'woocommerce_rest_cart_extensions_error', 'This is an error with cart context.', 400, array( 'context' => 'wc/cart' ) );
+				},
+			)
+		);
+	}
+}
+
+new Cart_Extensions_Test_Helper();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { expect, test as base, wpCLI } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { CheckoutPage } from '../checkout/checkout.page';
+import { REGULAR_PRICED_PRODUCT_NAME } from '../checkout/constants';
+
+const test = base.extend< { checkoutPageObject: CheckoutPage } >( {
+	checkoutPageObject: async ( { page }, use ) => {
+		const pageObject = new CheckoutPage( {
+			page,
+		} );
+		await use( pageObject );
+	},
+} );
+
+test.describe( 'Shopper → Cart Extension Callbacks', () => {
+	test( 'Custom error code creates exception', async ( {
+		frontendUtils,
+		requestUtils,
+		page,
+	} ) => {
+		await requestUtils.activatePlugin(
+			'woocommerce-blocks-test-cart-extensions'
+		);
+
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+		await frontendUtils.goToCart();
+
+		await expect(
+			page.evaluate( () =>
+				window.wc.blocksCheckout
+					.extensionCartUpdate( {
+						namespace: 'cart-extensions-test-helper',
+					} )
+					.catch( ( error ) => {
+						throw new Error( error.message );
+					} )
+			)
+		).rejects.toThrow( 'This is an error with cart context.' );
+	} );
+
+	test( 'Error code `woocommerce_rest_cart_extensions_error` creates notice', async ( {
+		frontendUtils,
+		requestUtils,
+		page,
+	} ) => {
+		await requestUtils.activatePlugin(
+			'woocommerce-blocks-test-cart-extensions'
+		);
+
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+		await frontendUtils.goToCart();
+
+		await page.evaluate( () => {
+			window.wc.blocksCheckout.extensionCartUpdate( {
+				namespace: 'cart-extensions-test-helper-2',
+			} );
+		} );
+
+		await expect(
+			page
+				.locator( '.wc-block-components-notice-banner__content' )
+				.getByText( 'This is an error with cart context.' )
+		).toBeVisible();
+	} );
+
+	test( 'Invalid callback namespace creates notice', async ( {
+		frontendUtils,
+		page,
+	} ) => {
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+		await frontendUtils.goToCart();
+
+		await page.evaluate( () => {
+			window.wc.blocksCheckout.extensionCartUpdate( {
+				namespace: 'invalid-namespace',
+			} );
+		} );
+
+		await expect(
+			page
+				.locator( '.wc-block-components-notice-banner__content' )
+				.getByText(
+					'There is no such namespace registered: invalid-namespace.'
+				)
+		).toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-extension-callbacks.shopper.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { expect, test as base, wpCLI } from '@woocommerce/e2e-utils';
+import { expect, test as base } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/changelog/fix-cart-error-handling-49724
+++ b/plugins/woocommerce/changelog/fix-cart-error-handling-49724
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix extensionCartUpdates not surfacing errors to cart and checkout

--- a/plugins/woocommerce/changelog/fix-cart-error-handling-49724
+++ b/plugins/woocommerce/changelog/fix-cart-error-handling-49724
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix extensionCartUpdates not surfacing errors to cart and checkout
+Fix extensionCartUpdates to surface generic error messages, and include documentation for the error handling.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When errors are received using the `receiveError` action, those errors are not surfaced in the UI. This can be tested using some code snippets:

```
add_action(
	'woocommerce_blocks_loaded',
	function () {
		woocommerce_store_api_register_update_callback(
			array(
				'namespace' => 'debug-test',
				'callback'  => function () {
					throw new Automattic\WooCommerce\StoreApi\Exceptions\RouteException( 'hello_error', 'This is an error with contact context.', 400, array( 'context' => 'wc/checkout/contact-information' ) );
				},
			)
		);
	}
);
```

And then running some commands in the console:

```
wc.blocksCheckout.extensionCartUpdate( { namespace: 'debug-test' } )
```

You'll see an uncaught promise error in the console, but nothing in the UI. Extensions need to capture these errors using the returned promise. I've included some basic examples of how to do this.

As for more generic errors, for instance, when a callback does not exist, or if something in the cart errors instead of the callback itself with a `woocommerce_rest_cart_extensions_error` exception, we can capture these and surface them accordingly. This PR however fixes this behaviour. Notices are caught and surfaced using (by default) `wc/cart` notice context, or a context provided in the response.

![Screenshot 2024-07-24 at 15 22 37](https://github.com/user-attachments/assets/41058cc4-cfcd-4582-bedc-0042bfa200f9)

If you run both of these commands you'll see a notice for the one which has no valid namespace:

```
wc.blocksCheckout.extensionCartUpdate( { namespace: 'debug-test' } )
wc.blocksCheckout.extensionCartUpdate( { namespace: 'debug-test-2' } )
```

Closes #49724

### How to test the changes in this Pull Request:

Developers should test using the snippet + console commands above. Non-developers should smoke test:

1. You can place an order on the block based checkout
2. Test some notices; e.g. apply an invalid coupon and ensure the notice saying the coupon does not exist is shown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
