### PR TITLE
[Automated] Skip flaky test: can create a simple product with categories, tags and with password required

### DIFF
--- a/plugins/woocommerce/plugins/woocommerce/changelog/changelog-eee1a609-f77c-8ea0-a6a6-e89c2ba52c1c
+++ b/plugins/woocommerce/plugins/woocommerce/changelog/changelog-eee1a609-f77c-8ea0-a6a6-e89c2ba52c1c
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can create a simple product with categories, tags and with password required

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
@@ -30,7 +30,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			'The block product editor is not being tested'
 		);
 
-		test( 'can create a simple product with categories, tags and with password required', async ( {
+		test.skip( 'can create a simple product with categories, tags and with password required', async ( {
 			page,
 		} ) => {
 			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );


### PR DESCRIPTION
This pull request skips the flaky test `can create a simple product with categories, tags and with password required` located at `tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js:33:3`.