### PR TITLE
[Automated] Skip flaky test: Clicking the "Delete" button on a pattern should remove it from the preview

### DIFF
--- a/plugins/woocommerce/changelog/changelog-642cf446-12b2-81fa-8cca-e4952035a143
+++ b/plugins/woocommerce/changelog/changelog-642cf446-12b2-81fa-8cca-e4952035a143
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Clicking the "Delete" button on a pattern should remove it from the preview

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -276,7 +276,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		);
 	} );
 
-	test( 'Clicking the "Delete" button on a pattern should remove it from the preview', async ( {
+	test.skip( 'Clicking the "Delete" button on a pattern should remove it from the preview', async ( {
 		pageObject,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Clicking the "Delete" button on a pattern should remove it from the preview` located at `tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js:265:2`.