### PR TITLE
CYS: Fix DeviceToolbar animation

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -218,11 +218,16 @@ export const Layout = () => {
 								{ ! isMobileViewport && (
 									<div className="edit-site-layout__canvas-container">
 										{ isFullComposabilityFeatureAndAPIAvailable() && (
-											<DeviceToolbar
-												isEditorLoading={
-													isEditorLoading
-												}
-											/>
+											<motion.div
+												initial={ false }
+												layout="position"
+											>
+												<DeviceToolbar
+													isEditorLoading={
+														isEditorLoading
+													}
+												/>
+											</motion.div>
 										) }
 										{ canvasResizer }
 										{ !! canvasSize.width && (

--- a/plugins/woocommerce/changelog/fix-cys-animation
+++ b/plugins/woocommerce/changelog/fix-cys-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix animation of devicetoolbar


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Wrap DeviceToolbar in same animation as iframe so they're consistent.

**Before**: https://www.loom.com/share/a418c91b3d9244aca71cf81edb0d5a42
**After**: https://www.loom.com/share/b09d00b32f2644888fa2a5dd37ec6123

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enter CYS experience 
2. Enter homepage design
3. Open pattern selector, close it. Ensure animation of the iframe and the devicetoolbar is consistent.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
