### PR TITLE
[e2e tests] Remove Github reporter

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -22,7 +22,6 @@ const config: PlaywrightTestConfig = {
 	forbidOnly: !! CI,
 	reporter: process.env.CI
 		? [
-				[ 'github' ],
 				[ 'list' ],
 				[ './flaky-tests-reporter.ts' ],
 				[

--- a/plugins/woocommerce/changelog/e2e-remove-github-reporter
+++ b/plugins/woocommerce/changelog/e2e-remove-github-reporter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: removed Github reporter

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -44,7 +44,6 @@ const reporter = [
 ];
 
 if ( process.env.CI ) {
-	reporter.push( [ 'github' ] );
 	reporter.push( [ 'buildkite-test-collector/playwright/reporter' ] );
 	reporter.push( [ `${ testsRootPath }/reporters/skipped-tests.js` ] );
 } else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Playwright's Github reporter is creating automatic failure annotations. We find it too noisy without real value, failures being discoverable with different other ways. This PR removes it.

Context: p1722280383738159-slack-C03CPM3UXDJ

### How to test the changes in this Pull Request:

CI should be green.
Check the `Files changes` section of the PR. No annotation should be present on test code showing any test failures.