### PR TITLE
[testing workflows] Update concurrency to not cancel the workflow when running on trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}-${{ inputs.trigger }}'
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'trunk' }}
 
 env:
   FORCE_COLOR: 1

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End-to-End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and `wp-env`.
+This is the documentation for the e2e testing setup based on Playwright and `wp-env`
 
 ## Table of contents
 

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End-to-End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and `wp-env`...
+This is the documentation for the e2e testing setup based on Playwright and `wp-env`.
 
 ## Table of contents
 

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End-to-End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and `wp-env`
+This is the documentation for the e2e testing setup based on Playwright and `wp-env`...
 
 ## Table of contents
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: p1722937422179649/1722607961.575119-slack-C03CPM3UXDJ

We want to have completed jobs when running against trunk. Updated the concurrency configuration to only cancel if the ref is not 'trunk'.

### How to test the changes in this Pull Request:

To be tested after merge.
Tested that the workflow still gets cancelled: https://github.com/woocommerce/woocommerce/actions/runs/10264795121?pr=50397