### PR TITLE
[Automated] Skip flaky test: Clicking on "Design your homepage" should open the Intro sidebar by default

### DIFF
--- a/plugins/woocommerce/changelog/changelog-d4cf9152-67bf-83fa-8d49-7f7f437867b2
+++ b/plugins/woocommerce/changelog/changelog-d4cf9152-67bf-83fa-8d49-7f7f437867b2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Clicking on "Design your homepage" should open the Intro sidebar by default

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -110,7 +110,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		await expect( categories ).toHaveCount( 6 );
 	} );
 
-	test( 'Clicking on "Design your homepage" should open the Intro sidebar by default', async ( {
+	test.skip( 'Clicking on "Design your homepage" should open the Intro sidebar by default', async ( {
 		pageObject,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Clicking on "Design your homepage" should open the Intro sidebar by default` located at `tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js:99:2`.