### PR TITLE
[e2e] Product Editor: Add SKU, GTIN, shipping, and custom fields to simple product creation test

### DIFF
--- a/packages/js/product-editor/changelog/update-e2e-product-editor-create-simple-product
+++ b/packages/js/product-editor/changelog/update-e2e-product-editor-create-simple-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix association of label and input for SKU field.

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-sku/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-sku/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockAttributes } from '@wordpress/blocks';
+import { useInstanceId } from '@wordpress/compose';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
@@ -46,10 +47,15 @@ export function Edit( {
 		[ sku ]
 	);
 
+	const inputControlId = useInstanceId(
+		BaseControl,
+		'product_sku'
+	) as string;
+
 	return (
 		<div { ...blockProps }>
 			<BaseControl
-				id={ 'product_sku' }
+				id={ inputControlId }
 				className="woocommerce-product-form_inventory-sku"
 				label={ createInterpolateElement(
 					__( 'Sku <description />', 'woocommerce' ),
@@ -64,6 +70,7 @@ export function Edit( {
 			>
 				<InputControl
 					ref={ skuRef }
+					id={ inputControlId }
 					name={ 'woocommerce-product-sku' }
 					onChange={ setSku }
 					value={ sku || '' }

--- a/plugins/woocommerce/changelog/update-e2e-product-editor-create-simple-product
+++ b/plugins/woocommerce/changelog/update-e2e-product-editor-create-simple-product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add additional fields to new product editor e2e tests.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -73,13 +73,19 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					.pressSequentially( productData.name );
 			} );
 
-			await test.step( 'add product description', async () => {
+			await test.step( 'add simple product description', async () => {
 				const descriptionSimpleParagraph = page.locator(
 					'[data-template-block-id="product-description__content"] > p'
 				);
 
 				await descriptionSimpleParagraph.fill(
 					productData.descriptionSimple
+				);
+			} );
+
+			await test.step( 'add full product description', async () => {
+				const descriptionSimpleParagraph = page.locator(
+					'[data-template-block-id="product-description__content"] > p'
 				);
 
 				// Helps to ensure that block toolbar appears
@@ -110,7 +116,9 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					.fill( productData.descriptionParagraph );
 
 				await page.getByRole( 'button', { name: 'Done' } ).click();
+			} );
 
+			await test.step( 'verify full product description', async () => {
 				const previewContainerIframe = page
 					.locator( '.block-editor-block-preview__container' )
 					.frameLocator( 'iframe[title="Editor canvas"]' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -202,7 +202,11 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			// from product-create-simple.spec.js, as both tests are just verifying that the
 			// product was created correctly by looking at the front end.
 			await test.step( 'verify the saved product in frontend', async () => {
-				await page.goto( `/?post_type=product&p=${ productId }` );
+				const permalink = await page
+					.locator( '.product-details-section__product-link a' )
+					.getAttribute( 'href' );
+
+				await page.goto( permalink );
 
 				// Verify product name
 				await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -379,6 +379,19 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					page.getByText( productData.summary )
 				).toBeVisible();
 
+				// Verify description
+				await page.getByRole( 'tab', { name: 'Description' } ).click();
+
+				await expect(
+					page.getByText( productData.descriptionTitle )
+				).toBeVisible();
+				await expect(
+					page.getByText( productData.descriptionSimple )
+				).toBeVisible();
+				await expect(
+					page.getByText( productData.descriptionParagraph )
+				).toBeVisible();
+
 				// Verify inventory details
 				await expect(
 					page.getByText( `SKU: ${ productData.sku }` )
@@ -388,6 +401,10 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				// Note: Shipping class is not displayed in the front end in the theme used in the test
 
 				// Verify shipping dimensions
+				await page
+					.getByRole( 'tab', { name: 'Additional information' } )
+					.click();
+
 				await expect(
 					page.getByText( `Weight ${ productData.shipping.weight }` )
 				).toBeVisible();

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -46,11 +46,15 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 		);
 
 		test( 'can create a simple product', async ( { page } ) => {
-			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
-			await clickOnTab( 'General', page );
-			await page
-				.getByPlaceholder( 'e.g. 12 oz Coffee Mug' )
-				.fill( productData.name );
+			await test.step( 'add new product', async () => {
+				await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
+			} );
+
+			await test.step( 'add product name, description, and summary', async () => {
+				await clickOnTab( 'General', page );
+				await page
+					.getByPlaceholder( 'e.g. 12 oz Coffee Mug' )
+					.fill( productData.name );
 
 			await page
 				.locator(
@@ -115,55 +119,62 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			).toBeVisible();
 
 			await page
-				.locator(
-					'[data-template-block-id="basic-details"] .components-summary-control'
-				)
-				.last()
-				.fill( productData.summary );
+					.locator(
+						'[data-template-block-id="basic-details"] .components-summary-control'
+					)
+					.last()
+					.fill( productData.summary );
 
-			// We blur the summary field to hide the toolbar before clicking on the regular price field.
-			await page
-				.locator(
-					'[data-template-block-id="basic-details"] .components-summary-control'
-				)
-				.last()
-				.blur();
+				// Blur the summary field to hide the toolbar before clicking on the regular price field.
+				await page
+					.locator(
+						'[data-template-block-id="basic-details"] .components-summary-control'
+					)
+					.last()
+					.blur();
+			} );
 
-			const regularPrice = page
-				.locator( 'input[name="regular_price"]' )
-				.first();
-			await regularPrice.waitFor( { state: 'visible' } );
-			await regularPrice.click();
-			await regularPrice.fill( productData.productPrice );
+			await test.step( 'add product price', async () => {
+				const regularPrice = page
+					.locator( 'input[name="regular_price"]' )
+					.first();
+				await regularPrice.waitFor( { state: 'visible' } );
+				await regularPrice.click();
+				await regularPrice.fill( productData.productPrice );
 
-			const salePrice = page
-				.locator( 'input[name="sale_price"]' )
-				.first();
-			await salePrice.waitFor( { state: 'visible' } );
-			await salePrice.click();
-			await salePrice.fill( productData.salePrice );
+				const salePrice = page
+					.locator( 'input[name="sale_price"]' )
+					.first();
+				await salePrice.waitFor( { state: 'visible' } );
+				await salePrice.click();
+				await salePrice.fill( productData.salePrice );
+			} );
 
-			await page
-				.locator( '.woocommerce-product-header__actions' )
-				.getByRole( 'button', {
-					name: 'Publish',
-				} )
-				.click();
+			await test.step( 'publish the product', async () => {
+				await page
+					.locator( '.woocommerce-product-header__actions' )
+					.getByRole( 'button', {
+						name: 'Publish',
+					} )
+					.click();
 
-			await expect(
-				page.getByLabel( 'Dismiss this notice' )
-			).toContainText( 'Product published' );
+				await expect(
+					page.getByLabel( 'Dismiss this notice' )
+				).toContainText( 'Product published' );
 
-			const title = page.locator( '.woocommerce-product-header__title' );
+				const title = page.locator(
+					'.woocommerce-product-header__title'
+				);
 
-			// Save product ID
-			const productIdRegex = /product%2F(\d+)/;
-			const url = page.url();
-			const productIdMatch = productIdRegex.exec( url );
-			productId = productIdMatch ? productIdMatch[ 1 ] : null;
+				// Save product ID
+				const productIdRegex = /product%2F(\d+)/;
+				const url = page.url();
+				const productIdMatch = productIdRegex.exec( url );
+				productId = productIdMatch ? productIdMatch[ 1 ] : null;
 
-			await expect( productId ).toBeDefined();
-			await expect( title ).toHaveText( productData.name );
+				await expect( productId ).toBeDefined();
+				await expect( title ).toHaveText( productData.name );
+			} );
 		} );
 
 		test( 'can not create a product with duplicated SKU', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -66,7 +66,11 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				await clickOnTab( 'General', page );
 				await page
 					.getByPlaceholder( 'e.g. 12 oz Coffee Mug' )
-					.fill( productData.name );
+					// Have to use pressSequentially in order for the SKU to be auto-updated
+					// before we move to the SKU field and attempt to fill it in; otherwise,
+					// the SKU field can sometimes end up getting auto-updated after we have filled it in,
+					// wiping out the value we entered.
+					.pressSequentially( productData.name );
 
 			await page
 				.locator(
@@ -374,7 +378,11 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				await clickOnTab( 'General', page );
 				await page
 					.locator( '//input[@placeholder="e.g. 12 oz Coffee Mug"]' )
-					.fill( productData.name );
+					// Have to use pressSequentially in order for the SKU to be auto-updated
+					// before we move to the SKU field and attempt to fill it in; otherwise,
+					// the SKU field can sometimes end up getting auto-updated after we have filled it in,
+					// wiping out the value we entered.
+					.pressSequentially( productData.name );
 			} );
 
 			await test.step( 'add product price', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -169,33 +169,41 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			await test.step( 'add custom fields', async () => {
 				await clickOnTab( 'Organization', page );
 
-				const customFieldsToggle = page.getByRole( 'checkbox', {
-					name: 'Show custom fields',
-				} );
-
-				await customFieldsToggle.scrollIntoViewIfNeeded();
+				const customFieldsAddNewButton = page
+					.getByLabel( 'Block: Product custom fields toggle control' )
+					.getByRole( 'button', { name: 'Add new' } );
 
 				// When re-running the test without resetting the env,
 				// the custom fields toggle might be already checked,
-				// so we need to check if it is checked before clicking it.
-				//
-				// Additionally, click() is used instead of check() because
-				// Playwright sometimes has issues with custom checkboxes:
-				// - https://github.com/microsoft/playwright/issues/13470
-				// - https://github.com/microsoft/playwright/issues/20893
-				// - https://github.com/microsoft/playwright/issues/27016
+				// so we need to check if the "Add new" button is already visible.
 				//
 				// eslint-disable-next-line playwright/no-conditional-in-test
-				if ( ! ( await customFieldsToggle.isChecked() ) ) {
-					await customFieldsToggle.click();
+				if ( ! ( await customFieldsAddNewButton.isVisible() ) ) {
+					// Toggle the "Show custom fields" so that the "Add new" button is visible
+
+					const customFieldsToggle = page.getByRole( 'checkbox', {
+						name: 'Show custom fields',
+					} );
+
+					await customFieldsToggle.scrollIntoViewIfNeeded();
+
+					// click() is used instead of check() because
+					// Playwright sometimes has issues with custom checkboxes:
+					// - https://github.com/microsoft/playwright/issues/13470
+					// - https://github.com/microsoft/playwright/issues/20893
+					// - https://github.com/microsoft/playwright/issues/27016
+					//
+					// eslint-disable-next-line playwright/no-conditional-in-test
+					if ( ! ( await customFieldsToggle.isChecked() ) ) {
+						await customFieldsToggle.click();
+					}
+
+					await customFieldsToggle.isEnabled();
 				}
 
-				await customFieldsToggle.isEnabled();
+				await expect( customFieldsAddNewButton ).toBeVisible();
 
-				await page
-					.getByLabel( 'Block: Product custom fields toggle control' )
-					.getByRole( 'button', { name: 'Add new' } )
-					.click();
+				await customFieldsAddNewButton.click();
 
 				// Add custom fields modal
 				const modal = page.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -23,6 +23,7 @@ const productData = {
 	sku: `sku_${ Date.now() }`,
 	gtin: `gtin_${ Date.now() }`,
 	shipping: {
+		shippingClassName: `shipping-class_${ Date.now() }`,
 		weight: '2',
 		length: '20',
 		width: '10',
@@ -171,6 +172,37 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 			await test.step( 'add shipping details', async () => {
 				await clickOnTab( 'Shipping', page );
+
+				// Shipping class
+				await page
+					.getByLabel( 'Shipping class', { exact: true } )
+					//.locator( 'select[name="shipping_class"]' )
+					.selectOption( 'Add new shipping class' );
+
+				// New shipping class modal
+				const modal = page.locator(
+					'.woocommerce-add-new-shipping-class-modal'
+				);
+
+				await expect(
+					modal.getByText( 'New shipping class' )
+				).toBeVisible();
+
+				await modal
+					.getByLabel( 'Name (Required)' )
+					.fill( productData.shipping.shippingClassName );
+
+				await modal.getByText( 'Add' ).click();
+
+				await expect(
+					modal.getByText( 'New shipping class' )
+				).toBeHidden();
+
+				await expect(
+					page.getByLabel( 'Shipping class', { exact: true } )
+				).toHaveValue( productData.shipping.shippingClassName );
+
+				// Shipping dimensions
 				await page
 					.getByLabel( 'Width A' )
 					.fill( productData.shipping.width );
@@ -246,6 +278,8 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					page.getByText( `SKU: ${ productData.sku }` )
 				).toBeVisible();
 				// Note: GTIN is not displayed in the front end in the theme used in the test
+
+				// Note: Shipping class is not displayed in the front end in the theme used in the test
 
 				// Verify shipping dimensions
 				await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -172,7 +172,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				const productIdMatch = productIdRegex.exec( url );
 				productId = productIdMatch ? productIdMatch[ 1 ] : null;
 
-				await expect( productId ).toBeDefined();
+				expect( productId ).toBeDefined();
 				await expect( title ).toHaveText( productData.name );
 			} );
 		} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -53,6 +53,8 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 		let productId;
 
 		test.skip(
+			// skip(condition, description) can be used at runtime to skip a test
+			// eslint-disable-next-line jest/valid-title
 			isTrackingSupposedToBeEnabled,
 			'The block product editor is not being tested'
 		);

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -86,10 +86,6 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			} );
 
 			await test.step( 'add full product description', async () => {
-				const descriptionSimpleParagraph = page.locator(
-					'[data-template-block-id="product-description__content"] > p'
-				);
-
 				// Helps to ensure that block toolbar appears, by letting the editor
 				// know that the user is done typing.
 				await page.keyboard.press( 'Escape' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -20,6 +20,12 @@ const productData = {
 	descriptionSimple: 'This is a product simple description',
 	productPrice: '100',
 	salePrice: '90',
+	shipping: {
+		weight: '2',
+		length: '20',
+		width: '10',
+		height: '30',
+	},
 };
 
 test.describe.configure( { mode: 'serial' } );
@@ -148,6 +154,22 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				await salePrice.waitFor( { state: 'visible' } );
 				await salePrice.click();
 				await salePrice.fill( productData.salePrice );
+			} );
+
+			await test.step( 'add shipping details', async () => {
+				await clickOnTab( 'Shipping', page );
+				await page
+					.getByLabel( 'Width A' )
+					.fill( productData.shipping.width );
+				await page
+					.getByLabel( 'Length B' )
+					.fill( productData.shipping.length );
+				await page
+					.getByLabel( 'Height C' )
+					.fill( productData.shipping.height );
+				await page
+					.getByLabel( 'Weight' )
+					.fill( productData.shipping.weight );
 			} );
 
 			await test.step( 'publish the product', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -184,7 +184,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				// - https://github.com/microsoft/playwright/issues/27016
 				//
 				// eslint-disable-next-line playwright/no-conditional-in-test
-				if ( ! customFieldsToggle.isChecked() ) {
+				if ( ! ( await customFieldsToggle.isChecked() ) ) {
 					await customFieldsToggle.click();
 				}
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -227,6 +227,16 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				await expect(
 					page.getByText( productData.summary )
 				).toBeVisible();
+
+				// Verify shipping dimensions
+				await expect(
+					page.getByText( `Weight ${ productData.shipping.weight }` )
+				).toBeVisible();
+				await expect(
+					page.getByText(
+						`Dimensions ${ productData.shipping.length } × ${ productData.shipping.width } × ${ productData.shipping.height }`
+					)
+				).toBeVisible();
 			} );
 		} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -88,8 +88,9 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					'[data-template-block-id="product-description__content"] > p'
 				);
 
-				// Helps to ensure that block toolbar appears
-				await descriptionSimpleParagraph.click();
+				// Helps to ensure that block toolbar appears, by letting the editor
+				// know that the user is done typing.
+				await page.keyboard.press( 'Escape' );
 
 				await page.getByText( 'Full editor' ).click();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -176,6 +176,13 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				// When re-running the test without resetting the env,
 				// the custom fields toggle might be already checked,
 				// so we need to check if it is checked before clicking it.
+				//
+				// Additionally, click() is used instead of check() because
+				// Playwright sometimes has issues with custom checkboxes:
+				// - https://github.com/microsoft/playwright/issues/13470
+				// - https://github.com/microsoft/playwright/issues/20893
+				// - https://github.com/microsoft/playwright/issues/27016
+				//
 				// eslint-disable-next-line playwright/no-conditional-in-test
 				if ( ! customFieldsToggle.isChecked() ) {
 					await customFieldsToggle.click();

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -190,8 +190,6 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 				await customFieldsToggle.isEnabled();
 
-				await expect( customFieldsToggle ).toBeChecked();
-
 				await page
 					.getByLabel( 'Block: Product custom fields toggle control' )
 					.getByRole( 'button', { name: 'Add new' } )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -173,6 +173,8 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					name: 'Show custom fields',
 				} );
 
+				await customFieldsToggle.scrollIntoViewIfNeeded();
+
 				// When re-running the test without resetting the env,
 				// the custom fields toggle might be already checked,
 				// so we need to check if it is checked before clicking it.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -62,7 +62,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
 			} );
 
-			await test.step( 'add product name, description, and summary', async () => {
+			await test.step( 'add product name', async () => {
 				await clickOnTab( 'General', page );
 				await page
 					.getByPlaceholder( 'e.g. 12 oz Coffee Mug' )
@@ -71,70 +71,79 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 					// the SKU field can sometimes end up getting auto-updated after we have filled it in,
 					// wiping out the value we entered.
 					.pressSequentially( productData.name );
+			} );
 
-			await page
-				.locator(
+			await test.step( 'add product description', async () => {
+				const descriptionSimpleParagraph = page.locator(
 					'[data-template-block-id="product-description__content"] > p'
-				)
-				.fill( productData.descriptionSimple );
+				);
 
-			await page.getByText( 'Full editor' ).click();
+				await descriptionSimpleParagraph.fill(
+					productData.descriptionSimple
+				);
 
-			const wordPressVersion = await getInstalledWordPressVersion();
-			await insertBlock( page, 'Heading', wordPressVersion );
+				// Helps to ensure that block toolbar appears
+				await descriptionSimpleParagraph.click();
 
-			const editorCanvasLocator = page.frameLocator(
-				'iframe[name="editor-canvas"]'
-			);
+				await page.getByText( 'Full editor' ).click();
 
-			await editorCanvasLocator
-				.locator( '[data-title="Heading"]' )
-				.fill( productData.descriptionTitle );
+				const wordPressVersion = await getInstalledWordPressVersion();
+				await insertBlock( page, 'Heading', wordPressVersion );
 
-			await editorCanvasLocator
-				.locator( '[data-title="Heading"]' )
-				.blur();
+				const editorCanvasLocator = page.frameLocator(
+					'iframe[name="editor-canvas"]'
+				);
 
-			await insertBlock( page, 'Paragraph', wordPressVersion );
+				await editorCanvasLocator
+					.locator( '[data-title="Heading"]' )
+					.fill( productData.descriptionTitle );
 
-			await editorCanvasLocator
-				.locator( '[data-title="Paragraph"]' )
-				.last()
-				.fill( productData.descriptionParagraph );
+				await editorCanvasLocator
+					.locator( '[data-title="Heading"]' )
+					.blur();
 
-			await page.getByRole( 'button', { name: 'Done' } ).click();
+				await insertBlock( page, 'Paragraph', wordPressVersion );
 
-			const previewContainerIframe = page
-				.locator( '.block-editor-block-preview__container' )
-				.frameLocator( 'iframe[title="Editor canvas"]' );
+				await editorCanvasLocator
+					.locator( '[data-title="Paragraph"]' )
+					.last()
+					.fill( productData.descriptionParagraph );
 
-			const descriptionTitle = previewContainerIframe.locator(
-				'[data-title="Heading"]'
-			);
-			const descriptionInitialParagraph = previewContainerIframe
-				.locator( '[data-title="Paragraph"]' )
-				.first();
-			const descriptionSecondParagraph = previewContainerIframe
-				.locator( '[data-title="Paragraph"]' )
-				.last();
+				await page.getByRole( 'button', { name: 'Done' } ).click();
 
-			await expect( descriptionTitle ).toHaveText(
-				productData.descriptionTitle
-			);
-			await expect( descriptionInitialParagraph ).toHaveText(
-				productData.descriptionSimple
-			);
-			await expect( descriptionSecondParagraph ).toHaveText(
-				productData.descriptionParagraph
-			);
+				const previewContainerIframe = page
+					.locator( '.block-editor-block-preview__container' )
+					.frameLocator( 'iframe[title="Editor canvas"]' );
 
-			await descriptionTitle.click();
+				const descriptionTitle = previewContainerIframe.locator(
+					'[data-title="Heading"]'
+				);
+				const descriptionInitialParagraph = previewContainerIframe
+					.locator( '[data-title="Paragraph"]' )
+					.first();
+				const descriptionSecondParagraph = previewContainerIframe
+					.locator( '[data-title="Paragraph"]' )
+					.last();
 
-			await expect(
-				page.getByText( 'Edit in full editor' )
-			).toBeVisible();
+				await expect( descriptionTitle ).toHaveText(
+					productData.descriptionTitle
+				);
+				await expect( descriptionInitialParagraph ).toHaveText(
+					productData.descriptionSimple
+				);
+				await expect( descriptionSecondParagraph ).toHaveText(
+					productData.descriptionParagraph
+				);
 
-			await page
+				await descriptionTitle.click();
+
+				await expect(
+					page.getByText( 'Edit in full editor' )
+				).toBeVisible();
+			} );
+
+			await test.step( 'add product summary', async () => {
+				await page
 					.locator(
 						'[data-template-block-id="basic-details"] .components-summary-control'
 					)

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -197,6 +197,33 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				expect( productId ).toBeDefined();
 				await expect( title ).toHaveText( productData.name );
 			} );
+
+			// Note for future refactoring: It would be good to reuse the verification step
+			// from product-create-simple.spec.js, as both tests are just verifying that the
+			// product was created correctly by looking at the front end.
+			await test.step( 'verify the saved product in frontend', async () => {
+				await page.goto( `/?post_type=product&p=${ productId }` );
+
+				// Verify product name
+				await expect(
+					page.getByRole( 'heading', {
+						name: productData.name,
+					} )
+				).toBeVisible();
+
+				// Verify price
+				await expect(
+					page.getByText( productData.productPrice ).first()
+				).toBeVisible();
+				await expect(
+					page.getByText( productData.salePrice ).first()
+				).toBeVisible();
+
+				// Verify summary
+				await expect(
+					page.getByText( productData.summary )
+				).toBeVisible();
+			} );
 		} );
 
 		test( 'can not create a product with duplicated SKU', async ( {
@@ -231,30 +258,13 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			).toContainText( 'Invalid or duplicated SKU.' );
 		} );
 
+		// Note for future refactoring: It would be good to reuse the verification step
+		// from product-create-simple.spec.js, as both tests are just verifying that the
+		// product that was created can be added to the cart in the front end.
 		test( 'can a shopper add the simple product to the cart', async ( {
 			page,
 		} ) => {
 			await page.goto( `/?post_type=product&p=${ productId }` );
-			await expect(
-				page.getByRole( 'heading', { name: productData.name } )
-			).toBeVisible();
-
-			await expect
-				.soft(
-					await page
-						.locator( 'del' )
-						.getByText( `$${ productData.productPrice }` )
-						.count()
-				)
-				.toBeGreaterThan( 0 );
-			await expect
-				.soft(
-					await page
-						.locator( 'ins' )
-						.getByText( `$${ productData.salePrice }` )
-						.count()
-				)
-				.toBeGreaterThan( 0 );
 
 			await page.locator( 'button[name="add-to-cart"]' ).click();
 			await page.getByRole( 'link', { name: 'View cart' } ).click();

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -346,6 +346,10 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				const productIdRegex = /product%2F(\d+)/;
 				const url = page.url();
 				const productIdMatch = productIdRegex.exec( url );
+				// This isn't really a conditional branch in the test;
+				// just making sure we don't blow up if the regex doesn't match
+				// (it will be caught in the expect below).
+				// eslint-disable-next-line playwright/no-conditional-in-test
 				productId = productIdMatch ? productIdMatch[ 1 ] : null;
 
 				expect( productId ).toBeDefined();

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -113,7 +113,10 @@ test(
 				.getByRole( 'heading', { name: 'Attributes' } )
 				.isVisible();
 
-			await page.getByRole( 'button', { name: 'Add new' } ).click();
+			await page
+				// Using a selector because there are many "Add new" buttons on the page
+				.locator( 'woocommerce-add-attribute-list-item__add-button' )
+				.click();
 
 			await page
 				.getByRole( 'heading', { name: 'Add variation options' } )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -115,7 +115,7 @@ test(
 
 			await page
 				// Using a selector because there are many "Add new" buttons on the page
-				.locator( 'woocommerce-add-attribute-list-item__add-button' )
+				.locator( '.woocommerce-add-attribute-list-item__add-button' )
 				.click();
 
 			await page


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the following to the creation of a simple product with the new product editor e2e test:

- SKU (verified on frontend)
- GTIN (the GTIN is not shown on the frontend with the theme used by e2e test, so no verification done)
- Shipping class (shipping class is not shown on the frontend with the theme used by e2e test, so no verification done)
- Shipping dimensions (verified on frontend)

In addition, the e2e test was refactored to break it up into steps, for easier debugging/viewing.

In order to fill the SKU field in the e2e tests, the association of the SKU label and input was fixed in the `@woocommerce/product-editor` package. Since this is a very small change, and tested by the e2e test, I included it in this PR.

There was a good deal of tweaking of these changes to get them to run reliably (not flaky) -- I've included comments for any implementation details that were due to this.

Closes #50036.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Automated tests

1. Verify e2e tests pass

#### Manual tests

The e2e tests now cover setting the SKU field. But, since the label and input association was fixed in order for the e2e tests to work, it would also be good to just quickly manually test that the SKU field still works.

With a WooCommerce env with the new product editor enabled (**WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**)...

1. Go to **Products** > **Add New**
2. On the **Inventory** tab, verify that the SKU field works (no visual change; accessibility improved because label is now correctly associated with field, so VoiceOver should correctly announce the field name)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
