### PR TITLE
[WIP] CI: speedup building WooCommerce zip-files.

### DIFF
--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -13,18 +13,21 @@ mkdir -p "$DEST_PATH"
 echo "Cleaning up assets..."
 find "$PROJECT_PATH/assets/css/." ! -name '.gitkeep' -type f -exec rm -f {} + && find "$PROJECT_PATH/assets/client/." ! -name '.gitkeep' -type f -exec rm -f {} + && find "$PROJECT_PATH/assets/js/." ! -name '.gitkeep' -type f -exec rm -f {} +
 
-echo "Installing PHP and JS dependencies..."
-pnpm install --frozen-lockfile
+echo "Installing JS dependencies..."
+pnpm install --frozen-lockfile --ignore-scripts
 
-echo "Running JS Build..."
 if [ -z "${NODE_ENV}" ]; then
 	export NODE_ENV=production
 fi
+echo "Running JS Build (${NODE_ENV})..."
 pnpm --filter='@woocommerce/plugin-woocommerce' build || exit "$?"
-echo "Cleaning up PHP dependencies..."
+
+echo "Installing PHP dependencies (production)..."
 composer install --no-dev --quiet --optimize-autoloader || exit "$?"
+
 echo "Run makepot..."
 pnpm --filter=@woocommerce/plugin-woocommerce makepot || exit "$?"
+
 echo "Syncing files..."
 rsync -rc --exclude-from="$PROJECT_PATH/.distignore" "$PROJECT_PATH/" "$DEST_PATH/" --delete --delete-excluded
 

--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -13,7 +13,9 @@ mkdir -p "$DEST_PATH"
 echo "Cleaning up assets..."
 find "$PROJECT_PATH/assets/css/." ! -name '.gitkeep' -type f -exec rm -f {} + && find "$PROJECT_PATH/assets/client/." ! -name '.gitkeep' -type f -exec rm -f {} + && find "$PROJECT_PATH/assets/js/." ! -name '.gitkeep' -type f -exec rm -f {} +
 
-echo "Installing JS dependencies..."
+echo "Installing JS and PHP dependencies (with dev-dependencies)..."
+# parallel installation of PHP/JS dependencies - we covered by JS building step to ensure both finished timely.
+composer install --quiet &
 pnpm install --frozen-lockfile --ignore-scripts
 
 if [ -z "${NODE_ENV}" ]; then
@@ -22,7 +24,7 @@ fi
 echo "Running JS Build (${NODE_ENV})..."
 pnpm --filter='@woocommerce/plugin-woocommerce' build || exit "$?"
 
-echo "Installing PHP dependencies (production)..."
+echo "Reinstalling PHP dependencies (production)..."
 composer install --no-dev --quiet --optimize-autoloader || exit "$?"
 
 echo "Run makepot..."


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

On top of the work in https://github.com/woocommerce/woocommerce/pull/50178, we can improve speed of building zip-files for WooCommerce core - we are re-installing prod deps for PHP as separate step, so disabling scripts will skip excessive step of running composer installation in postinstall scripts earlier.

TBD:
- investigate impact of ` WARN  The git-hosted package fetched from "https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50" has to be built but the build scripts were ignored.`
- investigate impact of ` WARN  The git-hosted package fetched from "https://codeload.github.com/woocommerce/sourcebuster-js/tar.gz/d7f4616d5a17e17db925ca1842457f309379d861" has to be built but the build scripts were ignored.`
