### PR TITLE
[Automated] Skip flaky test: Should show the "Want more patterns?" banner with the offline message when the user is offline and tracking is not allowed

### DIFF
--- a/plugins/woocommerce/changelog/changelog-12f63f2e-0c45-85b9-9915-68f817852930
+++ b/plugins/woocommerce/changelog/changelog-12f63f2e-0c45-85b9-9915-68f817852930
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Should show the "Want more patterns?" banner with the offline message when the user is offline and tracking is not allowed


### PR DESCRIPTION
This pull request skips the flaky test `Should show the "Want more patterns?" banner with the offline message when the user is offline and tracking is not allowed` located at `tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js:257:3`.