### PR TITLE
Monorepo: speedup 'Check Asset Sizes' job.

### DIFF
--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -50,6 +50,6 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
-                  clean-script: '--if-present distclean'
+                  clean-script: '--if-present buildclean'
                   minimum-change-threshold: 100
                   omit-unchanged: true

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -50,6 +50,6 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
-                  clean-script: '--if-present distclean'
+                  clean-script: 'rm -rf packages/js/*/build packages/js/*/build-style plugins/*/build plugins/*/build-style'
                   minimum-change-threshold: 100
                   omit-unchanged: true

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -44,6 +44,8 @@ jobs:
                   # Both install and build are handled by compressed-size-action.
                   install: false
                   build: false
+                  pull-package-deps: '@woocommerce/plugin-woocommerce'
+
             - uses: preactjs/compressed-size-action@f780fd104362cfce9e118f9198df2ee37d12946c
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -50,6 +50,6 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
-                  clean-script: 'rm -rf packages/js/*/build packages/js/*/build-style plugins/*/build plugins/*/build-style'
+                  clean-script: '--if-present distclean'
                   minimum-change-threshold: 100
                   omit-unchanged: true

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"lint": "pnpm -r lint",
 		"cherry-pick": "node ./tools/cherry-pick/bin/run",
 		"clean": "rimraf -g '**/node_modules' '**/.wireit' && pnpm store prune && pnpm i",
-		"distclean": "rm -rf packages/js/*/build packages/js/*/build-* plugins/*/build plugins/*/build-*",
+		"buildclean": "rimraf -g packages/js/*/build packages/js/*/build-* plugins/*/build plugins/*/build-*",
 		"preinstall": "npx only-allow pnpm",
 		"postinstall": "pnpm git:update-hooks",
 		"git:update-hooks": "if test -d .git; then rm -rf .git/hooks && mkdir -p .git/hooks && husky install; else husky install; fi",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"lint": "pnpm -r lint",
 		"cherry-pick": "node ./tools/cherry-pick/bin/run",
 		"clean": "rimraf -g '**/node_modules' '**/.wireit' && pnpm store prune && pnpm i",
-		"buildclean": "rimraf -g packages/js/*/build packages/js/*/build-* plugins/*/build plugins/*/build-*",
+		"buildclean": "git clean --force -d -X ./packages ./plugins ./tools",
 		"preinstall": "npx only-allow pnpm",
 		"postinstall": "pnpm git:update-hooks",
 		"git:update-hooks": "if test -d .git; then rm -rf .git/hooks && mkdir -p .git/hooks && husky install; else husky install; fi",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"lint": "pnpm -r lint",
 		"cherry-pick": "node ./tools/cherry-pick/bin/run",
 		"clean": "rimraf -g '**/node_modules' '**/.wireit' && pnpm store prune && pnpm i",
-		"distclean": "git clean --force -d -X",
+		"distclean": "rm -rf packages/js/*/build packages/js/*/build-* plugins/*/build plugins/*/build-*",
 		"preinstall": "npx only-allow pnpm",
 		"postinstall": "pnpm git:update-hooks",
 		"git:update-hooks": "if test -d .git; then rm -rf .git/hooks && mkdir -p .git/hooks && husky install; else husky install; fi",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enable deps pulling needed for faster building the assets.

### Testing

Note that the job tries to pull cached resources when setting up monorepo, similar to build process for other jobs.
