### PR TITLE
CI: speedup 'Check Asset Sizes' job (take 3)

### DIFF
--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -52,7 +52,7 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: './{packages/js/!(*e2e*|*internal*|*test*|*plugin*|*create*),plugins/woocommerce-blocks}/{build,build-style}/**/*.{js,css}'
-                  install-script: 'pnpm install --filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false'
+                  install-script: 'pnpm install --filter="@woocommerce/plugin-woocommerce..." --frozen-lockfile --config.dedupe-peer-dependents=false --ignore-scripts'
                   build-script: '--filter="@woocommerce/plugin-woocommerce" build'
                   clean-script: '--if-present buildclean'
                   minimum-change-threshold: 100

--- a/plugins/woocommerce-admin/bin/xstate5-react-script.js
+++ b/plugins/woocommerce-admin/bin/xstate5-react-script.js
@@ -1,9 +1,0 @@
-const fs = require( 'fs-extra' );
-const path = require( 'path' );
-
-const rootNodeModules = path.join( __dirname, '..', 'node_modules' );
-
-fs.ensureSymlinkSync(
-	path.join( rootNodeModules, 'xstate5' ),
-	path.join( rootNodeModules, '@xstate5', 'react', 'node_modules', 'xstate' )
-);

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -29,8 +29,7 @@
 		"watch:build": "pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel '/^watch:build:project:.*$/'",
 		"watch:build:project": "pnpm --if-present run '/^watch:build:project:.*$/'",
 		"watch:build:project:bundle": "wireit",
-		"watch:build:project:feature-config": "WC_ADMIN_PHASE=development php ../woocommerce/bin/generate-feature-config.php",
-		"postinstall": "node ./bin/xstate5-react-script.js"
+		"watch:build:project:feature-config": "WC_ADMIN_PHASE=development php ../woocommerce/bin/generate-feature-config.php"
 	},
 	"lint-staged": {
 		"*.scss": [

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -97,8 +97,8 @@ const outputSuffix = WC_ADMIN_PHASE === 'core' ? '' : '.min';
 // Here we are patching a dependency, see https://github.com/woocommerce/woocommerce/pull/45548 for more details.
 // Should be revisited: using the dependency patching, but seems we need some codebase tweaks as it uses xstate 4/5 mix.
 require( 'fs-extra' ).ensureSymlinkSync(
-	path.join( __dirname, '/node_modules/xstate5' ),
-	path.join( __dirname, '/node_modules/@xstate5/react/node_modules/xstate' )
+	path.join( __dirname, './node_modules/xstate5' ),
+	path.join( __dirname, './node_modules/@xstate5/react/node_modules/xstate' )
 );
 
 const webpackConfig = {

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -94,6 +94,13 @@ const getEntryPoints = () => {
 // WordPress.org’s translation infrastructure ignores files named “.min.js” so we need to name our JS files without min when releasing the plugin.
 const outputSuffix = WC_ADMIN_PHASE === 'core' ? '' : '.min';
 
+// Here we are patching a dependency, see https://github.com/woocommerce/woocommerce/pull/45548 for more details.
+// Should be revisited: using the dependency patching, but seems we need some codebase tweaks as it uses xstate 4/5 mix.
+require( 'fs-extra' ).ensureSymlinkSync(
+	path.join( __dirname, '/node_modules/xstate5' ),
+	path.join( __dirname, '/node_modules/@xstate5/react/node_modules/xstate' )
+);
+
 const webpackConfig = {
 	mode: NODE_ENV,
 	entry: getEntryPoints(),

--- a/plugins/woocommerce/changelog/dev-speedup-check-asset-sizes-take-3
+++ b/plugins/woocommerce/changelog/dev-speedup-check-asset-sizes-take-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: speedup assets size verification job execution time.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- relocate dep. patching admin package performing in postinstall to webpack itself.
- the remaining postinstall scripts are not affecting assets build, so we skip them in this job for faster execution

Effects:
- composer installation will be skipped (we don't need it here)
- reduced execution time for ~15 seconds for this job (no build time implications)
- the time gain gives us more safety buffer to stay under the 10-minute target in our jobs

### Testing

- CI checks shall pass
