### PR TITLE
[Automated] Skip flaky test: Clicking the "Shuffle" button on a patterns should replace it for another one

### DIFF
--- a/plugins/woocommerce/changelog/changelog-20d415e0-cbcc-8458-ab0b-399796ac6aef
+++ b/plugins/woocommerce/changelog/changelog-20d415e0-cbcc-8458-ab0b-399796ac6aef
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Clicking the "Shuffle" button on a patterns should replace it for another one

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -238,7 +238,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		expect( firstPatternContent ).toContain( sidebarPatternContent );
 	} );
 
-	test( 'Clicking the "Shuffle" button on a patterns should replace it for another one', async ( {
+	test.skip( 'Clicking the "Shuffle" button on a patterns should replace it for another one', async ( {
 		pageObject,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Clicking the "Shuffle" button on a patterns should replace it for another one` located at `tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js:227:2`.