### PR TITLE
Remove duplicate Add to Cart Form block from Webpack entries

### DIFF
--- a/plugins/woocommerce-blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce-blocks/bin/webpack-entries.js
@@ -16,7 +16,6 @@ const glob = require( 'glob' );
 // when you mark/unmark block experimental.
 const blocks = {
 	'active-filters': {},
-	'add-to-cart-form': {},
 	'all-products': {
 		customDir: 'products/all-products',
 	},

--- a/plugins/woocommerce/changelog/update--remove-add-to-cart-from-webpack-entries
+++ b/plugins/woocommerce/changelog/update--remove-add-to-cart-from-webpack-entries
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Remove duplicate Add to Cart Form block from Webpack entries
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -192,7 +192,7 @@ class AddToCartForm extends AbstractBlock {
 	}
 
 	/**
-	 * It isn't necessary register block assets because it is a server side block.
+	 * It isn't necessary to register block assets because it is a server side block.
 	 */
 	protected function register_block_type_assets() {
 		return null;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Add to Cart Form block was duplicated in the Webpack entries file. The first entry wasn't matching any files, I think:

https://github.com/woocommerce/woocommerce/blob/52119dfcc9cdd98ec21fd6189b2d51f4d4957f62/plugins/woocommerce-blocks/bin/webpack-entries.js#L19
https://github.com/woocommerce/woocommerce/blob/52119dfcc9cdd98ec21fd6189b2d51f4d4957f62/plugins/woocommerce-blocks/bin/webpack-entries.js#L211-L212

This PR removes it.

### How to test the changes in this Pull Request:

1. Go to Appearance > Site Editor > Templates > Single Product. 
2. If you see the Classic Template Placeholder block, click on Transform into blocks.
3. Verify the _Add to Cart with Options_ block looks good in the editor.
4. Go to the frontend and verify the Add to Cart form looks good too.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
