### PR TITLE
CI: speedup 'Check Asset Sizes' job (take 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
         'project-lint-jobs',
         'project-test-jobs',
       ]
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     steps:
       - uses: 'actions/checkout@v4'
         name: 'Checkout'
@@ -330,8 +330,11 @@ jobs:
   
   report-flaky-tests:
     name: 'Create issues for flaky tests'
-    if: ${{ !cancelled() && ! github.event.pull_request.head.repo.fork }}
-    needs: [ 'project-test-jobs' ]
+    if: ${{ !cancelled() && ! github.event.pull_request.head.repo.fork && needs.project-jobs.outputs.test-jobs != '[]' }}
+    needs:       [
+      'project-jobs',
+      'project-test-jobs',
+    ]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,10 +331,11 @@ jobs:
   report-flaky-tests:
     name: 'Create issues for flaky tests'
     if: ${{ !cancelled() && ! github.event.pull_request.head.repo.fork && needs.project-jobs.outputs.test-jobs != '[]' }}
-    needs:       [
-      'project-jobs',
-      'project-test-jobs',
-    ]
+    needs:
+      [
+        'project-jobs',
+        'project-test-jobs',
+      ]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -50,8 +50,8 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
-                  install-script: 'install --filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false'
-                  build-script: '--filter="@woocommerce/plugin-woocommerce" build'
+                  install-script: 'pnpm install --filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false'
+                  build-script: 'pnpm --filter="@woocommerce/plugin-woocommerce" build'
                   clean-script: '--if-present buildclean'
                   minimum-change-threshold: 100
                   omit-unchanged: true

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -50,6 +50,8 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
+                  install-script: '--filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false install'
+                  build-script: '--filter="@woocommerce/plugin-woocommerce" build'
                   clean-script: '--if-present buildclean'
                   minimum-change-threshold: 100
                   omit-unchanged: true

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -51,7 +51,7 @@ jobs:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
                   install-script: 'pnpm install --filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false'
-                  build-script: 'pnpm --filter="@woocommerce/plugin-woocommerce" build'
+                  build-script: '--filter="@woocommerce/plugin-woocommerce" build'
                   clean-script: '--if-present buildclean'
                   minimum-change-threshold: 100
                   omit-unchanged: true

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -50,7 +50,7 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
-                  install-script: '--filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false install'
+                  install-script: 'install --filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false'
                   build-script: '--filter="@woocommerce/plugin-woocommerce" build'
                   clean-script: '--if-present buildclean'
                   minimum-change-threshold: 100

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -47,6 +47,8 @@ jobs:
                   pull-package-deps: '@woocommerce/plugin-woocommerce'
 
             - uses: preactjs/compressed-size-action@f780fd104362cfce9e118f9198df2ee37d12946c
+              env:
+                  BROWSERSLIST_IGNORE_OLD_DATA: true
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Spinoff of https://github.com/woocommerce/woocommerce/pull/49793, where we actualize CI-optimized install/build commands (same as monorepo setup action used under the hood).

This and previous speedup attempts should give us around a 1-1.5 minute boost and allow us to stay within 10-minute goal.
Practical results, though, are to be evaluated from job execution times stats.

### Testing

- `Create issues for flaky tests` job details (under `CI`) should say it's been skipped (as no test-jobs were executed)
- `Check Asset Sizes` during assets build steps should mention `Scope: 34 of 49 workspace projects` (reduced build scope)