### PR TITLE
Hide main payment settings save changes button

### DIFF
--- a/plugins/woocommerce/changelog/fix-payment-settings-remove-save-changes-button
+++ b/plugins/woocommerce/changelog/fix-payment-settings-remove-save-changes-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide save changes button in main payments screen

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -55,18 +55,16 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	 */
 	public function output() {
 		//phpcs:disable WordPress.Security.NonceVerification.Recommended
-		global $current_section, $hide_save_button;
+		global $current_section;
 
 		// Load gateways so we can show any global options they may have.
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 
 		if ( $this->should_render_react_section( $current_section ) ) {
-			$hide_save_button = true;
 			$this->render_react_section( $current_section );
 		} elseif ( $current_section ) {
 			$this->render_classic_gateway_settings_page( $payment_gateways, $current_section );
 		} else {
-			$hide_save_button = true;
 			$this->render_react_section( 'main' );
 		}
 
@@ -90,6 +88,8 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 	 * @param string $section The section to render.
 	 */
 	private function render_react_section( $section ) {
+		global $hide_save_button;
+		$hide_save_button = true;
 		echo '<div id="experimental_wc_settings_payments_' . esc_attr( $section ) . '"></div>';
 	}
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways-react.php
@@ -66,6 +66,7 @@ class WC_Settings_Payment_Gateways_React extends WC_Settings_Page {
 		} elseif ( $current_section ) {
 			$this->render_classic_gateway_settings_page( $payment_gateways, $current_section );
 		} else {
+			$hide_save_button = true;
 			$this->render_react_section( 'main' );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR hides the `Save changes` button which is not intended to show for main payments screen

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/de2c5132-9379-46de-9ac4-9f569729c41e">


### How to test the changes in this Pull Request:

1. Turn on feature flag `reactify-classic-payments-settings`

### Test main component
1. Go to `WooCommerce > Settings > Payments`
1. Observe the `Save changes` button is not displayed
1. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=cod` and observe it shows cod form
2. Observe `Save changes` button is displayed
3. Update the title and click `Save changes`
4. Observe the page refreshes and the updated value is persisted

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
