### PR TITLE
Product Collection: Revert rename of "Sync with current query" option

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/use-page-context-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/use-page-context-control.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { usePrevious } from '@woocommerce/base-hooks';
+import { select } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import {
 	ToggleControl,
@@ -25,12 +26,53 @@ import {
 	getDefaultValueOfFilterable,
 } from '../../utils';
 
-const label = __( 'Use page context', 'woocommerce' );
+const label = __( 'Sync with current query', 'woocommerce' );
 
-const helpText = __(
+const productArchiveHelpText = __(
+	'Enable to adjust the displayed products based on the current template and any applied filters.',
+	'woocommerce'
+);
+
+const productsByCategoryHelpText = __(
+	'Enable to adjust the displayed products based on the current category and any applied filters.',
+	'woocommerce'
+);
+
+const productsByTagHelpText = __(
+	'Enable to adjust the displayed products based on the current tag and any applied filters.',
+	'woocommerce'
+);
+
+const productsByAttributeHelpText = __(
+	'Enable to adjust the displayed products based on the current attribute and any applied filters.',
+	'woocommerce'
+);
+
+const searchResultsHelpText = __(
+	'Enable to adjust the displayed products based on the current search and any applied filters.',
+	'woocommerce'
+);
+
+const filterableHelpText = __(
 	'Adjust the displayed products depending on the current template and any applied query filters.',
 	'woocommerce'
 );
+
+const getHelpTextForTemplate = ( templateId: string ): string => {
+	if ( templateId.includes( '//taxonomy-product_cat' ) ) {
+		return productsByCategoryHelpText;
+	}
+	if ( templateId.includes( '//taxonomy-product_tag' ) ) {
+		return productsByTagHelpText;
+	}
+	if ( templateId.includes( '//taxonomy-product_attribute' ) ) {
+		return productsByAttributeHelpText;
+	}
+	if ( templateId.includes( '//product-search-results' ) ) {
+		return searchResultsHelpText;
+	}
+	return productArchiveHelpText;
+};
 
 const InheritQueryControl = ( {
 	setQueryAttribute,
@@ -38,6 +80,7 @@ const InheritQueryControl = ( {
 	query,
 }: QueryControlProps ) => {
 	const inherit = query?.inherit;
+	const editSiteStore = select( 'core/edit-site' );
 
 	const queryObjectBeforeInheritEnabled = usePrevious(
 		query,
@@ -47,6 +90,9 @@ const InheritQueryControl = ( {
 	);
 
 	const defaultValue = useMemo( () => getDefaultValueOfInherit(), [] );
+
+	const currentTemplateId = editSiteStore.getEditedPostId() as string;
+	const helpText = getHelpTextForTemplate( currentTemplateId );
 
 	return (
 		<ToolsPanelItem
@@ -111,7 +157,7 @@ const FilterableControl = ( {
 			<ToggleControl
 				className="wc-block-product-collection__inherit-query-control"
 				label={ label }
-				help={ helpText }
+				help={ filterableHelpText }
 				checked={ !! filterable }
 				onChange={ ( value ) => {
 					setQueryAttribute( {

--- a/plugins/woocommerce/changelog/revert-sync-with-query-rename
+++ b/plugins/woocommerce/changelog/revert-sync-with-query-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Collection: revert renaming "Sync with current query" option


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

In https://github.com/woocommerce/woocommerce/pull/49627 the "Sync with current query" option was renamed to "Use page context". However, there's ongoing discussion to update this control even further in [Gutenberg's Query Loop](https://github.com/WordPress/gutenberg/issues/63598). Once confirmed in GB, we'd like to align it so we're reverting current rename to avoid double rename (and redesign) in a short period of time which would cause confusion.

Ref: pf59Ax-1Ar-p2#comment-1184

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### In Product Catalog

1. Go to Editor -> Product Catalog
2. Insert Product Collection
3. Choose "create your own"
4. **Expected:** There's "Sync with current query" option in inspector controls and no "Use page context"


#### In post 

1. Create new post
2. Insert Product Collection
3. Choose "create your own"
4. **Expected:** There's "Sync with current query" option in inspector controls and no "Use page context"

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>