### PR TITLE
CI: improve monorepo setup time in PHPUnit and API tests.

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -87,11 +87,13 @@ runs:
           shell: 'bash'
           # The installation command is a bit odd as it's a workaround for know bug - https://github.com/pnpm/pnpm/issues/6300.
           run: |
-            if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' ]]; then
-              echo 'Starting parallel installation of composer dependecies'
+            if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
+              # PHPUnit/REST testing optimized installation
               composer install --working-dir=./plugins/woocommerce --quiet &
+              pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
+            else
+              pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
             fi
-            pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
         # We want to include an option to build projects using this action so that we can make
         # sure that the build cache is always used when building projects.
         - name: 'Cache Build Output'

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -43,17 +43,17 @@ runs:
               php-version: '${{ inputs.php-version }}'
               coverage: 'none'
         - name: 'Cache: identify pnpm caching directory'
-          if: ${{ inputs.pull-package-deps != 'false' && inputs.build-type == 'full' }}
+          if: ${{ inputs.pull-package-deps != 'false' }}
           shell: 'bash'
           run: |
               echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
         - name: 'Cache: pnpm downloads'
-          if: ${{ inputs.pull-package-deps != 'false' && inputs.build-type == 'full' }}
+          if: ${{ inputs.pull-package-deps != 'false' }}
           uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
           with:
               path: "${{ env.PNPM_STORE_PATH }}"
-              key: "${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
-              restore-keys: '${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-'
+              key: "${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
+              restore-keys: '${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-'
         - name: 'Cache: node cache'
           if: ${{ inputs.pull-package-deps != 'false' }}
           uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
@@ -89,8 +89,8 @@ runs:
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
               # PHPUnit/REST testing optimized installation
-              composer install --working-dir=./plugins/woocommerce --quiet &
-              pnpm install --global @wordpress/env@^9.7.0
+              composer install --working-dir=./plugins/woocommerce --quiet --no-autoloader &
+              pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
             fi

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -89,12 +89,10 @@ runs:
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
               # PHPUnit/REST testing optimized installation of the deps:
-              # 1) If needed, start composer installation earlier, so when pnpm triggers postinstall hooks the heavy lifting is done already
-              if [[ ! -d ./plugins/woocommerce/vendor ]]; then
-                  composer install --working-dir=./plugins/woocommerce --quiet --no-autoloader &
-              fi
-              # 2) We mostly need wp-env and playwright, but installing intermediate package deps instead for maintainability reasons
-              pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
+              # 1) Start composer installation earlier, so when pnpm finishes installation composer is ready as well.
+              composer install --working-dir=./plugins/woocommerce --quiet &
+              # 2) We mostly need wp-env and playwright, but installing intermediate package deps instead for CI maintainability reasons.
+              pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false --ignore-scripts
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
             fi

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -88,10 +88,8 @@ runs:
           # The installation command is a bit odd as it's a workaround for know bug - https://github.com/pnpm/pnpm/issues/6300.
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
-              # PHPUnit/REST testing optimized installation of the deps:
-              # 1) Start composer installation earlier, so when pnpm finishes installation composer is ready as well.
+              # PHPUnit/REST testing optimized installation of the deps: minimalistic and parallellized between PHP/JS.
               composer install --working-dir=./plugins/woocommerce --quiet &
-              # 2) We mostly need wp-env and playwright, but installing intermediate package deps instead for CI maintainability reasons.
               pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false --ignore-scripts
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -88,10 +88,7 @@ runs:
           # The installation command is a bit odd as it's a workaround for know bug - https://github.com/pnpm/pnpm/issues/6300.
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
-              # PHPUnit/REST testing optimized installation of the deps:
-              # 1) Start composer earlier, so when pnpm triggers postinstall hooks the heavy lifting is done already
-              composer install --working-dir=./plugins/woocommerce --quiet --no-autoloader &
-              # 2) We mostly need wp-env and playwright, but installing intermediate package deps instead for mainatanability reasons
+              # PHPUnit/REST testing optimized installation of the deps - wee need only intermediate ones.
               pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -43,12 +43,12 @@ runs:
               php-version: '${{ inputs.php-version }}'
               coverage: 'none'
         - name: 'Cache: identify pnpm caching directory'
-          if: ${{ inputs.pull-package-deps != 'false' }}
+          if: ${{ inputs.pull-package-deps != 'false' && inputs.build-type == 'full' }}
           shell: 'bash'
           run: |
               echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
         - name: 'Cache: pnpm downloads'
-          if: ${{ inputs.pull-package-deps != 'false' }}
+          if: ${{ inputs.pull-package-deps != 'false' && inputs.build-type == 'full' }}
           uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
           with:
               path: "${{ env.PNPM_STORE_PATH }}"
@@ -90,7 +90,7 @@ runs:
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
               # PHPUnit/REST testing optimized installation
               composer install --working-dir=./plugins/woocommerce --quiet &
-              pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
+              pnpm install --frozen-lockfile --global @wordpress/env@^9.7.0
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
             fi

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -88,7 +88,12 @@ runs:
           # The installation command is a bit odd as it's a workaround for know bug - https://github.com/pnpm/pnpm/issues/6300.
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
-              # PHPUnit/REST testing optimized installation of the deps - wee need only intermediate ones.
+              # PHPUnit/REST testing optimized installation of the deps:
+              # 1) If needed, start composer installation earlier, so when pnpm triggers postinstall hooks the heavy lifting is done already
+              if [[ ! -d ./plugins/woocommerce/vendor ]]; then
+                  composer install --working-dir=./plugins/woocommerce --quiet --no-autoloader &
+              fi
+              # 2) We mostly need wp-env and playwright, but installing intermediate package deps instead for maintainability reasons
               pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -89,6 +89,7 @@ runs:
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
               # PHPUnit/REST testing optimized installation of the deps: minimalistic and parallellized between PHP/JS.
+              # JS deps installation is abit hard-core, but all we need actually is wp-env and playwright - we are good at that regard.
               composer install --working-dir=./plugins/woocommerce --quiet &
               pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false --ignore-scripts
             else

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -90,7 +90,7 @@ runs:
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
               # PHPUnit/REST testing optimized installation
               composer install --working-dir=./plugins/woocommerce --quiet &
-              pnpm install --frozen-lockfile --global @wordpress/env@^9.7.0
+              pnpm install --global @wordpress/env@^9.7.0
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
             fi

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -88,8 +88,10 @@ runs:
           # The installation command is a bit odd as it's a workaround for know bug - https://github.com/pnpm/pnpm/issues/6300.
           run: |
             if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' && '${{ inputs.build-type }}' == 'backend' ]]; then
-              # PHPUnit/REST testing optimized installation
+              # PHPUnit/REST testing optimized installation of the deps:
+              # 1) Start composer earlier, so when pnpm triggers postinstall hooks the heavy lifting is done already
               composer install --working-dir=./plugins/woocommerce --quiet --no-autoloader &
+              # 2) We mostly need wp-env and playwright, but installing intermediate package deps instead for mainatanability reasons
               pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false
             else
               pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -86,7 +86,12 @@ runs:
           if: ${{ inputs.install == 'true' || steps.project-filters.outputs.install != '' }}
           shell: 'bash'
           # The installation command is a bit odd as it's a workaround for know bug - https://github.com/pnpm/pnpm/issues/6300.
-          run: "pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}"
+          run: |
+            if [[ '${{ inputs.install }}' == '@woocommerce/plugin-woocommerce...' ]]; then
+              echo 'Starting parallel installation of composer dependecies'
+              composer install --working-dir=./plugins/woocommerce --quiet &
+            fi
+            pnpm install ${{ steps.project-filters.outputs.install }} --frozen-lockfile ${{ steps.project-filters.outputs.install != '' && '--config.dedupe-peer-dependents=false' || '' }}
         # We want to include an option to build projects using this action so that we can make
         # sure that the build cache is always used when building projects.
         - name: 'Cache Build Output'

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce",
-	"description": "An eCommerce toolkit that helps you sell anything. Beautifully...",
+	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
 	"homepage": "https://woocommerce.com/",
 	"version": "9.3.0",
 	"type": "wordpress-plugin",

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce",
-	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
+	"description": "An eCommerce toolkit that helps you sell anything. Beautifully...",
 	"homepage": "https://woocommerce.com/",
 	"version": "9.3.0",
 	"type": "wordpress-plugin",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Further reduce monorepo setup time for PHPUnit and API tests (~30 seconds)

### Testing

- CI checks shall pass ([here](https://github.com/woocommerce/woocommerce/actions/runs/10140355951/job/28036150797?pr=50032))
