### PR TITLE
Prevent Store API orders being placed with empty/invalid fields

### DIFF
--- a/plugins/woocommerce/changelog/fix-state-requirement
+++ b/plugins/woocommerce/changelog/fix-state-requirement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent Store API orders being placed with empty state

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -789,7 +789,7 @@ class CheckoutFields {
 	 * @return mixed
 	 */
 	public function update_default_locale_with_fields( $locale ) {
-		foreach ( $this->fields_locations['address'] as $field_id => $additional_field ) {
+		foreach ( $this->get_fields_for_location( 'address' ) as $field_id => $additional_field ) {
 			if ( empty( $locale[ $field_id ] ) ) {
 				$locale[ $field_id ] = $additional_field;
 			}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -1,12 +1,14 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use Automattic\WooCommerce\StoreApi\Exceptions\InvalidCartException;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStockException;
 use Automattic\WooCommerce\StoreApi\Utilities\CheckoutTrait;
+use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\AdditionalFields;
 use Automattic\WooCommerce\Utilities\RestApiUtil;
 
 /**
@@ -175,6 +177,52 @@ class Checkout extends AbstractCartRoute {
 	}
 
 	/**
+	 * Validate required additional fields on request.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 */
+	public function validate_required_additional_fields( \WP_REST_Request $request ) {
+		$contact_fields           = $this->additional_fields_controller->get_fields_for_location( 'contact' );
+		$order_fields             = $this->additional_fields_controller->get_fields_for_location( 'order' );
+		$order_and_contact_fields = array_merge( $contact_fields, $order_fields );
+
+		if ( ! empty( $order_and_contact_fields ) ) {
+			foreach ( $order_and_contact_fields as $field_key => $order_and_contact_field ) {
+				if ( $order_and_contact_field['required'] && ! isset( $request['additional_fields'][ $field_key ] ) ) {
+					throw new RouteException(
+						'woocommerce_rest_checkout_missing_required_field',
+						/* translators: %s: is the field label */
+						esc_html( sprintf( __( 'There was a problem with the provided additional fields: %s is required', 'woocommerce' ), $order_and_contact_field['label'] ) ),
+						400
+					);
+				}
+			}
+		}
+
+		$address_fields = $this->additional_fields_controller->get_fields_for_location( 'address' );
+		if ( ! empty( $address_fields ) ) {
+			foreach ( $address_fields as $field_key => $address_field ) {
+				if ( $address_field['required'] && ! isset( $request['billing_address'][ $field_key ] ) ) {
+					throw new RouteException(
+						'woocommerce_rest_checkout_missing_required_field',
+						/* translators: %s: is the field label */
+						esc_html( sprintf( __( 'There was a problem with the provided billing address: %s is required', 'woocommerce' ), $address_field['label'] ) ),
+						400
+					);
+				}
+				if ( $address_field['required'] && ! isset( $request['shipping_address'][ $field_key ] ) ) {
+					throw new RouteException(
+						'woocommerce_rest_checkout_missing_required_field',
+						/* translators: %s: is the field label */
+						esc_html( sprintf( __( 'There was a problem with the provided shipping address: %s is required', 'woocommerce' ), $address_field['label'] ) ),
+						400
+					);
+				}
+			}
+		}
+	}
+
+	/**
 	 * Process an order.
 	 *
 	 * 1. Obtain Draft Order
@@ -200,6 +248,11 @@ class Checkout extends AbstractCartRoute {
 		 * Validate items and fix violations before the order is processed.
 		 */
 		$this->cart_controller->validate_cart();
+
+		/**
+		 * Validate additional fields on request.
+		 */
+		$this->validate_required_additional_fields( $request );
 
 		/**
 		 * Persist customer session data from the request first so that OrderController::update_addresses_from_cart

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -180,6 +180,8 @@ class Checkout extends AbstractCartRoute {
 	 * Validate required additional fields on request.
 	 *
 	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @throws RouteException When a required additional field is missing.
 	 */
 	public function validate_required_additional_fields( \WP_REST_Request $request ) {
 		$contact_fields           = $this->additional_fields_controller->get_fields_for_location( 'contact' );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -269,7 +269,6 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			}
 		}
 
-
 		$result = $this->additional_fields_controller->validate_fields_for_location( $address, 'address', 'billing_address' === $this->title ? 'billing' : 'shipping' );
 
 		if ( is_wp_error( $result ) && $result->has_errors() ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -164,7 +164,8 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$address         = (array) $address;
 		$validation_util = new ValidationUtils();
 		$schema          = $this->get_properties();
-		// omit all keys from address that are not in the schema. This should account for email.
+
+		// Omit all keys from address that are not in the schema. This should account for email.
 		$address = array_intersect_key( $address, $schema );
 
 		// The flow is Validate -> Sanitize -> Re-Validate
@@ -179,6 +180,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 			if ( empty( $schema[ $key ] ) || empty( $address[ $key ] ) ) {
 				continue;
 			}
+
 			if ( is_wp_error( rest_validate_value_from_schema( $value, $schema[ $key ], $key ) ) ) {
 				$errors->add(
 					'invalid_' . $key,
@@ -266,6 +268,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 				$errors->merge_from( $result );
 			}
 		}
+
 
 		$result = $this->additional_fields_controller->validate_fields_for_location( $address, 'address', 'billing_address' === $this->title ? 'billing' : 'shipping' );
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -381,8 +381,8 @@ class OrderController {
 		$address        = $order->get_address( $address_type );
 		$current_locale = isset( $all_locales[ $address['country'] ] ) ? $all_locales[ $address['country'] ] : array();
 
-		foreach( $all_locales['default'] as $key => $value ) {
-			$default_value          = empty( $current_locale[ $key] ) ? [] : $current_locale[ $key ];
+		foreach ( $all_locales['default'] as $key => $value ) {
+			$default_value          = empty( $current_locale[ $key ] ) ? [] : $current_locale[ $key ];
 			$current_locale[ $key ] = wp_parse_args( $default_value, $value );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -381,6 +381,11 @@ class OrderController {
 		$address        = $order->get_address( $address_type );
 		$current_locale = isset( $all_locales[ $address['country'] ] ) ? $all_locales[ $address['country'] ] : array();
 
+		foreach( $all_locales['default'] as $key => $value ) {
+			$default_value          = empty( $current_locale[ $key] ) ? [] : $current_locale[ $key ];
+			$current_locale[ $key ] = wp_parse_args( $default_value, $value );
+		}
+
 		$additional_fields = $this->additional_fields_controller->get_all_fields_from_object( $order, $address_type );
 
 		$address = array_merge( $address, $additional_fields );

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -390,26 +390,7 @@ class OrderController {
 
 		$address = array_merge( $address, $additional_fields );
 
-		$fields              = $this->additional_fields_controller->get_additional_fields();
-		$address_fields_keys = $this->additional_fields_controller->get_address_fields_keys();
-		$address_fields      = array_filter(
-			$fields,
-			function ( $key ) use ( $address_fields_keys ) {
-				return in_array( $key, $address_fields_keys, true );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
-
-		if ( $current_locale ) {
-			foreach ( $current_locale as $key => $field ) {
-				if ( isset( $address_fields[ $key ] ) ) {
-					$address_fields[ $key ]['label']    = isset( $field['label'] ) ? $field['label'] : $address_fields[ $key ]['label'];
-					$address_fields[ $key ]['required'] = isset( $field['required'] ) ? $field['required'] : $address_fields[ $key ]['required'];
-				}
-			}
-		}
-
-		foreach ( $address_fields as $address_field_key => $address_field ) {
+		foreach ( $current_locale as $address_field_key => $address_field ) {
 			if ( empty( $address[ $address_field_key ] ) && $address_field['required'] ) {
 				/* translators: %s Field label. */
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woocommerce' ), $address_field['label'] ), $address_field_key );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1586,18 +1586,65 @@ class AdditionalFields extends MockeryTestCase {
 		$request->set_body_params(
 			array(
 				'billing_address'   => (object) array(
-					'first_name'              => 'test',
-					'last_name'               => 'test',
-					'company'                 => '',
-					'address_1'               => 'test',
-					'address_2'               => '',
-					'city'                    => 'test',
-					'state'                   => '',
-					'postcode'                => 'cb241ab',
-					'country'                 => 'GB',
-					'phone'                   => '',
-					'email'                   => 'testaccount@test.com',
-					'plugin-namespace/gov-id' => 'gov id',
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'email'                              => 'testaccount@test.com',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'req. field',
+				),
+				'shipping_address'  => (object) array(
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'req. field',
+				),
+				'payment_method'    => 'bacs',
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => 'engineering',
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
+
+		WC()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
+		WC()->cart->add_to_cart( $this->products[1]->get_id(), 1 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'   => (object) array(
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'email'                              => 'testaccount@test.com',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'gov id',
 				),
 				'shipping_address'  => (object) array(
 					'first_name'              => 'test',
@@ -1623,6 +1670,50 @@ class AdditionalFields extends MockeryTestCase {
 
 		$this->assertEquals( 400, $response->get_status(), print_r( $data, true ) );
 		$this->assertEquals( \sprintf( 'There was a problem with the provided shipping address: %s is required', $label ), $data['message'], print_r( $data, true ) );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'   => (object) array(
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'email'                              => 'testaccount@test.com',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'gov id',
+				),
+				'shipping_address'  => (object) array(
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'gov id',
+				),
+				'payment_method'    => 'bacs',
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => '',
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status(), print_r( $data, true ) );
 
 		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -81,6 +81,8 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	protected function tearDown(): void {
 		parent::tearDown();
+		unset( wc()->countries->locale );
+		remove_all_filters( 'woocommerce_get_country_locale' );
 		global $wp_rest_server;
 		$wp_rest_server = null;
 		$this->unregister_fields();

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -102,6 +102,7 @@ class Checkout extends MockeryTestCase {
 	 */
 	protected function tearDown(): void {
 		parent::tearDown();
+		unset( wc()->countries->locale );
 		$default_zone     = \WC_Shipping_Zones::get_zone( 0 );
 		$shipping_methods = $default_zone->get_shipping_methods();
 		foreach ( $shipping_methods as $method ) {
@@ -266,7 +267,6 @@ class Checkout extends MockeryTestCase {
 	 * Ensure that validation respects locale filtering.
 	 */
 	public function test_locale_required_filtering_post_data() {
-		unset( WC()->countries->locale );
 		add_filter(
 			'woocommerce_get_country_locale',
 			function ( $locale ) {
@@ -317,7 +317,6 @@ class Checkout extends MockeryTestCase {
 	 * Ensure that labels respect locale filtering.
 	 */
 	public function test_locale_label_filtering_post_data() {
-		unset( WC()->countries->locale );
 		add_filter(
 			'woocommerce_get_country_locale',
 			function ( $locale ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Get field information from country locale (falling back to default locale) for things like label/required
- Use `get_fields_for_location` helper method to fill in locale, this prevents numeric indexes being added to the locale (didn't break anything, just unnecessary and made refactoring possible).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### User-facing testing

0. Install and activate this plugin: [additional-checkout-fields-tester.zip](https://github.com/user-attachments/files/16393133/additional-checkout-fields-tester.zip)
1. Add an item to your cart and go to the Cart block. Open the shipping calculator.
2. Fill an address and ensure no errors appear relating to additional checkout fields.
3. Go to the Checkout block. Fill in a US address. Fill the additional fields. Do not update the State field.
4. Try to check out. Ensure an error shows on the state field.
5. If you see errors relating to additional select fields, re-select the value. This is a known bug and will be fixed by https://github.com/woocommerce/woocommerce/pull/49929
6. Change the state to a valid one. Check out successfully.

### Developer-facing testing.

1. Use Store API to check out.
2. Test with the following on a country that requires State (e.g. US). Ensure all requests fail and that the error message is relevant.
  1. No state sent in request
  2. Empty state sent in request
  3. Invalid state sent in request (e.g. `FF`)
3. Do the same, with postcode.
4. Use this filter to make US State optional.
```php
add_filter( 'woocommerce_get_country_locale', function( $locale ) {
	$locale['US']['state']['required']  = false;
	$locale['FR']['postcode']['label'] = 'French postcode';
	return $locale;
} );
```
5. Repeat step 2, ensure only the "invalid state" step fails.
6. Change country to FT, and don't send a postcode.
7. In the response, ensure the error message references the updated label "French postcode"

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
