### PR TITLE
[Automated] Skip flaky test: Clicking the "Move up/down" buttons should change the pattern order in the preview

### DIFF
--- a/plugins/woocommerce/changelog/changelog-3ce0fe43-335c-8cd7-9011-2d93aa038a89
+++ b/plugins/woocommerce/changelog/changelog-3ce0fe43-335c-8cd7-9011-2d93aa038a89
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Clicking the "Move up/down" buttons should change the pattern order in the preview

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -197,7 +197,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		);
 	} );
 
-	test( 'Clicking the "Move up/down" buttons should change the pattern order in the preview', async ( {
+	test.skip( 'Clicking the "Move up/down" buttons should change the pattern order in the preview', async ( {
 		pageObject,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Clicking the "Move up/down" buttons should change the pattern order in the preview` located at `tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js:186:2`.