### PR TITLE
Product Collection: Don't render when empty unless the no results block is present

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/style.scss
@@ -44,3 +44,7 @@
 		opacity: 0;
 	}
 }
+
+.wp-block-woocommerce-product-collection--empty {
+	display: none;
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/style.scss
@@ -44,7 +44,3 @@
 		opacity: 0;
 	}
 }
-
-.wp-block-woocommerce-product-collection--empty {
-	display: none;
-}

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -82,6 +82,64 @@ test.describe( 'Product Collection', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Is hidden when empty unless product-collection-no-results block is present', async ( {
+		admin,
+		page,
+		pageObject,
+	} ) => {
+		await admin.createNewPost();
+
+		await pageObject.insertProductCollection();
+		await pageObject.chooseCollectionInPost( 'featured' );
+		await pageObject.addFilter( 'Price Range' );
+		await pageObject.setPriceRange( {
+			max: '1',
+		} );
+
+		const featuredBlock = page.getByLabel( 'Block: Featured' );
+
+		await expect(
+			featuredBlock.getByText( 'Featured products' )
+		).toBeVisible();
+		await expect(
+			featuredBlock.getByText( 'No results found' )
+		).toBeVisible();
+
+		await pageObject.insertProductCollection();
+		await pageObject.chooseCollectionInPost( 'productCatalog' );
+		await pageObject.addFilter( 'Price Range' );
+		await pageObject.setPriceRange( {
+			max: '1',
+		} );
+
+		const productCatalogBlock = page.getByLabel(
+			'Block: Product Collection'
+		);
+
+		await expect(
+			productCatalogBlock.getByText( 'No results found' )
+		).toBeVisible();
+
+		await pageObject.publishAndGoToFrontend();
+
+		const collectionBlocks = page.locator(
+			'.wp-block-woocommerce-product-collection'
+		);
+
+		await expect( collectionBlocks ).toHaveCount( 2 );
+
+		await expect( collectionBlocks.first() ).toBeHidden();
+		await expect( collectionBlocks.first() ).toBeEmpty();
+		await expect( collectionBlocks.first() ).toHaveClass(
+			/wp-block-woocommerce-product-collection--empty/
+		);
+
+		await expect( collectionBlocks.last() ).toBeVisible();
+		await expect( collectionBlocks.last() ).toContainText(
+			'No results found'
+		);
+	} );
+
 	test.describe( 'Renders correctly with all Product Elements', () => {
 		const expectedProductContent = [
 			'Beanie', // core/post-title

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -113,6 +113,8 @@ test.describe( 'Product Collection', () => {
 			await expect( content ).not.toContainText( 'No results found' );
 		} );
 
+		// This test ensures the runtime render state is correctly reset for
+		// each block.
 		test( 'does not prevent subsequent blocks from render', async ( {
 			page,
 			pageObject,
@@ -157,40 +159,6 @@ test.describe( 'Product Collection', () => {
 			await pageObject.publishAndGoToFrontend();
 
 			await expect( noResultsFoundText ).toBeVisible();
-		} );
-
-		// See https://github.com/woocommerce/woocommerce/pull/50404#discussion_r1709377484
-		test( 'renders if No Results block is above the Product Template block', async ( {
-			page,
-			editor,
-			pageUtils,
-			pageObject,
-		} ) => {
-			await pageObject.insertProductCollection();
-			await pageObject.chooseCollectionInPost( 'productCatalog' );
-			await pageObject.addFilter( 'Price Range' );
-			await pageObject.setPriceRange( {
-				max: '1',
-			} );
-
-			const noResultsBlockSelector =
-				'[data-type="woocommerce/product-collection-no-results"]';
-			const productTemplateBlockSelector =
-				'[data-type="woocommerce/product-template"]';
-
-			// Move the No Results block to the top.
-			await editor.selectBlocks( page.locator( noResultsBlockSelector ) );
-			await pageUtils.pressKeys( 'secondary+t', { times: 2 } );
-
-			await expect(
-				page.locator(
-					`${ noResultsBlockSelector }:above(${ productTemplateBlockSelector })`
-				)
-			).toBeVisible();
-
-			await pageObject.publishAndGoToFrontend();
-
-			await expect( page.getByText( 'No results found' ) ).toBeVisible();
 		} );
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -82,7 +82,7 @@ test.describe( 'Product Collection', () => {
 		).toBeVisible();
 	} );
 
-	test( 'Is hidden when empty unless product-collection-no-results block is present', async ( {
+	test( 'Is not rendered when empty unless No Results block is present', async ( {
 		admin,
 		page,
 		pageObject,
@@ -101,6 +101,7 @@ test.describe( 'Product Collection', () => {
 		await expect(
 			featuredBlock.getByText( 'Featured products' )
 		).toBeVisible();
+		// The "No results found" info is rendered in editor for all collections.
 		await expect(
 			featuredBlock.getByText( 'No results found' )
 		).toBeVisible();
@@ -122,22 +123,16 @@ test.describe( 'Product Collection', () => {
 
 		await pageObject.publishAndGoToFrontend();
 
-		const collectionBlocks = page.locator(
+		const collectionBlock = page.locator(
 			'.wp-block-woocommerce-product-collection'
 		);
 
-		await expect( collectionBlocks ).toHaveCount( 2 );
-
-		await expect( collectionBlocks.first() ).toBeHidden();
-		await expect( collectionBlocks.first() ).toBeEmpty();
-		await expect( collectionBlocks.first() ).toHaveClass(
-			/wp-block-woocommerce-product-collection--empty/
+		await expect( collectionBlock ).toHaveCount( 1 );
+		await expect( collectionBlock ).not.toContainText(
+			'Featured products'
 		);
-
-		await expect( collectionBlocks.last() ).toBeVisible();
-		await expect( collectionBlocks.last() ).toContainText(
-			'No results found'
-		);
+		await expect( collectionBlock ).toBeVisible();
+		await expect( collectionBlock ).toContainText( 'No results found' );
 	} );
 
 	test.describe( 'Renders correctly with all Product Elements', () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -82,57 +82,116 @@ test.describe( 'Product Collection', () => {
 		).toBeVisible();
 	} );
 
-	test( 'Is not rendered when empty unless No Results block is present', async ( {
-		admin,
-		page,
-		pageObject,
-	} ) => {
-		await admin.createNewPost();
-
-		await pageObject.insertProductCollection();
-		await pageObject.chooseCollectionInPost( 'featured' );
-		await pageObject.addFilter( 'Price Range' );
-		await pageObject.setPriceRange( {
-			max: '1',
+	test.describe( 'when no results are found', () => {
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost();
 		} );
 
-		const featuredBlock = page.getByLabel( 'Block: Featured' );
+		test( 'does not render', async ( { page, pageObject } ) => {
+			await pageObject.insertProductCollection();
+			await pageObject.chooseCollectionInPost( 'featured' );
+			await pageObject.addFilter( 'Price Range' );
+			await pageObject.setPriceRange( {
+				max: '1',
+			} );
 
-		await expect(
-			featuredBlock.getByText( 'Featured products' )
-		).toBeVisible();
-		// The "No results found" info is rendered in editor for all collections.
-		await expect(
-			featuredBlock.getByText( 'No results found' )
-		).toBeVisible();
+			const featuredBlock = page.getByLabel( 'Block: Featured' );
 
-		await pageObject.insertProductCollection();
-		await pageObject.chooseCollectionInPost( 'productCatalog' );
-		await pageObject.addFilter( 'Price Range' );
-		await pageObject.setPriceRange( {
-			max: '1',
+			await expect(
+				featuredBlock.getByText( 'Featured products' )
+			).toBeVisible();
+			// The "No results found" info is rendered in editor for all collections.
+			await expect(
+				featuredBlock.getByText( 'No results found' )
+			).toBeVisible();
+
+			await pageObject.publishAndGoToFrontend();
+
+			const content = page.locator( 'main' );
+
+			await expect( content ).not.toContainText( 'Featured products' );
+			await expect( content ).not.toContainText( 'No results found' );
 		} );
 
-		const productCatalogBlock = page.getByLabel(
-			'Block: Product Collection'
-		);
+		test( 'does not prevent subsequent blocks from render', async ( {
+			page,
+			pageObject,
+		} ) => {
+			await pageObject.insertProductCollection();
+			await pageObject.chooseCollectionInPost( 'featured' );
+			await pageObject.addFilter( 'Price Range' );
+			await pageObject.setPriceRange( {
+				max: '1',
+			} );
 
-		await expect(
-			productCatalogBlock.getByText( 'No results found' )
-		).toBeVisible();
+			await pageObject.insertProductCollection();
+			await pageObject.chooseCollectionInPost( 'topRated' );
 
-		await pageObject.publishAndGoToFrontend();
+			await pageObject.refreshLocators( 'editor' );
+			await expect( pageObject.products ).toHaveCount( 5 );
 
-		const collectionBlock = page.locator(
-			'.wp-block-woocommerce-product-collection'
-		);
+			await pageObject.publishAndGoToFrontend();
 
-		await expect( collectionBlock ).toHaveCount( 1 );
-		await expect( collectionBlock ).not.toContainText(
-			'Featured products'
-		);
-		await expect( collectionBlock ).toBeVisible();
-		await expect( collectionBlock ).toContainText( 'No results found' );
+			await pageObject.refreshLocators( 'frontend' );
+			await expect( pageObject.products ).toHaveCount( 5 );
+			await expect( page.locator( 'main' ) ).not.toContainText(
+				'Featured products'
+			);
+		} );
+
+		test( 'renders if No Results block is present', async ( {
+			page,
+			pageObject,
+		} ) => {
+			await pageObject.insertProductCollection();
+			await pageObject.chooseCollectionInPost( 'productCatalog' );
+			await pageObject.addFilter( 'Price Range' );
+			await pageObject.setPriceRange( {
+				max: '1',
+			} );
+
+			const noResultsFoundText = page.getByText( 'No results found' );
+
+			await expect( noResultsFoundText ).toBeVisible();
+
+			await pageObject.publishAndGoToFrontend();
+
+			await expect( noResultsFoundText ).toBeVisible();
+		} );
+
+		// See https://github.com/woocommerce/woocommerce/pull/50404#discussion_r1709377484
+		test( 'renders if No Results block is above the Product Template block', async ( {
+			page,
+			editor,
+			pageUtils,
+			pageObject,
+		} ) => {
+			await pageObject.insertProductCollection();
+			await pageObject.chooseCollectionInPost( 'productCatalog' );
+			await pageObject.addFilter( 'Price Range' );
+			await pageObject.setPriceRange( {
+				max: '1',
+			} );
+
+			const noResultsBlockSelector =
+				'[data-type="woocommerce/product-collection-no-results"]';
+			const productTemplateBlockSelector =
+				'[data-type="woocommerce/product-template"]';
+
+			// Move the No Results block to the top.
+			await editor.selectBlocks( page.locator( noResultsBlockSelector ) );
+			await pageUtils.pressKeys( 'secondary+t', { times: 2 } );
+
+			await expect(
+				page.locator(
+					`${ noResultsBlockSelector }:above(${ productTemplateBlockSelector })`
+				)
+			).toBeVisible();
+
+			await pageObject.publishAndGoToFrontend();
+
+			await expect( page.getByText( 'No results found' ) ).toBeVisible();
+		} );
 	} );
 
 	test.describe( 'Renders correctly with all Product Elements', () => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -87,7 +87,7 @@ test.describe( 'Product Collection', () => {
 			await admin.createNewPost();
 		} );
 
-		test( 'does not render', async ( { page, pageObject } ) => {
+		test( 'does not render', async ( { page, editor, pageObject } ) => {
 			await pageObject.insertProductCollection();
 			await pageObject.chooseCollectionInPost( 'featured' );
 			await pageObject.addFilter( 'Price Range' );
@@ -95,7 +95,7 @@ test.describe( 'Product Collection', () => {
 				max: '1',
 			} );
 
-			const featuredBlock = page.getByLabel( 'Block: Featured' );
+			const featuredBlock = editor.canvas.getByLabel( 'Block: Featured' );
 
 			await expect(
 				featuredBlock.getByText( 'Featured products' )
@@ -143,6 +143,7 @@ test.describe( 'Product Collection', () => {
 
 		test( 'renders if No Results block is present', async ( {
 			page,
+			editor,
 			pageObject,
 		} ) => {
 			await pageObject.insertProductCollection();
@@ -152,13 +153,13 @@ test.describe( 'Product Collection', () => {
 				max: '1',
 			} );
 
-			const noResultsFoundText = page.getByText( 'No results found' );
-
-			await expect( noResultsFoundText ).toBeVisible();
+			await expect(
+				editor.canvas.getByText( 'No results found' )
+			).toBeVisible();
 
 			await pageObject.publishAndGoToFrontend();
 
-			await expect( noResultsFoundText ).toBeVisible();
+			await expect( page.getByText( 'No results found' ) ).toBeVisible();
 		} );
 	} );
 

--- a/plugins/woocommerce/changelog/fix-pc-prevent-rendering-on-empty-query
+++ b/plugins/woocommerce/changelog/fix-pc-prevent-rendering-on-empty-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Product Collection: Don't render when empty unless the no results block is present.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -50,6 +50,8 @@ class ProductCollection extends AbstractBlock {
 	/**
 	 * The render state of the product collection block.
 	 *
+	 * These props are runtime-based and reinitialize for every block on a page.
+	 *
 	 * @var array
 	 */
 	private $render_state = array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -115,7 +115,7 @@ class ProductCollection extends AbstractBlock {
 		);
 
 		// Interactivity API: Add navigation directives to the product collection block.
-		add_filter( 'render_block_woocommerce/product-collection', array( $this, 'handle_product_collection_rendering' ), 10, 2 );
+		add_filter( 'render_block_woocommerce/product-collection', array( $this, 'handle_rendering' ), 10, 2 );
 		add_filter( 'render_block_core/query-pagination', array( $this, 'add_navigation_link_directives' ), 10, 3 );
 
 		add_filter( 'posts_clauses', array( $this, 'add_price_range_filter_posts_clauses' ), 10, 2 );
@@ -132,7 +132,7 @@ class ProductCollection extends AbstractBlock {
 	 *
 	 * @return string
 	 */
-	public function handle_product_collection_rendering( $block_content, $block ) {
+	public function handle_rendering( $block_content, $block ) {
 		if ( $this->should_prevent_render() ) {
 			return ''; // Prevent rendering.
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -131,7 +131,7 @@ class ProductCollection extends AbstractBlock {
 	public function handle_product_collection_rendering( $block_content, $block ) {
 		if ( ! $this->should_render ) {
 			// Prevent rendering of the block. Print an empty div instead.
-			return '<div class="wp-block-woocommerce-product-collection"></div>';
+			return '<div class="wp-block-woocommerce-product-collection wp-block-woocommerce-product-collection--empty"></div>';
 		}
 
 		return $this->enhance_product_collection_with_interactivity( $block_content, $block );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -140,7 +140,7 @@ class ProductCollection extends AbstractBlock {
 		// Reset the render state for the next render.
 		$this->reset_render_state();
 
-		return $block_content;
+		return $this->enhance_product_collection_with_interactivity( $block_content, $block );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -132,8 +132,7 @@ class ProductCollection extends AbstractBlock {
 	 */
 	public function handle_product_collection_rendering( $block_content, $block ) {
 		if ( true === $this->prevent_render ) {
-			// Prevent rendering of the block. Print an empty div instead.
-			$block_content = '<div class="wp-block-woocommerce-product-collection wp-block-woocommerce-product-collection--empty"></div>';
+			$block_content = '';
 		} else {
 			$block_content = $this->enhance_product_collection_with_interactivity( $block_content, $block );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Disable the rendering of the Product Collection block when its content is empty (no results) unless the ProductCollectionNoResults block is rendered as well.

Closes: https://github.com/woocommerce/woocommerce/issues/43673

### How to test the changes in this Pull Request:

1. Add a couple of Product Collection blocks to the page, both static (Featured, On Sale, etc.) and the main catalog (`Create your own`).
2. Make some of them render empty, e.g., by adding a Price Range filter with a $1 max price.
3. Publish and go to the front end.
4. Ensure static collections aren't visible at all if empty.
5. Ensure main catalog collection is always rendered, regardless of whether it's empty or not.
6. Ensure non-empty collections are visible as usual.

