### PR TITLE
Text adjustments on shipping zones settings page

### DIFF
--- a/plugins/woocommerce/changelog/50136-update-46209-text-adjustments-on-shipping-zones-settings-page
+++ b/plugins/woocommerce/changelog/50136-update-46209-text-adjustments-on-shipping-zones-settings-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Text adjustments on shipping zones settings page

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -8,7 +8,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<span><?php esc_html_e( 'Shipping zones', 'woocommerce' ); ?></span>
 	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=new' ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add zone', 'woocommerce' ); ?></a>
 </h2>
-<p class="wc-shipping-zone-heading-help-text"><?php echo esc_html_e( 'A shipping zone consists of the region(s) you\'d like to ship to and the shipping method(s) offered. A shopper can only be matched to one zone, and we\'ll use their shipping address to show them the methods available in their area.', 'woocommerce' ); ?></p>
+<p class="wc-shipping-zone-heading-help-text">
+	<?php
+	echo wp_kses_post(
+		sprintf(
+			__(
+				"A shipping zone consists of the region(s) you'd like to ship to and the shipping method(s) offered. A shopper can only be matched to one zone, and we'll use their shipping address to show them the methods available in their area. To offer local pickup, configure your pickup locations in the <a href='%s'>local pickup settings</a>.",
+				'woocommerce'
+			),
+			esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=pickup_location' ) )
+		)
+	);
+	?>
+</p>
 <table class="wc-shipping-zones widefat">
 	<thead>
 		<tr>
@@ -59,7 +71,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<p class="main"><?php _e( 'A shipping zone is a geographic region where a certain set of shipping methods and rates apply.', 'woocommerce' ); ?></p>
 				<p><?php _e( 'For example:', 'woocommerce' ); ?></p>
 				<ul>
-					<li><?php _e( 'Local zone = California ZIP 90210 = Local pickup', 'woocommerce' ); ?>
 					<li><?php _e( 'US domestic zone = All US states = Flat rate shipping', 'woocommerce' ); ?>
 					<li><?php _e( 'Europe zone = Any country in Europe = Flat rate shipping', 'woocommerce' ); ?>
 				</ul>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php
 	echo wp_kses_post(
 		sprintf(
+			/* translators: %s: URL to local pickup settings */
 			__(
 				"A shipping zone consists of the region(s) you'd like to ship to and the shipping method(s) offered. A shopper can only be matched to one zone, and we'll use their shipping address to show them the methods available in their area. To offer local pickup, configure your pickup locations in the <a href='%s'>local pickup settings</a>.",
 				'woocommerce'
@@ -68,13 +69,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php if ( 0 === $method_count ) : ?>
 		<tr>
 			<td class="wc-shipping-zones-blank-state" colspan="5">
-				<p class="main"><?php _e( 'A shipping zone is a geographic region where a certain set of shipping methods and rates apply.', 'woocommerce' ); ?></p>
-				<p><?php _e( 'For example:', 'woocommerce' ); ?></p>
+				<p class="main"><?php esc_html_e( 'A shipping zone is a geographic region where a certain set of shipping methods and rates apply.', 'woocommerce' ); ?></p>
+				<p><?php esc_html_e( 'For example:', 'woocommerce' ); ?></p>
 				<ul>
-					<li><?php _e( 'US domestic zone = All US states = Flat rate shipping', 'woocommerce' ); ?>
-					<li><?php _e( 'Europe zone = Any country in Europe = Flat rate shipping', 'woocommerce' ); ?>
+					<li><?php esc_html_e( 'US domestic zone = All US states = Flat rate shipping', 'woocommerce' ); ?>
+					<li><?php esc_html_e( 'Europe zone = Any country in Europe = Flat rate shipping', 'woocommerce' ); ?>
 				</ul>
-				<p><?php _e( 'Add as many zones as you need &ndash; customers will only see the methods available for their address.', 'woocommerce' ); ?></p>
+				<p><?php esc_html_e( 'Add as many zones as you need &ndash; customers will only see the methods available for their address.', 'woocommerce' ); ?></p>
 				<a class="button button-primary wc-shipping-zone-add" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=new' ) ); ?>"><?php _e( 'Add shipping zone', 'woocommerce' ); ?></a>
 			</td>
 		</tr>
@@ -106,9 +107,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="wc-backbone-modal-content">
 			<section class="wc-backbone-modal-main" role="main">
 				<header class="wc-backbone-modal-header">
-					<h1><?php _e( 'Add shipping method', 'woocommerce' ); ?></h1>
+					<h1><?php esc_html_e( 'Add shipping method', 'woocommerce' ); ?></h1>
 					<button class="modal-close modal-close-link dashicons dashicons-no-alt">
-						<span class="screen-reader-text"><?php _e( 'Close modal panel', 'woocommerce' ); ?></span>
+						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
 					</button>
 				</header>
 				<article>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the following changes to the shipping zones settings page:

- Update the text _"A shipping zone consists of the region(s) you'd like to ship to and the shipping method(s) offered. A shopper can only be matched to one zone, and we'll use their shipping address to show them the methods available in their area. To offer local pickup, configure your pickup locations in the [local pickup settings]."_ to reference to the local pickup settings.
- Remove the text _"Local zone = California ZIP 90210 = Local pickup"_ from the main screen that is visible when no shipping zones and no shipping methods have been created/enabled yet.

Closes #46209.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section`.
2. Delete all shipping methods, if any shipping methods are available.
3. Verify that the text below the shipping zone page title reads:
> A shipping zone consists of the region(s) you'd like to ship to and the shipping method(s) offered. A shopper can only be matched to one zone, and we'll use their shipping address to show them the methods available in their area. To offer local pickup, configure your pickup locations in the [local pickup settings](https://store.test/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location).
4. Verify that the link `local pickup settings` points to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location`.
5. Verify that the following text is no longer available on the main screen:
> Local zone = California ZIP 90210 = Local pickup

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1337" alt="Screenshot 2024-07-30 at 16 14 00" src="https://github.com/user-attachments/assets/f330acd6-e58c-4180-aba9-78a2b9b36dba">
</td>
<td valign="top">After:
<br><br>
<img width="1338" alt="Screenshot 2024-07-30 at 16 13 41" src="https://github.com/user-attachments/assets/4b544f2b-09b2-46b5-9800-cdbce248eb50">
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Text adjustments on shipping zones settings page

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
