### PR TITLE
[Automated] Skip flaky test: can create an account during checkout with custom password

### DIFF
--- a/plugins/woocommerce/plugins/woocommerce/changelog/changelog-bb68dde6-9b7f-88a5-9fbe-6b28f5574c42.md
+++ b/plugins/woocommerce/plugins/woocommerce/changelog/changelog-bb68dde6-9b7f-88a5-9fbe-6b28f5574c42.md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can create an account during checkout with custom password

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -921,7 +921,7 @@ test.describe(
 			);
 		} );
 
-		test( 'can create an account during checkout with custom password', async ( {
+		test.skip( 'can create an account during checkout with custom password', async ( {
 			page,
 			testPage,
 			baseURL,


### PR DESCRIPTION
This pull request skips the flaky test `can create an account during checkout with custom password` located at `tests/e2e-pw/tests/shopper/checkout-block.spec.js:924:3`.