### PR TITLE
[e2e tests] Implement the flaky test reporter for core e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-core-e2e-add-new-flaky-reporter
+++ b/plugins/woocommerce/changelog/e2e-core-e2e-add-new-flaky-reporter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: add a flaky test reporter for Core e2e tests

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -41,6 +41,10 @@ const reporter = [
 		`${ testsRootPath }/reporters/environment-reporter.js`,
 		{ outputFolder: `${ testsRootPath }/test-results/allure-results` },
 	],
+	[
+		`${ testsRootPath }/reporters/flaky-tests-reporter.js`,
+		{ outputFolder: `${ testsRootPath }/test-results/flaky-tests` },
+	],
 ];
 
 if ( process.env.CI ) {

--- a/plugins/woocommerce/tests/e2e-pw/reporters/flaky-tests-reporter.js
+++ b/plugins/woocommerce/tests/e2e-pw/reporters/flaky-tests-reporter.js
@@ -1,0 +1,77 @@
+/**
+ * A **flaky** test is defined as a test which passed after auto-retrying.
+ * - By default, all tests run once if they pass.
+ * - If a test fails, it will automatically re-run at most 2 times.
+ * - If it passes after retrying (below 2 times), then it's marked as **flaky**
+ *   but displayed as **passed** in the original test suite.
+ * - If it failed all times, then it's a **failed** test.
+ */
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+require( '@playwright/test/reporter' );
+
+// Remove "steps" to prevent stringify circular structure.
+function formatTestResult( testResult ) {
+	const result = { ...testResult, steps: undefined };
+	delete result.steps;
+	return result;
+}
+
+class FlakyTestsReporter {
+	constructor( options ) {
+		this.outputFolder = options.outputFolder;
+		this.failingTestCaseResults = new Map();
+	}
+
+	onBegin() {
+		try {
+			fs.mkdirSync( this.outputFolder, {
+				recursive: true,
+			} );
+		} catch ( err ) {
+			if ( err.code === 'EEXIST' ) {
+				// Ignore the error if the directory already exists.
+			} else {
+				throw err;
+			}
+		}
+	}
+
+	onTestEnd( test, result ) {
+		const testPath = test.location.file;
+		const testTitle = test.title;
+
+		switch ( test.outcome() ) {
+			case 'unexpected': {
+				if ( ! this.failingTestCaseResults.has( testTitle ) ) {
+					this.failingTestCaseResults.set( testTitle, [] );
+				}
+				this.failingTestCaseResults
+					.get( testTitle )
+					.push( formatTestResult( result ) );
+				break;
+			}
+			case 'flaky': {
+				const safeFileName = testTitle.replace( /[^a-z0-9]/gi, '_' );
+				fs.writeFileSync(
+					`${ this.outputFolder }/${ safeFileName }.json`,
+					JSON.stringify( {
+						version: 1,
+						runner: '@playwright/test',
+						title: testTitle,
+						path: testPath,
+						results: this.failingTestCaseResults.get( testTitle ),
+					} ),
+					'utf-8'
+				);
+				break;
+			}
+			default:
+				break;
+		}
+	}
+}
+
+module.exports = FlakyTestsReporter;

--- a/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
@@ -2,8 +2,7 @@ const { test, expect } = require( '@playwright/test' );
 const { logIn } = require( '../utils/login' );
 const { admin, customer } = require( '../test-data/data' );
 
-test( 'Load the home page', async ( { page }, testInfo ) => {
-	expect( testInfo.retry ).toBe( 1 );
+test( 'Load the home page', async ( { page } ) => {
 	await page.goto( '/' );
 	await expect(
 		await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
@@ -2,7 +2,8 @@ const { test, expect } = require( '@playwright/test' );
 const { logIn } = require( '../utils/login' );
 const { admin, customer } = require( '../test-data/data' );
 
-test( 'Load the home page', async ( { page } ) => {
+test( 'Load the home page', async ( { page }, testInfo ) => {
+	expect( testInfo.retry ).toBe( 1 );
 	await page.goto( '/' );
 	await expect(
 		await page


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/48599

Implements a flaky test reporter in Core e2e tests solution. The reporter will create json report files for flaky tests so that the `report-flaky-tests` CI job can create issues for them.
This adds consistency in our reporting, this solution being copied from the blocks e2e tests project.

### How to test the changes in this Pull Request:

Check CI:
- flaky tests reports are generated and uploaded: https://github.com/woocommerce/woocommerce/actions/runs/10213556173/job/28259206422?pr=50259#step:10:20
- The `'Create issues for flaky tests'` job ran and passed: https://github.com/woocommerce/woocommerce/actions/runs/10213556173/job/28259862835?pr=50259

Issues are not created for first flaky occurrences in PRs. They need to first occur in trunk.

