### PR TITLE
Bust WC object cache on direct postmeta updates.

### DIFF
--- a/plugins/woocommerce/changelog/fix-50207
+++ b/plugins/woocommerce/changelog/fix-50207
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bust WC object cache on direct post meta update to prevent stale cache read.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -58,6 +58,8 @@ class WC_Post_Data {
 
 		// Meta cache flushing.
 		add_action( 'updated_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
+		add_action( 'added_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 		add_action( 'updated_order_item_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -114,4 +114,67 @@ class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		$product2->save();
 		$product3->save();
 	}
+
+	/**
+	 * @testDox Test that meta cache key is changed on direct post meta add.
+	 */
+	public function test_get_meta_data_is_busted_on_post_meta_add() {
+		$product = new WC_Product();
+		$product->save();
+
+		// Set the cache.
+		$product->get_meta_data();
+
+		$object_id_cache_key = WC_Cache_Helper::get_cache_prefix( 'object_' . $product->get_id() );
+		add_post_meta( $product->get_id(), 'test', 'value' );
+
+		$r_object_id_cache_key = WC_Cache_Helper::get_cache_prefix( 'object_' . $product->get_id() );
+		$this->assertNotEquals( $object_id_cache_key, $r_object_id_cache_key );
+
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 'value', $product->get_meta( 'test', true ) );
+	}
+
+
+	/**
+	 * @testDox Test that meta cache key is changed on direct post meta update.
+	 */
+	public function test_get_meta_data_is_busted_on_post_meta_update() {
+		$product = new WC_Product();
+		$product->add_meta_data( 'test', 'value' );
+		$product->save();
+
+		// Set the cache.
+		$product->get_meta_data();
+
+		$object_id_cache_key = WC_Cache_Helper::get_cache_prefix( 'object_' . $product->get_id() );
+		update_post_meta( $product->get_id(), 'test', 'value2' );
+
+		$r_object_id_cache_key = WC_Cache_Helper::get_cache_prefix( 'object_' . $product->get_id() );
+		$this->assertNotEquals( $object_id_cache_key, $r_object_id_cache_key );
+
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 'value2', $product->get_meta( 'test', true ) );
+	}
+
+	/**
+	 * @testDox Test that meta cache key is changed on direct post meta delete.
+	 */
+	public function test_get_meta_data_is_busted_on_post_meta_delete() {
+		$product = new WC_Product();
+		$product->add_meta_data( 'test', 'value' );
+		$product->save();
+
+		// Set the cache.
+		$product->get_meta_data();
+
+		$object_id_cache_key = WC_Cache_Helper::get_cache_prefix( 'object_' . $product->get_id() );
+		delete_post_meta( $product->get_id(), 'test' );
+
+		$r_object_id_cache_key = WC_Cache_Helper::get_cache_prefix( 'object_' . $product->get_id() );
+		$this->assertNotEquals( $object_id_cache_key, $r_object_id_cache_key );
+
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEmpty( $product->get_meta( 'test', true ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We clear post meta cache when metadata is updated, however, similar cache busting is not present when metadata is directly added or deleted. This PR fixes those gaps by liking cache busting to meta add and delete also.

Closes #50207 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following snippet to your site (note that each refresh will create a new product, so make sure to remove when you are done testing):
```php

add_action( 'init', 'flush_ob_cache_meta_test' );

function flush_ob_cache_meta_test() {
	// Create an object.
	$object = new WC_Product();
	$object->save();

	// Update a meta value.
	update_post_meta( $object->get_id(), '_some_meta_key', 'val1' );
	$product = wc_get_product( $object->get_id() );
	echo "<pre>" . var_dump( $product->get_meta( '_some_meta_key', true ) ) . "</pre>";
}

add_action( 'woocommerce_new_product', 'fail_the_test' );

function fail_the_test( $product_id ) {
	$product = wc_get_product( $product_id );
	// Bail if product isn't found.
	if ( ! $product instanceof WC_Product ) {
		return;
	}
	$product->get_meta( '_some_other_meta_key', true );
}
```
3. Verify that you see `val1` at the top of the screen. On trunk, this will be an empty string.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
