### PR TITLE
[Automated] Skip flaky test: can see empty cart, add and remove simple & cross sell product, increase to max quantity

### DIFF
--- a/plugins/woocommerce/changelog/changelog-51641544-c6e6-80ed-b025-57dd2bbcb636
+++ b/plugins/woocommerce/changelog/changelog-51641544-c6e6-80ed-b025-57dd2bbcb636
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: can see empty cart, add and remove simple & cross sell product, increase to max quantity

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
@@ -73,7 +73,7 @@ test.describe( 'Cart Block page', { tag: [ '@payments', '@services' ] }, () => {
 		} );
 	} );
 
-	test( 'can see empty cart, add and remove simple & cross sell product, increase to max quantity', async ( {
+	test.skip( 'can see empty cart, add and remove simple & cross sell product, increase to max quantity', async ( {
 		page,
 		testPage,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `can see empty cart, add and remove simple & cross sell product, increase to max quantity` located at `tests/e2e-pw/tests/shopper/cart-block.spec.js:76:2`.