### PR TITLE
[Automated] Skip flaky test: can update sku

### DIFF
--- a/plugins/woocommerce/plugins/woocommerce/changelog/changelog-62bd103c-b79a-8c77-aa69-7de8c2723520
+++ b/plugins/woocommerce/plugins/woocommerce/changelog/changelog-62bd103c-b79a-8c77-aa69-7de8c2723520
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can update sku


### PR DESCRIPTION
This pull request skips the flaky test `can update sku` located at `tests/e2e-pw/tests/merchant/products/block-editor/product-inventory-block-editor.spec.js:48:1`.