### PR TITLE
enhancement: making tooltips message be selected based on order status slug. changes to get_order_status_label filter

### DIFF
--- a/plugins/woocommerce/changelog/49812-enhancement-order-list-tooltip
+++ b/plugins/woocommerce/changelog/49812-enhancement-order-list-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tooltips message is now selected based on the order status instead of the label of the order status, which would break if the current WordPress language was not English. Also passes the order object to the woocommerce_get_order_status_labels filter to allow for more personalized tooltips.

--- a/plugins/woocommerce/changelog/enhancement-order-list-tooltip
+++ b/plugins/woocommerce/changelog/enhancement-order-list-tooltip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Tooltips message is now selected based on the order status instead of the label of the order status, which would break if the current WordPress language was not English. Also passes the order object to the woocommerce_get_order_status_labels filter to allow for more personalized tooltips.

--- a/plugins/woocommerce/changelog/enhancement-order-list-tooltip
+++ b/plugins/woocommerce/changelog/enhancement-order-list-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tooltips message is now selected based on the order status instead of the label of the order status, which would break if the current WordPress language was not English. Also passes the order object to the woocommerce_get_order_status_labels filter to allow for more personalized tooltips.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1064,12 +1064,12 @@ class ListTable extends WP_List_Table {
 	 */
 	private function get_order_status_label( WC_Order $order ): string {
 		$status_names = array(
-			'pending-payment' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
+			'pending' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
 			'on-hold'         => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
 			'processing'      => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
 			'completed'       => __( 'Order fulfilled and complete.', 'woocommerce' ),
 			'failed'          => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
-			'draft'           => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
+			'checkout-draft'           => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
 			'cancelled'       => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
 			'refunded'        => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1064,14 +1064,14 @@ class ListTable extends WP_List_Table {
 	 */
 	private function get_order_status_label( WC_Order $order ): string {
 		$status_names = array(
-			'Pending payment' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
-			'On hold'         => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
-			'Processing'      => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
-			'Completed'       => __( 'Order fulfilled and complete.', 'woocommerce' ),
-			'Failed'          => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
-			'Draft'           => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
-			'Canceled'        => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
-			'Refunded'        => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
+			'pending-payment' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
+			'on-hold'         => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
+			'processing'      => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
+			'completed'       => __( 'Order fulfilled and complete.', 'woocommerce' ),
+			'failed'          => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
+			'draft'           => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
+			'cancelled'       => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
+			'refunded'        => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
 		);
 
 		/**
@@ -1081,9 +1081,9 @@ class ListTable extends WP_List_Table {
 		 * @param WC_Order $order  Current order object.
 		 * @since 9.1.0
 		 */
-		$status_names = apply_filters( 'woocommerce_get_order_status_labels', $status_names );
+		$status_names = apply_filters( 'woocommerce_get_order_status_labels', $status_names, $order );
 
-		$status_name = wc_get_order_status_name( $order->get_status() );
+		$status_name = $order->get_status();
 
 		return isset( $status_names[ $status_name ] ) ? $status_names[ $status_name ] : '';
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1064,14 +1064,14 @@ class ListTable extends WP_List_Table {
 	 */
 	private function get_order_status_label( WC_Order $order ): string {
 		$status_names = array(
-			'pending' => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
-			'on-hold'         => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
-			'processing'      => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
-			'completed'       => __( 'Order fulfilled and complete.', 'woocommerce' ),
-			'failed'          => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
-			'checkout-draft'           => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
-			'cancelled'       => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
-			'refunded'        => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
+			'pending'        => __( 'The order has been received, but no payment has been made. Pending payment orders are generally awaiting customer action.', 'woocommerce' ),
+			'on-hold'        => __( 'The order is awaiting payment confirmation. Stock is reduced, but you need to confirm payment.', 'woocommerce' ),
+			'processing'     => __( 'Payment has been received (paid), and the stock has been reduced. The order is awaiting fulfillment.', 'woocommerce' ),
+			'completed'      => __( 'Order fulfilled and complete.', 'woocommerce' ),
+			'failed'         => __( 'The customer’s payment failed or was declined, and no payment has been successfully made.', 'woocommerce' ),
+			'checkout-draft' => __( 'Draft orders are created when customers start the checkout process while the block version of the checkout is in place.', 'woocommerce' ),
+			'cancelled'      => __( 'The order was canceled by an admin or the customer.', 'woocommerce' ),
+			'refunded'       => __( 'Orders are automatically put in the Refunded status when an admin or shop manager has fully refunded the order’s value after payment.', 'woocommerce' ),
 		);
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In a previous pull request https://github.com/woocommerce/woocommerce/pull/47861 a rework was introduced to how the tooltips in the WooCommerce Admin Order Listing works. 

As you can see in the new method `get_order_status_label` the message for the tooltip is retrieved from the `$status_names` array via checking if the label of the status (that is retrieved with the help of `wc_get_order_status_name`) is the same as the label in the arrays key. This has one big issue which is when a WordPress installation is not in English (and is in a language that has the WooCommerce strings translated), this will not work since the order status label's will be translated and will fail the retrieval from the array since the keys are different. 

In this PR I've changed the structure of the key-value pair of the `$status_names` array, making it be retrieved with the WooCommerce slugs for each order status, making translations a non-issue. I did not understand why this approach was not followed in the original PR, and if possible i would like to understand why! :)

Besides, in this pull request, i also added another change passing down the `WC_Order` object to the new filter `woocommerce_get_order_status_labels` so it allows for the tooltips message to be more customizable. 

For example, the old tooltips messages (tooltips before the original PR) we're absolutely "throw out" and one of the WooCommerce shops I run found the old tooltips useful. 

So in order for me to be able to customize the messages to make them the same as before, passing down the `WC_Order` object into the filter allows the messages to be customizable as one sees fits with the current order's info, for example making them the same as before.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check the tooltips on the WooCommerce Order Admin listing while the WordPress language is set to english and find that it works.
2. Change the WordPress language to anything else that's not English.
3. Go on the admin order listing page and you can find that the tooltips are no longer working due to the "bug" fixed in this PR.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Tooltips message is now selected based on the order status instead of the label of the order status, which would break if the current WordPress language was not English. Also passes the order object to the woocommerce_get_order_status_labels filter to allow for more personalized tooltips.

</details>