### PR TITLE
blueprint - Add woo blueprint exporters and importers

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Blueprint\UseWPFunctions;
  */
 class ExportWCCoreProfilerOptions implements StepExporter, HasAlias {
 	use UseWPFunctions;
+
 	/**
 	 * Export the step
 	 *

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
+use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+
+/**
+ * ExportWCCoreProfilerOptions class
+ */
+class ExportWCCoreProfilerOptions implements StepExporter, HasAlias {
+	use UseWPFunctions;
+	/**
+	 * Export the step
+	 *
+	 * @return SetSiteOptions
+	 */
+	public function export() {
+		$step = new SetSiteOptions(
+			array(
+				'blogname'                       => $this->wp_get_option( 'blogname' ),
+				'woocommerce_allow_tracking'     => $this->wp_get_option( 'woocommerce_allow_tracking' ),
+				'woocommerce_onboarding_profile' => $this->wp_get_option( 'woocommerce_onboarding_profile', array() ),
+			)
+		);
+		$step->set_meta_values(
+			array(
+				'plugin' => 'woocommerce',
+				'alias'  => $this->get_alias(),
+			)
+		);
+
+		return $step;
+	}
+
+	/**
+	 * Get the step name
+	 *
+	 * @return string
+	 */
+	public function get_step_name() {
+		return 'setSiteOptions';
+	}
+
+	/**
+	 * Get the alias
+	 *
+	 * @return string
+	 */
+	public function get_alias() {
+		return 'setWCCoreProfilerOptions';
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
@@ -26,6 +26,7 @@ class ExportWCCoreProfilerOptions implements StepExporter, HasAlias {
 				'blogname'                       => $this->wp_get_option( 'blogname' ),
 				'woocommerce_allow_tracking'     => $this->wp_get_option( 'woocommerce_allow_tracking' ),
 				'woocommerce_onboarding_profile' => $this->wp_get_option( 'woocommerce_onboarding_profile', array() ),
+				'woocommerce_default_country'    => $this->wp_get_option( 'woocommerce_default_country' ),
 			)
 		);
 		$step->set_meta_values(

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
@@ -43,6 +43,11 @@ class ExportWCPaymentGateways implements StepExporter {
 		return $step;
 	}
 
+	/**
+	 * Return the payment gateways resgietered in WooCommerce
+	 *
+	 * @return string
+	 */
 	public function get_wc_payment_gateways() {
 		return WC()->payment_gateways->payment_gateways();
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Steps\SetWCPaymentGateways;
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+use Automattic\WooCommerce\Blueprint\Steps\Step;
+
+/**
+ * ExportWCPaymentGateways class
+ */
+class ExportWCPaymentGateways implements StepExporter {
+	/**
+	 * Payment gateway IDs to exclude from export
+	 *
+	 * @var array|string[] Payment gateway IDs to exclude from export
+	 */
+	protected array $exclude_ids = array( 'pre_install_woocommerce_payments_promotion' );
+
+	/**
+	 * Export the step
+	 *
+	 * @return Step
+	 */
+	public function export(): Step {
+		$step = new SetWCPaymentGateways();
+		$this->maybe_hide_wcpay_gateways();
+		foreach ( $this->get_wc_payment_gateways() as $id => $payment_gateway ) {
+			if ( in_array( $id, $this->exclude_ids, true ) ) {
+				continue;
+			}
+
+			$step->add_payment_gateway(
+				$id,
+				$payment_gateway->get_title(),
+				$payment_gateway->get_description(),
+				$payment_gateway->is_available() ? 'yes' : 'no'
+			);
+		}
+
+		return $step;
+	}
+
+	public function get_wc_payment_gateways() {
+		return WC()->payment_gateways->payment_gateways();
+	}
+
+	/**
+	 * Get the step name
+	 *
+	 * @return string
+	 */
+	public function get_step_name() {
+		return SetWCPaymentGateways::get_step_name();
+	}
+
+	/**
+	 * Maybe hide WooCommerce Payments gateways
+	 *
+	 * @return void
+	 */
+	protected function maybe_hide_wcpay_gateways() {
+		if ( class_exists( 'WC_Payments' ) ) {
+			\WC_Payments::hide_gateways_on_settings_page();
+		}
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -1,0 +1,224 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+use Automattic\WooCommerce\Blueprint\Util;
+use WC_Admin_Settings;
+use WC_Settings_Page;
+
+/**
+ * Class ExportWCSettings
+ *
+ * This class exports WooCommerce settings and implements the StepExporter and HasAlias interfaces.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Exporters
+ */
+class ExportWCSettings implements StepExporter, HasAlias {
+	use UseWPFunctions;
+
+	/**
+	 * Array of WC_Settings_Page objects.
+	 *
+	 * @var WC_Settings_Page[]
+	 */
+	private array $setting_pages;
+
+	/**
+	 * Array of page IDs to exclude from export.
+	 *
+	 * @var array
+	 */
+	private array $exclude_pages = array( 'integration', 'site-visibility' );
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $setting_pages Optional array of setting pages.
+	 */
+	public function __construct( array $setting_pages = array() ) {
+		if ( empty( $setting_pages ) ) {
+			$setting_pages = WC_Admin_Settings::get_settings_pages();
+		}
+		$this->setting_pages = $setting_pages;
+		$this->wp_add_filter( 'wooblueprint_export_setttings', array( $this, 'add_site_visibility_setttings' ), 10, 3 );
+	}
+
+	/**
+	 * Export WooCommerce settings.
+	 *
+	 * @return SetSiteOptions
+	 */
+	public function export() {
+		$pages       = array();
+		$options     = array();
+		$option_info = array();
+
+		foreach ( $this->setting_pages as $page ) {
+			$id = $page->get_id();
+			if ( in_array( $id, $this->exclude_pages, true ) ) {
+				continue;
+			}
+			$pages[ $id ] = $this->get_page_info( $page );
+			foreach ( $pages[ $id ]['options'] as $option ) {
+				$options[ $option['id'] ]     = $option['value'];
+				$option_info[ $option['id'] ] = array(
+					'location' => $option['location'],
+					'title'    => $option['title'],
+				);
+			}
+			unset( $pages[ $id ]['options'] );
+		}
+
+		$filtered = $this->wp_apply_filters( 'wooblueprint_export_setttings', $options, $pages, $option_info );
+
+		$step = new SetSiteOptions( $filtered['options'] );
+		$step->set_meta_values(
+			array(
+				'plugin' => 'woocommerce',
+				'pages'  => $filtered['pages'],
+				'info'   => $option_info,
+				'alias'  => $this->get_alias(),
+			)
+		);
+
+		return $step;
+	}
+
+	/**
+	 * Get information about a settings page.
+	 *
+	 * @param WC_Settings_Page $page The settings page.
+	 * @return array
+	 */
+	protected function get_page_info( WC_Settings_Page $page ) {
+		$info = array(
+			'label'    => $page->get_label(),
+			'sections' => array(),
+		);
+
+		foreach ( $page->get_sections() as $id => $section ) {
+			$section_id                      = Util::camel_to_snake( strtolower( $section ) );
+			$info['sections'][ $section_id ] = array(
+				'label'       => $section,
+				'subsections' => array(),
+			);
+
+			$settings = $page->get_settings_for_section( $id );
+
+			// Get subsections.
+			$subsections = array_filter(
+				$settings,
+				function ( $setting ) {
+					return isset( $setting['type'] ) && 'title' === $setting['type'] && isset( $setting['title'] );
+				}
+			);
+
+			foreach ( $subsections as $subsection ) {
+				if ( ! isset( $subsection['id'] ) ) {
+					$subsection['id'] = Util::camel_to_snake( strtolower( $subsection['title'] ) );
+				}
+
+				$info['sections'][ $section_id ]['subsections'][ $subsection['id'] ] = array(
+					'label' => $subsection['title'],
+				);
+			}
+
+			// Get options.
+			$info['options'] = $this->get_page_section_settings( $settings, $page->get_id(), $section_id );
+		}
+		return $info;
+	}
+
+	/**
+	 * Get settings for a specific page section.
+	 *
+	 * @param array  $settings The settings.
+	 * @param string $page The page ID.
+	 * @param string $section The section ID.
+	 * @return array
+	 */
+	private function get_page_section_settings( $settings, $page, $section = '' ) {
+		$current_title = '';
+		$data          = array();
+		foreach ( $settings as $setting ) {
+			if ( 'sectionend' === $setting['type'] || 'slotfill_placeholder' === $setting['type'] || ! isset( $setting['id'] ) ) {
+				continue;
+			}
+
+			if ( 'title' === $setting['type'] ) {
+				$current_title = Util::camel_to_snake( strtolower( $setting['title'] ) );
+			} else {
+				$location = $page . '.' . $section;
+				if ( $current_title ) {
+					$location .= '.' . $current_title;
+				}
+
+				$data[] = array(
+					'id'       => $setting['id'],
+					'value'    => $this->wp_get_option( $setting['id'], $setting['default'] ?? null ),
+					'title'    => $setting['title'] ?? $setting['desc'] ?? '',
+					'location' => $location,
+				);
+			}
+		}
+		return $data;
+	}
+
+	/**
+	 * Add site visibility settings.
+	 *
+	 * @param array $options The options array.
+	 * @param array $pages The pages array.
+	 * @param array $option_info The option information array.
+	 * @return array
+	 */
+	public function add_site_visibility_setttings( array $options, array $pages, array $option_info ) {
+		$pages['site_visibility'] = array(
+			'label'    => 'Site Visibility',
+			'sections' => array(
+				'general' => array(
+					'label' => 'General',
+				),
+			),
+		);
+
+		$options['woocommerce_coming_soon']      = $this->wp_get_option( 'woocommerce_coming_soon' );
+		$options['woocommerce_store_pages_only'] = $this->wp_get_option( 'woocommerce_store_pages_only' );
+
+		$option_info['woocommerce_coming_soon'] = array(
+			'location' => 'site_visibilitty.general',
+			'title'    => 'Coming soon',
+		);
+
+		$option_info['woocommerce_store_pages_only'] = array(
+			'location' => 'site_visibilitty.general',
+			'title'    => 'Restrict to store pages only',
+		);
+
+		return compact( 'options', 'pages', 'option_info' );
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_name() {
+		return 'setSiteOptions';
+	}
+
+	/**
+	 * Get the alias for this exporter.
+	 *
+	 * @return string
+	 */
+	public function get_alias() {
+		return 'setWCSettings';
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -46,7 +46,7 @@ class ExportWCSettings implements StepExporter, HasAlias {
 			$setting_pages = WC_Admin_Settings::get_settings_pages();
 		}
 		$this->setting_pages = $setting_pages;
-		$this->wp_add_filter( 'wooblueprint_export_setttings', array( $this, 'add_site_visibility_setttings' ), 10, 3 );
+		$this->wp_add_filter( 'wooblueprint_export_settings', array( $this, 'add_site_visibility_settings' ), 10, 3 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -192,7 +192,7 @@ class ExportWCSettings implements StepExporter, HasAlias {
 		$options['woocommerce_store_pages_only'] = $this->wp_get_option( 'woocommerce_store_pages_only' );
 
 		$option_info['woocommerce_coming_soon'] = array(
-			'location' => 'site_visibilitty.general',
+			'location' => 'site_visibility.general',
 			'title'    => 'Coming soon',
 		);
 

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -178,7 +178,7 @@ class ExportWCSettings implements StepExporter, HasAlias {
 	 * @param array $option_info The option information array.
 	 * @return array
 	 */
-	public function add_site_visibility_setttings( array $options, array $pages, array $option_info ) {
+	public function add_site_visibility_settings( array $options, array $pages, array $option_info ) {
 		$pages['site_visibility'] = array(
 			'label'    => 'Site Visibility',
 			'sections' => array(

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -75,7 +75,7 @@ class ExportWCSettings implements StepExporter, HasAlias {
 			unset( $pages[ $id ]['options'] );
 		}
 
-		$filtered = $this->wp_apply_filters( 'wooblueprint_export_setttings', $options, $pages, $option_info );
+		$filtered = $this->wp_apply_filters( 'wooblueprint_export_settings', $options, $pages, $option_info );
 
 		$step = new SetSiteOptions( $filtered['options'] );
 		$step->set_meta_values(

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -197,7 +197,7 @@ class ExportWCSettings implements StepExporter, HasAlias {
 		);
 
 		$option_info['woocommerce_store_pages_only'] = array(
-			'location' => 'site_visibilitty.general',
+			'location' => 'site_visibility.general',
 			'title'    => 'Restrict to store pages only',
 		);
 

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
@@ -63,6 +63,10 @@ class ExportWCShipping implements StepExporter {
 			'locations' => get_option( 'pickup_location_pickup_locations', array() ),
 		);
 
+		if ( empty( $local_pickup['general'] ) ) {
+			$local_pickup['general'] = new \stdClass();
+		}
+
 		// Fetch shipping zones from the database.
 		$zones = $wpdb->get_results(
 			"

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
@@ -1,0 +1,130 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Steps\SetWCShipping;
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+
+/**
+ * Class ExportWCShipping
+ *
+ * This class exports WooCommerce shipping settings and implements the StepExporter interface.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Exporters
+ */
+class ExportWCShipping implements StepExporter {
+	/**
+	 * Export WooCommerce shipping settings.
+	 *
+	 * @return SetWCShipping
+	 */
+	public function export() {
+		global $wpdb;
+
+		// Fetch shipping classes from the database.
+		$classes = $wpdb->get_results(
+			"
+            SELECT *
+            FROM {$wpdb->prefix}term_taxonomy
+            WHERE taxonomy = 'product_shipping_class'
+        "
+		);
+
+		$term_ids = array();
+
+		// Collect term IDs.
+		foreach ( $classes as $term ) {
+			$term_ids[] = (int) $term->term_id;
+		}
+
+		$term_ids = implode( ', ', $term_ids );
+
+		// Fetch terms based on term IDs.
+		if ( ! empty( $term_ids ) ) {
+			$terms = $wpdb->get_results(
+				$wpdb->prepare(
+					"
+                SELECT *
+                FROM {$wpdb->prefix}terms
+                WHERE term_id IN (%s)
+      	  		",
+					$term_ids
+				)
+			);
+		} else {
+			$terms = array();
+		}
+
+
+		// Fetch local pickup settings.
+		$local_pickup = array(
+			'general'   => get_option( 'woocommerce_pickup_location_settings', array() ),
+			'locations' => get_option( 'pickup_location_pickup_locations', array() ),
+		);
+
+		// Fetch shipping zones from the database.
+		$zones = $wpdb->get_results(
+			"
+            SELECT *
+            FROM {$wpdb->prefix}woocommerce_shipping_zones
+        "
+		);
+
+		// Fetch shipping zone methods from the database.
+		$methods = $wpdb->get_results(
+			"
+            SELECT *
+            FROM {$wpdb->prefix}woocommerce_shipping_zone_methods
+        "
+		);
+
+		$methods_by_zone_id = array();
+
+		// Organize methods by zone ID.
+		foreach ( $methods as $method ) {
+			if ( ! isset( $methods_by_zone_id[ $method->zone_id ] ) ) {
+				$methods_by_zone_id[ $method->zone_id ] = array();
+			}
+			$methods_by_zone_id[ $method->zone_id ][] = $method->method_id;
+		}
+
+		// Fetch shipping zone locations from the database.
+		$locations = $wpdb->get_results(
+			"
+            SELECT *
+            FROM {$wpdb->prefix}woocommerce_shipping_zone_locations
+        "
+		);
+
+		$locations_by_zone_id = array();
+
+		// Organize locations by zone ID.
+		foreach ( $locations as $location ) {
+			if ( ! isset( $locations_by_zone_id[ $location->zone_id ] ) ) {
+				$locations_by_zone_id[ $location->zone_id ] = array();
+			}
+			$locations_by_zone_id[ $location->zone_id ][] = $location->location_id;
+		}
+
+		// Create a new SetWCShipping step with the fetched data.
+		$step = new SetWCShipping( $methods, $locations, $zones, $classes, $terms, $local_pickup );
+		$step->set_meta_values(
+			array(
+				'plugin' => 'woocommerce',
+			)
+		);
+
+		return $step;
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_name() {
+		return SetWCShipping::get_step_name();
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
@@ -57,7 +57,6 @@ class ExportWCShipping implements StepExporter {
 			$terms = array();
 		}
 
-
 		// Fetch local pickup settings.
 		$local_pickup = array(
 			'general'   => get_option( 'woocommerce_pickup_location_settings', array() ),

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
@@ -111,8 +111,9 @@ class ExportWCShipping implements StepExporter {
 			$locations_by_zone_id[ $location->zone_id ][] = $location->location_id;
 		}
 
+
 		// Create a new SetWCShipping step with the fetched data.
-		$step = new SetWCShipping( $methods, $locations, $zones, $classes, $terms, $local_pickup );
+		$step = new SetWCShipping( $methods, $locations, $zones, $terms, $classes, $local_pickup );
 		$step->set_meta_values(
 			array(
 				'plugin' => 'woocommerce',

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaskOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaskOptions.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Blueprint\Exporters\ExportsStep;
+use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+
+/**
+ * Class ExportWCTaskOptions
+ *
+ * This class exports WooCommerce task options and implements the StepExporter and HasAlias interfaces.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Exporters
+ */
+class ExportWCTaskOptions implements StepExporter, HasAlias {
+	use UseWPFunctions;
+
+	/**
+	 * Export WooCommerce task options.
+	 *
+	 * @return SetSiteOptions
+	 */
+	public function export() {
+		$step = new SetSiteOptions(
+			array(
+				'woocommerce_admin_customize_store_completed' => $this->wp_get_option( 'woocommerce_admin_customize_store_completed', 'no' ),
+				'woocommerce_task_list_tracked_completed_actions' => $this->wp_get_option( 'woocommerce_task_list_tracked_completed_actions', array() ),
+			)
+		);
+
+		$step->set_meta_values(
+			array(
+				'plugin' => 'woocommerce',
+				'alias'  => $this->get_alias(),
+			)
+		);
+
+		return $step;
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_name() {
+		return 'setOptions';
+	}
+
+	/**
+	 * Get the alias for this exporter.
+	 *
+	 * @return string
+	 */
+	public function get_alias() {
+		return 'setWCTaskOptions';
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaxRates.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaxRates.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Steps\SetWCTaxRates;
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+
+/**
+ * Class ExportWCTaxRates
+ *
+ * This class exports WooCommerce tax rates and implements the StepExporter interface.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Exporters
+ */
+class ExportWCTaxRates implements StepExporter {
+
+	/**
+	 * Export WooCommerce tax rates.
+	 *
+	 * @return SetWCTaxRates
+	 */
+	public function export() {
+		global $wpdb;
+
+		// Fetch tax rates from the database.
+		$rates = $wpdb->get_results(
+			"
+            SELECT *
+            FROM {$wpdb->prefix}woocommerce_tax_rates as tax_rates
+            ",
+			ARRAY_A
+		);
+
+		// Fetch tax rate locations from the database.
+		$locations = $wpdb->get_results(
+			"
+            SELECT *
+            FROM {$wpdb->prefix}woocommerce_tax_rate_locations as locations
+            ",
+			ARRAY_A
+		);
+
+		// Create a new SetWCTaxRates step with the fetched data.
+		$step = new SetWCTaxRates( $rates, $locations );
+		$step->set_meta_values(
+			array(
+				'plugin' => 'woocommerce',
+			)
+		);
+
+		return $step;
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_name() {
+		return 'setWCTaxRates';
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCPaymentGateways.php
@@ -51,6 +51,11 @@ class ImportSetWCPaymentGateways implements StepProcessor {
 		return $result;
 	}
 
+	/**
+	 * Return the payment gateways resgietered in WooCommerce
+	 *
+	 * @return string
+	 */
 	public function get_wc_payment_gateways() {
 		return WC()->payment_gateways->payment_gateways();
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCPaymentGateways.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Importers;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Steps\SetWCPaymentGateways;
+use Automattic\WooCommerce\Blueprint\StepProcessor;
+use Automattic\WooCommerce\Blueprint\StepProcessorResult;
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+
+/**
+ * Class ImportSetWCPaymentGateways
+ *
+ * This class imports WooCommerce payment gateways settings and implements the StepProcessor interface.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Importers
+ */
+class ImportSetWCPaymentGateways implements StepProcessor {
+	use UseWPFunctions;
+
+	/**
+	 * Process the import of WooCommerce payment gateways settings.
+	 *
+	 * @param object $schema The schema object containing import details.
+	 * @return StepProcessorResult
+	 */
+	public function process( $schema ): StepProcessorResult {
+		$result           = StepProcessorResult::success( SetWCPaymentGateways::get_step_name() );
+		$payment_gateways = $this->get_wc_payment_gateways();
+		$fields           = array( 'title', 'description', 'enabled' );
+
+		foreach ( $schema->payment_gateways as $id => $payment_gateway_data ) {
+			if ( ! isset( $payment_gateways[ $id ] ) ) {
+				$result->add_info( "Skipping {$id}. The payment gateway is not available" );
+				continue;
+			}
+
+			$payment_gateway = $payment_gateways[ $id ];
+
+			// Refer to https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-ajax.php#L3564.
+			foreach ( $fields as $field ) {
+				if ( isset( $payment_gateway_data->{$field} ) ) {
+					$payment_gateway->update_option( $field, $payment_gateway_data->{$field} );
+				}
+			}
+			$result->add_info( "{$id} has been updated." );
+			$this->wp_do_action( 'woocommerce_update_options' );
+		}
+
+		return $result;
+	}
+
+	public function get_wc_payment_gateways() {
+		return WC()->payment_gateways->payment_gateways();
+	}
+
+	/**
+	 * Get the class name for the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_class(): string {
+		return SetWCPaymentGateways::class;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
@@ -86,7 +86,7 @@ class ImportSetWCShipping implements StepProcessor {
 		}
 
 		if ( isset( $local_pickup->locations ) ) {
-			$local_pickup->locations = wp_json_encode( wp_json_encode( $local_pickup->locations ), true );
+			$local_pickup->locations = wp_json_decode( wp_json_encode( $local_pickup->locations ), true );
 			$this->wp_update_option( 'pickup_location_pickup_locations', $local_pickup->locations );
 		}
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
@@ -1,0 +1,101 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Importers;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Steps\SetWCShipping;
+use Automattic\WooCommerce\Blueprint\StepProcessor;
+use Automattic\WooCommerce\Blueprint\StepProcessorResult;
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+use WC_Tax;
+
+/**
+ * Class ImportSetWCShipping
+ *
+ * This class imports WooCommerce shipping settings and implements the StepProcessor interface.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Importers
+ */
+class ImportSetWCShipping implements StepProcessor {
+	use UseWPFunctions;
+	/**
+	 * Process the import of WooCommerce shipping settings.
+	 *
+	 * @param object $schema The schema object containing import details.
+	 * @return StepProcessorResult
+	 */
+	public function process( $schema ): StepProcessorResult {
+		$result = StepProcessorResult::success( SetWCShipping::get_step_name() );
+
+		$fields = array(
+			'terms'              => array( 'terms', array( '%d', '%s', '%s', '%d' ) ),
+			'classes'            => array( 'term_taxonomy', array( '%d', '%d', '%s', '%s', '%d', '%d' ) ),
+			'shipping_zones'     => array( 'woocommerce_shipping_zones', array( '%d', '%s', '%d' ) ),
+			'shipping_methods'   => array( 'woocommerce_shipping_zone_methods', array( '%d', '%d', '%s', '%d', '%d' ) ),
+			'shipping_locations' => array( 'woocommerce_shipping_zone_locations', array( '%d', '%d', '%s', '%s' ) ),
+		);
+
+		foreach ( $fields as $name => $data ) {
+			if ( isset( $schema->values->{$name} ) ) {
+				$this->insert( $data[0], $data[1], $schema->values->{$name} );
+			}
+		}
+
+		if ( isset( $schema->values->local_pickup ) ) {
+			$this->add_local_pickup( $schema->values->local_pickup );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Insert data into the specified table.
+	 *
+	 * @param string $table The table name.
+	 * @param array  $format The data format.
+	 * @param array  $rows The rows to insert.
+	 * @global \wpdb $wpdb WordPress database abstraction object.
+	 * @return array The IDs of the inserted rows.
+	 */
+	protected function insert( $table, $format, $rows ) {
+		global $wpdb;
+		$inserted_ids = array();
+		$table        = $wpdb->prefix . $table;
+		$format       = implode( ', ', $format );
+		foreach ( $rows as $row ) {
+			$row     = (array) $row;
+			$columns = implode( ', ', array_keys( $row ) );
+			// phpcs:ignore
+			$sql     = $wpdb->prepare( "REPLACE INTO $table ($columns) VALUES ($format)", $row );
+			// phpcs:ignore
+			$wpdb->query( $sql );
+		}
+		return $inserted_ids;
+	}
+
+	/**
+	 * Add local pickup settings.
+	 *
+	 * @param object $local_pickup The local pickup settings.
+	 */
+	private function add_local_pickup( $local_pickup ) {
+		if ( isset( $local_pickup->general ) ) {
+			$this->wp_update_option( 'woocommerce_pickup_location_settings', (array) $local_pickup->general );
+		}
+
+		if ( isset( $local_pickup->locations ) ) {
+			$local_pickup->locations = wp_json_decode( wp_json_encode( $local_pickup->locations ), true );
+			$this->wp_update_option( 'pickup_location_pickup_locations', $local_pickup->locations );
+		}
+	}
+
+	/**
+	 * Get the class name for the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_class(): string {
+		return SetWCShipping::class;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
@@ -19,6 +19,7 @@ use WC_Tax;
  */
 class ImportSetWCShipping implements StepProcessor {
 	use UseWPFunctions;
+
 	/**
 	 * Process the import of WooCommerce shipping settings.
 	 *

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
@@ -86,7 +86,7 @@ class ImportSetWCShipping implements StepProcessor {
 		}
 
 		if ( isset( $local_pickup->locations ) ) {
-			$local_pickup->locations = wp_json_decode( wp_json_encode( $local_pickup->locations ), true );
+			$local_pickup->locations = json_decode( wp_json_encode( $local_pickup->locations ), true );
 			$this->wp_update_option( 'pickup_location_pickup_locations', $local_pickup->locations );
 		}
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
@@ -86,7 +86,7 @@ class ImportSetWCShipping implements StepProcessor {
 		}
 
 		if ( isset( $local_pickup->locations ) ) {
-			$local_pickup->locations = wp_json_decode( wp_json_encode( $local_pickup->locations ), true );
+			$local_pickup->locations = wp_json_encode( wp_json_encode( $local_pickup->locations ), true );
 			$this->wp_update_option( 'pickup_location_pickup_locations', $local_pickup->locations );
 		}
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCShipping.php
@@ -47,7 +47,7 @@ class ImportSetWCShipping implements StepProcessor {
 				}
 
 				$this->insert( $data[0], $data[1], $insert_values );
-				// check if function with process_$name exist and call it
+				// check if function with process_$name exist and call it.
 				$method = 'post_process_' . $name;
 				if ( method_exists( $this, $method ) ) {
 					$this->$method( $schema->values->{$name} );
@@ -62,6 +62,13 @@ class ImportSetWCShipping implements StepProcessor {
 		return $result;
 	}
 
+	/**
+	 * Filter shipping methods data.
+	 *
+	 * @param array $methods The shipping methods.
+	 *
+	 * @return mixed
+	 */
 	protected function filter_shipping_methods_data( $methods ) {
 		return array_map(
 			function ( $method ) {
@@ -72,6 +79,13 @@ class ImportSetWCShipping implements StepProcessor {
 		);
 	}
 
+	/**
+	 * Post process shipping methods.
+	 *
+	 * @param array $methods The shipping methods.
+	 *
+	 * @return void
+	 */
 	protected function post_process_shipping_methods( $methods ) {
 		foreach ( $methods as $method ) {
 			if ( isset( $method->settings ) ) {

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRates.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRates.php
@@ -1,0 +1,124 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Importers;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Steps\SetWCTaxRates;
+use Automattic\WooCommerce\Blueprint\StepProcessor;
+use Automattic\WooCommerce\Blueprint\StepProcessorResult;
+use WC_Tax;
+
+/**
+ * Class ImportSetWCTaxRates
+ *
+ * This class imports WooCommerce tax rates and implements the StepProcessor interface.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Importers
+ */
+class ImportSetWCTaxRates implements StepProcessor {
+	/**
+	 * The result of the step processing.
+	 *
+	 * @var StepProcessorResult $result The result of the step processing.
+	 */
+	private StepProcessorResult $result;
+
+	/**
+	 * Process the import of WooCommerce tax rates.
+	 *
+	 * @param object $schema The schema object containing import details.
+	 * @return StepProcessorResult
+	 */
+	public function process( $schema ): StepProcessorResult {
+		$this->result = StepProcessorResult::success( SetWCTaxRates::get_step_name() );
+
+		foreach ( $schema->values->rates as $rate ) {
+			$this->add_rate( $rate );
+		}
+
+		foreach ( $schema->values->locations as $location ) {
+			$this->add_location( $location );
+		}
+
+		return $this->result;
+	}
+
+	/**
+	 * Check if a tax rate exists in the database.
+	 *
+	 * @param int $id The tax rate ID.
+	 * @global \wpdb $wpdb WordPress database abstraction object.
+	 * @return array|null The tax rate row if found, null otherwise.
+	 */
+	protected function exist( $id ) {
+		global $wpdb;
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				"
+                SELECT *
+                FROM {$wpdb->prefix}woocommerce_tax_rates
+                WHERE tax_rate_id = %d
+                ",
+				$id
+			),
+			ARRAY_A
+		);
+	}
+
+	/**
+	 * Add a tax rate to the database.
+	 *
+	 * @param object $rate The tax rate object.
+	 * @return int|false The tax rate ID if successfully added, false otherwise.
+	 */
+	protected function add_rate( $rate ) {
+		$tax_rate = (array) $rate;
+
+		if ( $this->exist( $tax_rate['tax_rate_id'] ) ) {
+			$this->result->add_info( "Tax rate with I.D {$tax_rate['tax_rate_id']} already exists. Skipped creating it." );
+			return false;
+		}
+
+		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
+
+		if ( isset( $rate->postcode ) ) {
+			$postcode = array_map( 'wc_clean', explode( ';', $rate->postcode ) );
+			$postcode = array_map( 'wc_normalize_postcode', $postcode );
+			WC_Tax::_update_tax_rate_postcodes( $tax_rate_id, $postcode );
+		}
+		if ( isset( $rate->city ) ) {
+			$cities = explode( ';', $rate->city );
+			WC_Tax::_update_tax_rate_cities( $tax_rate_id, array_map( 'wc_clean', array_map( 'wp_unslash', $cities ) ) );
+		}
+
+		return $tax_rate_id;
+	}
+
+	/**
+	 * Add a tax rate location to the database.
+	 *
+	 * @param object $location The location object.
+	 * @global \wpdb $wpdb WordPress database abstraction object.
+	 */
+	public function add_location( $location ) {
+		global $wpdb;
+		$location = (array) $location;
+		$columns  = implode( ',', array_keys( $location ) );
+		$format   = implode( ',', array( '%d', '%s', '%d', '%s' ) );
+		$table    = $wpdb->prefix . 'woocommerce_tax_rate_locations';
+		// phpcs:ignore
+		$sql      = $wpdb->prepare( "REPLACE INTO $table ($columns) VALUES ($format)", $location );
+		// phpcs:ignore
+		$wpdb->query( $sql );
+	}
+
+	/**
+	 * Get the class name for the step.
+	 *
+	 * @return string
+	 */
+	public function get_step_class(): string {
+		return SetWCTaxRates::class;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -4,7 +4,18 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Admin\Features\Blueprint;
 
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCCoreProfilerOptions;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCPaymentGateways;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettings;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCShipping;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCTaskOptions;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCTaxRates;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Importers\ImportSetWCPaymentGateways;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Importers\ImportSetWCShipping;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Importers\ImportSetWCTaxRates;
 use Automattic\WooCommerce\Admin\PageController;
+use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
+use Automattic\WooCommerce\Blueprint\StepProcessor;
 
 /**
  * Class Init
@@ -18,6 +29,16 @@ class Init {
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'init_rest_api' ) );
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'add_upload_nonce_to_settings' ) );
+
+		add_filter(
+			'wooblueprint_export_landingpage',
+			function () {
+				return 'admin.php?page=wc-admin';
+			}
+		);
+
+		add_filter( 'wooblueprint_exporters', array( $this, 'add_woo_exporters' ) );
+		add_filter( 'wooblueprint_importers', array( $this, 'add_woo_importers' ) );
 	}
 
 	/**
@@ -51,5 +72,44 @@ class Init {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Add Woo Specific Exporters.
+	 *
+	 * @param StepExporter[] $exporters Array of step exporters.
+	 *
+	 * @return StepExporter[]
+	 */
+	public function add_woo_exporters( array $exporters ) {
+		return array_merge(
+			$exporters,
+			array(
+				new ExportWCCoreProfilerOptions(),
+				new ExportWCSettings(),
+				new ExportWCPaymentGateways(),
+				new ExportWCShipping(),
+				new ExportWCTaskOptions(),
+				new ExportWCTaxRates(),
+			)
+		);
+	}
+
+	/**
+	 * Add Woo Specific Importers.
+	 *
+	 * @param StepProcessor[] $importers Array of step processors.
+	 *
+	 * @return array
+	 */
+	public function add_woo_importers( array $importers ) {
+		return array_merge(
+			$importers,
+			array(
+				new ImportSetWCPaymentGateways(),
+				new ImportSetWCShipping(),
+				new ImportSetWCTaxRates(),
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCPaymentGateways.php
@@ -1,0 +1,111 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Steps;
+
+use Automattic\WooCommerce\Blueprint\Steps\Step;
+
+/**
+ * Class SetWCPaymentGateways
+ *
+ * This class sets WooCommerce payment gateways and extends the Step class.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Steps
+ */
+class SetWCPaymentGateways extends Step {
+
+	/**
+	 * Payment gateways.
+	 *
+	 * @var array $payment_gateways Array of payment gateways.
+	 */
+	protected array $payment_gateways = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $payment_gateways Optional array of payment gateways.
+	 */
+	public function __construct( array $payment_gateways = array() ) {
+		$this->payment_gateways = $payment_gateways;
+	}
+
+	/**
+	 * Add a payment gateway.
+	 *
+	 * @param string $id The ID of the payment gateway.
+	 * @param string $title The title of the payment gateway.
+	 * @param string $description The description of the payment gateway.
+	 * @param string $enabled Whether the payment gateway is enabled ('yes' or 'no').
+	 */
+	public function add_payment_gateway( $id, $title, $description, $enabled ) {
+		$this->payment_gateways[ $id ] = array(
+			'title'       => $title,
+			'description' => $description,
+			'enabled'     => $enabled,
+		);
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public static function get_step_name() {
+		return 'setWCPaymentGateways';
+	}
+
+	/**
+	 * Get the schema for the step.
+	 *
+	 * @param int $version Optional version number of the schema.
+	 * @return array The schema array.
+	 */
+	public static function get_schema( $version = 1 ) {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'step'             => array(
+					'type' => 'string',
+					'enum' => array( 'setWCPaymentGateways' ),
+				),
+				'payment_gateways' => array(
+					'type'                 => 'object',
+					'patternProperties'    => array(
+						'^[a-zA-Z0-9_]+$' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'title'       => array(
+									'type' => 'string',
+								),
+								'description' => array(
+									'type' => 'string',
+								),
+								'enabled'     => array(
+									'type' => 'string',
+									'enum' => array( 'yes', 'no' ),
+								),
+							),
+							'required'   => array( 'title', 'description', 'enabled' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+			),
+			'required'   => array( 'step', 'payment_gateways' ),
+		);
+	}
+
+	/**
+	 * Prepare the JSON array for the step.
+	 *
+	 * @return array The JSON array.
+	 */
+	public function prepare_json_array() {
+		return array(
+			'step'             => static::get_step_name(),
+			'payment_gateways' => $this->payment_gateways,
+		);
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCPaymentGateways.php
@@ -52,7 +52,7 @@ class SetWCPaymentGateways extends Step {
 	 *
 	 * @return string
 	 */
-	public static function get_step_name() {
+	public static function get_step_name(): string {
 		return 'setWCPaymentGateways';
 	}
 
@@ -62,7 +62,7 @@ class SetWCPaymentGateways extends Step {
 	 * @param int $version Optional version number of the schema.
 	 * @return array The schema array.
 	 */
-	public static function get_schema( $version = 1 ) {
+	public static function get_schema( $version = 1 ): array {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
@@ -102,7 +102,7 @@ class SetWCPaymentGateways extends Step {
 	 *
 	 * @return array The JSON array.
 	 */
-	public function prepare_json_array() {
+	public function prepare_json_array(): array {
 		return array(
 			'step'             => static::get_step_name(),
 			'payment_gateways' => $this->payment_gateways,

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
@@ -1,0 +1,229 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Steps;
+
+use Automattic\WooCommerce\Blueprint\Steps\Step;
+
+/**
+ * Class SetWCShipping
+ *
+ * This class sets WooCommerce shipping settings and extends the Step class.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Steps
+ */
+class SetWCShipping extends Step {
+
+	/**
+	 * Shipping methods.
+	 *
+	 * @var array $methods Shipping methods.
+	 */
+	private array $methods;
+
+	/**
+	 * Shipping locations.
+	 *
+	 * @var array $locations Shipping locations.
+	 */
+	private array $locations;
+
+	/**
+	 * Shipping zones.
+	 *
+	 * @var array $zones Shipping zones.
+	 */
+	private array $zones;
+
+	/**
+	 * Shipping terms.
+	 * @var array $terms Shipping terms.
+	 */
+	private array $terms;
+
+	/**
+	 * Shipping classes.
+	 * @var array $classes Shipping classes.
+	 */
+	private array $classes;
+
+	/**
+	 * Local pickup settings.
+	 * @var array $local_pickup Local pickup settings.
+	 */
+	private array $local_pickup;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $methods Shipping methods.
+	 * @param array $locations Shipping locations.
+	 * @param array $zones Shipping zones.
+	 * @param array $terms Shipping terms.
+	 * @param array $classes Shipping classes.
+	 * @param array $local_pickup Local pickup settings.
+	 */
+	public function __construct( array $methods, array $locations, array $zones, array $terms, array $classes, array $local_pickup ) {
+		$this->methods      = $methods;
+		$this->locations    = $locations;
+		$this->zones        = $zones;
+		$this->terms        = $terms;
+		$this->classes      = $classes;
+		$this->local_pickup = $local_pickup;
+	}
+
+	/**
+	 * Prepare the JSON array for the step.
+	 *
+	 * @return array The JSON array.
+	 */
+	public function prepare_json_array() {
+		return array(
+			'step'   => static::get_step_name(),
+			'values' => array(
+				'methods'   => $this->methods,
+				'locations' => $this->locations,
+				'zones'     => $this->zones,
+				'terms'    => $this->terms,
+				'classes'  => $this->classes,
+				'local_pickup' => $this->local_pickup,
+			),
+		);
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public static function get_step_name() {
+		return 'setWCShipping';
+	}
+
+	/**
+	 * Get the schema for the step.
+	 *
+	 * @param int $version Optional version number of the schema.
+	 * @return array The schema array.
+	 */
+	public static function get_schema( $version = 1 ) {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'step'   => array(
+					'type' => 'string',
+					'enum' => array( static::get_step_name() ),
+				),
+				'values' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'classes'            => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'term_taxonomy_id' => array( 'type' => 'string' ),
+									'term_id'          => array( 'type' => 'string' ),
+									'taxonomy'         => array( 'type' => 'string' ),
+									'description'      => array( 'type' => 'string' ),
+									'parent'           => array( 'type' => 'string' ),
+									'count'            => array( 'type' => 'string' ),
+								),
+								'required'   => array( 'term_taxonomy_id', 'term_id', 'taxonomy', 'description', 'parent', 'count' ),
+							),
+						),
+						'terms'              => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'term_id'    => array( 'type' => 'string' ),
+									'name'       => array( 'type' => 'string' ),
+									'slug'       => array( 'type' => 'string' ),
+									'term_group' => array( 'type' => 'string' ),
+								),
+								'required'   => array( 'term_id', 'name', 'slug', 'term_group' ),
+							),
+						),
+						'local_pickup'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'general'   => array(
+									'type'       => 'object',
+									'properties' => array(
+										'enabled'    => array( 'type' => 'string' ),
+										'title'      => array( 'type' => 'string' ),
+										'tax_status' => array( 'type' => 'string' ),
+										'cost'       => array( 'type' => 'string' ),
+									),
+								),
+								'locations' => array(
+									'type'  => 'array',
+									'items' => array(
+										'type'       => 'object',
+										'properties' => array(
+											'name'    => array( 'type' => 'string' ),
+											'address' => array(
+												'type' => 'object',
+												'properties' => array(
+													'address_1' => array( 'type' => 'string' ),
+													'city' => array( 'type' => 'string' ),
+													'state' => array( 'type' => 'string' ),
+													'postcode' => array( 'type' => 'string' ),
+													'country' => array( 'type' => 'string' ),
+												),
+											),
+											'details' => array( 'type' => 'string' ),
+											'enabled' => array( 'type' => 'boolean' ),
+										),
+									),
+								),
+							),
+						),
+						'shipping_methods'   => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'zone_id'      => array( 'type' => 'string' ),
+									'instance_id'  => array( 'type' => 'string' ),
+									'method_id'    => array( 'type' => 'string' ),
+									'method_order' => array( 'type' => 'string' ),
+									'is_enabled'   => array( 'type' => 'string' ),
+								),
+								'required'   => array( 'zone_id', 'instance_id', 'method_id', 'method_order', 'is_enabled' ),
+							),
+						),
+						'shipping_locations' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'location_id'   => array( 'type' => 'string' ),
+									'zone_id'       => array( 'type' => 'string' ),
+									'location_code' => array( 'type' => 'string' ),
+									'location_type' => array( 'type' => 'string' ),
+								),
+								'required'   => array( 'location_id', 'zone_id', 'location_code', 'location_type' ),
+							),
+						),
+						'shipping_zones'     => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'zone_id'    => array( 'type' => 'string' ),
+									'zone_name'  => array( 'type' => 'string' ),
+									'zone_order' => array( 'type' => 'string' ),
+								),
+								'required'   => array( 'zone_id', 'zone_name', 'zone_order' ),
+							),
+						),
+					),
+				),
+			),
+			'required'   => array( 'step', 'values' ),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
@@ -85,11 +85,11 @@ class SetWCShipping extends Step {
 		return array(
 			'step'   => static::get_step_name(),
 			'values' => array(
-				'methods'   => $this->methods,
-				'locations' => $this->locations,
-				'zones'     => $this->zones,
-				'terms'    => $this->terms,
-				'classes'  => $this->classes,
+				'methods'      => $this->methods,
+				'locations'    => $this->locations,
+				'zones'        => $this->zones,
+				'terms'        => $this->terms,
+				'classes'      => $this->classes,
 				'local_pickup' => $this->local_pickup,
 			),
 		);

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
@@ -38,18 +38,21 @@ class SetWCShipping extends Step {
 
 	/**
 	 * Shipping terms.
+	 *
 	 * @var array $terms Shipping terms.
 	 */
 	private array $terms;
 
 	/**
 	 * Shipping classes.
+	 *
 	 * @var array $classes Shipping classes.
 	 */
 	private array $classes;
 
 	/**
 	 * Local pickup settings.
+	 *
 	 * @var array $local_pickup Local pickup settings.
 	 */
 	private array $local_pickup;

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
@@ -85,12 +85,12 @@ class SetWCShipping extends Step {
 		return array(
 			'step'   => static::get_step_name(),
 			'values' => array(
-				'shipping_methods'      => $this->methods,
-				'shipping_locations'    => $this->locations,
-				'shipping_zones'        => $this->zones,
-				'terms'        => $this->terms,
-				'classes'      => $this->classes,
-				'local_pickup' => $this->local_pickup,
+				'shipping_methods'   => $this->methods,
+				'shipping_locations' => $this->locations,
+				'shipping_zones'     => $this->zones,
+				'terms'              => $this->terms,
+				'classes'            => $this->classes,
+				'local_pickup'       => $this->local_pickup,
 			),
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
@@ -85,9 +85,9 @@ class SetWCShipping extends Step {
 		return array(
 			'step'   => static::get_step_name(),
 			'values' => array(
-				'methods'      => $this->methods,
-				'locations'    => $this->locations,
-				'zones'        => $this->zones,
+				'shipping_methods'      => $this->methods,
+				'shipping_locations'    => $this->locations,
+				'shipping_zones'        => $this->zones,
 				'terms'        => $this->terms,
 				'classes'      => $this->classes,
 				'local_pickup' => $this->local_pickup,

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCShipping.php
@@ -81,7 +81,7 @@ class SetWCShipping extends Step {
 	 *
 	 * @return array The JSON array.
 	 */
-	public function prepare_json_array() {
+	public function prepare_json_array(): array {
 		return array(
 			'step'   => static::get_step_name(),
 			'values' => array(
@@ -100,7 +100,7 @@ class SetWCShipping extends Step {
 	 *
 	 * @return string
 	 */
-	public static function get_step_name() {
+	public static function get_step_name(): string {
 		return 'setWCShipping';
 	}
 
@@ -110,7 +110,7 @@ class SetWCShipping extends Step {
 	 * @param int $version Optional version number of the schema.
 	 * @return array The schema array.
 	 */
-	public static function get_schema( $version = 1 ) {
+	public static function get_schema( $version = 1 ): array {
 		return array(
 			'type'       => 'object',
 			'properties' => array(

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCTaxRates.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCTaxRates.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types = 1);
+
+namespace Automattic\WooCommerce\Admin\Features\Blueprint\Steps;
+
+use Automattic\WooCommerce\Blueprint\Steps\Step;
+
+/**
+ * Class SetWCTaxRates
+ *
+ * This class sets WooCommerce tax rates and extends the Step class.
+ *
+ * @package Automattic\WooCommerce\Admin\Features\Blueprint\Steps
+ */
+class SetWCTaxRates extends Step {
+
+	/**
+	 * Tax rates.
+	 *
+	 * @var array $rates Tax rates.
+	 */
+	private array $rates;
+
+	/**
+	 * Tax rate locations.
+	 *
+	 * @var array $locations Tax rate locations.
+	 */
+	private array $locations;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $rates Tax rates.
+	 * @param array $locations Tax rate locations.
+	 */
+	public function __construct( array $rates, array $locations ) {
+		$this->rates     = $rates;
+		$this->locations = $locations;
+	}
+
+	/**
+	 * Prepare the JSON array for the step.
+	 *
+	 * @return array The JSON array.
+	 */
+	public function prepare_json_array() {
+		return array(
+			'step'   => static::get_step_name(),
+			'values' => array(
+				'rates'     => $this->rates,
+				'locations' => $this->locations,
+			),
+		);
+	}
+
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string
+	 */
+	public static function get_step_name() {
+		return 'setWCTaxRates';
+	}
+
+	/**
+	 * Get the schema for the step.
+	 *
+	 * @param int $version Optional version number of the schema.
+	 * @return array The schema array.
+	 */
+	public static function get_schema( $version = 1 ) {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'step'   => array(
+					'type' => 'string',
+					'enum' => array( static::get_step_name() ),
+				),
+				'values' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'rates'     => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'tax_rate_id'       => array( 'type' => 'string' ),
+									'tax_rate_country'  => array( 'type' => 'string' ),
+									'tax_rate_state'    => array( 'type' => 'string' ),
+									'tax_rate'          => array( 'type' => 'string' ),
+									'tax_rate_name'     => array( 'type' => 'string' ),
+									'tax_rate_priority' => array( 'type' => 'string' ),
+									'tax_rate_compound' => array( 'type' => 'string' ),
+									'tax_rate_shipping' => array( 'type' => 'string' ),
+									'tax_rate_order'    => array( 'type' => 'string' ),
+									'tax_rate_class'    => array( 'type' => 'string' ),
+								),
+								'required'   => array(
+									'tax_rate_id',
+									'tax_rate_country',
+									'tax_rate_state',
+									'tax_rate',
+									'tax_rate_name',
+									'tax_rate_priority',
+									'tax_rate_compound',
+									'tax_rate_shipping',
+									'tax_rate_order',
+									'tax_rate_class',
+								),
+							),
+						),
+						'locations' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'location_id'   => array( 'type' => 'string' ),
+									'location_code' => array( 'type' => 'string' ),
+									'tax_rate_id'   => array( 'type' => 'string' ),
+									'location_type' => array( 'type' => 'string' ),
+								),
+								'required'   => array( 'location_id', 'location_code', 'tax_rate_id', 'location_type' ),
+							),
+						),
+					),
+					'required'   => array( 'rates' ),
+				),
+			),
+			'required'   => array( 'step', 'values' ),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCTaxRates.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Steps/SetWCTaxRates.php
@@ -45,7 +45,7 @@ class SetWCTaxRates extends Step {
 	 *
 	 * @return array The JSON array.
 	 */
-	public function prepare_json_array() {
+	public function prepare_json_array(): array {
 		return array(
 			'step'   => static::get_step_name(),
 			'values' => array(
@@ -60,7 +60,7 @@ class SetWCTaxRates extends Step {
 	 *
 	 * @return string
 	 */
-	public static function get_step_name() {
+	public static function get_step_name(): string {
 		return 'setWCTaxRates';
 	}
 
@@ -70,7 +70,7 @@ class SetWCTaxRates extends Step {
 	 * @param int $version Optional version number of the schema.
 	 * @return array The schema array.
 	 */
-	public static function get_schema( $version = 1 ) {
+	public static function get_schema( $version = 1 ): array {
 		return array(
 			'type'       => 'object',
 			'properties' => array(

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRatesTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRatesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace php\src\Admin\Features\Blueprint\Importers;
+
+use Automattic\WooCommerce\Admin\Features\Blueprint\Importers\ImportSetWCTaxRates;
+use WC_Unit_Test_Case;
+
+class ImportSetWCTaxRatesTest extends WC_Unit_Test_Case {
+	public function test() {
+		$fixture  = json_decode( file_get_contents( __DIR__ . '/../fixtures/woo-blueprint-taxrates.json' ) );
+		$importer = new ImportSetWCTaxRates();
+		$importer->process( $fixture->steps[0] );
+
+		$this->assertTaxRate();
+		$this->assertLocations();
+	}
+
+	private function assertTaxRate() {
+		global $wpdb;
+		$rate = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = 1" );
+		$this->assertEquals( 'US', $rate->tax_rate_country );
+		$this->assertEquals( 'CA', $rate->tax_rate_state );
+		$this->assertEquals( '9.5000', $rate->tax_rate );
+		$this->assertEquals( 'Tax', $rate->tax_rate_name );
+		$this->assertEquals( '1', $rate->tax_rate_priority );
+		$this->assertEquals( '0', $rate->tax_rate_compound );
+		$this->assertEquals( '1', $rate->tax_rate_shipping );
+		$this->assertEquals( '0', $rate->tax_rate_order );
+		$this->assertEquals( '', $rate->tax_rate_class );
+	}
+
+	private function assertLocations() {
+		global $wpdb;
+		$locations = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = 1" );
+		$postcode  = $locations[0];
+		$city      = $locations[1];
+
+		$this->assertEquals( '90020', $postcode->location_code );
+		$this->assertEquals( 'LOS ANGELES', $city->location_code );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRatesTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRatesTest.php
@@ -5,8 +5,16 @@ namespace php\src\Admin\Features\Blueprint\Importers;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Importers\ImportSetWCTaxRates;
 use WC_Unit_Test_Case;
 
+/**
+ * Class ImportSetWCTaxRatesTest
+ */
 class ImportSetWCTaxRatesTest extends WC_Unit_Test_Case {
+	/**
+	 * Test tax rate import.
+	 * @return void
+	 */
 	public function test() {
+		// phpcs:ignore
 		$fixture  = json_decode( file_get_contents( __DIR__ . '/../fixtures/woo-blueprint-taxrates.json' ) );
 		$importer = new ImportSetWCTaxRates();
 		$importer->process( $fixture->steps[0] );
@@ -15,6 +23,10 @@ class ImportSetWCTaxRatesTest extends WC_Unit_Test_Case {
 		$this->assertLocations();
 	}
 
+	/**
+	 * Assert tax rate.
+	 * @return void
+	 */
 	private function assertTaxRate() {
 		global $wpdb;
 		$rate = $wpdb->get_row( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = 1" );
@@ -29,6 +41,10 @@ class ImportSetWCTaxRatesTest extends WC_Unit_Test_Case {
 		$this->assertEquals( '', $rate->tax_rate_class );
 	}
 
+	/**
+	 * Assert locations
+	 * @return void
+	 */
 	private function assertLocations() {
 		global $wpdb;
 		$locations = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = 1" );

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRatesTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Importers/ImportSetWCTaxRatesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1);
+
 namespace php\src\Admin\Features\Blueprint\Importers;
 
 use Automattic\WooCommerce\Admin\Features\Blueprint\Importers\ImportSetWCTaxRates;

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/fixtures/woo-blueprint-taxrates.json
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/fixtures/woo-blueprint-taxrates.json
@@ -1,0 +1,41 @@
+{
+  "landingPage": "admin.php?page=wc-admin",
+  "steps": [
+	{
+	  "step": "setWCTaxRates",
+	  "values": {
+		"rates": [
+		  {
+			"tax_rate_id": "1",
+			"tax_rate_country": "US",
+			"tax_rate_state": "CA",
+			"tax_rate": "9.5000",
+			"tax_rate_name": "Tax",
+			"tax_rate_priority": "1",
+			"tax_rate_compound": "0",
+			"tax_rate_shipping": "1",
+			"tax_rate_order": "0",
+			"tax_rate_class": ""
+		  }
+		],
+		"locations": [
+		  {
+			"location_id": "1",
+			"location_code": "90020",
+			"tax_rate_id": "1",
+			"location_type": "postcode"
+		  },
+		  {
+			"location_id": "2",
+			"location_code": "LOS ANGELES",
+			"tax_rate_id": "1",
+			"location_type": "city"
+		  }
+		]
+	  },
+	  "meta": {
+		"plugin": "woocommerce"
+	  }
+	}
+  ]
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the following exporters and importers.

| Exporter   | Checkbox Name        |
|--------|-------------------|
| WCCoreProfilerOptions |  Core Profiler Options   |
| WCPaymentGateways | Payment Gateways     |
| WCSettings | Settings      |
| WCShipping | Shipping     |
| WCTaskOptions | Task Options     |
| WCTaxRates | Tax rates     |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Exporter**
1. Create a new JN site with this branch.
2. Navigate to `Tools -> WCA Test Helper -> Features` and enable `blueprint`
3. Navigate to `WooCommerce -> Settings -> Advanced -> Blueprint`
4. Click on `Toggle selections` to uncheck all checkboxes.
5. We'll start with `WCCoreProfilerOptions`. 
6. Check `Core Profiler Options`
7. Click on the `Export` button. The default filename is `woo-blueprint.json`. Add 'core-profiler-options` at the end of the file.
8. Open the exported JSON file and confirm it has `Core Profiler Options` data.
9. Repeat the export for the rest exporters. You should have six JSON files.

*Importers*
1. Create another JN site with this branch.
2. Navigate to `Tools -> WCA Test Helper -> Features` and enable `blueprint`
3. Navigate to `WooCommerce -> Settings -> Advanced -> Blueprint`
4. Click on the `builder setup page` link.
5. Upload the exported JSON files one by one and confirm the values are imported.



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
