### PR TITLE
Whitelist a line in WC Beta Tester from QIT security tests

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/update-qit-false-positive
+++ b/plugins/woocommerce-beta-tester/changelog/update-qit-false-positive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Whitelist line with maybe_unserialize() function call from QIT security tests.

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-import-export.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-import-export.php
@@ -78,7 +78,7 @@ class WC_Beta_Tester_Import_Export {
 		// show error/update messages.
 		if ( ! empty( $this->message ) ) {
 			?>
-			<div class="notice 
+			<div class="notice
 			<?php
 				echo ! empty( $this->message['type'] ) ? esc_attr( $this->message['type'] ) : '';
 			?>
@@ -172,6 +172,7 @@ class WC_Beta_Tester_Import_Export {
 				if ( ! isset( $settings[ $option_name ] ) ) {
 					continue;
 				}
+				// nosemgrep scanner.php.wp.security.object-injection, audit.php.wp.security.object-injection
 				$setting = maybe_unserialize( $settings[ $option_name ] );
 				if ( is_null( $setting ) ) {
 					delete_option( $option_name );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the necessary `nosemgrep` comment to whitelist a line that was being flagged as a false positive in QIT security tests.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

No need to test this PR, as it just adds a comment to tell the QIT security tests to ignore a line of code. Anyway, this change already passed the QIT security tests during the submission of WC Beta Tester 2.3.2 to the marketplace.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
