### PR TITLE
[Automated] Skip flaky test: The list of categories should be displayed

### DIFF
--- a/plugins/woocommerce/changelog/changelog-ce3493c5-f159-8fc4-9c49-224a8152f933
+++ b/plugins/woocommerce/changelog/changelog-ce3493c5-f159-8fc4-9c49-224a8152f933
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: The list of categories should be displayed

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -96,7 +96,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		}
 	} );
 
-	test( 'The list of categories should be displayed', async ( {
+	test.skip( 'The list of categories should be displayed', async ( {
 		pageObject,
 		baseURL,
 	} ) => {


### PR DESCRIPTION
This pull request skips the flaky test `The list of categories should be displayed` located at `tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js:85:2`.