### PR TITLE
[WIP] CI: optimize Core API tests execution speed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           install: '${{ matrix.projectName }}...'
           build: ${{ ( github.ref_type == 'tag' && 'false' ) || matrix.projectName }}
-          build-type: ${{ ( matrix.testType == 'unit:php' && 'backend' ) || 'full' }}
+          build-type: ${{ ( ( matrix.testType == 'unit:php' || matrix.testType == 'api' ) && 'backend' ) || 'full' }}
           pull-playwright-cache: ${{ matrix.testEnv.shouldCreate && matrix.testType == 'e2e' }}
           pull-package-deps: '${{ matrix.projectName }}'
 

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -16,8 +16,8 @@
 		"test-data/images/": "./tests/e2e-pw/test-data/images/"
 	},
 	"lifecycleScripts": {
-		"afterStart": "./tests/e2e-pw/bin/test-env-setup.sh",
-		"afterClean": "./tests/e2e-pw/bin/test-env-setup.sh"
+		"afterStart": "wp-env run tests-cli bash wp-content/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh",
+		"afterClean": "wp-env run tests-cli bash wp-content/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh"
 	},
 	"env": {
 		"development": {},

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -442,6 +442,7 @@
 						"patterns/**/*.php",
 						"src/**/*.php",
 						"templates/**/*.php",
+						"tests/e2e-pw/**",
 						".wp-env.json"
 					],
 					"testEnv": {

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
 echo -e 'Activate default theme \n'
-wp-env run tests-cli wp theme activate twentytwentythree
+wp theme activate twentytwentythree
 
 echo -e 'Update URL structure \n'
-wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
+wp rewrite structure '/%postname%/' --hard
 
 echo -e 'Activate Filter Setter utility plugin \n'
-wp-env run tests-cli wp plugin activate filter-setter
+wp plugin activate filter-setter
 
 # This plugin allows you to process queued scheduled actions immediately.
 # It's used in the analytics e2e tests so that order numbers are shown in Analytics.
 echo -e 'Activate Process Waiting Actions utility plugin \n'
-wp-env run tests-cli wp plugin activate process-waiting-actions
+wp plugin activate process-waiting-actions
 
 echo -e 'Activate Test Helper APIs utility plugin \n'
-wp-env run tests-cli wp plugin activate test-helper-apis
+wp plugin activate test-helper-apis
 
 echo -e 'Add Customer user \n'
-wp-env run tests-cli wp user create customer customer@woocommercecoree2etestsuite.com \
+wp user create customer customer@woocommercecoree2etestsuite.com \
 	--user_pass=password \
 	--role=customer \
 	--first_name='Jane' \
@@ -26,20 +26,20 @@ wp-env run tests-cli wp user create customer customer@woocommercecoree2etestsuit
 	--user_registered='2022-01-01 12:23:45'
 
 echo -e 'Update Blog Name \n'
-wp-env run tests-cli wp option update blogname 'WooCommerce Core E2E Test Suite'
+wp option update blogname 'WooCommerce Core E2E Test Suite'
 
 echo -e 'Preparing Test Files \n'
-wp-env run tests-cli sudo cp /var/www/html/wp-content/plugins/woocommerce/tests/legacy/unit-tests/importer/sample.csv /var/www/sample.csv
+sudo cp /var/www/html/wp-content/plugins/woocommerce/tests/legacy/unit-tests/importer/sample.csv /var/www/sample.csv
 
 ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
 if [ $ENABLE_TRACKING == 1 ]; then
 	echo -e 'Enable tracking\n'
-	wp-env run tests-cli wp option update woocommerce_allow_tracking 'yes'
+	wp option update woocommerce_allow_tracking 'yes'
 fi
 
 echo -e 'Disabling coming soon option\n'
-wp-env run tests-cli wp option update woocommerce_coming_soon 'no'
+wp option update woocommerce_coming_soon 'no'
 
 echo -e 'Upload test images \n'
-wp-env run tests-cli wp media import './test-data/images/image-01.png' './test-data/images/image-02.png' './test-data/images/image-03.png'
+wp media import './test-data/images/image-01.png' './test-data/images/image-02.png' './test-data/images/image-03.png'

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -68,8 +68,6 @@ const config = {
 		: 120 * 1000,
 	expect: { timeout: 20 * 1000 },
 	outputDir: testsResultsPath,
-	globalSetup: require.resolve( './global-setup' ),
-	globalTeardown: require.resolve( './global-teardown' ),
 	testDir: `${ testsRootPath }/tests`,
 	retries: CI ? 1 : 0,
 	repeatEach: REPEAT_EACH ? Number( REPEAT_EACH ) : 1,
@@ -92,15 +90,28 @@ const config = {
 	},
 	snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}',
 	projects: [
-		{
-			name: 'ui',
-			use: { ...devices[ 'Desktop Chrome' ] },
-			testIgnore: '**/api-tests/**',
-		},
+		// API: REST API testing. Requires NO global setup/teardown.
 		{
 			name: 'api',
 			use: { ...devices[ 'Desktop Chrome' ] },
 			testMatch: '**/api-tests/**',
+		},
+		// UI: E2E testing. Requires global setup/teardown.
+		{
+			name: 'ui',
+			use: { ...devices[ 'Desktop Chrome' ] },
+			testIgnore: '**/api-tests/**',
+			dependencies: [ 'global-setup.js' ],
+		},
+		// Pseudo-projects: global setup/teardown, which hooks in as per projects needs.
+		{
+			name: 'global-setup.js',
+			testMatch: /global-setup\.js/,
+			teardown: 'global-teardown.js',
+		},
+		{
+			name: 'global-teardown.js',
+			testMatch: /global-teardown\.js/,
 		},
 	],
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tweaks projects definitions as per official documentation, so global setup/teardown can be skipped for some and kept for other projects.

### Testing

- CI checks shall pass

### Dev-notes

Action items:
- Remove any UI steps from global-setup / global-teardown => same setup/teardown will work for both api and e2e.
- Refactor the api and wcAdminApi fixtures in e2e-pw/fixtures/fixtures.js to use basic auth instead of consumerKey and consumerSecret Same as wpApi fixture. (maybe we can merge them all and have a single api fixture... :thinking_face:)
- Refactor all tests that make api calls to use the :point_up: fixture.
- Add a new e2e test to cover the creation and usage of the consumerKey and secret, just to have that covered if we're not using them anymore.
