### PR TITLE
Skip WC_Admin_Tests_PaymentGatewaySuggestions_Init::test_empty_suggestions

### DIFF
--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -165,6 +165,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 	 * Test that empty suggestions are replaced with defaults.
 	 */
 	public function test_empty_suggestions() {
+		$this->markTestSkipped('Skipped in release/9.1 due to a breaking change in an external resource. Will be fixed in trunk.');
 		set_transient(
 			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
 			array(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -165,7 +165,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 	 * Test that empty suggestions are replaced with defaults.
 	 */
 	public function test_empty_suggestions() {
-		$this->markTestSkipped('Skipped in release/9.1 due to a breaking change in an external resource. Will be fixed in trunk.');
+		$this->markTestSkipped( 'Skipped in release/9.1 due to a breaking change in an external resource. Will be fixed in trunk.' );
 		set_transient(
 			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
 			array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: p1722336175503569-slack-C060B25RT41

`WC_Admin_Tests_PaymentGatewaySuggestions_Init::test_empty_suggestion` is broken because of a change in an external resource.

### How to test the changes in this Pull Request:

Check PHP unit tests. `WC_Admin_Tests_PaymentGatewaySuggestions_Init::test_empty_suggestion` should be skipped.

