### PR TITLE
Adding support for optgroups in `woocommerce_wp_select` function

### DIFF
--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -258,7 +258,17 @@ function woocommerce_wp_select( $field, WC_Data $data = null ) {
 		<select <?php echo wc_implode_html_attributes( $field_attributes ); // WPCS: XSS ok. ?>>
 			<?php
 			foreach ( $field['options'] as $key => $value ) {
-				echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $field['value'] ) . '>' . esc_html( $value ) . '</option>';
+				if(is_array($value)){
+					echo '<optgroup label="' . esc_attr( $key ) . '">';
+
+					foreach ( $value as $k => $v ) {
+						echo '<option value="' . esc_attr( $k ) . '"' . wc_selected( $k, $field['value'] ) . '>' . esc_html( $v ) . '</option>';
+					}
+
+					echo '</optgroup>';
+				} else {
+					echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $field['value'] ) . '>' . esc_html( $value ) . '</option>';
+				}
 			}
 			?>
 		</select>


### PR DESCRIPTION
This PR makes the `woocommerce_wp_select` function compatible with [optgroup](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup).

### Usage

Example code:

```php
woocommerce_wp_select( [
   'id' => 'your-id',
   'name' => 'field-name',
   'label' => __('Field label', 'woocommerce'),
   'description' => __('field description', 'woocommerce'),
   'options' => [
            'Theropods' => [
	            'Tyrannosaurus' => 'Tyrannosaurus',
	            'Velociraptor' => 'Velociraptor',
                    'Deinonychus' => 'Deinonychus',
            ],
            'Sauropods' => [
	            'Diplodocus' => 'Diplodocus',
                    'Saltasaurus' => 'Saltasaurus',
                    'Apatosaurus' => 'Apatosaurus',
            ],
        ],
    'desc_tip' => true,
    'class' => 'cb-admin-multiselect',
] );
```
