### PR TITLE
[Automated] Skip flaky test: can create a simple product

### DIFF
--- a/plugins/woocommerce/changelog/changelog-0aa124a4-d91f-8259-9fa3-55226a9c9d98
+++ b/plugins/woocommerce/changelog/changelog-0aa124a4-d91f-8259-9fa3-55226a9c9d98
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can create a simple product

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -38,7 +38,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			'The block product editor is not being tested'
 		);
 
-		test( 'can create a simple product', async ( { page } ) => {
+		test.skip( 'can create a simple product', async ( { page } ) => {
 			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
 			await clickOnTab( 'General', page );
 			await page


### PR DESCRIPTION
This pull request skips the flaky test `can create a simple product` located at `tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js:41:3`.