### PR TITLE
Fix e2e Google for WooCommerce strict mode violation error

### DIFF
--- a/plugins/woocommerce/changelog/fix-google-for-woocommerce-e2e
+++ b/plugins/woocommerce/changelog/fix-google-for-woocommerce-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix e2e Google for WooCommerce strict mode violation error

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -120,11 +120,7 @@ test.describe( 'Store owner can complete the core profiler', () => {
 				page.getByText( 'Pinterest for WooCommerce', { exact: true } )
 			).toBeHidden();
 			await expect(
-				page
-					.getByRole( 'cell', {
-						name: 'Google for WooCommerce Get',
-					} )
-					.getByRole( 'strong' )
+				page.getByText( 'Google for WooCommerce', { exact: true } )
 			).toBeHidden();
 		} );
 
@@ -268,22 +264,13 @@ test.describe( 'Store owner can complete the core profiler', () => {
 			} catch ( e ) {
 				console.log( 'Checkbox not present for MailPoet' );
 			}
-			try {
-				await page
-					.getByText(
-						'Drive sales with Google for WooCommerceReach millions of active shoppers across'
-					)
-					.getByRole( 'checkbox' )
-					.check( { timeout: 2000 } );
-			} catch ( e ) {
-				// Temporary fix until rebranding is done.
-				await page
-					.getByText(
-						'Drive sales with Google Listings & AdsReach millions of active shoppers across'
-					)
-					.getByRole( 'checkbox' )
-					.check( { timeout: 2000 } );
-			}
+
+			await page
+				.getByText(
+					'Drive sales with Google for WooCommerceReach millions of active shoppers across'
+				)
+				.getByRole( 'checkbox' )
+				.check( { timeout: 2000 } );
 			await page.getByRole( 'button', { name: 'Continue' } ).click();
 		} );
 
@@ -320,6 +307,14 @@ test.describe( 'Store owner can complete the core profiler', () => {
 			// confirm that the optional plugins are present
 			await expect(
 				page.getByText( 'Pinterest for WooCommerce', { exact: true } )
+			).toBeVisible();
+
+			await expect(
+				page
+					.getByRole( 'cell', {
+						name: 'Google for WooCommerce Get',
+					} )
+					.getByRole( 'strong' )
 			).toBeVisible();
 
 			await expect( page.getByText( 'MailPoet' ) ).toBeHidden();

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -120,7 +120,11 @@ test.describe( 'Store owner can complete the core profiler', () => {
 				page.getByText( 'Pinterest for WooCommerce', { exact: true } )
 			).toBeHidden();
 			await expect(
-				page.getByText( 'Google for WooCommerce', { exact: true } )
+				page
+					.getByRole( 'cell', {
+						name: 'Google for WooCommerce Get',
+					} )
+					.getByRole( 'strong' )
 			).toBeHidden();
 		} );
 
@@ -318,12 +322,6 @@ test.describe( 'Store owner can complete the core profiler', () => {
 				page.getByText( 'Pinterest for WooCommerce', { exact: true } )
 			).toBeVisible();
 
-			await expect(
-				page.getByText(
-					/(Google for WooCommerce|Google Listings & Ads)/,
-					{ exact: true }
-				)
-			).toBeVisible();
 			await expect( page.getByText( 'MailPoet' ) ).toBeHidden();
 			await expect( page.getByText( 'Jetpack' ) ).toBeHidden();
 		} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1722471429914569-slack-C03CPM3UXDJ


The e2e tests are failing due to the new version of Google for WooCommerce. The tests are looking for the Google for WooCommerce text, but new version has multiple instances of the text. The tests need to be updated to look for a more specific element.


**Error:**

```bash
1 failed
    [ui] › activate-and-setup/core-profiler.spec.js:152:2 › Store owner can complete the core profiler › Can complete the core profiler installing default extensions 
  82 passed (13.1m)
Getting environment details
Error:   1) [ui] › activate-and-setup/core-profiler.spec.js:152:2 › Store owner can complete the core profiler › Can complete the core profiler installing default extensions 
    Error: expect.toBeVisible: Error: strict mode violation: getByText(/(Google for WooCommerce|Google Listings & Ads)/) resolved to 4 elements:
        1) <a href="admin.php?page=wc-admin&path=/google/start">Google for WooCommerce</a> aka getByRole('link', { name: 'Google for WooCommerce', exact: true })
        2) <span class="screen-reader-text">Select Google for WooCommerce</span> aka getByText('Select Google for WooCommerce')
        3) <strong>Google for WooCommerce</strong> aka getByRole('cell', { name: 'Google for WooCommerce Get' }).getByRole('strong')
        4) <p>…</p> aka getByText('Required by: Google for')

    Call log:
      - expect.toBeVisible with timeout 20000ms
      - waiting for getByText(/(Google for WooCommerce|Google Listings & Ads)/)


      324 | 					{ exact: true }
      325 | 				)
    > 326 | 			).toBeVisible();
          | 			  ^
      327 | 			await expect( page.getByText( 'MailPoet' ) ).toBeHidden();
      328 | 			await expect( page.getByText( 'Jetpack' ) ).toBeHidden();
      329 | 		} );

        at /home/runner/work/woocommerce/woocommerce/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js:326:6
        at /home/runner/work/woocommerce/woocommerce/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js:286:3
Error:   1) [ui] › activate-and-setup/core-profiler.spec.js:152:2 › Store owner can complete the core profiler › Can complete the core profiler installing default extensions 

```

**Playwright locator:**
 
<img width="1116" alt="Screenshot 2024-08-01 at 12 05 04" src="https://github.com/user-attachments/assets/ef5b29c2-a142-4327-a0e6-c732f5d9fb0d">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Confirm e2e tests passed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>