### PR TITLE
Only filter page title on order confirmation page when using an FSE theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-page-titles-49798
+++ b/plugins/woocommerce/changelog/fix-page-titles-49798
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix page titles of the cart and checkout page when using blocks and FSE themes.

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractPageTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractPageTemplate.php
@@ -14,7 +14,6 @@ abstract class AbstractPageTemplate extends AbstractTemplate {
 	 */
 	public function init() {
 		add_filter( 'page_template_hierarchy', array( $this, 'page_template_hierarchy' ), 1 );
-		add_filter( 'pre_get_document_title', array( $this, 'page_template_title' ) );
 	}
 
 	/**
@@ -48,7 +47,10 @@ abstract class AbstractPageTemplate extends AbstractTemplate {
 	}
 
 	/**
-	 * Filter the page title when the template is active.
+	 * Forces the page title to match the template title when this template is active.
+	 *
+	 * Only applies when hooked into `pre_get_document_title`. Most templates used for pages will not require this because
+	 * the page title should be used instead.
 	 *
 	 * @param string $title Page title.
 	 * @return string

--- a/plugins/woocommerce/src/Blocks/Templates/OrderConfirmationTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/OrderConfirmationTemplate.php
@@ -20,7 +20,7 @@ class OrderConfirmationTemplate extends AbstractPageTemplate {
 	 */
 	public function init() {
 		add_action( 'wp_before_admin_bar_render', array( $this, 'remove_edit_page_link' ) );
-
+		add_filter( 'pre_get_document_title', array( $this, 'page_template_title' ) );
 		parent::init();
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using an FSE theme, the title tag of pages such as Cart and Checkout would use the template title (e.g. `Page: Cart`) instead of the page title. This PR fixes this behaviour, while leaving the title of `Order Confirmation` as-is.

Closes #49798

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using a FSE theme such as Twenty Twenty Four, ensure you've setup a cart and checkout page using blocks.
2. Go to the Cart page. Check the page title in your browser tab. It should be the same as the "page" in WordPress, so most likely "Cart".
3. Same for checkout. It should be "Checkout", not "Page: Checkout"
4. Place order and check the order confirmation page uses "Order Confirmation" as its title.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
