### PR TITLE
CI: speedup 'Build Project Jobs'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
       - uses: 'actions/checkout@v4'
         name: 'Checkout'
         with:
-          fetch-depth: 0
+          # If 'base_ref' is available, the 'Build Matrix' step requires non-shallow git-history to identify changed files.
+          fetch-depth: ${{ ( ( github.base_ref && '0' ) || '1' ) }}
       - uses: './.github/actions/setup-woocommerce-monorepo'
         name: 'Setup Monorepo'
         with:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replicate approach from https://github.com/woocommerce/woocommerce/pull/50169 to the job which builds ci-jobs matrix.
There are no changes for PRs, but they are faster for pushes.

### Testing

- The checkout step still talked ~40 seconds in this branch checks
- The checkout step should be around 8 seconds on trunk merge run.
