### PR TITLE
[Automated] Skip flaky test: should show correct total cart block price with 2 different products and flat rate/local pickup

### DIFF
--- a/plugins/woocommerce/changelog/changelog-7ee59cd7-4b8e-8b4f-b4c2-729f5f8a5c7a
+++ b/plugins/woocommerce/changelog/changelog-7ee59cd7-4b8e-8b4f-b4c2-729f5f8a5c7a
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: should show correct total cart block price with 2 different products and flat rate/local pickup

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -234,7 +234,7 @@ test.describe(
 			).toBeVisible();
 		} );
 
-		test( 'should show correct total cart block price with 2 different products and flat rate/local pickup', async ( {
+		test.skip( 'should show correct total cart block price with 2 different products and flat rate/local pickup', async ( {
 			page,
 			context,
 			cartBlockPage,


### PR DESCRIPTION
This pull request skips the flaky test `should show correct total cart block price with 2 different products and flat rate/local pickup` located at `tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js:237:3`.