### PR TITLE
Product Editor: Fix shipping dimensions length field label

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-length-label
+++ b/packages/js/product-editor/changelog/fix-product-editor-length-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct label of shipping dimensions length field.

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
@@ -223,7 +223,7 @@ export function Edit( {
 					/>
 					<NumberControl
 						label={ createInterpolateElement(
-							__( 'Width <Side />', 'woocommerce' ),
+							__( 'Length <Side />', 'woocommerce' ),
 							{ Side: <span>B</span> }
 						) }
 						error={ dimensionsLengthValidationError }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR corrects the shipping dimensions length field label, which was mistakenly changed in #49205.

Closes #50179.

Before:

<img width="1118" alt="Screenshot 2024-07-31 at 11 48 46" src="https://github.com/user-attachments/assets/686c5b77-c1e7-4773-bac6-7f2a6243196c">

After:

<img width="1118" alt="Screenshot 2024-07-31 at 12 21 42" src="https://github.com/user-attachments/assets/0367f0f3-7b30-45c6-ba3f-670c34761091">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. On the **Shipping** tab, verify that the length field is correctly labeled "Length B"

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
