### PR TITLE
Revert "Fix terms counts in wcadmin_product_add_publish Tracks event"

### DIFF
--- a/plugins/woocommerce/changelog/revert-48194-fix-wcadmin_product_add_publish_terms_count
+++ b/plugins/woocommerce/changelog/revert-48194-fix-wcadmin_product_add_publish_terms_count
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Revert fixing terms count in tracking PR as it caused product_add_publish to be triggered more than usual.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -333,8 +333,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$product->apply_changes();
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		do_action( 'woocommerce_update_product', $product->get_id(), $product, $changes );
+		do_action( 'woocommerce_update_product', $product->get_id(), $product );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -333,6 +333,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$product->apply_changes();
 
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_update_product', $product->get_id(), $product );
 	}
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -29,8 +29,7 @@ class WC_Products_Tracking {
 		add_action( 'load-edit.php', array( $this, 'track_products_view' ), 10 );
 		add_action( 'load-edit-tags.php', array( $this, 'track_categories_and_tags_view' ), 10, 2 );
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
-		add_action( 'woocommerce_new_product', array( $this, 'track_product_published' ), 10, 3 );
-		add_action( 'woocommerce_update_product', array( $this, 'track_product_published' ), 10, 3 );
+		add_action( 'wp_after_insert_post', array( $this, 'track_product_published' ), 10, 4 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
 		add_action( 'edited_product_cat', array( $this, 'track_product_category_updated' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
@@ -304,21 +303,24 @@ class WC_Products_Tracking {
 	/**
 	 * Send a Tracks event when a product is published.
 	 *
-	 * @param int        $product_id  Product ID.
-	 * @param WC_Product $product     Product object.
-	 * @param array      $changes     Product changes.
+	 * @param int          $post_id     Post ID.
+	 * @param WP_Post      $post        Post object.
+	 * @param bool         $update      Whether this is an existing post being updated.
+	 * @param null|WP_Post $post_before Null for new posts, the WP_Post object prior
+	 *                                  to the update for updated posts.
 	 */
-	public function track_product_published( $product_id, $product, $changes = null ) {
+	public function track_product_published( $post_id, $post, $update, $post_before ) {
 		if (
-			! isset( $product ) ||
-			'product' !== $product->post_type ||
-			'publish' !== $product->get_status( 'edit' ) ||
-			( $changes && ! isset( $changes['status'] ) )
+			'product' !== $post->post_type ||
+			'publish' !== $post->post_status ||
+			( $post_before && 'publish' === $post_before->post_status )
 		) {
 			return;
 		}
 
-		$product_type_options        = self::get_product_type_options( $product_id );
+		$product = wc_get_product( $post_id );
+
+		$product_type_options        = self::get_product_type_options( $post_id );
 		$product_type_options_string = self::get_product_type_options_string( $product_type_options );
 
 		$properties = array(
@@ -332,7 +334,7 @@ class WC_Products_Tracking {
 			'is_virtual'           => $product->is_virtual() ? 'yes' : 'no',
 			'manage_stock'         => $product->get_manage_stock() ? 'yes' : 'no',
 			'menu_order'           => $product->get_menu_order() ? 'yes' : 'no',
-			'product_id'           => $product_id,
+			'product_id'           => $post_id,
 			'product_gallery'      => count( $product->get_gallery_image_ids() ),
 			'product_image'        => $product->get_image_id() ? 'yes' : 'no',
 			'product_type'         => $product->get_type(),


### PR DESCRIPTION
Reverts woocommerce/woocommerce#48194 as this is causing an increased amount of `product_add_publish` tracks being triggered even if stock is being decreased.

Given this is a revert, please load https://github.com/woocommerce/woocommerce/pull/48194 and this PR side by side and walk through the changes, it should be an exact revert ( the only exception being the changelog ).

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Test this with both the classic product form and the new one that you can enable under Settings > Advanced > Features**

1. Install the **WooCommerce Beta Tester** plugin, this will allow you to see the PHP fired track events
2. Make sure you have tracking enabled under **Settings > Advanced > woocommerce.com**
3. Go to **Products** > **Add New**
4. Make some changes in the product, like adding a name and description
5. Save the product as draft ( important to keep as draft )
6. Confirm there is not a new `wcadmin_product_add_publish` event in the events `Tracks` event for this product yet.
(`/wp-admin/admin.php?page=wc-status&tab=logs`)
7. Publish the product
8. Confirm now there is a new `wcadmin_product_add_publish` for your current product
9. Now update the title and publish the product again
10. Confirm there is not a new `wcadmin_product_add_publish` event in the events `Tracks` event for this product yet.
(`/wp-admin/admin.php?page=wc-status&tab=logs`)