### PR TITLE
Rename and move errorHandler method

### DIFF
--- a/packages/js/product-editor/changelog/dev-50276_rename_and_move_error_handler
+++ b/packages/js/product-editor/changelog/dev-50276_rename_and_move_error_handler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Rename and move errorHandler method #50277

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/edit.tsx
@@ -42,7 +42,7 @@ import type {
 import { ProductDetailsSectionDescriptionBlockAttributes } from './types';
 import * as wooIcons from '../../../icons';
 import isProductFormTemplateSystemEnabled from '../../../utils/is-product-form-template-system-enabled';
-import { errorHandler } from '../../../hooks/use-product-manager';
+import { formatProductError } from '../../../utils/format-product-error';
 
 export function ProductDetailsSectionDescriptionBlockEdit( {
 	attributes,
@@ -189,7 +189,7 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 			} catch ( error ) {
 				const { message, errorProps } =
 					await getProductErrorMessageAndProps(
-						errorHandler(
+						formatProductError(
 							error as WPError,
 							productStatus
 						) as WPError,
@@ -311,7 +311,10 @@ export function ProductDetailsSectionDescriptionBlockEdit( {
 		} catch ( error ) {
 			const { message, errorProps } =
 				await getProductErrorMessageAndProps(
-					errorHandler( error as WPError, productStatus ) as WPError,
+					formatProductError(
+						error as WPError,
+						productStatus
+					) as WPError,
 					selectedTab
 				);
 			createErrorNotice( message, errorProps );

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -16,7 +16,7 @@ import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../hooks/use-error-handler';
 import { useProductURL } from '../../../../hooks/use-product-url';
 import { PreviewButtonProps } from '../../preview-button';
-import { errorHandler } from '../../../../hooks/use-product-manager';
+import { formatProductError } from '../../../../utils/format-product-error';
 
 export function usePreview( {
 	productStatus,
@@ -129,7 +129,10 @@ export function usePreview( {
 		} catch ( error ) {
 			if ( onSaveError ) {
 				onSaveError(
-					errorHandler( error as WPError, productStatus ) as WPError
+					formatProductError(
+						error as WPError,
+						productStatus
+					) as WPError
 				);
 			}
 		}

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -18,7 +18,7 @@ import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../hooks/use-error-handler';
 import { SaveDraftButtonProps } from '../../save-draft-button';
 import { recordProductEvent } from '../../../../utils/record-product-event';
-import { errorHandler } from '../../../../hooks/use-product-manager';
+import { formatProductError } from '../../../../utils/format-product-error';
 
 export function useSaveDraft( {
 	productStatus,
@@ -108,7 +108,10 @@ export function useSaveDraft( {
 		} catch ( error ) {
 			if ( onSaveError ) {
 				onSaveError(
-					errorHandler( error as WPError, productStatus ) as WPError
+					formatProductError(
+						error as WPError,
+						productStatus
+					) as WPError
 				);
 			}
 		}

--- a/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
+++ b/packages/js/product-editor/src/hooks/use-product-manager/use-product-manager.ts
@@ -12,37 +12,7 @@ import { Product, ProductStatus, PRODUCTS_STORE_NAME } from '@woocommerce/data';
 import { useValidations } from '../../contexts/validation-context';
 import type { WPError } from '../../hooks/use-error-handler';
 import { AUTO_DRAFT_NAME } from '../../utils/constants';
-
-export function errorHandler( error: WPError, productStatus: ProductStatus ) {
-	if ( error.code ) {
-		return error;
-	}
-
-	const errorObj = Object.values( error ).find(
-		( value ) => value !== undefined
-	) as WPError | undefined;
-
-	if ( 'variations' in error && error.variations ) {
-		return {
-			...errorObj,
-			code: 'variable_product_no_variation_prices',
-		};
-	}
-
-	if ( errorObj !== undefined ) {
-		return {
-			...errorObj,
-			code: 'product_form_field_error',
-		};
-	}
-
-	return {
-		code:
-			productStatus === 'publish' || productStatus === 'future'
-				? 'product_publish_error'
-				: 'product_create_error',
-	};
-}
+import { formatProductError } from '../../utils/format-product-error';
 
 export function useProductManager< T = Product >( postType: string ) {
 	const [ id ] = useEntityProp< number >( 'postType', postType, 'id' );
@@ -107,7 +77,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return savedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status );
+			throw formatProductError( error as WPError, status );
 		} finally {
 			setIsSaving( false );
 		}
@@ -128,7 +98,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return duplicatedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status );
+			throw formatProductError( error as WPError, status );
 		} finally {
 			setIsSaving( false );
 		}
@@ -174,7 +144,7 @@ export function useProductManager< T = Product >( postType: string ) {
 
 			return deletedProduct as T;
 		} catch ( error ) {
-			throw errorHandler( error as WPError, status );
+			throw formatProductError( error as WPError, status );
 		} finally {
 			setTrashing( false );
 		}

--- a/packages/js/product-editor/src/utils/format-product-error.ts
+++ b/packages/js/product-editor/src/utils/format-product-error.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { ProductStatus } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import type { WPError } from '../hooks/use-error-handler';
+
+export function formatProductError(
+	error: WPError,
+	productStatus: ProductStatus
+) {
+	if ( error.code ) {
+		return error;
+	}
+
+	const errorObj = Object.values( error ).find(
+		( value ) => value !== undefined
+	) as WPError | undefined;
+
+	if ( 'variations' in error && error.variations ) {
+		return {
+			...errorObj,
+			code: 'variable_product_no_variation_prices',
+		};
+	}
+
+	if ( errorObj !== undefined ) {
+		return {
+			...errorObj,
+			code: 'product_form_field_error',
+		};
+	}
+
+	return {
+		code:
+			productStatus === 'publish' || productStatus === 'future'
+				? 'product_publish_error'
+				: 'product_create_error',
+	};
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR renames the method `errorHandler` to `formatProductError` and moves it to its own utility file `format-product-error`.

This change is part of the changes needed [to add a link to the error snackbar](https://github.com/woocommerce/woocommerce/issues/46768).

Closes #50276.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`.
2. Go to Product > Add New.
3. Test different error scenarios (ensure to test the error from a different tab than the field with the error and the same one):
  - _**Same tab**: Trigger the error from the same tab as the field with the error. The error will display and dismiss automatically after a few seconds._
  - _**Different tab**: Trigger the error from a different tab than the field with the error. You will see a link pointing to the field with the error._
  - Try to save a product without a name.
  - Try to enable a `Schedule sale` and set a finishing date earlier than the beginning date.
  - Go to the `Shipping` tab and set one of the `Dimensions` to zero.
  - Go to the `Inventory` tab and set a repeated SKU.
  - In a brand new product, try creating a few variations and save the product before adding a price to them. (For Variations, no field will be focused when clicking the link.)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
