### PR TITLE
[Automated] Skip flaky test: Should show the "Want more patterns?" banner with the Opt-in message when tracking is not allowed

### DIFF
--- a/plugins/woocommerce/changelog/changelog-2d3b5f5c-3a7e-8c7e-b228-5fb77248e806
+++ b/plugins/woocommerce/changelog/changelog-2d3b5f5c-3a7e-8c7e-b228-5fb77248e806
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Should show the "Want more patterns?" banner with the Opt-in message when tracking is not allowed


### PR DESCRIPTION
This pull request skips the flaky test `Should show the "Want more patterns?" banner with the Opt-in message when tracking is not allowed` located at `tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js:233:3`.