### PR TITLE
Remove WP 6.6 hardcoded version from WC Blocks e2e tests

### DIFF
--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,4 @@
 {
-	"core": "https://wordpress.org/wordpress-6.6-RC2.zip",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/wordpress-importer.0.8.zip",

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -99,27 +99,17 @@ export class Editor extends CoreEditor {
 		templateName: string;
 	} ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+		await this.page.getByLabel( templateName, { exact: true } ).click();
 
 		const resetNotice = this.page
 			.getByLabel( 'Dismiss this notice' )
 			.getByText( `"${ templateName }" reset.` );
-		const savedButton = this.page.getByRole( 'button', {
-			name: 'Saved',
-		} );
 
-		// Wait until search has finished.
-		const searchResults = this.page.getByLabel( 'Actions' );
-		const initialSearchResultsCount = await searchResults.count();
-		await expect
-			.poll( async () => await searchResults.count() )
-			.toBeLessThan( initialSearchResultsCount );
-
-		await searchResults.first().click();
+		await this.page.getByLabel( 'Actions' ).click();
 		await this.page.getByRole( 'menuitem', { name: 'Reset' } ).click();
 		await this.page.getByRole( 'button', { name: 'Reset' } ).click();
 
 		await expect( resetNotice ).toBeVisible();
-		await expect( savedButton ).toBeVisible();
 	}
 
 	async publishAndVisitPost() {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -74,19 +74,13 @@ export class Editor extends CoreEditor {
 
 	async revertTemplateCreation( templateName: string ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+		await this.page.getByLabel( templateName, { exact: true } ).click();
 
 		const deletedNotice = this.page
 			.getByLabel( 'Dismiss this notice' )
 			.getByText( `"${ templateName }" deleted.` );
 
-		// Wait until search has finished.
-		const searchResults = this.page.getByLabel( 'Actions' );
-		const initialSearchResultsCount = await searchResults.count();
-		await expect
-			.poll( async () => await searchResults.count() )
-			.toBeLessThan( initialSearchResultsCount );
-
-		await searchResults.first().click();
+		await this.page.getByLabel( 'Actions' ).click();
 		await this.page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 		await this.page.getByRole( 'button', { name: 'Delete' } ).click();
 

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-e2e-tests-wp-version
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-e2e-tests-wp-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Remove WP 6.6 hardcoded version from WC Blocks e2e tests
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove the hardcoded WP 6.6 version from WC Blocks e2e tests now that WP 6.6 has been released.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

_(No need to test when testing the release)_

1. Make sure e2e tests pass.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
