### PR TITLE
[Automated] Skip flaky test: Enabling cash on delivery enables the payment method

### DIFF
--- a/plugins/woocommerce/changelog/changelog-8f24fa74-4ce9-82f1-af4f-4dc284fa4409
+++ b/plugins/woocommerce/changelog/changelog-8f24fa74-4ce9-82f1-af4f-4dc284fa4409
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Enabling cash on delivery enables the payment method

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
@@ -119,7 +119,7 @@ test.describe( 'Payment setup task', () => {
 		).toHaveText( 'Get paid' );
 	} );
 
-	test( 'Enabling cash on delivery enables the payment method', async ( {
+	test.skip( 'Enabling cash on delivery enables the payment method', async ( {
 		page,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Enabling cash on delivery enables the payment method` located at `tests/e2e-pw/tests/admin-tasks/payment.spec.js:122:2`.