### PR TITLE
CYS - Run appropriate tests depending on the WordPress version

### DIFF
--- a/plugins/woocommerce/changelog/50016-skip-cys-test-wordpress-version
+++ b/plugins/woocommerce/changelog/50016-skip-cys-test-wordpress-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS - Run appropriate tests depending on the WordPress version.

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -2,7 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { setOption } = require( '../../../utils/options' );
-const { setFeatureFlag } = require( '../../../utils/features' );
+const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {
@@ -51,12 +51,13 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 			console.log( 'Store completed option not updated' );
 		}
 
-		await setFeatureFlag(
-			request,
-			baseURL,
-			'pattern-toolkit-full-composability',
-			true
-		);
+		const wordPressVersion = await getInstalledWordPressVersion();
+
+		if ( wordPressVersion <= 6.5 ) {
+			test.skip(
+				'Skipping Full Composability tests: WordPress version is below 6.5, which does not support this feature.'
+			);
+		}
 	} );
 
 	test.afterAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -3,7 +3,6 @@ const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 const { setOption } = require( '../../../utils/options' );
-const { setFeatureFlag } = require( '../../../utils/features' );
 const { encodeCredentials } = require( '../../../utils/plugin-utils' );
 
 const test = base.extend( {
@@ -39,12 +38,13 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 			console.log( 'Store completed option not updated' );
 		}
 
-		await setFeatureFlag(
-			request,
-			baseURL,
-			'pattern-toolkit-full-composability',
-			false
-		);
+		const wordPressVersion = await getInstalledWordPressVersion();
+
+		if ( wordPressVersion > 6.5 ) {
+			test.skip(
+				'Skipping Assembler Homepage tests: WordPress version is above 6.5, which does not support this feature.'
+			);
+		}
 	} );
 
 	test.afterAll( async ( { baseURL } ) => {
@@ -219,145 +219,102 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 			}
 		}
 	} );
-
-	test.describe( 'Homepage tracking banner', () => {
-		test.beforeAll( async ( { baseURL } ) => {
-			await setFeatureFlag(
-				request,
-				baseURL,
-				'pattern-toolkit-full-composability',
-				true
-			);
-		} );
-
-		test( 'Should show the "Want more patterns?" banner with the Opt-in message when tracking is not allowed', async ( {
-			pageObject,
-			baseURL,
-		} ) => {
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_allow_tracking',
-				'no'
-			);
-
-			await prepareAssembler( pageObject, baseURL );
-
-			const assembler = await pageObject.getAssembler();
-			await expect(
-				assembler.getByText( 'Want more patterns?' )
-			).toBeVisible();
-			await expect(
-				assembler.getByText(
-					'Opt in to usage tracking to get access to more patterns.'
-				)
-			).toBeVisible();
-		} );
-
-		test( 'Should show the "Want more patterns?" banner with the offline message when the user is offline and tracking is not allowed', async ( {
-			context,
-			pageObject,
-			baseURL,
-		} ) => {
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_allow_tracking',
-				'no'
-			);
-
-			await prepareAssembler( pageObject, baseURL );
-
-			await context.setOffline( true );
-
-			const assembler = await pageObject.getAssembler();
-			await expect(
-				assembler.getByText( 'Want more patterns?' )
-			).toBeVisible();
-			await expect(
-				assembler.getByText(
-					"Looks like we can't detect your network. Please double-check your internet connection and refresh the page."
-				)
-			).toBeVisible();
-		} );
-
-		test( 'Should not show the "Want more patterns?" banner when tracking is allowed', async ( {
-			baseURL,
-			pageObject,
-		} ) => {
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_allow_tracking',
-				'yes'
-			);
-
-			await prepareAssembler( pageObject, baseURL );
-
-			const assembler = await pageObject.getAssembler();
-			await expect(
-				assembler.getByText( 'Want more patterns?' )
-			).toBeHidden();
-		} );
-	} );
 } );
 
-test.describe(
-	'Assembler -> Homepage -> PTK API is down',
-	{ tag: '@gutenberg' },
-	() => {
-		test.use( { storageState: process.env.ADMINSTATE } );
+test.describe( 'Homepage tracking banner', () => {
+	test.beforeAll( async () => {
+		const wordPressVersion = await getInstalledWordPressVersion();
 
-		test.beforeAll( async ( { baseURL } ) => {
-			const wordPressVersion = await getInstalledWordPressVersion();
-
-			if ( wordPressVersion <= 6.5 ) {
-				test.skip(
-					'Skipping PTK API test: WordPress version is below 6.5, which does not support this feature.'
-				);
-			}
-			try {
-				// In some environments the tour blocks clicking other elements.
-				await setOption(
-					request,
-					baseURL,
-					'woocommerce_customize_store_onboarding_tour_hidden',
-					'yes'
-				);
-			} catch ( error ) {
-				console.log( 'Store completed option not updated' );
-			}
-		} );
-
-		test( 'Should show the "Want more patterns?" banner with the PTK API unavailable message', async ( {
-			baseURL,
-			pageObject,
-			page,
-		} ) => {
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_allow_tracking',
-				'no'
+		if ( wordPressVersion <= 6.5 ) {
+			test.skip(
+				'Skipping PTK API test: WordPress version is below 6.5, which does not support this feature.'
 			);
+		}
+	} );
 
-			await page.route( '**/wp-json/wc/private/patterns*', ( route ) => {
-				route.fulfill( {
-					status: 500,
-				} );
+	test( 'Should show the "Want more patterns?" banner with the PTK API unavailable message', async ( {
+		baseURL,
+		pageObject,
+		page,
+	} ) => {
+		await setOption( request, baseURL, 'woocommerce_allow_tracking', 'no' );
+
+		await page.route( '**/wp-json/wc/private/patterns*', ( route ) => {
+			route.fulfill( {
+				status: 500,
 			} );
-
-			await prepareAssembler( pageObject, baseURL );
-
-			const assembler = await pageObject.getAssembler();
-			await expect(
-				assembler.getByText( 'Want more patterns?' )
-			).toBeVisible();
-			await expect(
-				assembler.getByText(
-					"Unfortunately, we're experiencing some technical issues — please come back later to access more patterns."
-				)
-			).toBeVisible();
 		} );
-	}
-);
+
+		await prepareAssembler( pageObject, baseURL );
+
+		const assembler = await pageObject.getAssembler();
+		await expect(
+			assembler.getByText( 'Want more patterns?' )
+		).toBeVisible();
+		await expect(
+			assembler.getByText(
+				"Unfortunately, we're experiencing some technical issues — please come back later to access more patterns."
+			)
+		).toBeVisible();
+	} );
+
+	test( 'Should show the "Want more patterns?" banner with the Opt-in message when tracking is not allowed', async ( {
+		pageObject,
+		baseURL,
+	} ) => {
+		await setOption( request, baseURL, 'woocommerce_allow_tracking', 'no' );
+
+		await prepareAssembler( pageObject, baseURL );
+
+		const assembler = await pageObject.getAssembler();
+		await expect(
+			assembler.getByText( 'Want more patterns?' )
+		).toBeVisible();
+		await expect(
+			assembler.getByText(
+				'Opt in to usage tracking to get access to more patterns.'
+			)
+		).toBeVisible();
+	} );
+
+	test( 'Should show the "Want more patterns?" banner with the offline message when the user is offline and tracking is not allowed', async ( {
+		context,
+		pageObject,
+		baseURL,
+	} ) => {
+		await setOption( request, baseURL, 'woocommerce_allow_tracking', 'no' );
+
+		await prepareAssembler( pageObject, baseURL );
+
+		await context.setOffline( true );
+
+		const assembler = await pageObject.getAssembler();
+		await expect(
+			assembler.getByText( 'Want more patterns?' )
+		).toBeVisible();
+		await expect(
+			assembler.getByText(
+				"Looks like we can't detect your network. Please double-check your internet connection and refresh the page."
+			)
+		).toBeVisible();
+	} );
+
+	test( 'Should not show the "Want more patterns?" banner when tracking is allowed', async ( {
+		baseURL,
+		pageObject,
+	} ) => {
+		await setOption(
+			request,
+			baseURL,
+			'woocommerce_allow_tracking',
+			'yes'
+		);
+
+		await prepareAssembler( pageObject, baseURL );
+
+		const assembler = await pageObject.getAssembler();
+		await expect(
+			assembler.getByText( 'Want more patterns?' )
+		).toBeHidden();
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -224,7 +224,7 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 test.describe( 'Homepage tracking banner', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeAll( async () => {
+	test.beforeAll( async ( { baseURL } ) => {
 		try {
 			// In some environments the tour blocks clicking other elements.
 			await setOption(

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -222,7 +222,21 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 } );
 
 test.describe( 'Homepage tracking banner', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
 	test.beforeAll( async () => {
+		try {
+			// In some environments the tour blocks clicking other elements.
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_customize_store_onboarding_tour_hidden',
+				'yes'
+			);
+		} catch ( error ) {
+			console.log( 'Store completed option not updated' );
+		}
+
 		const wordPressVersion = await getInstalledWordPressVersion();
 
 		if ( wordPressVersion <= 6.5 ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" env:start`
2. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" test:e2e plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js`
3. Ensure that `Homepage tracking banner` test runs and the `Assembler -> Homepage` are skipped.
4. Run `pnpm --filter="@woocommerce/plugin-woocommerce" test:e2e customize-store/assembler/full-composability.spec.js`.
5. Ensure there are no skipped tests.
6. Update `plugins/woocommerce/.wp-env.json` adding `"core": "WordPress/WordPress#6.5"`
7. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" env:start`
8. Run `pnpm run --filter="@woocommerce/plugin-woocommerce" test:e2e plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js`
9. Ensure that `Homepage tracking banner` tests are skipped and the `Assembler -> Homepage` run.
10. Run `pnpm --filter="@woocommerce/plugin-woocommerce" test:e2e customize-store/assembler/full-composability.spec.js`.
11. Ensure all tests are skipped.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Run appropriate tests depending on the WordPress version.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
