### PR TITLE
Checkout: Fix display of coupon removal notices

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
@@ -24,7 +24,7 @@ import { ACTION_TYPES as types } from './action-types';
 import { apiFetchWithHeaders } from '../shared-controls';
 import { ReturnOrGeneratorYieldUnion } from '../mapped-types';
 import { CartDispatchFromMap, CartSelectFromMap } from './index';
-import { Thunks } from './thunks';
+import type { Thunks } from './thunks';
 
 // Thunks are functions that can be dispatched, similar to actions creators
 // @todo Many of the functions that return promises in this file need to be moved to thunks.ts.

--- a/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/actions.ts
@@ -15,7 +15,6 @@ import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
 import {
 	triggerAddedToCartEvent,
 	triggerAddingToCartEvent,
-	camelCaseKeys,
 } from '@woocommerce/base-utils';
 
 /**
@@ -25,7 +24,7 @@ import { ACTION_TYPES as types } from './action-types';
 import { apiFetchWithHeaders } from '../shared-controls';
 import { ReturnOrGeneratorYieldUnion } from '../mapped-types';
 import { CartDispatchFromMap, CartSelectFromMap } from './index';
-import type { Thunks } from './thunks';
+import { Thunks } from './thunks';
 
 // Thunks are functions that can be dispatched, similar to actions creators
 // @todo Many of the functions that return promises in this file need to be moved to thunks.ts.
@@ -54,27 +53,6 @@ export const setErrorData = (
 	return {
 		type: types.SET_ERROR_DATA,
 		error,
-	};
-};
-
-/**
- * Returns an action object used in updating the store with the provided cart.
- *
- * This omits the customer addresses so that only updates to cart items and totals are received. This is useful when
- * currently editing address information to prevent it being overwritten from the server.
- *
- * This is a generic response action.
- *
- * @param {CartResponse} response
- */
-export const receiveCartContents = (
-	response: CartResponse
-): { type: string; response: Partial< Cart > } => {
-	const cart = camelCaseKeys( response ) as unknown as Cart;
-	const { shippingAddress, billingAddress, ...cartWithoutAddress } = cart;
-	return {
-		type: types.SET_CART_DATA,
-		response: cartWithoutAddress,
 	};
 };
 
@@ -503,7 +481,6 @@ type Actions =
 	| typeof itemIsPendingDelete
 	| typeof itemIsPendingQuantity
 	| typeof receiveApplyingCoupon
-	| typeof receiveCartContents
 	| typeof receiveCartItem
 	| typeof receiveRemovingCoupon
 	| typeof removeCoupon

--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-errors.ts
@@ -25,7 +25,6 @@ export const notifyCartErrors = (
 				createNotice( 'error', decodeEntities( error.message ), {
 					id: error.code,
 					context: 'wc/cart',
-					isDismissible: false,
 				} );
 			}
 		} );

--- a/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
@@ -157,7 +157,6 @@ const updateCustomerData = (): void => {
 			localState.dirtyProps.billingAddress = [];
 			localState.dirtyProps.shippingAddress = [];
 			localState.doingPush = false;
-			removeAllNotices();
 		} )
 		.catch( ( response ) => {
 			localState.doingPush = false;

--- a/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/push-changes.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { removeAllNotices, debounce, pick } from '@woocommerce/base-utils';
+import { debounce, pick } from '@woocommerce/base-utils';
 import {
 	CartBillingAddress,
 	CartShippingAddress,

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -23,7 +23,7 @@ import { CartDispatchFromMap, CartSelectFromMap } from './index';
  * @param {CartResponse} response
  */
 export const receiveCart =
-	( response: CartResponse ) =>
+	( response: Partial< CartResponse > ) =>
 	( {
 		dispatch,
 		select,
@@ -44,6 +44,22 @@ export const receiveCart =
 	};
 
 /**
+ * Updates the store with the provided cart but omits the customer addresses.
+ *
+ * This is useful when currently editing address information to prevent it being overwritten from the server.
+ *
+ * @param {CartResponse} response
+ */
+export const receiveCartContents =
+	( response: Partial< CartResponse > ) =>
+	( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		const { shipping_address, billing_address, ...cartWithoutAddress } =
+			response;
+		dispatch.receiveCart( cartWithoutAddress );
+	};
+
+/**
  * A thunk used in updating the store with cart errors retrieved from a request.
  */
 export const receiveError =
@@ -58,4 +74,7 @@ export const receiveError =
 		}
 	};
 
-export type Thunks = typeof receiveCart | typeof receiveError;
+export type Thunks =
+	| typeof receiveCart
+	| typeof receiveCartContents
+	| typeof receiveError;

--- a/plugins/woocommerce/changelog/fix-44906-coupon-removal-notices
+++ b/plugins/woocommerce/changelog/fix-44906-coupon-removal-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure coupon errors are visible on block checkout when invalid coupons are removed.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . '/legacy/class-wc-legacy-coupon.php';
+require_once __DIR__ . '/legacy/class-wc-legacy-coupon.php';
 
 /**
  * Coupon class.
@@ -1066,7 +1066,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 				$err = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
 				break;
 			case self::E_WC_COUPON_USAGE_LIMIT_COUPON_STUCK:
-				if ( is_user_logged_in() && wc_get_page_id( 'myaccount' ) > 0 ) {
+				if ( is_user_logged_in() && wc_get_page_id( 'myaccount' ) > 0 && ! WC()->is_store_api_request() ) {
 					/* translators: %s: myaccount page link. */
 					$err = sprintf( __( 'Coupon usage limit has been reached. If you were using this coupon just now but your order was not complete, you can retry or cancel the order by going to the <a href="%s">my account page</a>.', 'woocommerce' ), wc_get_endpoint_url( 'orders', '', wc_get_page_permalink( 'myaccount' ) ) );
 				} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When changes are pushed to the data store from the API, `receiveCartContents` is used to avoid overwriting customer data. However, this is problematic because unlike `receiveCart`, `receiveCartContents` does not handle `errors` in the response. This means if the cart changed, e.g. a coupon was removed, it would happen silently.

This PR updates `receiveCartContents` to make use of `receiveCart` so errors are preserved.

In addition, push changes was removing all notices. I had to remove this call to prevent notices being removed before the customer could view them. It was not apparent exactly why they were being removed, however, I think it was partly to do with the lack of error handling, since `receiveCart` is also responsible for removing old errors from the previous cart.

Closes #44906

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Before testing:

1. Create a coupon with no usage limit.
2. Add something to cart, apply the coupon, and do a full checkout.

This ensures you have a coupon to work with which has been used at least once. Next:

1. Add an item to the cart and go to block checkout.
2. Apply the coupon.
3. In another browser, edit the coupon and set usage limit to 1.
4. Now try to place order. **Notice an error is shown and the coupon is removed.**
5. Edit the coupon again and unset the usage limit. Then reapply it via checkout.
6. Edit the coupon again and set usage limit to 1.
7. Back on checkout, edit an address field, such as the zip code.
8. After changes have pushed, notice an error is shown and the coupon is removed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
