### PR TITLE
Compatibility Layer: fix  'woocommerce_before_single_product_summary'  hook position

### DIFF
--- a/plugins/woocommerce-blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
@@ -55,7 +55,7 @@ The following table shows where the hooks are injected into the page.
 | woocommerce_after_main_content            | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)  | after    |
 | woocommerce_sidebar                       | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)  | after    |
 | woocommerce_before_single_product         | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | before   |
-| woocommerce_before_single_product_summary | First `core/post-excerpt` block (before `woocommerce_single_product_summary`) | before   |
+| woocommerce_before_single_product_summary | First block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs) | before |
 | woocommerce_single_product_summary        | First `core/post-excerpt` block                                                                                                                         | before   |
 | woocommerce_after_single_product          | Last block related to the Single Product Template (Product Image Gallery, Product Details, Add to Cart Form, Product Meta, Product Price, Breadcrumbs)  | after    |
 | woocommerce_product_meta_start            | Product Meta                                                                                                                                           | before   |

--- a/plugins/woocommerce/changelog/50392-fix-compatibility-layer
+++ b/plugins/woocommerce/changelog/50392-fix-compatibility-layer
@@ -1,0 +1,4 @@
+Significance: major
+Type: fix
+
+Compatibility Layer: fix 'woocommerce_before_single_product_summary' hook position.

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -55,6 +55,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * Since that there is a custom logic for the first and last block, we have to inject the hooks manually.
 	 * The first block supports the following hooks:
 	 * woocommerce_before_single_product
+	 * woocommerce_before_single_product_summary
 	 *
 	 * The last block supports the following hooks:
 	 * woocommerce_after_single_product
@@ -69,6 +70,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 			'before' => array(
 				'woocommerce_before_main_content'   => $this->hook_data['woocommerce_before_main_content'],
 				'woocommerce_before_single_product' => $this->hook_data['woocommerce_before_single_product'],
+				'woocommerce_before_single_product_summary' => $this->hook_data['woocommerce_before_single_product_summary'],
 			),
 			'after'  => array(),
 		);
@@ -195,7 +197,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 				),
 			),
 			'woocommerce_before_single_product_summary' => array(
-				'block_names' => array( 'core/post-excerpt' ),
+				'block_names' => array(),
 				'position'    => 'before',
 				'hooked'      => array(
 					'woocommerce_show_product_sale_flash' => 10,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes https://github.com/woocommerce/woocommerce/issues/50056. With https://github.com/woocommerce/woocommerce-blocks/pull/11953, I updated the position of the `woocommerce_before_single_product_summary` hook, but it was wrong. This PR restores the correct position of this hook.

Slack discussion: p1722927043234809-slack-C02FL3X7KR6



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Please consider any edge cases this change may have, and also other areas of the product this may impact.

1. Ensure that you are using a block theme.
2. Install `Code Snippets` plugin
3. Visit the WP admin dashboard
4. Click on Snippets > Add new.
5. Copy paste this code:
```
add_action('woocommerce_before_single_product_summary', function() {
	echo 'woocommerce_before_single_product_summary';
});
```
6. Visit a product page.
7. Ensure that the string woocommerce_before_single_product_summary is visible before the Product Title.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Compatibility Layer: fix 'woocommerce_before_single_product_summary' hook position.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>