### PR TITLE
Remove changelog file that was created for `9.1.4`

### DIFF
--- a/plugins/woocommerce/changelog/fix-woocommerce_product_add_to_cart_text-filter-core-approach
+++ b/plugins/woocommerce/changelog/fix-woocommerce_product_add_to_cart_text-filter-core-approach
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Enhance escaping for block attributes


### PR DESCRIPTION
We have a stray changelog file in the `trunk` branch. To keep things tidy, let's remove it.