### PR TITLE
[Automated] Skip flaky test: Clicking on a pattern should insert it in the preview

### DIFF
--- a/plugins/woocommerce/changelog/changelog-b3dc6078-2746-8b40-b53a-02c1c4e073eb
+++ b/plugins/woocommerce/changelog/changelog-b3dc6078-2746-8b40-b53a-02c1c4e073eb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: Clicking on a pattern should insert it in the preview

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -164,7 +164,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		}
 	} );
 
-	test( 'Clicking on a pattern should insert it in the preview', async ( {
+	test.skip( 'Clicking on a pattern should insert it in the preview', async ( {
 		pageObject,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `Clicking on a pattern should insert it in the preview` located at `tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js:153:2`.