### PR TITLE
[Automated] Skip flaky test: allows cart block to apply coupon of any type

### DIFF
--- a/plugins/woocommerce/changelog/changelog-ca72c651-9caf-8112-b798-d665ca42abb7
+++ b/plugins/woocommerce/changelog/changelog-ca72c651-9caf-8112-b798-d665ca42abb7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: allows cart block to apply coupon of any type

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
@@ -127,7 +127,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'allows cart block to apply coupon of any type', async ( {
+		test.skip( 'allows cart block to apply coupon of any type', async ( {
 			page,
 		} ) => {
 			const totals = [ '$50.00', '$27.50', '$45.00' ];


### PR DESCRIPTION
This pull request skips the flaky test `allows cart block to apply coupon of any type` located at `tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js:130:3`.