### PR TITLE
[Product Editor] Attribute create term failed request causes unlimited loading state

### DIFF
--- a/packages/js/product-editor/changelog/fix-49402
+++ b/packages/js/product-editor/changelog/fix-49402
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unhandled promise rejection when creating an attribute term and the create request fails

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -317,7 +317,9 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 		} );
 
 		const newTerms = await Promise.all( promises );
-		const storedTerms = newTerms.filter( ( term ) => term !== undefined );
+		const storedTerms = newTerms.filter(
+			( term ) => term !== undefined
+		) as ProductAttributeTerm[];
 
 		// Remove the recently created terms from the temporary state,
 		setTemporaryTerms( ( prevTerms ) =>

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	createElement,
 	useEffect,
@@ -30,7 +31,6 @@ import type { MouseEventHandler } from 'react';
  */
 import AttributesComboboxControl from '../attribute-combobox-field';
 import type { AttributeTableRowProps } from './types';
-import { __ } from '@wordpress/i18n';
 
 interface FormTokenFieldProps extends CoreFormTokenField.Props {
 	__experimentalExpandOnFocus: boolean;
@@ -303,9 +303,13 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 				return newTerm;
 			} catch ( error ) {
 				dispatch( 'core/notices' ).createErrorNotice(
-					__(
-						`There was an error trying to create the term "${ token.value }".`,
-						'woocommerce'
+					sprintf(
+						/* translators: %s: the attribute term */
+						__(
+							'There was an error trying to create the attribute term "%s".',
+							'woocommerce'
+						),
+						token.value
 					)
 				);
 				return undefined;

--- a/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-table-row.tsx
@@ -12,7 +12,12 @@ import {
 	Button,
 	FormTokenField as CoreFormTokenField,
 } from '@wordpress/components';
-import { useSelect, useDispatch, select as sel } from '@wordpress/data';
+import {
+	useSelect,
+	useDispatch,
+	select as sel,
+	dispatch,
+} from '@wordpress/data';
 import { cleanForSlug } from '@wordpress/url';
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME,
@@ -25,6 +30,7 @@ import type { MouseEventHandler } from 'react';
  */
 import AttributesComboboxControl from '../attribute-combobox-field';
 import type { AttributeTableRowProps } from './types';
+import { __ } from '@wordpress/i18n';
 
 interface FormTokenFieldProps extends CoreFormTokenField.Props {
 	__experimentalExpandOnFocus: boolean;
@@ -281,22 +287,33 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 
 		// Create the new terms.
 		const promises = newTokens.map( async ( token ) => {
-			const newTerm = ( await createProductAttributeTerm(
-				{
-					name: token.value,
-					slug: token.slug,
-					attribute_id: attributeId,
-				},
-				{
-					optimisticQueryUpdate: selectItemsQuery,
-					optimisticUrlParameters: [ attributeId ],
-				}
-			) ) as ProductAttributeTerm;
+			try {
+				const newTerm = ( await createProductAttributeTerm(
+					{
+						name: token.value,
+						slug: token.slug,
+						attribute_id: attributeId,
+					},
+					{
+						optimisticQueryUpdate: selectItemsQuery,
+						optimisticUrlParameters: [ attributeId ],
+					}
+				) ) satisfies ProductAttributeTerm;
 
-			return newTerm;
+				return newTerm;
+			} catch ( error ) {
+				dispatch( 'core/notices' ).createErrorNotice(
+					__(
+						`There was an error trying to create the term "${ token.value }".`,
+						'woocommerce'
+					)
+				);
+				return undefined;
+			}
 		} );
 
 		const newTerms = await Promise.all( promises );
+		const storedTerms = newTerms.filter( ( term ) => term !== undefined );
 
 		// Remove the recently created terms from the temporary state,
 		setTemporaryTerms( ( prevTerms ) =>
@@ -324,7 +341,11 @@ export const AttributeTableRow: React.FC< AttributeTableRowProps > = ( {
 		);
 
 		// Call the callback to update the Form terms.
-		onTermsSelect( [ ...newSelectedTerms, ...newTerms ], index, attribute );
+		onTermsSelect(
+			[ ...newSelectedTerms, ...storedTerms ],
+			index,
+			attribute
+		);
 	}
 
 	/*


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49402

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable WooCommerce and enable the new product form in **Settings > Advanced > Features**
2. Go to **Products > Add new**
3. Go to the Organization or Variation tab.
4. Either **Add new** attributes or attribute options ( in variation tab ).
5. Select a an attribute
6. Open your network panel
7. Create a new term by typing something and hitting comma
8. Right click on the terms POST request and click block request URL
9. Now edit the blocked request and remove `?name=test6&slug=test6&_locale=user` part and replace it with `*`
10. Now create a new tag by typing a name and hitting comma 
11. The request will fail and you will see the unlimited loading state reported in https://github.com/woocommerce/woocommerce/issues/49402 is not longer happening
12. A new success notice should be shown notifying the user something went wrong while creating the new term.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
