### PR TITLE
[Automated] Skip flaky test: Clicking opt-in new fonts should be available

### DIFF
--- a/plugins/woocommerce/changelog/changelog-3c38bc09-83b6-87c1-b50d-e5d787e12b42
+++ b/plugins/woocommerce/changelog/changelog-3c38bc09-83b6-87c1-b50d-e5d787e12b42
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Clicking opt-in new fonts should be available

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -230,7 +230,7 @@ test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
 		expect( isSecondaryFontUsed ).toBe( true );
 	} );
 
-	test( 'Clicking opt-in new fonts should be available', async ( {
+	test.skip( 'Clicking opt-in new fonts should be available', async ( {
 		pageObject,
 		page,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Clicking opt-in new fonts should be available` located at `tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js:233:2`.