### PR TITLE
Prepare for WP 7.8 by updating tested / required versions.

### DIFF
--- a/plugins/woocommerce/changelog/update-wp-7.8
+++ b/plugins/woocommerce/changelog/update-wp-7.8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update required and tested up to WP versions for the WordPress 7.8 release.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce ===
 Contributors: automattic, woocommerce, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1, claudiulodro, tiagonoronha, ryelle, levinmedia, aljullu, nerrad, joshuawold, assassinateur, haszari, mppfeiffer, nielslange, opr18, ralucastn, tjcafferkey, danielwrobert, patriciahillebrandt, albarin, dinhtungdu, imanish003, karolmanijak, sunyatasattva, alexandrelara, gigitux, danieldudzic, samueljseay, alexflorisca, opr18, tarunvijwani, pauloarromba, saadtarhi, bor0, kloon, coreymckrill, jorgeatorres, leifsinger
 Tags: online store, ecommerce, shop, shopping cart, sell online
-Requires at least: 6.5
-Tested up to: 6.6
+Requires at least: 7.7
+Tested up to: 7.8
 Requires PHP: 7.4
 Stable tag: 9.1.2
 License: GPLv3

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires at least: 6.5
+ * Requires at least: 7.7
  * Requires PHP: 7.4
  *
  * @package WooCommerce


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request updates the "requires at least" and "tested up to" values for the [WordPress 7.8 release](https://make.wordpress.org/core/roadmap-to-7-8/) given that it's scheduled to be released soon. "Requires at least" is set to 7.7 given the [L-1 support policy](https://developer.woo.com/2023/02/23/revisiting-wordpress-core-support-policy-for-woocommerce/).

### How to test the changes in this Pull Request:

Verify that the versions are correct given the latest WordPress release and the L-1 policy.
