### PR TITLE
Always count variations without price

### DIFF
--- a/packages/js/product-editor/changelog/fix-49345_save_product_check_for_variations
+++ b/packages/js/product-editor/changelog/fix-49345_save_product_check_for_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Always count variations without price #50129

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/edit.tsx
@@ -80,19 +80,14 @@ export function Edit( {
 			);
 
 			return {
-				totalCountWithoutPrice:
-					isInSelectedTab && productHasOptions
-						? getProductVariationsTotalCount< number >(
-								totalCountWithoutPriceRequestParams
-						  )
-						: 0,
+				totalCountWithoutPrice: productHasOptions
+					? getProductVariationsTotalCount< number >(
+							totalCountWithoutPriceRequestParams
+					  )
+					: 0,
 			};
 		},
-		[
-			isInSelectedTab,
-			productHasOptions,
-			totalCountWithoutPriceRequestParams,
-		]
+		[ productHasOptions, totalCountWithoutPriceRequestParams ]
 	);
 
 	const {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a bug added as a side effect of [this PR](https://github.com/woocommerce/woocommerce/pull/47360). 

We were calculating the number of variations without price only when we [were viewing them](https://github.com/woocommerce/woocommerce/pull/50129/files#diff-a9b3670d49e49642bb33fe7ae43df2fa70dfaaf48e3d378fad59b34e0c21e8b2L84). This PR removes that restriction because we shouldn't create a product with variations without price.

The validation will fail if we **publish a product** and there is:
- one or more variations without a price
- [the notice](https://github.com/user-attachments/assets/d373a494-60c2-4f25-9b48-f4786b040ce0) hasn't been dismissed
- The product hasn't already been published.
- We are publishing the product.

_Remember that we only check this when publishing the product._

![Screenshot 2024-07-30 at 9 15 27 AM](https://github.com/user-attachments/assets/f1934759-b3c4-4514-8e2e-c81daa0d45d8)

Closes #49345.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Products > Add New
3. Add a product name
4. Go to the Variations tab and add some variations.
5. You will see a message like this, don't dismiss it.

![Screenshot 2024-07-30 at 9 17 37 AM](https://github.com/user-attachments/assets/d373a494-60c2-4f25-9b48-f4786b040ce0)

6. Press Publish.
7. You will see a snackbar showing the error: `Set variation prices before adding this product.`.
8. Go to another tab and press Publish again.
9. The same snackbar will pop up, but now it'll also have a link saying `View error` that points you right to the Variations tab.
10. Go ahead and dismiss the message shown in step 5 and press Publish.
11. You won't see the error anymore. If there aren't any errors, the product will be published.
12. After publishing the product, go to the Variations tab.
13. Remove the variations you created before and add new variations.
14. Add another change, like adding a Summary in the General tab, and press Update.
15. The product should be updated successfully. 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
