### PR TITLE
Use the validatorId to get access to the field instead of the context

### DIFF
--- a/packages/js/product-editor/changelog/dev-49581_use_validatorid_instead_of_context
+++ b/packages/js/product-editor/changelog/dev-49581_use_validatorid_instead_of_context
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Use the validatorId to get access to the field instead of the context #50035

--- a/packages/js/product-editor/src/blocks/generic/number/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/number/edit.tsx
@@ -17,7 +17,6 @@ import { useProductEdits } from '../../../hooks/use-product-edits';
 
 export function Edit( {
 	attributes,
-	clientId,
 	context: { postType },
 }: ProductEditorBlockEditProps< NumberBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
@@ -57,7 +56,6 @@ export function Edit( {
 						),
 						min
 					),
-					context: clientId,
 				};
 			}
 			if (
@@ -74,13 +72,11 @@ export function Edit( {
 						),
 						min
 					),
-					context: clientId,
 				};
 			}
 			if ( required && ! value ) {
 				return {
 					message: __( 'This field is required.', 'woocommerce' ),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/generic/text/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text/edit.tsx
@@ -21,7 +21,6 @@ import { TextBlockAttributes } from './types';
 
 export function Edit( {
 	attributes,
-	clientId,
 	context: { postType },
 }: ProductEditorBlockEditProps< TextBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
@@ -135,7 +134,6 @@ export function Edit( {
 			if ( ! input.validity.valid ) {
 				return {
 					message: customErrorMessage,
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-email/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-email/edit.tsx
@@ -57,7 +57,6 @@ export function Edit( {
 						'This field must be a positive number.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/edit.tsx
@@ -57,7 +57,6 @@ export function Edit( {
 						'Stock quantity must be a positive number.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -85,7 +85,6 @@ export function NameBlockEdit( {
 			if ( ! name || name === AUTO_DRAFT_NAME ) {
 				return {
 					message: __( 'Product name is required.', 'woocommerce' ),
-					context: clientId,
 				};
 			}
 
@@ -95,7 +94,6 @@ export function NameBlockEdit( {
 						'Please enter a product name shorter than 120 characters.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -187,10 +187,14 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 					template: productTemplate.id,
 				} );
 			} catch ( error ) {
-				const { message, errorProps } = getProductErrorMessageAndProps(
-					errorHandler( error as WPError, productStatus ) as WPError,
-					selectedTab
-				);
+				const { message, errorProps } =
+					await getProductErrorMessageAndProps(
+						errorHandler(
+							error as WPError,
+							productStatus
+						) as WPError,
+						selectedTab
+					);
 				createErrorNotice( message, errorProps );
 			}
 

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -309,10 +309,11 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 			// by the product editor.
 			window.location.href = getNewPath( {}, `/product/${ productId }` );
 		} catch ( error ) {
-			const { message, errorProps } = getProductErrorMessageAndProps(
-				errorHandler( error as WPError, productStatus ) as WPError,
-				selectedTab
-			);
+			const { message, errorProps } =
+				await getProductErrorMessageAndProps(
+					errorHandler( error as WPError, productStatus ) as WPError,
+					selectedTab
+				);
 			createErrorNotice( message, errorProps );
 		}
 	}

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
@@ -72,7 +72,6 @@ export function Edit( {
 							'Regular price must be greater than or equals to zero.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 				if (
@@ -84,7 +83,6 @@ export function Edit( {
 							'Regular price must be greater than the sale price.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 			} else if ( isRequired ) {
@@ -94,7 +92,6 @@ export function Edit( {
 						__( '%s is required.', 'woocommerce' ),
 						label
 					),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
@@ -64,7 +64,6 @@ export function Edit( {
 							'Sale price must be greater than or equals to zero.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 				const listPrice = Number.parseFloat( regularPrice );
@@ -77,7 +76,6 @@ export function Edit( {
 							'Sale price must be lower than the regular price.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 			}

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
@@ -91,12 +91,14 @@ export function Edit( {
 	const _dateOnSaleFrom = moment( dateOnSaleFromGmt, moment.ISO_8601, true );
 	const _dateOnSaleTo = moment( dateOnSaleToGmt, moment.ISO_8601, true );
 
+	const dateOnSaleFromGmtId = `date_on_sale_from_gmt-${ clientId }`;
+
 	const {
 		ref: dateOnSaleFromGmtRef,
 		error: dateOnSaleFromGmtValidationError,
 		validate: validateDateOnSaleFromGmt,
 	} = useValidation< Product >(
-		`date_on_sale_from_gmt-${ clientId }`,
+		dateOnSaleFromGmtId,
 		async function dateOnSaleFromValidator() {
 			if ( showScheduleSale && dateOnSaleFromGmt ) {
 				if ( ! _dateOnSaleFrom.isValid() ) {
@@ -105,7 +107,6 @@ export function Edit( {
 							'Please enter a valid date.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 
@@ -115,7 +116,6 @@ export function Edit( {
 							'The start date of the sale must be before the end date.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 			}
@@ -123,12 +123,14 @@ export function Edit( {
 		[ showScheduleSale, dateOnSaleFromGmt, _dateOnSaleFrom, _dateOnSaleTo ]
 	);
 
+	const dateOnSaleToGmtId = `date_on_sale_to_gmt-${ clientId }`;
+
 	const {
 		ref: dateOnSaleToGmtRef,
 		error: dateOnSaleToGmtValidationError,
 		validate: validateDateOnSaleToGmt,
 	} = useValidation< Product >(
-		`date_on_sale_to_gmt-${ clientId }`,
+		dateOnSaleToGmtId,
 		async function dateOnSaleToValidator() {
 			if ( showScheduleSale && dateOnSaleToGmt ) {
 				if ( ! _dateOnSaleTo.isValid() ) {
@@ -137,7 +139,6 @@ export function Edit( {
 							'Please enter a valid date.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 
@@ -147,7 +148,6 @@ export function Edit( {
 							'The end date of the sale must be after the start date.',
 							'woocommerce'
 						),
-						context: clientId,
 					};
 				}
 			}
@@ -170,6 +170,7 @@ export function Edit( {
 				<div className="wp-block-columns wp-block-woocommerce-product-schedule-sale-fields__content">
 					<div className="wp-block-column">
 						<DateTimePickerControl
+							id={ dateOnSaleFromGmtId }
 							ref={
 								dateOnSaleFromGmtRef as React.Ref< HTMLInputElement >
 							}
@@ -191,6 +192,7 @@ export function Edit( {
 
 					<div className="wp-block-column">
 						<DateTimePickerControl
+							id={ dateOnSaleToGmtId }
 							ref={
 								dateOnSaleToGmtRef as React.Ref< HTMLInputElement >
 							}

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
@@ -91,14 +91,12 @@ export function Edit( {
 	const _dateOnSaleFrom = moment( dateOnSaleFromGmt, moment.ISO_8601, true );
 	const _dateOnSaleTo = moment( dateOnSaleToGmt, moment.ISO_8601, true );
 
-	const dateOnSaleFromGmtId = `date_on_sale_from_gmt-${ clientId }`;
-
 	const {
 		ref: dateOnSaleFromGmtRef,
 		error: dateOnSaleFromGmtValidationError,
 		validate: validateDateOnSaleFromGmt,
 	} = useValidation< Product >(
-		dateOnSaleFromGmtId,
+		`date_on_sale_from_gmt-${ clientId }`,
 		async function dateOnSaleFromValidator() {
 			if ( showScheduleSale && dateOnSaleFromGmt ) {
 				if ( ! _dateOnSaleFrom.isValid() ) {
@@ -123,14 +121,12 @@ export function Edit( {
 		[ showScheduleSale, dateOnSaleFromGmt, _dateOnSaleFrom, _dateOnSaleTo ]
 	);
 
-	const dateOnSaleToGmtId = `date_on_sale_to_gmt-${ clientId }`;
-
 	const {
 		ref: dateOnSaleToGmtRef,
 		error: dateOnSaleToGmtValidationError,
 		validate: validateDateOnSaleToGmt,
 	} = useValidation< Product >(
-		dateOnSaleToGmtId,
+		`date_on_sale_to_gmt-${ clientId }`,
 		async function dateOnSaleToValidator() {
 			if ( showScheduleSale && dateOnSaleToGmt ) {
 				if ( ! _dateOnSaleTo.isValid() ) {
@@ -170,7 +166,6 @@ export function Edit( {
 				<div className="wp-block-columns wp-block-woocommerce-product-schedule-sale-fields__content">
 					<div className="wp-block-column">
 						<DateTimePickerControl
-							id={ dateOnSaleFromGmtId }
 							ref={
 								dateOnSaleFromGmtRef as React.Ref< HTMLInputElement >
 							}
@@ -192,7 +187,6 @@ export function Edit( {
 
 					<div className="wp-block-column">
 						<DateTimePickerControl
-							id={ dateOnSaleToGmtId }
 							ref={
 								dateOnSaleToGmtRef as React.Ref< HTMLInputElement >
 							}

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
@@ -103,7 +103,6 @@ export function Edit( {
 						'Width must be greater than zero.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},
@@ -125,7 +124,6 @@ export function Edit( {
 						'Length must be greater than zero.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},
@@ -147,7 +145,6 @@ export function Edit( {
 						'Height must be greater than zero.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},
@@ -169,7 +166,6 @@ export function Edit( {
 						'Weight must be greater than zero.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/edit.tsx
@@ -32,7 +32,6 @@ import { EmptyState } from '../../../components/empty-state';
 
 export function Edit( {
 	attributes,
-	clientId,
 	context: { isInSelectedTab },
 }: ProductEditorBlockEditProps< VariationOptionsBlockAttributes > ) {
 	const noticeDimissed = useRef( false );
@@ -126,7 +125,6 @@ export function Edit( {
 						'Set variation prices before adding this product.',
 						'woocommerce'
 					),
-					context: clientId,
 				};
 			}
 		},

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -36,11 +36,9 @@ export function PreviewButton( {
 				navigateTo( { url } );
 			}
 		},
-		onSaveError( error ) {
-			const { message, errorProps } = getProductErrorMessageAndProps(
-				error,
-				visibleTab
-			);
+		async onSaveError( error ) {
+			const { message, errorProps } =
+				await getProductErrorMessageAndProps( error, visibleTab );
 			createErrorNotice( message, errorProps );
 		},
 	} );

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button-menu/publish-button-menu.tsx
@@ -51,11 +51,9 @@ export function PublishButtonMenu( {
 
 				showSuccessNotice( scheduledProduct );
 			} )
-			.catch( ( error ) => {
-				const { message, errorProps } = getProductErrorMessageAndProps(
-					error,
-					visibleTab
-				);
+			.catch( async ( error ) => {
+				const { message, errorProps } =
+					await getProductErrorMessageAndProps( error, visibleTab );
 				createErrorNotice( message, errorProps );
 			} )
 			.finally( () => {
@@ -138,9 +136,9 @@ export function PublishButtonMenu( {
 										);
 										navigateTo( { url } );
 									} )
-									.catch( ( error ) => {
+									.catch( async ( error ) => {
 										const { message, errorProps } =
-											getProductErrorMessageAndProps(
+											await getProductErrorMessageAndProps(
 												error,
 												visibleTab
 											);
@@ -176,9 +174,9 @@ export function PublishButtonMenu( {
 											url: productListUrl,
 										} );
 									} )
-									.catch( ( error ) => {
+									.catch( async ( error ) => {
 										const { message, errorProps } =
-											getProductErrorMessageAndProps(
+											await getProductErrorMessageAndProps(
 												error,
 												visibleTab
 											);

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -62,11 +62,9 @@ export function PublishButton( {
 				navigateTo( { url } );
 			}
 		},
-		onPublishError( error ) {
-			const { message, errorProps } = getProductErrorMessageAndProps(
-				error,
-				visibleTab
-			);
+		async onPublishError( error ) {
+			const { message, errorProps } =
+				await getProductErrorMessageAndProps( error, visibleTab );
 			createErrorNotice( message, errorProps );
 		},
 	} );

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -48,11 +48,9 @@ export function SaveDraftButton( {
 				navigateTo( { url } );
 			}
 		},
-		onSaveError( error ) {
-			const { message, errorProps } = getProductErrorMessageAndProps(
-				error,
-				visibleTab
-			);
+		async onSaveError( error ) {
+			const { message, errorProps } =
+				await getProductErrorMessageAndProps( error, visibleTab );
 			createErrorNotice( message, errorProps );
 		},
 	} );

--- a/packages/js/product-editor/src/contexts/validation-context/types.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/types.ts
@@ -26,7 +26,7 @@ export type ValidationProviderProps = {
 };
 
 export type ValidationError =
-	| { message?: string; context?: string; validatorId?: string }
+	| { message?: string; validatorId?: string }
 	| undefined;
 export type ValidationErrors = Record< string, ValidationError >;
 

--- a/packages/js/product-editor/src/contexts/validation-context/use-validations.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/use-validations.ts
@@ -62,5 +62,6 @@ export function useValidations< T = unknown >() {
 			} );
 		},
 		focusByValidatorId,
+		getFieldByValidatorId: context.getFieldByValidatorId,
 	};
 }

--- a/packages/js/product-editor/src/hooks/use-blocks-helper/use-blocks-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-blocks-helper/use-blocks-helper.ts
@@ -22,7 +22,12 @@ export function useBlocksHelper() {
 		return attributes?.id;
 	}
 
-	function getParentTabId( clientId?: string ) {
+	function getClientIdByField( field: HTMLElement ) {
+		const ancestorWithAttribute = field.closest( '[data-block]' );
+		return ancestorWithAttribute?.getAttribute( 'data-block' );
+	}
+
+	function getParentTabId( clientId?: string | null ) {
 		if ( clientId ) {
 			return getClosestParentTabId( clientId );
 		}
@@ -41,6 +46,7 @@ export function useBlocksHelper() {
 	}
 
 	return {
+		getClientIdByField,
 		getParentTabId,
 		getParentTabIdByBlockName,
 	};

--- a/packages/js/product-editor/src/hooks/use-blocks-helper/use-blocks-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-blocks-helper/use-blocks-helper.ts
@@ -23,8 +23,10 @@ export function useBlocksHelper() {
 	}
 
 	function getClientIdByField( field: HTMLElement ) {
-		const ancestorWithAttribute = field.closest( '[data-block]' );
-		return ancestorWithAttribute?.getAttribute( 'data-block' );
+		const parentBlockElement = field.closest(
+			'[data-block]'
+		) as HTMLElement;
+		return parentBlockElement?.dataset.block;
 	}
 
 	function getParentTabId( clientId?: string | null ) {

--- a/packages/js/product-editor/src/hooks/use-error-handler.ts
+++ b/packages/js/product-editor/src/hooks/use-error-handler.ts
@@ -24,7 +24,6 @@ export type WPError = {
 	code: WPErrorCode;
 	message: string;
 	validatorId?: string;
-	context?: string;
 };
 
 type ErrorProps = {
@@ -41,10 +40,10 @@ type UseErrorHandlerTypes = {
 	getProductErrorMessageAndProps: (
 		error: WPError,
 		visibleTab: string | null
-	) => {
+	) => Promise< {
 		message: string;
 		errorProps: ErrorProps;
-	};
+	} >;
 };
 
 function getUrl( tab: string ): string {
@@ -74,22 +73,29 @@ function getErrorPropsWithActions(
 }
 
 export const useErrorHandler = (): UseErrorHandlerTypes => {
-	const { focusByValidatorId } = useValidations();
-	const { getParentTabId, getParentTabIdByBlockName } = useBlocksHelper();
+	const { focusByValidatorId, getFieldByValidatorId } = useValidations();
+	const { getClientIdByField, getParentTabId, getParentTabIdByBlockName } =
+		useBlocksHelper();
+
+	async function getClientIdByValidatorId( validatorId: string ) {
+		if ( ! validatorId ) {
+			return null;
+		}
+		const field = await getFieldByValidatorId( validatorId );
+		return getClientIdByField( field );
+	}
 
 	const getProductErrorMessageAndProps = useCallback(
-		( error: WPError, visibleTab: string | null ) => {
+		async ( error: WPError, visibleTab: string | null ) => {
 			const response = {
 				message: '',
 				errorProps: {} as ErrorProps,
 			};
-			const {
-				code,
-				context = '',
-				message: errorMessage,
-				validatorId = '',
-			} = error;
-			const errorContext = getParentTabId( context );
+			const { code, message: errorMessage, validatorId = '' } = error;
+
+			const clientId = await getClientIdByValidatorId( validatorId );
+			const errorContext = getParentTabId( clientId );
+
 			switch ( code ) {
 				case 'variable_product_no_variation_prices':
 					response.message = errorMessage;

--- a/packages/js/product-editor/src/hooks/use-error-handler.ts
+++ b/packages/js/product-editor/src/hooks/use-error-handler.ts
@@ -82,6 +82,9 @@ export const useErrorHandler = (): UseErrorHandlerTypes => {
 			return null;
 		}
 		const field = await getFieldByValidatorId( validatorId );
+		if ( ! field ) {
+			return null;
+		}
 		return getClientIdByField( field );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to use the `validatorId` instead of `context` when possible. 

Closes #49581.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New
3. Add a regular price.
4. Go to the Inventory tab and press Publish.
5. You will see a snackbar with the error `Product name is required.` and a link with the text `View error`.
6. Go to the General tab again.
7. Press `Publish`.
8. You will a snackbar with the error `Product name is required.` without a link.
9. Press `Schedule sale` and set a `to` date older than the `from` date.
10.  Go to the Inventory tab and press Publish.
11. You will a snackbar with the error `The start date of the sale must be before the end date.` and a link with the text `View error`.
12. Pressing the `View error` link should redirect you to the `General` tab and focus on the `from` date.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
