### PR TITLE
Use a `RichText` control for the separator price in "Place order" button

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
@@ -16,12 +16,14 @@ import {
 
 interface PlaceOrderButton {
 	label: string;
+	separatorText?: string;
 	fullWidth?: boolean | undefined;
 	showPrice?: boolean | undefined;
 }
 
 const PlaceOrderButton = ( {
 	label,
+	separatorText = '·',
 	fullWidth = false,
 	showPrice = false,
 }: PlaceOrderButton ): JSX.Element => {
@@ -32,6 +34,11 @@ const PlaceOrderButton = ( {
 		waitingForProcessing,
 		waitingForRedirect,
 	} = useCheckoutSubmit();
+
+	// Merchant deleted the separator, leaving the · placeholder. It won't be undefined because it has a default value.
+	if ( separatorText === '' ) {
+		separatorText = '·';
+	}
 
 	const { cartTotals } = useStoreCart();
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
@@ -52,7 +59,9 @@ const PlaceOrderButton = ( {
 			{ label }
 			{ showPrice && (
 				<>
-					<div className="wc-block-components-checkout-place-order-button__separator" />
+					<div className="wc-block-components-checkout-place-order-button__separator">
+						{ separatorText }
+					</div>
 					<div className="wc-block-components-checkout-place-order-button__price">
 						<FormattedMonetaryAmount
 							value={ cartTotals.total_price }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.json
@@ -32,6 +32,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"separatorText": {
+			"type": "string",
+			"default": "·"
+		},
 		"className": {
 			"type": "string",
 			"default": ""

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
@@ -24,12 +24,14 @@ const Block = ( {
 	className,
 	showPrice,
 	placeOrderButtonLabel,
+	separatorText,
 }: {
 	cartPageId: number;
 	showReturnToCart: boolean;
 	showPrice: boolean;
 	className?: string;
 	placeOrderButtonLabel: string;
+	separatorText: string;
 } ): JSX.Element => {
 	const { paymentMethodButtonLabel } = useCheckoutSubmit();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
@@ -55,6 +55,7 @@ const Block = ( {
 					/>
 				) }
 				<PlaceOrderButton
+					separatorText={ separatorText }
 					showPrice={ showPrice }
 					label={ label }
 					fullWidth={ ! showReturnToCart }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx';
 import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import PageSelector from '@woocommerce/editor-components/page-selector';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
@@ -146,7 +150,18 @@ export const Edit = ( {
 					>
 						{ showPrice && (
 							<>
-								<div className="wc-block-components-checkout-place-order-button__separator"></div>
+								<RichText
+									multiline={ false }
+									allowedFormats={ [] }
+									value={ separatorText }
+									placeholder="·"
+									className="wc-block-components-checkout-place-order-button__separator"
+									onChange={ ( newSeparator ) => {
+										setAttributes( {
+											separatorText: newSeparator,
+										} );
+									} }
+								/>
 								<div className="wc-block-components-checkout-place-order-button__price">
 									<FormattedMonetaryAmount
 										value={ cartTotals.total_price }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -32,6 +32,7 @@ export const Edit = ( {
 		showPrice: boolean;
 		cartPageId: number;
 		placeOrderButtonLabel: string;
+		separatorText: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
@@ -41,6 +42,7 @@ export const Edit = ( {
 		showReturnToCart = false,
 		placeOrderButtonLabel,
 		showPrice = false,
+		separatorText = '·',
 	} = attributes;
 	const { cartTotals } = useStoreCart();
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
@@ -30,6 +30,8 @@
 
 			.wc-block-components-checkout-place-order-button__separator {
 				margin: 0 20px;
+				// This is required because if this element becomes too narrow, the placeholder's vertical alignment is off.
+				min-width: auto !important;
 			}
 
 			.wc-block-components-button__text {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
@@ -30,11 +30,6 @@
 
 			.wc-block-components-checkout-place-order-button__separator {
 				margin: 0 20px;
-
-				// This selector displays the separator so it can be targeted and edited by extensions.
-				&::after {
-					content: "·";
-				}
 			}
 
 			.wc-block-components-button__text {

--- a/plugins/woocommerce/changelog/fix-use-rich-text-for-price-separator
+++ b/plugins/woocommerce/changelog/fix-use-rich-text-for-price-separator
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a bug-fix/enhancement to an unreleased feature #49252
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replaces the CSS-implementation of the separator with an actual text node. This can be controlled with a `RichText` control in the editor.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an item to your cart and go to the Checkout page.
2. Look at the place order button. It should not have a price or separator visible.
4. Go to the Checkout page in the editor.
5. Select the Checkout Actions Block (The place order button).
6. In the sidebar, toggle the `Show price in the button` option **on**.
7. In the editor, look at the place order button. Ensure the price is visible with a separator between the text and the price.
9. Ensure you can edit the text (click into it and type, it's not super obvious it's editable).
10. Ensure you can edit the separator (click into it and type, it's not super obvious it's editable).
11. Delete the separator, ensure it defaults to `·`.
12. Repeat the next 2 steps a few times with a different separator, try using special characters and non-ascii characters:
13. Change the separator and save your changes.
14. Visit the front end, ensure the separator shows, that it is the value you entered in the editor, and that the button looks correct.
15. Ensure this works in multiple browsers.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
