### PR TITLE
[testing workflows] Use choices for on-demand test run input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
         type: string
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.ref }}'
+  group: '${{ github.workflow }}-${{ github.ref }}-${{ inputs.trigger }}'
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -8,7 +8,6 @@ on:
         description: 'Event name: it will be used to filter the jobs to run in ci.yml.'
         required: true
         options:
-          - pull_request
           - push
           - daily-checks
           - pre-release

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -4,11 +4,32 @@ on:
   workflow_dispatch:
     inputs:
       trigger:
+        type: choice
         description: 'Event name. It will be used to filter the jobs to run in ci.yml. It can be anything, as long as the job you want to run has this event configured in the `events` list. Example: daily-checks, pull_request, on-demand, etc.'
         required: true
-        default: ''
+        options:
+          - pull_request
+          - push
+          - daily-checks
+          - pre-release
+          - on-demand
+          - custom
+        default: on-demand
+      custom-trigger:
+        type: string
+        description: 'Custom event name. In case the `trigger` is set to `custom`, this field is required.'
+        required: false
 
 jobs:
+  validate-input:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check inputs'
+        run: |
+          if [ "${{ inputs.trigger }}" == "custom" ] && [ -z "${{ inputs.custom-trigger }}" ]; then
+            echo "Custom trigger is required when trigger is set to custom."
+            exit 1
+          fi
   run-tests:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -19,10 +19,6 @@ on:
         type: string
         description: 'Custom event name. In case the `Event name` choice is `custom`, this field is required.'
         required: false
-        
-concurrency:
-  group: ${{ inputs.trigger }}-${{ inputs.custom-trigger }}
-  cancel-in-progress: true
 
 jobs:
   validate-input:

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -19,6 +19,10 @@ on:
         type: string
         description: 'Custom event name. In case the `Event name` choice is `custom`, this field is required.'
         required: false
+        
+concurrency:
+  group: ${{ inputs.trigger }}-${{ inputs.custom-trigger }}
+  cancel-in-progress: true
 
 jobs:
   validate-input:

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -17,19 +17,26 @@ on:
         default: on-demand
       custom-trigger:
         type: string
-        description: 'Custom event name. In case the `trigger` choice is `custom`, this field is required.'
+        description: 'Custom event name. In case the `Event name` choice is `custom`, this field is required.'
         required: false
 
 jobs:
   validate-input:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Check inputs'
+      - name: 'Validate trigger event'
         run: |
           if [ "${{ inputs.trigger }}" == "custom" ] && [ -z "${{ inputs.custom-trigger }}" ]; then
             echo "Custom trigger is required when trigger is set to custom."
             exit 1
           fi
+          
+          if [ "${{ inputs.trigger }}" == "custom" ]; then
+            echo "TRIGGER=${{ inputs.custom-trigger }}" >> $GITHUB_ENV
+          else
+            echo "TRIGGER=${{ inputs.trigger }}" >> $GITHUB_ENV
+          fi
+
   run-tests:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -28,22 +28,16 @@ jobs:
   validate-input:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Validate trigger event'
+      - name: 'Validate input'
         run: |
           if [ "${{ inputs.trigger }}" == "custom" ] && [ -z "${{ inputs.custom-trigger }}" ]; then
             echo "Custom trigger is required when trigger is set to custom."
             exit 1
-          fi
-          
-          if [ "${{ inputs.trigger }}" == "custom" ]; then
-            echo "TRIGGER=${{ inputs.custom-trigger }}" >> $GITHUB_ENV
-          else
-            echo "TRIGGER=${{ inputs.trigger }}" >> $GITHUB_ENV
           fi
 
   run-tests:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml
     with:
-      trigger: ${{ env.TRIGGER }}
+      trigger: ${{ inputs.trigger == 'custom' && inputs.custom-trigger || inputs.trigger }}
     secrets: inherit

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -45,5 +45,5 @@ jobs:
     name: 'Run tests'
     uses: ./.github/workflows/ci.yml
     with:
-      trigger: ${{ inputs.trigger }}
+      trigger: ${{ env.TRIGGER }}
     secrets: inherit

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       trigger:
         type: choice
-        description: 'Event name. It will be used to filter the jobs to run in ci.yml.'
+        description: 'Event name: it will be used to filter the jobs to run in ci.yml.'
         required: true
         options:
           - pull_request
@@ -17,7 +17,7 @@ on:
         default: on-demand
       custom-trigger:
         type: string
-        description: 'Custom event name. In case the `Event name` choice is `custom`, this field is required.'
+        description: 'Custom event name: In case the `Event name` choice is `custom`, this field is required.'
         required: false
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
       - name: 'Validate input'
         run: |
           if [ "${{ inputs.trigger }}" == "custom" ] && [ -z "${{ inputs.custom-trigger }}" ]; then
-            echo "Custom trigger is required when trigger is set to custom."
+            echo "Custom event name is required when event name choice `custom`."
             exit 1
           fi
 

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       trigger:
         type: choice
-        description: 'Event name. It will be used to filter the jobs to run in ci.yml. It can be anything, as long as the job you want to run has this event configured in the `events` list. Example: daily-checks, pull_request, on-demand, etc.'
+        description: 'Event name. It will be used to filter the jobs to run in ci.yml.'
         required: true
         options:
           - pull_request
@@ -17,7 +17,7 @@ on:
         default: on-demand
       custom-trigger:
         type: string
-        description: 'Custom event name. In case the `trigger` is set to `custom`, this field is required.'
+        description: 'Custom event name. In case the `trigger` choice is `custom`, this field is required.'
         required: false
 
 jobs:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/50172

Updates the inputs config in the On demand workflow to use some common choices. If the choice is `custom` a free text input is required to be filled. This leaves some flexibility so that we can use any custom event we need without updating this workflow.

### How to test the changes in this Pull Request:

Go to [On demand test run workflow](https://github.com/woocommerce/woocommerce/actions/workflows/tests-on-demand.yml) -> Run workflow -> select this branch