### PR TITLE
Customer Account - Maintain the size of the icon in smaller screens

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/customer-account/style.scss
@@ -17,8 +17,13 @@
 
 .wp-block-woocommerce-customer-account {
 	display: flex;
+	align-items: center;
+	white-space: nowrap;
+	overflow: hidden;
 
 	a {
+		flex: 1;
+		overflow: hidden;
 		text-decoration: none !important;
 		align-items: center;
 		display: flex;

--- a/plugins/woocommerce-blocks/assets/js/blocks/customer-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/customer-account/style.scss
@@ -35,6 +35,8 @@
 
 		.wc-block-customer-account__account-icon {
 			box-sizing: content-box !important;
+			min-height: em(23px);
+			min-width: em(23px);
 			height: em(23px);
 			width: em(23px);
 			padding: em($gap-smaller);

--- a/plugins/woocommerce/changelog/50410-50369-customer-account-icon-mobile
+++ b/plugins/woocommerce/changelog/50410-50369-customer-account-icon-mobile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Customer Account - Maintain the size of the icon in smaller screens.

--- a/plugins/woocommerce/patterns/header-centered-pattern.php
+++ b/plugins/woocommerce/patterns/header-centered-pattern.php
@@ -11,8 +11,8 @@
 <div class="wc-blocks-pattern-header-centered-menu wc-blocks-header-pattern wp-block-group alignfull">
 	<!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"align":"full","style":{"spacing":{"padding":{"top":"24px","bottom":"24px","left":"40px","right":"40px"}}}} -->
 	<div class="wp-block-columns alignfull are-vertically-aligned-center is-not-stacked-on-mobile" style="padding-top:24px;padding-right:40px;padding-bottom:24px;padding-left:40px">
-		<!-- wp:column {"verticalAlignment":"center","width":"70%","layout":{"type":"default"}} -->
-		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:70%">
+		<!-- wp:column {"verticalAlignment":"center","layout":{"type":"default"}} -->
+		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
 			<div class="wp-block-group"><!-- wp:site-logo {"shouldSyncIcon":false} /-->
 				<!-- wp:site-title {"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50369

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new page or post or edit the site.
2. Insert the `Centered Header Menu` pattern.
4. Modify the `Customer Account` block icon options to `Icon and Text`.
5. Save and open the page in responsive mode.
6. Check that the account icon is the same size and that the `My account` text is partially hidden instead of breaking into multiple lines.

| Before | After |
|--------|--------|
| <img width="331" alt="Screenshot 2024-08-07 at 14 44 39" src="https://github.com/user-attachments/assets/369ccad1-2f28-403d-bcac-c8c515e5edc6"> | <img width="320" alt="Screenshot 2024-08-07 at 14 45 18" src="https://github.com/user-attachments/assets/c703f145-6797-40d8-8f83-d1f44a03ef42">|

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Customer Account - Maintain the size of the icon in smaller screens.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
