### PR TITLE
[Automated] Skip flaky test: Can connect to WooCommerce.com

### DIFF
--- a/plugins/woocommerce/changelog/changelog-20e51871-2bee-8253-a184-c68a251e1b10
+++ b/plugins/woocommerce/changelog/changelog-20e51871-2bee-8253-a184-c68a251e1b10
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Can connect to WooCommerce.com

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -428,7 +428,7 @@ test.describe( 'Store owner can skip the core profiler', () => {
 		).toBeVisible();
 	} );
 
-	test( 'Can connect to WooCommerce.com', async ( { page } ) => {
+	test.skip( 'Can connect to WooCommerce.com', async ( { page } ) => {
 		await test.step( 'Go to WC Home and make sure the total sales is visible', async () => {
 			await page.goto( 'wp-admin/admin.php?page=wc-admin' );
 			await page


### PR DESCRIPTION
This pull request skips the flaky test `Can connect to WooCommerce.com` located at `tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js:431:2`.