### PR TITLE
CI: Retry 'Start Test Environment' step in testing jobs if it fails.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,9 @@ jobs:
         id: 'prepare-test-environment'
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
-        run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
+        run: |
+          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}' || (echo 'Re-trying' && pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}')
+        shell: bash
 
       - name: 'Get commit message'
         id: 'get_commit_message'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
         run: |
-          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}' || (echo 'Re-trying' && pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}')
+          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }} || (echo 'Re-trying' && pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }})
         shell: bash
 
       - name: 'Get commit message'

--- a/plugins/woocommerce/changelog/dev-retry-wp-env-start
+++ b/plugins/woocommerce/changelog/dev-retry-wp-env-start
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: retry 'Start Test Environment' step in testing jobs if it fails.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce",
-	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
+	"description": "An eCommerce toolkit that helps you sell anything. Beautifully...",
 	"homepage": "https://woocommerce.com/",
 	"version": "9.3.0",
 	"type": "wordpress-plugin",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sometimes the step fails (e.g. [here](https://github.com/woocommerce/woocommerce/actions/runs/10105247997/job/27945451564#step:5:28)), and in this PR we adding a retry to see if it helps.
