### PR TITLE
Logging: Add parameter to avoid log directory creation

### DIFF
--- a/plugins/woocommerce/changelog/update-log-directory-init
+++ b/plugins/woocommerce/changelog/update-log-directory-init
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add parameter to avoid attempting to create the logs directory if it doesn't exist

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -416,8 +416,6 @@ final class WooCommerce {
 	 * Define WC Constants.
 	 */
 	private function define_constants() {
-		$upload_dir = wp_upload_dir( null, false );
-
 		$this->define( 'WC_ABSPATH', dirname( WC_PLUGIN_FILE ) . '/' );
 		$this->define( 'WC_PLUGIN_BASENAME', plugin_basename( WC_PLUGIN_FILE ) );
 		$this->define( 'WC_VERSION', $this->version );
@@ -436,8 +434,9 @@ final class WooCommerce {
 		 */
 		if ( defined( 'WC_LOG_DIR' ) ) {
 			$this->define( 'WC_LOG_DIR_CUSTOM', true );
+		} else {
+			$this->define( 'WC_LOG_DIR', LoggingUtil::get_log_directory( false ) );
 		}
-		$this->define( 'WC_LOG_DIR', LoggingUtil::get_log_directory( false ) );
 
 		// These three are kept defined for compatibility, but are no longer used.
 		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.2' );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -437,7 +437,7 @@ final class WooCommerce {
 		if ( defined( 'WC_LOG_DIR' ) ) {
 			$this->define( 'WC_LOG_DIR_CUSTOM', true );
 		}
-		$this->define( 'WC_LOG_DIR', LoggingUtil::get_log_directory() );
+		$this->define( 'WC_LOG_DIR', LoggingUtil::get_log_directory( false ) );
 
 		// These three are kept defined for compatibility, but are no longer used.
 		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.2' );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Classes\Payment
  */
 
+use Automattic\WooCommerce\Utilities\LoggingUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 return array(
@@ -55,7 +57,10 @@ return array(
 		'label'       => __( 'Enable logging', 'woocommerce' ),
 		'default'     => 'no',
 		/* translators: %s: URL */
-		'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside %s Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ), '<code>' . WC_Log_Handler_File::get_log_file_path( 'paypal' ) . '</code>' ),
+		'description' => sprintf(
+			__( 'Log PayPal events such as IPN requests and review them on the <a href="%s">Logs screen</a>. Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ),
+			esc_url( LoggingUtil::get_logs_tab_url() )
+		),
 	),
 	'ipn_notification'      => array(
 		'title'       => __( 'IPN email notifications', 'woocommerce' ),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -58,6 +58,7 @@ return array(
 		'default'     => 'no',
 		/* translators: %s: URL */
 		'description' => sprintf(
+			// translators: %s is a placeholder for a URL.
 			__( 'Log PayPal events such as IPN requests and review them on the <a href="%s">Logs screen</a>. Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ),
 			esc_url( LoggingUtil::get_logs_tab_url() )
 		),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -864,7 +864,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		}
 
 		$database_version = wc_get_server_database_version();
-		$log_directory    = LoggingUtil::get_log_directory();
+		$log_directory    = LoggingUtil::get_log_directory( false );
 
 		// Return all environment info. Described by JSON Schema.
 		return array(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -656,7 +656,7 @@ class FileController {
 	 */
 	public function get_log_directory_size(): int {
 		$bytes = 0;
-		$path  = realpath( Settings::get_log_directory() );
+		$path  = realpath( Settings::get_log_directory( false ) );
 
 		if ( wp_is_writable( $path ) ) {
 			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ), \RecursiveIteratorIterator::CATCH_GET_CHILD );

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -54,15 +54,15 @@ class Settings {
 	 * The `wp_upload_dir` function takes into account the possibility of multisite, and handles changing
 	 * the directory if the context is switched to a different site in the network mid-request.
 	 *
-	 * @param bool $initialize Optional. True to attempt to create the log directory if it doesn't exist. Default true.
+	 * @param bool $create_dir Optional. True to attempt to create the log directory if it doesn't exist. Default true.
 	 *
 	 * @return string The full directory path, with trailing slash.
 	 */
-	public static function get_log_directory( bool $initialize = true ): string {
+	public static function get_log_directory( bool $create_dir = true ): string {
 		if ( true === Constants::get_constant( 'WC_LOG_DIR_CUSTOM' ) ) {
 			$dir = Constants::get_constant( 'WC_LOG_DIR' );
 		} else {
-			$upload_dir = wc_get_container()->get( LegacyProxy::class )->call_function( 'wp_upload_dir', null, $initialize );
+			$upload_dir = wc_get_container()->get( LegacyProxy::class )->call_function( 'wp_upload_dir', null, $create_dir );
 
 			/**
 			 * Filter to change the directory for storing WooCommerce's log files.
@@ -76,7 +76,7 @@ class Settings {
 
 		$dir = trailingslashit( $dir );
 
-		if ( true === $initialize ) {
+		if ( true === $create_dir ) {
 			$realpath = realpath( $dir );
 			if ( false === $realpath ) {
 				$result = wp_mkdir_p( $dir );

--- a/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/Settings.php
@@ -54,13 +54,15 @@ class Settings {
 	 * The `wp_upload_dir` function takes into account the possibility of multisite, and handles changing
 	 * the directory if the context is switched to a different site in the network mid-request.
 	 *
+	 * @param bool $initialize Optional. True to attempt to create the log directory if it doesn't exist. Default true.
+	 *
 	 * @return string The full directory path, with trailing slash.
 	 */
-	public static function get_log_directory(): string {
+	public static function get_log_directory( bool $initialize = true ): string {
 		if ( true === Constants::get_constant( 'WC_LOG_DIR_CUSTOM' ) ) {
 			$dir = Constants::get_constant( 'WC_LOG_DIR' );
 		} else {
-			$upload_dir = wc_get_container()->get( LegacyProxy::class )->call_function( 'wp_upload_dir' );
+			$upload_dir = wc_get_container()->get( LegacyProxy::class )->call_function( 'wp_upload_dir', null, $initialize );
 
 			/**
 			 * Filter to change the directory for storing WooCommerce's log files.
@@ -74,18 +76,20 @@ class Settings {
 
 		$dir = trailingslashit( $dir );
 
-		$realpath = realpath( $dir );
-		if ( false === $realpath ) {
-			$result = wp_mkdir_p( $dir );
+		if ( true === $initialize ) {
+			$realpath = realpath( $dir );
+			if ( false === $realpath ) {
+				$result = wp_mkdir_p( $dir );
 
-			if ( true === $result ) {
-				// Create infrastructure to prevent listing contents of the logs directory.
-				try {
-					$filesystem = FilesystemUtil::get_wp_filesystem();
-					$filesystem->put_contents( $dir . '.htaccess', 'deny from all' );
-					$filesystem->put_contents( $dir . 'index.html', '' );
-				} catch ( Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-					// Creation failed.
+				if ( true === $result ) {
+					// Create infrastructure to prevent listing contents of the logs directory.
+					try {
+						$filesystem = FilesystemUtil::get_wp_filesystem();
+						$filesystem->put_contents( $dir . '.htaccess', 'deny from all' );
+						$filesystem->put_contents( $dir . 'index.html', '' );
+					} catch ( Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+						// Creation failed.
+					}
 				}
 			}
 		}

--- a/plugins/woocommerce/src/Utilities/LoggingUtil.php
+++ b/plugins/woocommerce/src/Utilities/LoggingUtil.php
@@ -86,12 +86,12 @@ final class LoggingUtil {
 	/**
 	 * Get the directory for storing log files.
 	 *
-	 * @param bool $initialize Optional. True to attempt to create the log directory if it doesn't exist. Default true.
+	 * @param bool $create_dir Optional. True to attempt to create the log directory if it doesn't exist. Default true.
 	 *
 	 * @return string The full directory path, with trailing slash.
 	 */
-	public static function get_log_directory( bool $initialize = true ): string {
-		return Settings::get_log_directory( $initialize );
+	public static function get_log_directory( bool $create_dir = true ): string {
+		return Settings::get_log_directory( $create_dir );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/LoggingUtil.php
+++ b/plugins/woocommerce/src/Utilities/LoggingUtil.php
@@ -86,10 +86,12 @@ final class LoggingUtil {
 	/**
 	 * Get the directory for storing log files.
 	 *
+	 * @param bool $initialize Optional. True to attempt to create the log directory if it doesn't exist. Default true.
+	 *
 	 * @return string The full directory path, with trailing slash.
 	 */
-	public static function get_log_directory(): string {
-		return Settings::get_log_directory();
+	public static function get_log_directory( bool $initialize = true ): string {
+		return Settings::get_log_directory( $initialize );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/SettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/SettingsTest.php
@@ -120,6 +120,15 @@ class SettingsTest extends WC_Unit_Test_Case {
 		$callback = fn() => $path;
 		add_filter( 'woocommerce_log_directory', $callback );
 
+		// First check that the test directory doesn't exist yet.
+		$this->assertFalse( wp_is_writable( $path ) );
+
+		// Then test that the $initialize param works when set to false.
+		$actual_path = Settings::get_log_directory( false );
+		$this->assertEquals( $path, $actual_path );
+		$this->assertFalse( wp_is_writable( $actual_path ) );
+
+		// Finally test directory creation.
 		$actual_path = Settings::get_log_directory();
 		$this->assertEquals( $path, $actual_path );
 		$this->assertTrue( wp_is_writable( $actual_path ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `get_log_directory` method, by default, attempts to create the directory if it doesn't exist yet. However, the method is called early in the initialization of the WooCommerce plugin, regardless of whether the logging system is configured to use the filesystem. This adds a parameter to `get_log_directory` to specify whether to attempt directory creation, and ensures that the parameter is set to false in a few specific places.

### How to test the changes in this Pull Request:

1. On your test site, deactivate WooCommerce. Then in the file system, go to the uploads directory and remove the `wc-logs` directory if it exists.
2. Re-activate WooCommerce. Check in the filesystem and make sure that `wc-logs` did _not_ get recreated.
3. Click around in WP Admin (anywhere except WooCommerce > Status > Logs) and ensure that `wc-logs` does not get created.
4. Now go to WooCommerce > Status > Logs. Assuming that the logger is configured to use the filesystem log handler, the `wc-logs` directory should now get created.
5. Go to the Logs Settings screen and switch the log storage setting to database, then repeat the test steps. The `wc-logs` directory should not get created at any point.