### PR TITLE
[Automated] Skip flaky test: should hide loading screen and steps on subsequent runs

### DIFF
--- a/plugins/woocommerce/changelog/changelog-1cbf3393-65be-8d59-b92d-d92fc67f0832
+++ b/plugins/woocommerce/changelog/changelog-1cbf3393-65be-8d59-b92d-d92fc67f0832
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skipped flaky test: should hide loading screen and steps on subsequent runs

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -114,7 +114,7 @@ test.describe( 'Assembler - Loading Page', { tag: '@gutenberg' }, () => {
 		).toBeVisible();
 	} );
 
-	test( 'should hide loading screen and steps on subsequent runs', async ( {
+	test.skip( 'should hide loading screen and steps on subsequent runs', async ( {
 		pageObject,
 		baseURL,
 		page,


### PR DESCRIPTION
This pull request skips the flaky test `should hide loading screen and steps on subsequent runs` located at `tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js:117:2`.