### PR TITLE
Prevent creation of password-protected coupons

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-password-protected-coupons
+++ b/plugins/woocommerce/changelog/enhancement-password-protected-coupons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Prevent creation of password-protected coupons.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-coupon.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-coupon.js
@@ -66,5 +66,37 @@ jQuery(function( $ ) {
 		}
 	};
 
+	/**
+	 * Handles warning about coupons using password protection.
+	 */
+	const wc_coupon_password_warning = {
+		init: function() {
+			const $warning = $( '#wc-password-protected-coupon-warning' );
+			// Bail out early if necessary.
+			if ( 0 === $warning.length ) {
+				return;
+			}
+
+			const $visibility = $( 'input[name="visibility"]' ),
+				  $password_visibility = $( '#visibility-radio-password' ),
+				  $password_label = $( 'label[for="visibility-radio-password"]' );
+
+			// For coupons without password, prevent setting it.
+			if ( ! $password_visibility.is( ':checked' ) ) {
+				$password_visibility.prop( 'disabled', true );
+				$password_label.css( 'text-decoration', 'line-through' );
+				return;
+			}
+
+			$visibility.on(
+				'change',
+				function() {
+					$warning.toggleClass( 'hidden', ! $password_visibility.is( ':checked' ) );
+				}
+			);
+		}
+	};
+
 	wc_meta_boxes_coupon_actions.init();
+	wc_coupon_password_warning.init();
 });

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -43,6 +43,12 @@ class WC_Admin_Post_Types {
 		add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
 		add_filter( 'woocommerce_order_updated_messages', array( $this, 'order_updated_messages' ) );
 		add_filter( 'bulk_post_updated_messages', array( $this, 'bulk_post_updated_messages' ), 10, 2 );
+		add_action(
+			'admin_notices',
+			function () {
+				$this->maybe_display_warning_for_password_protected_coupon();
+			}
+		);
 
 		// Disable Auto Save.
 		add_action( 'admin_print_scripts', array( $this, 'disable_autosave' ) );
@@ -254,6 +260,33 @@ class WC_Admin_Post_Types {
 		);
 
 		return $bulk_messages;
+	}
+
+	/**
+	 * Shows a warning when editing a password-protected coupon.
+	 *
+	 * @since 9.2.0
+	 */
+	private function maybe_display_warning_for_password_protected_coupon() {
+		if ( ! function_exists( 'get_current_screen' ) || 'shop_coupon' !== get_current_screen()->id ) {
+			return;
+		}
+
+		if ( ! isset( $GLOBALS['post'] ) || 'shop_coupon' !== $GLOBALS['post']->post_type ) {
+			return;
+		}
+
+		wp_admin_notice(
+			__(
+				'This coupon is password protected. WooCommerce does not support password protection for coupons. You can temporarily hide a coupon by making it private. Alternatively, usage limits and restrictions can be configured below.',
+				'woocommerce'
+			),
+			array(
+				'type'               => 'warning',
+				'id'                 => 'wc-password-protected-coupon-warning',
+				'additional_classes' => empty( $GLOBALS['post']->post_password ) ? array( 'hidden' ) : array(),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As the admin UI for editing coupons is the same as for any other custom post type, it allows, in principle, setting a coupon as password-protected, but this apparent protection doesn't make any difference in the cart or at checkout time, where it can be applied regardless.

Given there are no current plans to actively support this, this PR adds an admin notice visible when editing a coupon that is password-protected and also disables the "Password Protected" visibility option so that it can't be selected for new coupons.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC > Coupons > Add Coupon.
2. On the **Publish** metabox, click **Edit** on the **Visibility** row.
3. Make sure that you're not able to select **Password protected**.
   <img width="341" alt="Screenshot 2024-07-18 at 18 57 52" src="https://github.com/user-attachments/assets/60e5d42a-7a3f-41b9-966a-4456087b2fcb">
4. Create and publish a coupon and take note of its ID.
5. We'll set a password for this coupon via CLI to simulate a coupon that had a password prior to the changes being introduced here. To do so, run the following command:
   ```
   wp post update <post_id> --post_password=mypass
   ```
6. Go to WC > Coupons again and open the edit page for that coupon.
7. Confirm that you see a warning at the top indicating that the coupon is password protected and this is not supported.
   <img width="1062" alt="Screenshot 2024-07-18 at 18 58 13" src="https://github.com/user-attachments/assets/4b5a6403-27d4-4ca8-9d3f-f55f5b7bf6e9">
8. Click **Edit** to set the **Visibility** for the coupon.
9. Confirm that choosing any visibility other than **Password protected** hides the warning.
10. Restore visibility to **Password protected** and make any change to the coupon.
11. Click **Update**.
12. Confirm that the password is still set on the coupon and that the warning still appears.
13. Change **Visibility** for the coupon to anything other than **Password protected**.
14. Click **Update** and confirm that the warning has disappeared and the **Password protected** option can't be selected (as in step 3).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
