### PR TITLE
CYS: Hide shuffle button when only one pattern is available

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/toolbar/shuffle.tsx
@@ -106,7 +106,8 @@ export default function Shuffle( { clientId }: { clientId: string } ) {
 	// @ts-expect-error missing type
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
-	if ( patterns.length === 0 ) {
+	// We need at least two patterns to shuffle.
+	if ( patterns.length < 2 ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/changelog/49790-fix-hide-shuffle-icon
+++ b/plugins/woocommerce/changelog/49790-fix-hide-shuffle-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS: Hide shuffle button when only one pattern is available


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR hides shuffle button when only one pattern is available


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to WooCommerce > Home > Customize your store.
2. Click on "Design your Homepage"
3. Click on "Social Media".
4. Add the pattern
5. Hover the pattern on the site preview
6. Ensure that the block toolbar doesn't show the shuffle button.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Hide shuffle button when only one pattern is available

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
