### PR TITLE
[e2e tests] Updated docs with new pnpm commands

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-readme-pnpm-commands
+++ b/plugins/woocommerce/changelog/e2e-update-readme-pnpm-commands
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -38,7 +38,7 @@ Start in the repository root folder:
 - `pnpm --filter='@woocommerce/plugin-woocommerce' build` (builds WooCommerce locally)
 - `cd plugins/woocommerce` (changes into the WooCommerce plugin folder)
 - `pnpm env:start` (starts the `wp-env` based local environment)
-- `pnpm test:e2e-pw` (runs all the tests in headless mode)
+- `pnpm test:e2e` (runs all the tests in headless mode)
 
 To re-create the environment for a fresh state:
 
@@ -49,17 +49,17 @@ for managing the `wp-env` environment.
 
 Other ways of running tests (make sure you are in the `plugins/woocommerce` folder):
 
-- `pnpm test:e2e-pw` (usual, headless run)
-- `pnpm test:e2e-pw --headed` (headed -- displaying browser window and test interactions)
-- `pnpm test:e2e-pw --debug` (runs tests in debug mode)
-- `pnpm test:e2e-pw ./tests/e2e-pw/tests/**/basic.spec.js` (runs a single test file - `basic.spec.js` in this case)
-- `pnpm test:e2e-pw --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode)). You may need
+- `pnpm test:e2e` (usual, headless run)
+- `pnpm test:e2e --headed` (headed -- displaying browser window and test interactions)
+- `pnpm test:e2e --debug` (runs tests in debug mode)
+- `pnpm test:e2e ./tests/e2e-pw/tests/**/basic.spec.js` (runs a single test file - `basic.spec.js` in this case)
+- `pnpm test:e2e --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode)). You may need
   to increase the [test timeout](https://playwright.dev/docs/api/class-testconfig#test-config-timeout) by setting
   the `DEFAULT_TIMEOUT_OVERRIDE` environment variable like so:
 
     ```bash
     # Increase test timeout to 3 minutes
-    export DEFAULT_TIMEOUT_OVERRIDE=180000 pnpm test:e2e-pw --ui
+    export DEFAULT_TIMEOUT_OVERRIDE=180000 pnpm test:e2e --ui
     ```
 
 To see all the Playwright options, make sure you are in the `plugins/woocommerce` folder and
@@ -91,6 +91,8 @@ CUSTOMER_PASSWORD='customer.password'
 There are some pre-defined environments set in the `tests/e2e-pw/envs` path.
 Each folder represents an environment, and contains a setup script, a `playwright.config.js` file and optionally an
 encrypted `.env` file.
+Running the tests with one of these environments will decrypt the `.env.enc` file if it exists, execute the setup 
+script and then run the tests using the configuration in the `playwright.config.js` file.
 
 To run the tests using one of these environment, you can use the `test:e2e:with-env` script. Some examples:
 
@@ -104,14 +106,12 @@ pnpm test:e2e:with-env gutenberg-stable
 # The envs/default-pressable/.env.enc file will be decrypted into .env and used to set the required environment variables
 pnpm test:e2e:with-env default-pressable
 
-# Runs all the tests with the default environment, similar to running `pnpm test:e2e-pw`
+# Runs all the tests with the default environment. `pnpm test:e2e` already does that, but only runs e2e, ignoring the API tests.
 pnpm test:e2e:with-env default 
 ```
 
-Some of the environments are using encrypted `.env` files.
-To run command includes a decryption step, which requires the `E2E_ENV_KEY` environment variable to be set.
+To decrypt the .env file, the `E2E_ENV_KEY` environment variable must be set.
 If you're an a11n you can find the key in the Secret Store.
-
 Run with the `E2E_ENV_KEY` environment variable set:
 
 ```bash


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the e2e tests readme.
https://github.com/woocommerce/woocommerce/pull/50024 removed the `test:e2e-pw` scripts but the docs still reference them. 


### How to test the changes in this Pull Request:

Check the updated docs.

