### PR TITLE
[Accessibility] Update product order status colors to ensure accessible color contrasts

### DIFF
--- a/plugins/woocommerce/changelog/fix-40589-order-status-color-contrast
+++ b/plugins/woocommerce/changelog/fix-40589-order-status-color-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update product order status colors to ensure accessible color contrasts

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3165,7 +3165,7 @@ ul.wc_coupon_list_block {
 .order-status {
 	display: inline-flex;
 	line-height: 2.5em;
-	color: #777;
+	color: #454545;
 	background: #e5e5e5;
 	border-radius: 4px;
 	border-bottom: 1px solid rgba(0, 0, 0, 0.05);
@@ -3176,27 +3176,27 @@ ul.wc_coupon_list_block {
 
 	&.status-completed {
 		background: #c8d7e1;
-		color: #2e4453;
+		color: #003d66;
 	}
 
 	&.status-on-hold {
 		background: #f8dda7;
-		color: #94660c;
+		color: #573B00;
 	}
 
 	&.status-failed {
 		background: #eba3a3;
-		color: #761919;
+		color: #570000;
 	}
 
 	&.status-processing {
 		background: #c6e1c6;
-		color: #5b841b;
+		color: #2c4700;
 	}
 
 	&.status-trash {
 		background: #eba3a3;
-		color: #761919;
+		color: #550202;
 	}
 
 	> span {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Updated the text color on the Order Status Buttons so that they meet the minimum color contrast at Level AAA for the size of the text used (minimum 7:1).

Closes #40589.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create 10 orders (feel free to do this in the Admin)
![image](https://github.com/user-attachments/assets/d5d2a8e2-59be-45f4-9e3f-f2575b1ccfbf)
2. Update the Status of each so that you have a list of all of the various status (including putting one in the trash
![image](https://github.com/user-attachments/assets/9c79e36d-8e0f-4900-99f2-5c375daf266a)
3. Either inspect each status chip, using a color contrast tool, such as https://color.a11y.com/ to check the contrast of the background to the foreground. 
4. Or an automated scanning tool, such as [WAVE](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US) to make sure there are no color contrast failures on the order status ships.

- **Default**: background: #e5e5e5; color: #454545;  [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=e5e5e5&fgcolor=454545)

- **Pending Payment**: background: #e5e5e5; color: #454545; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=e5e5e5&fgcolor=454545)

- **Processing**: background: #c6e1c6; color: #2c4700; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=c6e1c6&fgcolor=2c4700)

- **On hold**: background: #f8dda7; color: #573B00; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=f8dda7&fgcolor=573B00)

- **Cancelled**: background: #e5e5e5; color: #454545; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=e5e5e5&fgcolor=454545)

- **Refunded**: background: #e5e5e5; color: #454545; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=e5e5e5&fgcolor=454545)

- **Failed**: background: #eba3a3; color: #570000; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=eba3a3&fgcolor=570000)

- **Draft**: background: #e5e5e5; color: #454545; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=e5e5e5&fgcolor=454545)

- **Trash**: background: #eba3a3; color: #550202; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=eba3a3&fgcolor=550202)

- **Completed**: background: #c8d7e1 color: #003d66; [View Contrast](https://color.a11y.com/ContrastPair/?bgcolor=c8d7e1&fgcolor=003d66)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
