### PR TITLE
Adds concurrency limit to workflow run

### DIFF
--- a/.github/workflows/review-testing-instructions.yml
+++ b/.github/workflows/review-testing-instructions.yml
@@ -1,66 +1,70 @@
 name: Remind reviewers to also review the testing instructions and test coverage
 on:
-  pull_request_target:
-    types: [review_requested]
+    pull_request_target:
+        types: [review_requested]
 
 permissions: {}
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
-  add-testing-instructions-review-comment:
-    runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v3
+    add-testing-instructions-review-comment:
+        runs-on: ubuntu-20.04
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+            - name: Setup Node.js
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
 
-      - name: Install Octokit
-        run: npm --prefix .github/workflows/scripts install @octokit/action@~6.1.0
+            - name: Install Octokit
+              run: npm --prefix .github/workflows/scripts install @octokit/action@~6.1.0
 
-      - name: Install Actions Core
-        run: npm --prefix .github/workflows/scripts install @actions/core@~1.10.1
+            - name: Install Actions Core
+              run: npm --prefix .github/workflows/scripts install @actions/core@~1.10.1
 
-      - name: Check if user is a community contributor
-        id: is-community-contributor
-        run: node .github/workflows/scripts/is-community-contributor.js
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Check if user is a community contributor
+              id: is-community-contributor
+              run: node .github/workflows/scripts/is-community-contributor.js
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get the username of requested reviewers
-        if: steps.is-community-contributor.outputs.is-community == 'no'
-        id: get_reviewer_username
-        run: |
-          # Retrieves the username of all reviewers and stores them in a comma-separated list
-          reviewers=$(echo '${{ toJson(github.event.pull_request.requested_reviewers[*].login) }}' | jq -r 'map("@\(.)") | join(", ")')
-          echo "REVIEWERS=$reviewers" >> $GITHUB_ENV
+            - name: Get the username of requested reviewers
+              if: steps.is-community-contributor.outputs.is-community == 'no'
+              id: get_reviewer_username
+              run: |
+                  # Retrieves the username of all reviewers and stores them in a comma-separated list
+                  reviewers=$(echo '${{ toJson(github.event.pull_request.requested_reviewers[*].login) }}' | jq -r 'map("@\(.)") | join(", ")')
+                  echo "REVIEWERS=$reviewers" >> $GITHUB_ENV
 
-      - name: Get the name of requested teams
-        id: get_team_name
-        run: |
-          # Retrieves the name of all teams asked for review and stores them in a comma-separated list
-          teams=$(echo '${{ toJson(github.event.pull_request.requested_teams[*].slug) }}' | jq -r 'map("@woocommerce/\(.)") | join(", ")')
-          echo "TEAMS=$teams" >> $GITHUB_ENV
+            - name: Get the name of requested teams
+              id: get_team_name
+              run: |
+                  # Retrieves the name of all teams asked for review and stores them in a comma-separated list
+                  teams=$(echo '${{ toJson(github.event.pull_request.requested_teams[*].slug) }}' | jq -r 'map("@woocommerce/\(.)") | join(", ")')
+                  echo "TEAMS=$teams" >> $GITHUB_ENV
 
-      - name: Find the comment by github-actions[bot] asking for reviewing the testing instructions
-        uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
-        id: find-comment
-        with:
-            issue-number: ${{ github.event.pull_request.number }}
-            comment-author: 'github-actions[bot]'
-            body-includes: please make sure to review the testing instructions
+            - name: Find the comment by github-actions[bot] asking for reviewing the testing instructions
+              uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: 'github-actions[bot]'
+                  body-includes: please make sure to review the testing instructions
 
-      - name: Create or update PR comment asking for reviewers to review the testing instructions and test coverage
-        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
-        with:
-            comment-id: ${{ steps.find-comment.outputs.comment-id }}
-            issue-number: ${{ github.event.pull_request.number }}
-            body: |
-              Hi ${{ env.REVIEWERS }}, ${{ env.TEAMS }}
-              
-              Apart from reviewing the code changes, please make sure to review the testing instructions and verify that relevant tests (E2E, Unit, Integration, etc.) have been added or updated as needed.
-              
-              You can follow this guide to find out what good testing instructions should look like:
-              https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions
-            edit-mode: replace
+            - name: Create or update PR comment asking for reviewers to review the testing instructions and test coverage
+              uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: |
+                      Hi ${{ env.REVIEWERS }}, ${{ env.TEAMS }}
+
+                      Apart from reviewing the code changes, please make sure to review the testing instructions and verify that relevant tests (E2E, Unit, Integration, etc.) have been added or updated as needed.
+
+                      You can follow this guide to find out what good testing instructions should look like:
+                      https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions
+                  edit-mode: replace

--- a/plugins/woocommerce/changelog/dev-fix-double-posting-review-comment
+++ b/plugins/woocommerce/changelog/dev-fix-double-posting-review-comment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated the workflow prompting for testing instructions to only run once (preventing double comments)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue where a comment is duplicated on a PR prompting the reviewer to review testing instructions (like in this PR: https://github.com/woocommerce/woocommerce/pull/49737)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

It's hard to trigger the circumstances that cause the duplicate testing instructions comment, it only happens intermittently.  You could try assigning a number of reviewers to a pull request all at once.

Most importantly, ensure that the comment is still posted on PRs.

<!-- End testing instructions -->


