### PR TITLE
Store API: Remove the need for nonces when using cart tokens. Remove deprecated `X-WC-Store-API-Nonce` header.

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-token-disable-nonces-42341
+++ b/plugins/woocommerce/changelog/fix-cart-token-disable-nonces-42341
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Store API: Remove the need for nonces when using cart tokens. Remove deprecated X-WC-Store-API-Nonce header.

--- a/plugins/woocommerce/src/StoreApi/Authentication.php
+++ b/plugins/woocommerce/src/StoreApi/Authentication.php
@@ -33,7 +33,6 @@ class Authentication {
 	public function allowed_cors_headers( $allowed_headers ) {
 		$allowed_headers[] = 'Cart-Token';
 		$allowed_headers[] = 'Nonce';
-		$allowed_headers[] = 'X-WC-Store-API-Nonce';
 		return $allowed_headers;
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -231,7 +231,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	protected function has_cart_token( \WP_REST_Request $request ) {
 		if ( is_null( $this->has_cart_token ) ) {
-			$this->has_cart_token = JsonWebToken::validate( $request->get_header( 'Cart-Token' ), $this->get_cart_token_secret() );
+			$this->has_cart_token = JsonWebToken::validate( $request->get_header( 'Cart-Token' ) ?? '', $this->get_cart_token_secret() );
 		}
 		return $this->has_cart_token;
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -158,9 +158,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		$response->header( 'User-ID', get_current_user_id() );
 		$response->header( 'Cart-Token', $this->get_cart_token() );
 
-		// The following headers are deprecated and should be removed in a future version.
-		$response->header( 'X-WC-Store-API-Nonce', $nonce );
-
 		return $response;
 	}
 
@@ -303,12 +300,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 
 		if ( $request->get_header( 'Nonce' ) ) {
 			$nonce = $request->get_header( 'Nonce' );
-		} elseif ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
-			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
-
-			// @todo Remove handling and sending of deprecated X-WC-Store-API-Nonce Header (Blocks 7.5.0)
-			wc_deprecated_argument( 'X-WC-Store-API-Nonce', '7.2.0', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5' );
-			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5', '7.2.0' );
 		}
 
 		/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -128,7 +128,6 @@ class Batch extends AbstractRoute implements RouteInterface {
 		$nonce = wp_create_nonce( 'wc_store_api' );
 
 		$response->header( 'Nonce', $nonce );
-		$response->header( 'X-WC-Store-API-Nonce', $nonce );
 		$response->header( 'Nonce-Timestamp', time() );
 		$response->header( 'User-ID', get_current_user_id() );
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -62,7 +62,7 @@ class Checkout extends AbstractCartRoute {
 	 * @return bool
 	 */
 	protected function requires_nonce( \WP_REST_Request $request ) {
-		return true;
+		return ! $this->has_cart_token( $request );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/JsonWebToken.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/JsonWebToken.php
@@ -50,6 +50,10 @@ final class JsonWebToken {
 	 * @return bool
 	 */
 	public static function validate( string $token, string $secret ) {
+		if ( ! $token ) {
+			return false;
+		}
+
 		/**
 		 * Confirm the structure of a JSON Web Token, it has three parts separated
 		 * by dots and complies with Base64URL standards.

--- a/plugins/woocommerce/src/StoreApi/docs/cart-tokens.md
+++ b/plugins/woocommerce/src/StoreApi/docs/cart-tokens.md
@@ -1,0 +1,37 @@
+# Cart Tokens <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [Obtaining a Cart Token](#obtaining-a-cart-token)
+- [How to use a Cart-Token](#how-to-use-a-cart-token)
+
+Cart tokens can be used instead of cookies based sessions for headless interaction with carts. When using a `Cart-Token` a  [Nonce Token](nonce-tokens.md) is not required.
+
+## Obtaining a Cart Token
+
+Requests to `/cart` endpoints return a `Cart-Token` header alongside the response. This contains a token which can later be sent as a request header to the Store API Cart and Checkout endpoints to identify the cart.
+
+The quickest method of obtaining a Cart Token is to make a GET request `/wp-json/wc/store/v1/cart` and observe the response headers. You should see a `Cart-Token` header there.
+
+## How to use a Cart-Token
+
+To use a `Cart-Token`, include it as a header with your request. The response will contain the current cart state from the session associated with the `Cart-Token`.
+
+**Example:**
+
+```sh
+curl --header "Cart-Token: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/cart
+```
+
+The same method will allow you to checkout using a `Cart-Token` on the `/checkout` route.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/cart-tokens.md)
+
+<!-- /FEEDBACK -->
+

--- a/plugins/woocommerce/src/StoreApi/docs/cart.md
+++ b/plugins/woocommerce/src/StoreApi/docs/cart.md
@@ -16,7 +16,7 @@
 
 The cart API returns the current state of the cart for the current session or logged in user.
 
-All POST endpoints require [Nonce Tokens](nonce-tokens.md) and return the updated state of the full cart once complete.
+All POST endpoints require a [Nonce Token](nonce-tokens.md) or a [Cart Token](cart-tokens.md) and return the updated state of the full cart once complete.
 
 ## Get Cart
 
@@ -391,7 +391,7 @@ This allows the client to remain in sync with the cart data without additional r
 
 Add an item to the cart and return the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/add-item
@@ -494,7 +494,7 @@ The JSON payload for adding multiple items to the cart would look like this:
 
 Remove an item from the cart and return the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/remove-item
@@ -514,7 +514,7 @@ Returns the full [Cart Response](#cart-response) on success, or an [Error Respon
 
 Update an item in the cart and return the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/update-item
@@ -535,7 +535,7 @@ Returns the full [Cart Response](#cart-response) on success, or an [Error Respon
 
 Apply a coupon to the cart and return the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/apply-coupon/
@@ -555,7 +555,7 @@ Returns the full [Cart Response](#cart-response) on success, or an [Error Respon
 
 Remove a coupon from the cart and return the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/remove-coupon/
@@ -575,7 +575,7 @@ Returns the full [Cart Response](#cart-response) on success, or an [Error Respon
 
 Update customer data and return the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/update-customer
@@ -610,7 +610,7 @@ Returns the full [Cart Response](#cart-response) on success, or an [Error Respon
 
 Selects an available shipping rate for a package, then returns the full cart response, or an error.
 
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
+This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) or [Cart Token](cart-tokens.md) is provided.
 
 ```http
 POST /cart/select-shipping-rate

--- a/plugins/woocommerce/src/StoreApi/docs/checkout-order.md
+++ b/plugins/woocommerce/src/StoreApi/docs/checkout-order.md
@@ -7,14 +7,12 @@
 
 The checkout order API facilitates the processing of existing orders and handling payments.
 
-All checkout order endpoints require [Nonce Tokens](nonce-tokens.md).
+All checkout order endpoints require a [Nonce Token](nonce-tokens.md) or a [Cart Token](cart-tokens.md) otherwise these endpoints will return an error.
 
 ## Process Order and Payment
 
 Accepts the final chosen payment method, and any additional payment data, then attempts payment and
 returns the result.
-
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
 
 ```http
 POST /wc/store/v1/checkout/{ORDER_ID}

--- a/plugins/woocommerce/src/StoreApi/docs/checkout.md
+++ b/plugins/woocommerce/src/StoreApi/docs/checkout.md
@@ -7,16 +7,11 @@
 
 The checkout API facilitates the creation of orders (from the current cart) and handling payments for payment methods.
 
-All checkout endpoints require [Nonce Tokens](nonce-tokens.md).
-
--   [Get Checkout Data](#get-checkout-data)
--   [Process Order and Payment](#process-order-and-payment)
+All checkout endpoints require either a [Nonce Token](nonce-tokens.md) or a [Cart Token](cart-tokens.md) otherwise these endpoints will return an error.
 
 ## Get Checkout Data
 
 Returns data required for the checkout. This includes a draft order (created from the current cart) and customer billing and shipping addresses. The payment information will be empty, as it's only persisted when the order gets updated via POST requests (right before payment processing).
-
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
 
 ```http
 GET /wc/store/v1/checkout
@@ -74,8 +69,6 @@ curl --header "Nonce: 12345" --request GET https://example-store.com/wp-json/wc/
 
 Accepts the final customer addresses and chosen payment method, and any additional payment data, then attempts payment and
 returns the result.
-
-This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md) is provided.
 
 ```http
 POST /wc/store/v1/checkout

--- a/plugins/woocommerce/src/StoreApi/docs/nonce-tokens.md
+++ b/plugins/woocommerce/src/StoreApi/docs/nonce-tokens.md
@@ -11,7 +11,7 @@ Nonces are generated numbers used to verify origin and intent of requests for se
 
 ## Store API Endpoints that Require Nonces
 
-POST requests to the `/cart` endpoints and all requests to the `/checkout` endpoints require a nonce to function. Failure to provide a valid nonce will return an error response.
+POST requests to the `/cart` endpoints and all requests to the `/checkout` endpoints require a nonce to function. Failure to provide a valid nonce will return an error response, unless you're using [Cart Tokens](cart-tokens.md) instead.
 
 ## Sending Nonce Tokens with requests
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the need for nonce tokens when using cart tokens. With cart tokens we're not relying on any form of session cookie so the nonce offers no additional protection:

> the cart token is in itself an enhanced nonce, it's sent as a header, and only belongs to single customer, so it can't be used in a CSRF attack

In addition to this change, I've included documentation for cart tokens and removed the deprecated `X-WC-Store-API-Nonce` which was due to be removed in Blocks 7.5 before core merge.

Closes #42341

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Smoke test adding items to the cart
2. Smoke test updating product quantities in cart
3. Smoke test placing an order via checkout 

**For developers:**

1. Make sure nonces are enabled and make sure you clear cookies in your REST api client. If you are using this snippet in your test environment, remove it:

```php
add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
```

4. POST `{ "id": 16 }` (replace 16 with a valid product ID) to `wp-json/wc/store/v1/cart/add-item`. Confirm you see a 401 unauthorised due to missing nonce.
5. GET `wp-json/wc/store/v1/cart`. Confirm you get back an empty cart.
6. Look at the headers of the above response. Copy the `Cart-Token`
7. POST `{ "id": 16 }` (replace 16 with a valid product ID) to `wp-json/wc/store/v1/cart/add-item`. This time add the `Cart-Token` to the request headers using the value you copied earlier. Confirm it succeeds with 201 created.
5.  POST the below data to `wp-json/wc/store/v1/checkout` without the Cart Token header. Confirm the request is rejected.
8. Repeat with the `Cart-Token` header and confirm the order is placed. 200 OK response.

<details>
<summary>JSON for checkout:</summary>

```json
{
  "shipping_address": {
    "first_name": "John",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test Road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": ""
	},
  "billing_address": {
    "first_name": "Jon",
    "last_name": "Doe",
    "company": "",
    "address_1": "30 Test road",
    "address_2": "",
    "city": "Testville",
    "state": "CA",
    "postcode": "90210",
    "country": "US",
    "phone": "",
    "email": "test@test.com",
    "phone": ""
  },
  "customer_note": "",
  "create_account": false,
  "payment_method": "bacs"
}
```

</details>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
