### PR TITLE
CYS - Update the `show_on_front` setting to `posts`

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -128,6 +128,20 @@ const updateGlobalStylesWithDefaultValues = async (
 	);
 };
 
+const updateShowOnFront = async () => {
+	try {
+		await apiFetch( {
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: {
+				show_on_front: 'posts',
+			},
+		} );
+	} catch ( error ) {
+		throw error;
+	}
+};
+
 const installAndActivateTheme = async (
 	context: DesignWithoutAIStateMachineContext
 ) => {
@@ -281,4 +295,5 @@ export const services = {
 	installPatterns,
 	updateGlobalStylesWithDefaultValues,
 	enableTracking,
+	updateShowOnFront,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -213,6 +213,24 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 						},
 						type: 'parallel',
 						states: {
+							updateShowOnFront: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'updateShowOnFront',
+											onDone: {
+												target: 'success',
+											},
+											onError: {
+												actions:
+													'redirectToIntroWithError',
+											},
+										},
+									},
+									success: { type: 'final' },
+								},
+							},
 							installAndActivateTheme: {
 								initial: 'pending',
 								states: {

--- a/plugins/woocommerce/changelog/50083-49192-update-show-on-front-setting
+++ b/plugins/woocommerce/changelog/50083-49192-update-show-on-front-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+CYS - Update the "show_on_front" setting to "posts" to avoid overriding the "page" template.


### PR DESCRIPTION
This is needed for the CYS flow to work properly

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49192

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure all your templates in the TT4 theme are the default ones in `wp-admin/site-editor.php?postType=wp_template`. If they are not, reset each of them until they are.
2. Go to `wp-admin/options-reading.php` and make sure you select `A static page` and save.
![Screenshot 2024-07-29 at 13 52 04](https://github.com/user-attachments/assets/b5e336a9-cc1f-4f66-95c5-d233bf6d7b4c)
3. Go to `wp-admin/tools.php?page=woocommerce-admin-test-helper` and run the `Reset Customize Your Store` command.
3. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store` and click `Start designing`.
4. After the assembler loads go to `wp-admin/options-reading.php` and make sure the `Your homepage displays` is set to `Your latest posts`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS - Update the "show_on_front" setting to "posts" to avoid overriding the "page" template.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
