### PR TITLE
[Automated] Skip flaky test: allows customer to calculate Flat rate and Local pickup in cart block if in Portugal

### DIFF
--- a/plugins/woocommerce/changelog/changelog-709ea2c5-e34c-838d-ad87-3e992bf7c119
+++ b/plugins/woocommerce/changelog/changelog-709ea2c5-e34c-838d-ad87-3e992bf7c119
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: allows customer to calculate Flat rate and Local pickup in cart block if in Portugal

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -162,7 +162,7 @@ test.describe(
 			);
 		} );
 
-		test( 'allows customer to calculate Flat rate and Local pickup in cart block if in Portugal', async ( {
+		test.skip( 'allows customer to calculate Flat rate and Local pickup in cart block if in Portugal', async ( {
 			page,
 			context,
 			cartBlockPage,


### PR DESCRIPTION
This pull request skips the flaky test `allows customer to calculate Flat rate and Local pickup in cart block if in Portugal` located at `tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js:165:3`.