### PR TITLE
[Automated] Skip flaky test: Changing the image width should update the site preview and the frontend

### DIFF
--- a/plugins/woocommerce/changelog/changelog-b7fc7f0f-3092-8cfc-b42a-5381f12b1cdb
+++ b/plugins/woocommerce/changelog/changelog-b7fc7f0f-3092-8cfc-b42a-5381f12b1cdb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Changing the image width should update the site preview and the frontend

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -126,7 +126,7 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		await expect( useAsSiteIcon ).toBeVisible();
 	} );
 
-	test( 'Changing the image width should update the site preview and the frontend', async ( {
+	test.skip( 'Changing the image width should update the site preview and the frontend', async ( {
 		assemblerPageObject,
 		logoPickerPageObject,
 		baseURL,


### PR DESCRIPTION
This pull request skips the flaky test `Changing the image width should update the site preview and the frontend` located at `tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js:129:2`.