### PR TITLE
[testing workflows] Harden the run condition for reporting jobs to only run in the monorepo 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         'project-lint-jobs',
         'project-test-jobs',
       ]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork  }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'woocommerce/woocommerce'  }}
     steps:
       - uses: 'actions/checkout@v4'
         name: 'Checkout'
@@ -273,7 +273,7 @@ jobs:
         'project-jobs',
         'project-test-jobs',
       ]
-    if: ${{ !cancelled() && needs.project-jobs.outputs.report-jobs != '[]' && ! github.event.pull_request.head.repo.fork  }}
+    if: ${{ !cancelled() && needs.project-jobs.outputs.report-jobs != '[]' && github.repository == 'woocommerce/woocommerce' }}
     strategy:
       fail-fast: false
       matrix:
@@ -330,7 +330,7 @@ jobs:
   
   report-flaky-tests:
     name: 'Create issues for flaky tests'
-    if: ${{ !cancelled() && ! github.event.pull_request.head.repo.fork && needs.project-jobs.outputs.test-jobs != '[]' }}
+    if: ${{ !cancelled() && github.repository == 'woocommerce/woocommerce' && needs.project-jobs.outputs.test-jobs != '[]' }}
     needs:
       [
         'project-jobs',

--- a/.github/workflows/tests-daily-run.yml
+++ b/.github/workflows/tests-daily-run.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   run-tests:
     name: 'Run tests'
+    if: github.repository == 'woocommerce/woocommerce'
     uses: ./.github/workflows/ci.yml
     with:
       trigger: 'daily-checks'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The reporting jobs (slack alerts, test reports, flaky tests issues) are only running if the repo is not a fork. Updated this condition to make sure they only run in this repo, covering more cases, like repos that are synced but not forks.

### How to test the changes in this Pull Request:

Check CI. The updated jobs should run as before. Tested with https://github.com/woocommerce/woocommerce/actions/runs/10110081436/job/27959374597