### PR TITLE
CYS: Fix opt-in flow fonts

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
@@ -14,7 +14,7 @@ import { SidebarNavigationScreenFooter } from './sidebar-navigation-screen-foote
 import { SidebarNavigationScreenHeader } from './sidebar-navigation-screen-header/sidebar-navigation-screen-header';
 import { SidebarNavigationScreenHomepage } from './sidebar-navigation-screen-homepage/sidebar-navigation-screen-homepage';
 import { SidebarNavigationScreenMain } from './sidebar-navigation-screen-main';
-import { SidebarNavigationScreenTypography } from './sidebar-navigation-screen-typography';
+import { SidebarNavigationScreenTypography } from './sidebar-navigation-screen-typography/sidebar-navigation-screen-typography';
 // import { SidebarNavigationScreenPages } from './sidebar-navigation-screen-pages';
 
 import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/fonts.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/utils/fonts.ts
@@ -1,0 +1,282 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { resolveSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FontFace,
+	FontFamiliesToInstall,
+	FontFamily,
+} from '~/customize-store/types/font';
+import { FONT_FAMILIES_TO_INSTALL } from '../sidebar/global-styles/font-pairing-variations/constants';
+
+export type FontCollectionsResponse = Array< {
+	slug: string;
+	description: string;
+	name: string;
+} >;
+
+export type FontCollectionResponse = {
+	slug: string;
+	name: string;
+	font_families: Array< {
+		font_family_settings: FontFamily;
+		categories: Array< string >;
+	} >;
+};
+
+const getInstalledFontFamilyByNameFontFamily = (
+	installedFontFamilies: Array< {
+		id: number;
+		font_family_settings: FontFamily;
+		font_face: Array< FontFace >;
+	} >,
+	nameFontFamily: string
+) => {
+	return installedFontFamilies.find(
+		( { font_family_settings } ) =>
+			font_family_settings.slug === nameFontFamily
+	);
+};
+
+const getFontFamiliesToInstall = (
+	fontCollection: FontCollectionResponse,
+	slugFontFamily: string,
+	fontFamilyToInstall: FontFamiliesToInstall[ 'slug' ]
+) => {
+	const fontFromCollection = fontCollection.font_families.find(
+		( { font_family_settings } ) =>
+			font_family_settings.slug === slugFontFamily
+	);
+
+	if ( ! fontFromCollection ) {
+		return null;
+	}
+
+	const fontFace = fontFromCollection?.font_family_settings.fontFace.filter(
+		( { fontWeight } ) =>
+			fontFamilyToInstall.fontWeights.includes( fontWeight )
+	);
+
+	const fontFamilyWithFontFace = {
+		...fontFromCollection?.font_family_settings,
+		fontFace,
+	};
+
+	return fontFamilyWithFontFace;
+};
+
+/**
+ * Retrieves font families and font faces to install based on a provided font collection and a list of installed font families.
+ * The fontFamilyWithFontFaceToInstall include fontFamilies with font faces that are not installed yet.
+ * The fontFaceToInstall include font faces that are not installed yet, but already have the font family installed.
+ *
+ * @param fontCollection        - The complete font collection containing all available font data.
+ * @param installedFontFamilies - An array of installed font families with associated font faces and settings.
+ * @return An object containing font families with font faces to install and individual font faces to install.
+ */
+export const getFontFamiliesAndFontFaceToInstall = (
+	fontCollection: FontCollectionResponse,
+	installedFontFamilies: Array< {
+		id: number;
+		font_face: Array< FontFace >;
+		font_family_settings: FontFamily;
+	} >
+) => {
+	return Object.entries( FONT_FAMILIES_TO_INSTALL ).reduce(
+		( acc, [ slug, fontData ] ) => {
+			const fontFamilyWithFontFaceToInstall = getFontFamiliesToInstall(
+				fontCollection,
+				slug,
+				fontData
+			);
+
+			if ( ! fontFamilyWithFontFaceToInstall ) {
+				return acc;
+			}
+
+			const fontFamily = getInstalledFontFamilyByNameFontFamily(
+				installedFontFamilies,
+				fontFamilyWithFontFaceToInstall.slug
+			);
+
+			if ( ! fontFamily ) {
+				return {
+					...acc,
+					fontFamiliesWithFontFacesToInstall: [
+						...acc.fontFamiliesWithFontFacesToInstall,
+						fontFamilyWithFontFaceToInstall,
+					],
+				};
+			}
+
+			const fontFace = fontFamily.font_face.filter( ( { fontWeight } ) =>
+				fontData.fontWeights.includes( fontWeight )
+			);
+
+			return {
+				...acc,
+				fontFacesToInstall: [
+					...acc.fontFacesToInstall,
+					...fontFace.map( ( face ) => ( {
+						...face,
+						fontFamilyId: fontFamily.id,
+					} ) ),
+				],
+			};
+		},
+		{
+			fontFamiliesWithFontFacesToInstall: [],
+			fontFacesToInstall: [],
+		} as {
+			fontFamiliesWithFontFacesToInstall: Array< FontFamily >;
+			fontFacesToInstall: Array<
+				FontFace & {
+					fontFamilyId: number;
+				}
+			>;
+		}
+	);
+};
+
+export const installFontFamily = ( data: FontFamily ) => {
+	const config = {
+		path: '/wp/v2/font-families',
+		method: 'POST',
+		data: {
+			font_family_settings: JSON.stringify( {
+				name: data.name,
+				slug: data.slug,
+				fontFamily: data.fontFamily,
+				preview: data.preview,
+			} ),
+		},
+	};
+
+	return apiFetch< {
+		id: number;
+		font_family_settings: string;
+	} >( config );
+};
+
+async function downloadFontFaceAssets( src: string ) {
+	try {
+		const fontBlob = await ( await fetch( new Request( src ) ) ).blob();
+		const fileName = src.split( '/' ).pop() as string;
+		return new File( [ fontBlob ], fileName, {
+			type: fontBlob.type,
+		} );
+	} catch ( error ) {
+		throw new Error( `Error downloading font face asset from ${ src }` );
+	}
+}
+
+function makeFontFacesFormData(
+	fontFaceFile: File,
+	formData: FormData,
+	index: number
+) {
+	const fileId = `file-${ index }`;
+	formData.append( fileId, fontFaceFile, fontFaceFile.name );
+	return fileId;
+}
+
+export const installFontFace = async (
+	data: FontFace & {
+		fontFamilyId: number;
+	},
+	index: number
+) => {
+	const { fontFamilyId, ...font } = data;
+	const fontFaceAssets = await downloadFontFaceAssets(
+		Array.isArray( font.src ) ? font.src[ 0 ] : font.src
+	);
+	const formData = new FormData();
+
+	const fontFile = await makeFontFacesFormData(
+		fontFaceAssets,
+		formData,
+		index
+	);
+
+	formData.append(
+		'font_face_settings',
+		JSON.stringify( { ...font, src: fontFile } )
+	);
+	const config = {
+		path: `/wp/v2/font-families/${ data.fontFamilyId }/font-faces/`,
+		method: 'POST',
+		body: formData,
+	};
+
+	return apiFetch( config );
+};
+
+export const installFontFamilies = async () => {
+	const installedFontFamily = ( await resolveSelect(
+		'core'
+	).getEntityRecords( 'postType', 'wp_font_family', {
+		per_page: -1,
+	} ) ) as Array< {
+		id: number;
+		font_faces: Array< number >;
+		font_family_settings: FontFamily;
+	} >;
+
+	const installedFontFamiliesWithFontFaces = await Promise.all(
+		installedFontFamily.map( async ( fontFamily ) => {
+			const fontFaces = await apiFetch< Array< FontFace > >( {
+				path: `/wp/v2/font-families/${ fontFamily.id }/font-faces`,
+				method: 'GET',
+			} );
+
+			return {
+				...fontFamily,
+				font_face: fontFaces,
+			};
+		} )
+	);
+
+	const fontCollection = await apiFetch< FontCollectionResponse >( {
+		path: `/wp/v2/font-collections/google-fonts`,
+		method: 'GET',
+	} );
+
+	const { fontFacesToInstall, fontFamiliesWithFontFacesToInstall } =
+		getFontFamiliesAndFontFaceToInstall(
+			fontCollection,
+			installedFontFamiliesWithFontFaces
+		);
+
+	const fontFamiliesWithFontFaceToInstallPromises =
+		fontFamiliesWithFontFacesToInstall.map( async ( fontFamily ) => {
+			const fontFamilyResponse = await installFontFamily( fontFamily );
+			return Promise.all(
+				fontFamily.fontFace.map( async ( fontFace, index ) => {
+					return installFontFace(
+						{
+							...fontFace,
+							fontFamilyId: fontFamilyResponse.id,
+						},
+						index
+					);
+				} )
+			);
+		} );
+
+	const fontFacesToInstallPromises =
+		fontFacesToInstall.map( installFontFace );
+
+	return ( await Promise.all( [
+		...fontFamiliesWithFontFaceToInstallPromises,
+		...fontFacesToInstallPromises,
+	] ) ) as Array<
+		Array< {
+			font_face_settings: FontFace;
+		} >
+	>;
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { Sender } from 'xstate';
-import apiFetch from '@wordpress/api-fetch';
-import { resolveSelect, dispatch } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch, resolveSelect } from '@wordpress/data';
+import { Sender } from 'xstate';
 // @ts-expect-error -- No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
@@ -15,24 +15,18 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { updateTemplate } from '../data/actions';
-import { HOMEPAGE_TEMPLATES } from '../data/homepageTemplates';
-import { installAndActivateTheme as setTheme } from '../data/service';
-import { THEME_SLUG } from '../data/constants';
-import { FontFace, FontFamily } from '../types/font';
-import {
-	FontCollectionResponse,
-	installFontFace,
-	installFontFamily,
-	getFontFamiliesAndFontFaceToInstall,
-} from './fonts';
 import { COLOR_PALETTES } from '../assembler-hub/sidebar/global-styles/color-palette-variations/constants';
 import {
 	FONT_PAIRINGS_WHEN_AI_IS_OFFLINE,
 	FONT_PAIRINGS_WHEN_USER_DID_NOT_ALLOW_TRACKING,
 } from '../assembler-hub/sidebar/global-styles/font-pairing-variations/constants';
-import { DesignWithoutAIStateMachineContext, Theme } from './types';
+import { updateTemplate } from '../data/actions';
+import { THEME_SLUG } from '../data/constants';
+import { HOMEPAGE_TEMPLATES } from '../data/homepageTemplates';
+import { installAndActivateTheme as setTheme } from '../data/service';
 import { trackEvent } from '../tracking';
+import { DesignWithoutAIStateMachineContext, Theme } from './types';
+import { installFontFamilies as installDefaultFontFamilies } from '../assembler-hub/utils/fonts';
 
 const assembleSite = async () => {
 	await updateTemplate( {
@@ -179,66 +173,7 @@ const installFontFamilies = async () => {
 	}
 
 	try {
-		const installedFontFamily = ( await resolveSelect(
-			'core'
-		).getEntityRecords( 'postType', 'wp_font_family', {
-			per_page: -1,
-		} ) ) as Array< {
-			id: number;
-			font_faces: Array< number >;
-			font_family_settings: FontFamily;
-		} >;
-
-		const installedFontFamiliesWithFontFaces = await Promise.all(
-			installedFontFamily.map( async ( fontFamily ) => {
-				const fontFaces = await apiFetch< Array< FontFace > >( {
-					path: `/wp/v2/font-families/${ fontFamily.id }/font-faces`,
-					method: 'GET',
-				} );
-
-				return {
-					...fontFamily,
-					font_face: fontFaces,
-				};
-			} )
-		);
-
-		const fontCollection = await apiFetch< FontCollectionResponse >( {
-			path: `/wp/v2/font-collections/google-fonts`,
-			method: 'GET',
-		} );
-
-		const { fontFacesToInstall, fontFamiliesWithFontFacesToInstall } =
-			getFontFamiliesAndFontFaceToInstall(
-				fontCollection,
-				installedFontFamiliesWithFontFaces
-			);
-
-		const fontFamiliesWithFontFaceToInstallPromises =
-			fontFamiliesWithFontFacesToInstall.map( async ( fontFamily ) => {
-				const fontFamilyResponse = await installFontFamily(
-					fontFamily
-				);
-				return Promise.all(
-					fontFamily.fontFace.map( async ( fontFace, index ) => {
-						installFontFace(
-							{
-								...fontFace,
-								fontFamilyId: fontFamilyResponse.id,
-							},
-							index
-						);
-					} )
-				);
-			} );
-
-		const fontFacesToInstallPromises =
-			fontFacesToInstall.map( installFontFace );
-
-		await Promise.all( [
-			...fontFamiliesWithFontFaceToInstallPromises,
-			...fontFacesToInstallPromises,
-		] );
+		await installDefaultFontFamilies();
 	} catch ( error ) {
 		throw error;
 	}

--- a/plugins/woocommerce/changelog/50086-fix-opt-in-fonts
+++ b/plugins/woocommerce/changelog/50086-fix-opt-in-fonts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+CYS: Improve opt-in flow fonts.

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -57,6 +57,13 @@ test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
 				'woocommerce_customize_store_onboarding_tour_hidden',
 				'yes'
 			);
+
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_allow_tracking',
+				'no'
+			);
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}
@@ -75,6 +82,13 @@ test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
 				request,
 				baseURL,
 				'woocommerce_admin_customize_store_completed',
+				'no'
+			);
+
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_allow_tracking',
 				'no'
 			);
 
@@ -208,5 +222,27 @@ test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
 
 		expect( isPrimaryFontUsed ).toBe( true );
 		expect( isSecondaryFontUsed ).toBe( true );
+	} );
+
+	test( 'Clicking opt-in new fonts should be available', async ( {
+		pageObject,
+	} ) => {
+		const assembler = await pageObject.getAssembler();
+
+		await assembler.getByText( 'Usage tracking' ).click();
+		await expect(
+			assembler.getByText( 'Access more patterns' )
+		).toBeVisible();
+
+		await assembler.getByRole( 'button', { name: 'Opt in' } ).click();
+
+		await assembler
+			.getByText( 'Access more fonts' )
+			.waitFor( { state: 'hidden' } );
+
+		const fontPickers = assembler.locator(
+			'.woocommerce-customize-store_global-styles-variations_item'
+		);
+		await expect( fontPickers ).toHaveCount( 10 );
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -231,7 +231,7 @@ test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
 
 		await assembler.getByText( 'Usage tracking' ).click();
 		await expect(
-			assembler.getByText( 'Access more patterns' )
+			assembler.getByText( 'Access more fonts' )
 		).toBeVisible();
 
 		await assembler.getByRole( 'button', { name: 'Opt in' } ).click();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49161


https://github.com/user-attachments/assets/c7e34585-dd4f-432d-9a69-4f75f36a3fd6



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that the tracking is disabled (`wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` -> enable tracking setting)
2. Head over to WooCommerce > Home > Customize your store.
3. Click on "Choose your fonts".
4. Ensure that you see only two font pairs.
5. Ensure that `Opt in to usage tracking to get access to more fonts.` is visible.
6. Click on `usage tracking`.
7. Ensure that the modal is visible.
8. Click on `Opt-in`.
9. Ensure that the modal is closed and other font pairs are visible.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Improve opt-in flow fonts.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>