### PR TITLE
[Automated] Skip flaky test: can delete a variation

### DIFF
--- a/plugins/woocommerce/plugins/woocommerce/changelog/changelog-babebbaa-47f3-8611-957d-8b0f69e2317e.md
+++ b/plugins/woocommerce/plugins/woocommerce/changelog/changelog-babebbaa-47f3-8611-957d-8b0f69e2317e.md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can delete a variation

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -338,7 +338,7 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 			).toBeVisible();
 		} );
 
-		test( 'can delete a variation', async ( { page } ) => {
+		test.skip( 'can delete a variation', async ( { page } ) => {
 			await page.goto(
 				`/wp-admin/admin.php?page=wc-admin&path=/product/${ productId_deleteVariations }`
 			);


### PR DESCRIPTION
This pull request skips the flaky test `can delete a variation` located at `tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js:341:3`.