### PR TITLE
[testing workflows] Add pre-release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
             // Intended behaviour of the jobs generation:
             // - PRs: run CI jobs aiming PRs and filter out jobs based on the content changes
             // - Pushes: run CI jobs aiming pushes without filtering based on the content changes
+            
+            // github.base_ref is only available for pull_request events
             let baseRef = ${{ toJson( github.base_ref ) }};
             if ( baseRef ) {
               baseRef = `--base-ref origin/${ baseRef }`;
@@ -72,6 +74,12 @@ jobs:
             let trigger = ${{ toJson( inputs.trigger ) }};
             if ( trigger ) {
               githubEvent = trigger;
+            }
+            
+            // `pre-release` should trigger `release-checks`, but without a 'tag' ref. 
+            // This will run all release-checks against the branch the workflow targeted, instead of a release artifact.
+            if ( trigger === 'pre-release' ) {
+              githubEvent = 'release-checks';
             }
             
             const child_process = require( 'node:child_process' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/50172

This PR adds a new type of check, the `pre-release` check. It should run the same tests as the `release-checks` but against a selected branch instead of an existing release artifact.

### How to test the changes in this Pull Request:

Go to [On demand test run workflow](https://github.com/woocommerce/woocommerce/actions/workflows/tests-on-demand.yml) -> Run workflow -> select this branch -> Select `pre-release`
It should:
- run all `release-checks` jobs, against the selected branch
- the `Update wp-env config` step should be skipped
- the `Install Monorepo` step should include the build
See this run: https://github.com/woocommerce/woocommerce/actions/runs/10197131891/job/28209400732

cc @juliaamosova 
