### PR TITLE
[Automated] Skip flaky test: can transform classic cart to cart block

### DIFF
--- a/plugins/woocommerce/changelog/changelog-740876bb-1554-8671-9eae-06603712d934
+++ b/plugins/woocommerce/changelog/changelog-740876bb-1554-8671-9eae-06603712d934
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can transform classic cart to cart block

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
@@ -17,7 +17,7 @@ test.describe(
 	'Transform Classic Cart To Cart Block',
 	{ tag: [ '@gutenberg', '@services' ] },
 	() => {
-		test( 'can transform classic cart to cart block', async ( {
+		test.skip( 'can transform classic cart to cart block', async ( {
 			page,
 			testPage,
 		} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `can transform classic cart to cart block` located at `tests/e2e-pw/tests/merchant/create-cart-block.spec.js:20:3`.