### PR TITLE
Fix Gutenberg modal conflict around CSS specificity

### DIFF
--- a/packages/js/product-editor/changelog/fix-50058_gb_modal_conflict
+++ b/packages/js/product-editor/changelog/fix-50058_gb_modal_conflict
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Increase specificity of modal styling to avoid Gutenberg styling conflicts.

--- a/packages/js/product-editor/src/components/add-products-modal/style.scss
+++ b/packages/js/product-editor/src/components/add-products-modal/style.scss
@@ -1,5 +1,5 @@
-.woocommerce-add-products-modal,
-.woocommerce-reorder-products-modal {
+.components-modal__frame.woocommerce-add-products-modal,
+.components-modal__frame.woocommerce-reorder-products-modal {
 	@include breakpoint(">600px") {
 		width: calc(100% - 32px);
 	}
@@ -11,7 +11,9 @@
 			width: 50%;
 		}
 	}
-
+}
+.woocommerce-add-products-modal,
+.woocommerce-reorder-products-modal {
 	&__input-suffix {
 		margin-right: $grid-unit-15;
 	}

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -1,5 +1,7 @@
-.woocommerce-new-attribute-modal {
+.components-modal__frame.woocommerce-new-attribute-modal {
 	min-width: 75%;
+}
+.woocommerce-new-attribute-modal {
 	.components-notice.is-info {
 		margin-left: 0;
 		margin-right: 0;

--- a/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
+++ b/packages/js/product-editor/src/components/custom-fields/create-modal/style.scss
@@ -1,6 +1,8 @@
-.woocommerce-product-custom-fields__create-modal {
+.components-modal__frame.woocommerce-product-custom-fields__create-modal {
 	min-width: 75%;
+}
 
+.woocommerce-product-custom-fields__create-modal {
 	[role="table"] {
 		width: 100%;
 

--- a/packages/js/product-editor/src/components/modal-editor/style.scss
+++ b/packages/js/product-editor/src/components/modal-editor/style.scss
@@ -1,6 +1,6 @@
 $modal-editor-height: 60px;
 
-.woocommerce-modal-editor {
+.components-modal__frame.woocommerce-modal-editor {
     width: 100%;
     height: 100%;
     max-height: calc( 100% - 40px );

--- a/packages/js/product-editor/src/components/tags-field/create-tag-modal.scss
+++ b/packages/js/product-editor/src/components/tags-field/create-tag-modal.scss
@@ -1,6 +1,8 @@
 .woocommerce-create-new-tag-modal {
-	min-width: 650px;
-	overflow: visible;
+	&__wrapper {
+		min-width: 590px;
+		overflow: visible;
+	}
 
 	&__buttons {
 		margin-top: $gap-larger;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some CSS specificity changed in the latest GB `trunk` version, causing modals that only use the passed in class name to use the wrong width. This addresses that. 

Closes #50058  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build this branch on a fresh WooCommerce site **without** Gutenberg enabled ( note: you will need to enable this later )
2. Enable the new **Product form** under **Settings > Advanced > Features**
3. Go to **products > add new** and add a title
4. Scroll down to the **Description** field and click **Full editor** the editor modal should popup in full screen ( not small as shown in the linked issue ) close it again.
5. Go to the **organization** tab and click **Add new** in the attributes and add an attribute ( note the modal should not be super small, but relatively big )
6. Scroll down and toggle the **Show custom fields**
7. Click **Add new** and add a custom field ( the modal should be similar size as the add attribute modal )
8. Scroll up and click on the **Tags** field and click **Create new** modal should be around 650 pixels
9. Go back to the **general** tab and change the product type to **Grouped**
10. Scroll down to the **Products in this group** and click **Add products**
11. **Add products** modal should be 640 pixels
12. Now go to **Plugins** and enable the Gutenberg plugin, make sure you build and install [the `trunk` version ](https://github.com/WordPress/gutenberg/tree/trunk)
13. Once Gutenberg is enabled follow steps 3 till 11 again to make sure all the widths of the Modals are the same.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
