### PR TITLE
Fix: Make woocommerce/product-price available in the Single Product template

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
@@ -30,7 +30,6 @@ const blockConfig = {
 
 registerBlockSingleProductTemplate( {
 	blockName: 'woocommerce/product-price',
-	blockMetadata: 'woocommerce/product-price',
 	blockSettings: blockConfig,
 	isAvailableOnPostEditor: false,
 } );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
 
 /**
  * Internal dependencies
@@ -28,4 +28,9 @@ const blockConfig = {
 	edit,
 };
 
-registerBlockType( 'woocommerce/product-price', blockConfig );
+registerBlockSingleProductTemplate( {
+	blockName: 'woocommerce/product-price',
+	blockMetadata: 'woocommerce/product-price',
+	blockSettings: blockConfig,
+	isAvailableOnPostEditor: false,
+} );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/index.tsx
@@ -31,5 +31,5 @@ const blockConfig = {
 registerBlockSingleProductTemplate( {
 	blockName: 'woocommerce/product-price',
 	blockSettings: blockConfig,
-	isAvailableOnPostEditor: false,
+	isAvailableOnPostEditor: true,
 } );

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -32,13 +32,17 @@ export const registerBlockSingleProductTemplate = ( {
 	isAvailableOnPostEditor,
 }: {
 	blockName: string;
-	blockMetadata: Partial< BlockConfiguration >;
+	blockMetadata?: string | Partial< BlockConfiguration >;
 	blockSettings: Partial< BlockConfiguration >;
 	isAvailableOnPostEditor: boolean;
 	isVariationBlock?: boolean;
 	variationName?: string;
 } ) => {
 	let currentTemplateId: string | undefined = '';
+
+	if ( ! blockMetadata ) {
+		blockMetadata = blockName;
+	}
 
 	subscribe( () => {
 		const previousTemplateId = currentTemplateId;

--- a/plugins/woocommerce/changelog/fix-register-product-price-using-custom-method
+++ b/plugins/woocommerce/changelog/fix-register-product-price-using-custom-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Make woocommerce/product-price available in the Single Product template


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR update the registration of the `woocommerce/product-price` block to using our custom method `registerBlockSingleProductTemplate` so the block is available when users edit the Single Product template in the Site Editor.

This PR also updates the `registerBlockSingleProductTemplate` function to make the `blockMetadata` optional, allowing to use that function without block.json file.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Single Product template in the Site Editor.
2. Verify you can search for and add the `Product Price` block to the template.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
