### PR TITLE
[Enhancement] Create new filter `woocommerce_is_store_page` for filtering if the URL is a store page.

### DIFF
--- a/plugins/woocommerce/changelog/50174-fix-50173
+++ b/plugins/woocommerce/changelog/50174-fix-50173
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add filter `woocommerce_is_store_page` to modify whether Coming Soon mode considers a URL a store page or not.

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -238,7 +238,7 @@ class WCAdminHelper {
 		 * @param string $url           URL to check.
 		 */
 		$is_store_page = apply_filters( 'woocommerce_is_store_page', false, $url );
-		
+
 		return filter_var( $is_store_page, FILTER_VALIDATE_BOOL );
 	}
 

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -233,11 +233,13 @@ class WCAdminHelper {
 		/**
 		 * Filter if a URL is a store page.
 		 *
-		 * @since 9.2.0
+		 * @since 9.3.0
 		 * @param bool   $is_store_page Whether or not the URL is a store page.
 		 * @param string $url           URL to check.
 		 */
-		return apply_filters( 'woocommerce_is_store_page', false, $url );
+		$is_store_page = apply_filters( 'woocommerce_is_store_page', false, $url );
+		
+		return filter_var( $is_store_page, FILTER_VALIDATE_BOOL );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -237,7 +237,8 @@ class WCAdminHelper {
 		 * @param bool   $is_store_page Whether or not the URL is a store page.
 		 * @param string $url           URL to check.
 		 */
-		return apply_filters( 'woocommerce_is_store_page', false, $url );	}
+		return apply_filters( 'woocommerce_is_store_page', false, $url );
+	}
 
 	/**
 	 * Get normalized URL path.

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -230,8 +230,14 @@ class WCAdminHelper {
 			}
 		}
 
-		return false;
-	}
+		/**
+		 * Filter if a URL is a store page.
+		 *
+		 * @since 9.2.0
+		 * @param bool   $is_store_page Whether or not the URL is a store page.
+		 * @param string $url           URL to check.
+		 */
+		return apply_filters( 'woocommerce_is_store_page', false, $url );	}
 
 	/**
 	 * Get normalized URL path.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Create a new filter `woocommerce_is_store_page` for filtering if the URL is a store page.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50173.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. You can test either manually by adding a custom product taxonomy, or by using the **WooCommerce Brands** plugin (which will add the **Brands** taxonomy).
2. Then create a term for this taxonomy and link a product to this term.
3. To test if the Coming Soon template is well displayed on store pages, please check the following option: 
**WooCommerce > Settings > Site Visibility > Coming Soon > Restrict to store pages only** and **saves changes**.
4. Finally, visit this taxonomy page on front (not as admin).
The page should display the Coming Soon template, but it displays the taxonomy page with the associated products.

5. With the new filter added to this PR, we can do the following: 
```php
	add_filter( 'woocommerce_is_store_page', 'test_is_store_page' );

	function test_is_store_page( $is_store_page ) {
                // `product_brand` is the taxonomy added by WooCommerce Brands plugin.
		if ( is_tax( 'product_brand' ) ) {
                        // When the archive page for taxonomy of 'product_brand' is being displayed.
			return true;
		}

		return $is_store_page;
	}
```
6. Visit the taxonomy page again, and the Coming Soon template is well displayed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add filter `woocommerce_is_store_page` to modify whether Coming Soon mode considers a URL a store page or not.

</details>