### PR TITLE
Product Block Editor: clicking outside of the attribute modal triggers an error

### DIFF
--- a/packages/js/product-editor/changelog/fix-46638
+++ b/packages/js/product-editor/changelog/fix-46638
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix clicking outside of the attribute modal triggers an error

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -363,7 +363,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 									| React.MouseEvent< Element >
 									| React.FocusEvent< Element >
 							) => {
-								if ( ! event.isPropagationStopped() ) {
+								if ( ! event?.isPropagationStopped() ) {
 									onCancel();
 								}
 							} }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #46638

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable WooCommerce and enable the new product form in **Settings > Advanced > Features**
2. Go to **Products > Add new**
3. Go to the Organization or Variation tab.
4. Either **Add new** attributes or attribute options ( in variation tab ).
5. A modal to add an attribute should be shown.
6. When clicking outside of the modal, it should be closed without any error. And the following error from the devtools console should not be shown anymore 
![image](https://github.com/user-attachments/assets/5eea2e85-dcf1-446f-a753-93b8c6d6b9af)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
