### PR TITLE
CYS: Skip PTK is down test on WordPress 6.5

### DIFF
--- a/plugins/woocommerce/changelog/49970-fix-cys-skip-test-wordpress-6-5
+++ b/plugins/woocommerce/changelog/49970-fix-cys-skip-test-wordpress-6-5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Skip PTK is down test on WordPress 6.5
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -1,6 +1,7 @@
 const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
+const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 const { setOption } = require( '../../../utils/options' );
 const { encodeCredentials } = require( '../../../utils/plugin-utils' );
 
@@ -291,6 +292,13 @@ test.describe(
 		test.use( { storageState: process.env.ADMINSTATE } );
 
 		test.beforeAll( async ( { baseURL } ) => {
+			const wordPressVersion = await getInstalledWordPressVersion();
+
+			if ( wordPressVersion <= 6.5 ) {
+				test.skip(
+					'Skipping PTK API test: WordPress version is below 6.5, which does not support this feature.'
+				);
+			}
 			try {
 				// In some environments the tour blocks clicking other elements.
 				await setOption(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" env:start`
2. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" test:e2e plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js`
3. Ensure that `Assembler -> Homepage -> PTK API is down` test runs.
4. Update `plugins/woocommerce/.wp-env.json` adding `"core": "WordPress/WordPress#6.5"`
5. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" env:start`
6. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" test:e2e plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js`
7.  Ensure that `Assembler -> Homepage -> PTK API is down` test **doesn't run**.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Skip PTK is down test on WordPress 6.5

</details>
