### PR TITLE
add: render react placeholders for offline and woocommerce_payments settings sections

### DIFF
--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -138,6 +138,9 @@ if (
 		const paymentsOfflineRoot = document.getElementById(
 			'experimental_wc_settings_payments_offline'
 		);
+		const paymentsWooCommercePaymentsRoot = document.getElementById(
+			'experimental_wc_settings_payments_woocommerce_payments'
+		);
 
 		if ( paymentsMainRoot ) {
 			createRoot(
@@ -156,10 +159,6 @@ if (
 				)
 			).render( <SettingsPaymentsOfflineWrapper /> );
 		}
-
-		const paymentsWooCommercePaymentsRoot = document.getElementById(
-			'experimental_wc_settings_payments_woocommerce_payments'
-		);
 
 		if ( paymentsWooCommercePaymentsRoot ) {
 			createRoot(

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -22,7 +22,7 @@ import { possiblyRenderSettingsSlots } from './settings/settings-slots';
 import { registerTaxSettingsConflictErrorFill } from './settings/conflict-error-slotfill';
 import { registerPaymentsSettingsBannerFill } from './payments/payments-settings-banner-slotfill';
 import { registerSiteVisibilitySlotFill } from './launch-your-store';
-import { SettingsPaymentsMainWrapper, SettingsPaymentsOfflineWrapper } from './settings-payments';
+import { SettingsPaymentsMainWrapper, SettingsPaymentsOfflineWrapper, SettingsPaymentsWooCommercePaymentsWrapper } from './settings-payments';
 import { ErrorBoundary } from './error-boundary';
 
 const appRoot = document.getElementById( 'root' );
@@ -152,6 +152,18 @@ if (
 				)
 			).render( <SettingsPaymentsOfflineWrapper /> );
 		}
-		// Todo: SlotFill for WooPayments & others
+
+		const paymentsWooCommercePaymentsRoot = document.getElementById(
+			'experimental_wc_settings_payments_woocommerce_payments'
+		);
+
+		if ( paymentsWooCommercePaymentsRoot ) {
+			createRoot(
+				paymentsWooCommercePaymentsRoot.insertBefore(
+					document.createElement( 'div' ),
+					null
+				)
+			).render( <SettingsPaymentsWooCommercePaymentsWrapper /> );
+		}
 	} )();
 }

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -22,7 +22,11 @@ import { possiblyRenderSettingsSlots } from './settings/settings-slots';
 import { registerTaxSettingsConflictErrorFill } from './settings/conflict-error-slotfill';
 import { registerPaymentsSettingsBannerFill } from './payments/payments-settings-banner-slotfill';
 import { registerSiteVisibilitySlotFill } from './launch-your-store';
-import { SettingsPaymentsMainWrapper, SettingsPaymentsOfflineWrapper, SettingsPaymentsWooCommercePaymentsWrapper } from './settings-payments';
+import {
+	SettingsPaymentsMainWrapper,
+	SettingsPaymentsOfflineWrapper,
+	SettingsPaymentsWooCommercePaymentsWrapper,
+} from './settings-payments';
 import { ErrorBoundary } from './error-boundary';
 
 const appRoot = document.getElementById( 'root' );

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -131,6 +131,9 @@ if (
 		const paymentsMainRoot = document.getElementById(
 			'experimental_wc_settings_payments_main'
 		);
+		const paymentsOfflineRoot = document.getElementById(
+			'experimental_wc_settings_payments_offline'
+		);
 
 		if ( paymentsMainRoot ) {
 			createRoot(
@@ -140,7 +143,15 @@ if (
 				)
 			).render( <SettingsPaymentsMainWrapper /> );
 		}
-		// Todo: SettingsPaymentsOfflineWrapper
+
+		if ( paymentsOfflineRoot ) {
+			createRoot(
+				paymentsOfflineRoot.insertBefore(
+					document.createElement( 'div' ),
+					null
+				)
+			).render( <SettingsPaymentsOfflineWrapper /> );
+		}
 		// Todo: SlotFill for WooPayments & others
 	} )();
 }

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -22,7 +22,7 @@ import { possiblyRenderSettingsSlots } from './settings/settings-slots';
 import { registerTaxSettingsConflictErrorFill } from './settings/conflict-error-slotfill';
 import { registerPaymentsSettingsBannerFill } from './payments/payments-settings-banner-slotfill';
 import { registerSiteVisibilitySlotFill } from './launch-your-store';
-import { SettingsPaymentsMainWrapper } from './settings-payments';
+import { SettingsPaymentsMainWrapper, SettingsPaymentsOfflineWrapper } from './settings-payments';
 import { ErrorBoundary } from './error-boundary';
 
 const appRoot = document.getElementById( 'root' );

--- a/plugins/woocommerce-admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/index.tsx
@@ -10,10 +10,25 @@ const SettingsPaymentsMainChunk = lazy(
 		)
 );
 
+const SettingsPaymentsOfflineChunk = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "settings-payments-offline" */ './settings-payments-offline'
+		)
+);
+
 export const SettingsPaymentsMainWrapper: React.FC = () => {
 	return (
 		<Suspense fallback={ null }>
 			<SettingsPaymentsMainChunk />
+		</Suspense>
+	);
+};
+
+export const SettingsPaymentsOfflineWrapper: React.FC = () => {
+	return (
+		<Suspense fallback={ null }>
+			<SettingsPaymentsOfflineChunk />
 		</Suspense>
 	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/index.tsx
@@ -4,31 +4,46 @@
 import { lazy, Suspense } from '@wordpress/element';
 
 const SettingsPaymentsMainChunk = lazy(
-	() =>
-		import(
-			/* webpackChunkName: "settings-payments-main" */ './settings-payments-main'
-		)
+    () =>
+        import(
+            /* webpackChunkName: "settings-payments-main" */ './settings-payments-main'
+        )
 );
 
 const SettingsPaymentsOfflineChunk = lazy(
-	() =>
-		import(
-			/* webpackChunkName: "settings-payments-offline" */ './settings-payments-offline'
-		)
+    () =>
+        import(
+            /* webpackChunkName: "settings-payments-offline" */ './settings-payments-offline'
+        )
+);
+
+const SettingsPaymentsWooCommercePaymentsChunk = lazy(
+    () =>
+        import(
+            /* webpackChunkName: "settings-payments-woocommerce-payments" */ './settings-payments-woocommerce-payments'
+        )
 );
 
 export const SettingsPaymentsMainWrapper: React.FC = () => {
-	return (
-		<Suspense fallback={ <div>Loading main settings...</div> }>
-			<SettingsPaymentsMainChunk />
-		</Suspense>
-	);
+    return (
+        <Suspense fallback={ <div>Loading main settings...</div> }>
+            <SettingsPaymentsMainChunk />
+        </Suspense>
+    );
 };
 
 export const SettingsPaymentsOfflineWrapper: React.FC = () => {
-	return (
-		<Suspense fallback={ <div>Loading offline settings...</div> }>
-			<SettingsPaymentsOfflineChunk />
-		</Suspense>
-	);
+    return (
+        <Suspense fallback={ <div>Loading offline settings...</div> }>
+            <SettingsPaymentsOfflineChunk />
+        </Suspense>
+    );
+};
+
+export const SettingsPaymentsWooCommercePaymentsWrapper: React.FC = () => {
+    return (
+        <Suspense fallback={ <div>Loading WooCommerce Payments settings...</div> }>
+            <SettingsPaymentsWooCommercePaymentsChunk />
+        </Suspense>
+    );
 };

--- a/plugins/woocommerce-admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/index.tsx
@@ -4,46 +4,48 @@
 import { lazy, Suspense } from '@wordpress/element';
 
 const SettingsPaymentsMainChunk = lazy(
-    () =>
-        import(
-            /* webpackChunkName: "settings-payments-main" */ './settings-payments-main'
-        )
+	() =>
+		import(
+			/* webpackChunkName: "settings-payments-main" */ './settings-payments-main'
+		)
 );
 
 const SettingsPaymentsOfflineChunk = lazy(
-    () =>
-        import(
-            /* webpackChunkName: "settings-payments-offline" */ './settings-payments-offline'
-        )
+	() =>
+		import(
+			/* webpackChunkName: "settings-payments-offline" */ './settings-payments-offline'
+		)
 );
 
 const SettingsPaymentsWooCommercePaymentsChunk = lazy(
-    () =>
-        import(
-            /* webpackChunkName: "settings-payments-woocommerce-payments" */ './settings-payments-woocommerce-payments'
-        )
+	() =>
+		import(
+			/* webpackChunkName: "settings-payments-woocommerce-payments" */ './settings-payments-woocommerce-payments'
+		)
 );
 
 export const SettingsPaymentsMainWrapper: React.FC = () => {
-    return (
-        <Suspense fallback={ <div>Loading main settings...</div> }>
-            <SettingsPaymentsMainChunk />
-        </Suspense>
-    );
+	return (
+		<Suspense fallback={ <div>Loading main settings...</div> }>
+			<SettingsPaymentsMainChunk />
+		</Suspense>
+	);
 };
 
 export const SettingsPaymentsOfflineWrapper: React.FC = () => {
-    return (
-        <Suspense fallback={ <div>Loading offline settings...</div> }>
-            <SettingsPaymentsOfflineChunk />
-        </Suspense>
-    );
+	return (
+		<Suspense fallback={ <div>Loading offline settings...</div> }>
+			<SettingsPaymentsOfflineChunk />
+		</Suspense>
+	);
 };
 
 export const SettingsPaymentsWooCommercePaymentsWrapper: React.FC = () => {
-    return (
-        <Suspense fallback={ <div>Loading WooCommerce Payments settings...</div> }>
-            <SettingsPaymentsWooCommercePaymentsChunk />
-        </Suspense>
-    );
+	return (
+		<Suspense
+			fallback={ <div>Loading WooCommerce Payments settings...</div> }
+		>
+			<SettingsPaymentsWooCommercePaymentsChunk />
+		</Suspense>
+	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/index.tsx
@@ -19,16 +19,20 @@ const SettingsPaymentsOfflineChunk = lazy(
 
 export const SettingsPaymentsMainWrapper: React.FC = () => {
 	return (
-		<Suspense fallback={ null }>
-			<SettingsPaymentsMainChunk />
+		<Suspense fallback={ <div>Loading main settings...</div> }>
+			<ErrorBoundary fallback={ <div>Error loading main settings</div> }>
+				<SettingsPaymentsMainChunk />
+			</ErrorBoundary>
 		</Suspense>
 	);
 };
 
 export const SettingsPaymentsOfflineWrapper: React.FC = () => {
 	return (
-		<Suspense fallback={ null }>
-			<SettingsPaymentsOfflineChunk />
+		<Suspense fallback={ <div>Loading offline settings...</div> }>
+			<ErrorBoundary fallback={ <div>Error loading offline settings</div> }>
+				<SettingsPaymentsOfflineChunk />
+			</ErrorBoundary>
 		</Suspense>
 	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/index.tsx
@@ -20,9 +20,7 @@ const SettingsPaymentsOfflineChunk = lazy(
 export const SettingsPaymentsMainWrapper: React.FC = () => {
 	return (
 		<Suspense fallback={ <div>Loading main settings...</div> }>
-			<ErrorBoundary fallback={ <div>Error loading main settings</div> }>
-				<SettingsPaymentsMainChunk />
-			</ErrorBoundary>
+			<SettingsPaymentsMainChunk />
 		</Suspense>
 	);
 };
@@ -30,9 +28,7 @@ export const SettingsPaymentsMainWrapper: React.FC = () => {
 export const SettingsPaymentsOfflineWrapper: React.FC = () => {
 	return (
 		<Suspense fallback={ <div>Loading offline settings...</div> }>
-			<ErrorBoundary fallback={ <div>Error loading offline settings</div> }>
-				<SettingsPaymentsOfflineChunk />
-			</ErrorBoundary>
+			<SettingsPaymentsOfflineChunk />
 		</Suspense>
 	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.scss
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.scss
@@ -1,0 +1,9 @@
+.settings-payments-offline__container {
+	h1 {
+		color: #fff;
+	}
+	background: #333;
+	text-align: center;
+	padding: 50px 0;
+	width: 100%;
+}

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './settings-payments-offline.scss';
+
+export const SettingsPaymentsOffline: React.FC = () => {
+	return (
+		<div className="settings-payments-offline__container">
+			<h1>Offline payments screen</h1>
+		</div>
+	);
+};
+
+export default SettingsPaymentsOffline;

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
@@ -12,7 +12,7 @@ export const SettingsPaymentsOffline: React.FC = () => {
 	return (
 		<div className="settings-payments-offline__container">
 			<h1>Offline payments screen</h1>
-			{/* Add more content or components here */}
+			{ /* Add more content or components here */ }
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
@@ -12,7 +12,6 @@ export const SettingsPaymentsOffline: React.FC = () => {
 	return (
 		<div className="settings-payments-offline__container">
 			<h1>Offline payments screen</h1>
-			{ /* Add more content or components here */ }
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-offline.tsx
@@ -12,6 +12,7 @@ export const SettingsPaymentsOffline: React.FC = () => {
 	return (
 		<div className="settings-payments-offline__container">
 			<h1>Offline payments screen</h1>
+			{/* Add more content or components here */}
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.scss
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.scss
@@ -1,0 +1,9 @@
+.settings-payments-woocommerce-payments__container {
+    h1 {
+        color: #fff;
+    }
+    background: #7f54b3;
+    text-align: center;
+    padding: 50px 0;
+    width: 100%;
+}

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.scss
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.scss
@@ -1,9 +1,9 @@
 .settings-payments-woocommerce-payments__container {
-    h1 {
-        color: #fff;
-    }
-    background: #7f54b3;
-    text-align: center;
-    padding: 50px 0;
-    width: 100%;
+	h1 {
+		color: #fff;
+	}
+	background: #333;
+	text-align: center;
+	padding: 50px 0;
+	width: 100%;
 }

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.tsx
@@ -1,65 +1,23 @@
 /**
  * External dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { Card, ToggleControl } from '@wordpress/components';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { Card } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './settings-payments-woocommerce-payments.scss';
 
-interface WooCommercePaymentsSettings {
-    enabled: boolean;
-    // Add other WooCommerce Payments specific settings here
-}
-
 export const SettingsPaymentsWooCommercePayments: React.FC = () => {
-    const [settings, setSettings] = useState<WooCommercePaymentsSettings | null>(null);
-
-    const { woocommercePaymentsSettings, isLoading } = useSelect((select) => {
-        const { getSettings, hasFinishedResolution } = select(SETTINGS_STORE_NAME);
-        const settingsGroup = getSettings('wc_woocommerce_payments');
-        return {
-            woocommercePaymentsSettings: settingsGroup,
-            isLoading: !hasFinishedResolution('getSettings', ['wc_woocommerce_payments']),
-        };
-    });
-
-    useEffect(() => {
-        if (woocommercePaymentsSettings) {
-            setSettings(woocommercePaymentsSettings);
-        }
-    }, [woocommercePaymentsSettings]);
-
-    const handleToggle = (value: boolean) => {
-        setSettings((prevSettings) => ({
-            ...prevSettings!,
-            enabled: value,
-        }));
-        // Here you would typically dispatch an action to update the settings in the store
-        // and make an API call to save the changes
-    };
-
-    if (isLoading || !settings) {
-        return <div>Loading WooCommerce Payments settings...</div>;
-    }
-
-    return (
-        <div className="settings-payments-woocommerce-payments__container">
-            <h1>WooCommerce Payments Settings</h1>
-            <Card>
-                <ToggleControl
-                    label="Enable WooCommerce Payments"
-                    checked={settings.enabled}
-                    onChange={handleToggle}
-                />
-                {/* Add more WooCommerce Payments specific settings here */}
-            </Card>
-        </div>
-    );
+	return (
+		<div className="settings-payments-woocommerce-payments__container">
+			<h1>WooCommerce Payments Settings</h1>
+			<Card>
+				<p>This is a placeholder for WooCommerce Payments settings.</p>
+				{ /* Add more WooCommerce Payments specific settings here */ }
+			</Card>
+		</div>
+	);
 };
 
 export default SettingsPaymentsWooCommercePayments;

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { Card, ToggleControl } from '@wordpress/components';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import './settings-payments-woocommerce-payments.scss';
+
+interface WooCommercePaymentsSettings {
+    enabled: boolean;
+    // Add other WooCommerce Payments specific settings here
+}
+
+export const SettingsPaymentsWooCommercePayments: React.FC = () => {
+    const [settings, setSettings] = useState<WooCommercePaymentsSettings | null>(null);
+
+    const { woocommercePaymentsSettings, isLoading } = useSelect((select) => {
+        const { getSettings, hasFinishedResolution } = select(SETTINGS_STORE_NAME);
+        const settingsGroup = getSettings('wc_woocommerce_payments');
+        return {
+            woocommercePaymentsSettings: settingsGroup,
+            isLoading: !hasFinishedResolution('getSettings', ['wc_woocommerce_payments']),
+        };
+    });
+
+    useEffect(() => {
+        if (woocommercePaymentsSettings) {
+            setSettings(woocommercePaymentsSettings);
+        }
+    }, [woocommercePaymentsSettings]);
+
+    const handleToggle = (value: boolean) => {
+        setSettings((prevSettings) => ({
+            ...prevSettings!,
+            enabled: value,
+        }));
+        // Here you would typically dispatch an action to update the settings in the store
+        // and make an API call to save the changes
+    };
+
+    if (isLoading || !settings) {
+        return <div>Loading WooCommerce Payments settings...</div>;
+    }
+
+    return (
+        <div className="settings-payments-woocommerce-payments__container">
+            <h1>WooCommerce Payments Settings</h1>
+            <Card>
+                <ToggleControl
+                    label="Enable WooCommerce Payments"
+                    checked={settings.enabled}
+                    onChange={handleToggle}
+                />
+                {/* Add more WooCommerce Payments specific settings here */}
+            </Card>
+        </div>
+    );
+};
+
+export default SettingsPaymentsWooCommercePayments;

--- a/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.tsx
+++ b/plugins/woocommerce-admin/client/settings-payments/settings-payments-woocommerce-payments.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { Card } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import './settings-payments-woocommerce-payments.scss';
@@ -12,10 +7,6 @@ export const SettingsPaymentsWooCommercePayments: React.FC = () => {
 	return (
 		<div className="settings-payments-woocommerce-payments__container">
 			<h1>WooCommerce Payments Settings</h1>
-			<Card>
-				<p>This is a placeholder for WooCommerce Payments settings.</p>
-				{ /* Add more WooCommerce Payments specific settings here */ }
-			</Card>
 		</div>
 	);
 };

--- a/plugins/woocommerce/changelog/add-reactify-offline-wcpay-settings-pages
+++ b/plugins/woocommerce/changelog/add-reactify-offline-wcpay-settings-pages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Render a React placeholder for offline and WooCommerce Payments settings sections

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -24,17 +24,22 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	 *
 	 * @return array List of section identifiers.
 	 */
+	/**
+	 * Get the whitelist of sections to render using React.
+	 *
+	 * @return array List of section identifiers.
+	 */
 	private function get_reactify_render_sections() {
-		$sections = [
+		$sections = array(
 			'offline',
 			'woocommerce_payments',
 			'main',
-		];
+		);
 
 		/**
 		 * Filters the list of payment settings sections to be rendered using React.
 		 *
-		 * @since x.x.x
+		 * @since 8.0.0
 		 *
 		 * @param array $sections List of section identifiers.
 		 */
@@ -73,18 +78,35 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		//phpcs:enable
 	}
 
+	/**
+	 * Check if the given section should be rendered using React.
+	 *
+	 * @param string $section The section to check.
+	 * @return bool Whether the section should be rendered using React.
+	 */
 	private function should_render_react_section( $section ) {
 		return in_array( $section, $this->get_reactify_render_sections(), true );
 	}
 
+	/**
+	 * Render the React section.
+	 *
+	 * @param string $section The section to render.
+	 */
 	private function render_react_section( $section ) {
 		echo '<div id="experimental_wc_settings_payments_' . esc_attr( $section ) . '"></div>';
 	}
 
+	/**
+	 * Render the classic gateway settings page.
+	 *
+	 * @param array  $payment_gateways The payment gateways.
+	 * @param string $current_section The current section.
+	 */
 	private function render_classic_gateway_settings_page( $payment_gateways, $current_section ) {
 		foreach ( $payment_gateways as $gateway ) {
 			if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
-				if ( isset( $_GET['toggle_enabled'] ) ) {
+				if ( isset( $_GET['toggle_enabled'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 					$enabled = $gateway->get_option( 'enabled' );
 
 					if ( $enabled ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -53,7 +53,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		if ( $this->should_render_react_section( $current_section ) ) {
 			$this->render_react_section( $current_section );
 		} elseif ( $current_section ) {
-			$this->render_gateway_section( $payment_gateways, $current_section );
+			$this->render_classic_gateway_settings_page( $payment_gateways, $current_section );
 		} else {
 			$this->render_react_section( 'main' );
 		}
@@ -70,7 +70,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		echo '<div id="experimental_wc_settings_payments_' . esc_attr( $section ) . '"></div>';
 	}
 
-	private function render_gateway_section( $payment_gateways, $current_section ) {
+	private function render_classic_gateway_settings_page( $payment_gateways, $current_section ) {
 		foreach ( $payment_gateways as $gateway ) {
 			if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
 				if ( isset( $_GET['toggle_enabled'] ) ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -132,6 +132,40 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	public function get_sections() {
 		return array();
 	}
+
+	/**
+	 * Save settings.
+	 */
+	public function save() {
+		global $current_section;
+
+		$wc_payment_gateways = WC_Payment_Gateways::instance();
+
+		$this->save_settings_for_current_section();
+
+		if ( ! $current_section ) {
+			// If section is empty, we're on the main settings page. This makes sure 'gateway ordering' is saved.
+			$wc_payment_gateways->process_admin_options();
+			$wc_payment_gateways->init();
+		} else {
+			// There is a section - this may be a gateway or custom section.
+			foreach ( $wc_payment_gateways->payment_gateways() as $gateway ) {
+				if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
+					/**
+					 * Fires update actions for payment gateways.
+					 *
+					 * @since 3.4.0
+					 *
+					 * @param int $gateway->id Gateway ID.
+					 */
+					do_action( 'woocommerce_update_options_payment_gateways_' . $gateway->id );
+					$wc_payment_gateways->init();
+				}
+			}
+
+			$this->do_update_options_action();
+		}
+	}
 }
 
 return new WC_Settings_Payment_Gateways_React();

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -24,11 +24,6 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	 *
 	 * @return array List of section identifiers.
 	 */
-	/**
-	 * Get the whitelist of sections to render using React.
-	 *
-	 * @return array List of section identifiers.
-	 */
 	private function get_reactify_render_sections() {
 		$sections = array(
 			'offline',
@@ -39,7 +34,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		/**
 		 * Filters the list of payment settings sections to be rendered using React.
 		 *
-		 * @since 8.0.0
+		 * @since 9.3.0
 		 *
 		 * @param array $sections List of section identifiers.
 		 */

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -56,12 +56,12 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	public function output() {
 		//phpcs:disable WordPress.Security.NonceVerification.Recommended
 		global $current_section, $hide_save_button;
-		$hide_save_button = true;
 
 		// Load gateways so we can show any global options they may have.
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 
 		if ( $this->should_render_react_section( $current_section ) ) {
+			$hide_save_button = true;
 			$this->render_react_section( $current_section );
 		} elseif ( $current_section ) {
 			$this->render_classic_gateway_settings_page( $payment_gateways, $current_section );

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -20,6 +20,17 @@ if ( class_exists( 'WC_Settings_Payment_Gateways_React', false ) ) {
 class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 
 	/**
+	 * Whitelist of sections to render an alternative output.
+	 *
+	 * @var array
+	 */
+	private const ALTERNATIVE_RENDER_SECTIONS = [
+		'stripe',
+		'paypal',
+		'cod',
+	];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -26,6 +26,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	 */
 	private const REACTIFY_RENDER_SECTIONS = [
 		'offline',
+		'woocommerce_payments',
 	];
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -27,6 +27,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	private const REACTIFY_RENDER_SECTIONS = [
 		'offline',
 		'woocommerce_payments',
+		'main',
 	];
 
 	/**
@@ -49,30 +50,40 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		// Load gateways so we can show any global options they may have.
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 
-		if ( $current_section ) {
-			if ( in_array( $current_section, self::REACTIFY_RENDER_SECTIONS, true ) ) {
-				echo '<div id="experimental_wc_settings_payments_' . esc_attr( $current_section ) . '"></div>';
-			} else {
-				foreach ( $payment_gateways as $gateway ) {
-					if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
-						if ( isset( $_GET['toggle_enabled'] ) ) {
-								$enabled = $gateway->get_option( 'enabled' );
-
-							if ( $enabled ) {
-								$gateway->settings['enabled'] = wc_string_to_bool( $enabled ) ? 'no' : 'yes';
-							}
-						}
-						$this->run_gateway_admin_options( $gateway );
-						break;
-					}
-				}
-			}
+		if ( $this->should_render_react_section( $current_section ) ) {
+			$this->render_react_section( $current_section );
+		} elseif ( $current_section ) {
+			$this->render_gateway_section( $payment_gateways, $current_section );
 		} else {
-			echo '<div id="experimental_wc_settings_payments_main"></div>';
+			$this->render_react_section( 'main' );
 		}
 
 		parent::output();
 		//phpcs:enable
+	}
+
+	private function should_render_react_section( $section ) {
+		return in_array( $section, self::REACTIFY_RENDER_SECTIONS, true );
+	}
+
+	private function render_react_section( $section ) {
+		echo '<div id="experimental_wc_settings_payments_' . esc_attr( $section ) . '"></div>';
+	}
+
+	private function render_gateway_section( $payment_gateways, $current_section ) {
+		foreach ( $payment_gateways as $gateway ) {
+			if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
+				if ( isset( $_GET['toggle_enabled'] ) ) {
+					$enabled = $gateway->get_option( 'enabled' );
+
+					if ( $enabled ) {
+						$gateway->settings['enabled'] = wc_string_to_bool( $enabled ) ? 'no' : 'yes';
+					}
+				}
+				$this->run_gateway_admin_options( $gateway );
+				break;
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -22,13 +22,17 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	/**
 	 * Whitelist of sections to render using React.
 	 *
-	 * @var array
+	 * @return array
 	 */
-	private const REACTIFY_RENDER_SECTIONS = [
-		'offline',
-		'woocommerce_payments',
-		'main',
-	];
+	private function get_reactify_render_sections() {
+		$sections = [
+			'offline',
+			'woocommerce_payments',
+			'main',
+		];
+
+		return apply_filters( 'woocommerce_admin_payment_reactify_render_sections', $sections );
+	}
 
 	/**
 	 * Constructor.
@@ -63,7 +67,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	}
 
 	private function should_render_react_section( $section ) {
-		return in_array( $section, self::REACTIFY_RENDER_SECTIONS, true );
+		return in_array( $section, $this->get_reactify_render_sections(), true );
 	}
 
 	private function render_react_section( $section ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -38,7 +38,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		 *
 		 * @param array $sections List of section identifiers.
 		 */
-		return apply_filters( 'woocommerce_admin_payment_reactify_render_sections', $sections );
+		return apply_filters( 'experimental_woocommerce_admin_payment_reactify_render_sections', $sections );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -50,7 +50,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 
 		if ( $current_section ) {
 			if ( in_array( $current_section, self::REACTIFY_RENDER_SECTIONS, true ) ) {
-				echo '<div id="wc_settings_payments_' . esc_attr( $current_section ) . '"></div>';
+				echo '<div id="experimental_wc_settings_payments_' . esc_attr( $current_section ) . '"></div>';
 			} else {
 				foreach ( $payment_gateways as $gateway ) {
 					if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -20,9 +20,9 @@ if ( class_exists( 'WC_Settings_Payment_Gateways_React', false ) ) {
 class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 
 	/**
-	 * Whitelist of sections to render using React.
+	 * Get the whitelist of sections to render using React.
 	 *
-	 * @return array
+	 * @return array List of section identifiers.
 	 */
 	private function get_reactify_render_sections() {
 		$sections = [
@@ -31,6 +31,13 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 			'main',
 		];
 
+		/**
+		 * Filters the list of payment settings sections to be rendered using React.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array $sections List of section identifiers.
+		 */
 		return apply_filters( 'woocommerce_admin_payment_reactify_render_sections', $sections );
 	}
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -20,14 +20,12 @@ if ( class_exists( 'WC_Settings_Payment_Gateways_React', false ) ) {
 class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 
 	/**
-	 * Whitelist of sections to render an alternative output.
+	 * Whitelist of sections to render using React.
 	 *
 	 * @var array
 	 */
-	private const ALTERNATIVE_RENDER_SECTIONS = [
-		'stripe',
-		'paypal',
-		'cod',
+	private const REACTIFY_RENDER_SECTIONS = [
+		'offline',
 	];
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -49,17 +49,21 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 
 		if ( $current_section ) {
-			foreach ( $payment_gateways as $gateway ) {
-				if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
-					if ( isset( $_GET['toggle_enabled'] ) ) {
-							$enabled = $gateway->get_option( 'enabled' );
+			if ( in_array( $current_section, self::REACTIFY_RENDER_SECTIONS, true ) ) {
+				echo '<div id="wc_settings_payments_' . esc_attr( $current_section ) . '"></div>';
+			} else {
+				foreach ( $payment_gateways as $gateway ) {
+					if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
+						if ( isset( $_GET['toggle_enabled'] ) ) {
+								$enabled = $gateway->get_option( 'enabled' );
 
-						if ( $enabled ) {
-							$gateway->settings['enabled'] = wc_string_to_bool( $enabled ) ? 'no' : 'yes';
+							if ( $enabled ) {
+								$gateway->settings['enabled'] = wc_string_to_bool( $enabled ) ? 'no' : 'yes';
+							}
 						}
+						$this->run_gateway_admin_options( $gateway );
+						break;
 					}
-					$this->run_gateway_admin_options( $gateway );
-					break;
 				}
 			}
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49928 , #49930.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Turn on feature flag `reactify-classic-payments-settings`

### Test main component
1. In a fresh site with beta tester plugin installed, go through onboarding wizard and set country to Mexico
4. Go to `WooCommerce > Settings > Payments`
5. Observe the `Main payments screen` text as per screenshot
6. Observe notices are still displayed above it
7. Observe breadcrumbs are not shown between the center component and notices

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/eea5e3a8-3bd1-41d1-a223-864430f206d4">

### Test Reactified payment settings 
1. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=offline` and observe it shows the React placeholder
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments` and observe it shows the React placeholder (note you need to not have woocommerce payments installed or it will redirect somewhere else)

![image](https://github.com/user-attachments/assets/25adda42-7720-40d4-b268-0a518f8dd004)

![image](https://github.com/user-attachments/assets/7909a402-8e5a-4053-9f96-0b708079303c)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
