### PR TITLE
CI: minor speed boost for Check Asset Sizes and Build Project Jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,8 @@ jobs:
         with:
           # If 'base_ref' is available, the 'Build Matrix' step requires non-shallow git-history to identify changed files.
           fetch-depth: ${{ ( ( github.base_ref && '0' ) || '1' ) }}
-      - uses: './.github/actions/setup-woocommerce-monorepo'
-        name: 'Setup Monorepo'
-        with:
-          php-version: false # We don't want to waste time installing PHP since we aren't using it in this job.
+      - name: 'Setup PNPM'
+        uses: 'pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d'
       - uses: actions/github-script@v7
         name: 'Build Matrix'
         id: 'project-jobs'
@@ -254,10 +252,8 @@ jobs:
       - uses: 'actions/checkout@v4'
         name: 'Checkout'
 
-      - uses: './.github/actions/setup-woocommerce-monorepo'
-        name: 'Setup Monorepo'
-        with:
-          php-version: false
+      - name: 'Setup PNPM'
+        uses: 'pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d'
 
       - name: 'Send messages for failed jobs'
         env:

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -41,9 +41,7 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  # Both install and build are handled by compressed-size-action.
-                  install: false
-                  build: false
+                  php-version: false
                   pull-package-deps: '@woocommerce/plugin-woocommerce'
 
             - uses: preactjs/compressed-size-action@f780fd104362cfce9e118f9198df2ee37d12946c

--- a/.github/workflows/pr-lint-markdown.yml
+++ b/.github/workflows/pr-lint-markdown.yml
@@ -39,8 +39,6 @@ jobs:
 
             - name: Setup PNPM
               uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-              with:
-                  version: '8.6.7'
 
             - name: Setup Node
               uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"title": "WooCommerce Monorepo",
 	"description": "Monorepo for the WooCommerce ecosystem",
 	"homepage": "https://woocommerce.com/",
+	"packageManager": "pnpm@^9.1.0",
 	"engines": {
 		"node": "^20.11.1",
 		"pnpm": "^9.1.0"

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@woocommerce/plugin-woocommerce",
 	"private": true,
-	"title": "WooCommerce...",
+	"title": "WooCommerce",
 	"version": "9.3.0",
 	"homepage": "https://woocommerce.com/",
 	"repository": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@woocommerce/plugin-woocommerce",
 	"private": true,
-	"title": "WooCommerce",
+	"title": "WooCommerce...",
 	"version": "9.3.0",
 	"homepage": "https://woocommerce.com/",
 	"repository": {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm partially extracting changes from https://github.com/woocommerce/woocommerce/pull/50261: the boost is several seconds, but the changes also clears a bit the jobs dependencies.

### Testing

- CI checks shall pass (sample run - https://github.com/woocommerce/woocommerce/actions/runs/10243406103/job/28334631333?pr=50342)
