### PR TITLE
[testing workflows] Fix artifacts path for blocks e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,10 @@ jobs:
         # https://github.com/actions/upload-artifact/issues/176
         env:
           ARTIFACTS_PATH: '${{ matrix.projectPath }}/${{ matrix.report.resultsPath }}'
-        run: echo "ARTIFACTS_PATH=$(realpath $ARTIFACTS_PATH)" >> $GITHUB_ENV
+        run: |
+          # first runs will probably not have the directory, so we need to create it so that realpath doesn't fail
+          mkdir -p $ARTIFACTS_PATH
+          echo "ARTIFACTS_PATH=$(realpath $ARTIFACTS_PATH)" >> $GITHUB_ENV
 
       - name: 'Download Playwright last run info'
         id: 'download-last-run-info'

--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Blocks End-to-End Tests.
+# WooCommerce Blocks End-to-End Tests
 
 This document provides an overview of the WooCommerce Blocks end-to-end testing process. For detailed instructions and comprehensive guidelines, please refer to the [contributor guidelines document](../../docs/contributors/e2e-guidelines.md).
 

--- a/plugins/woocommerce-blocks/tests/e2e/README.md
+++ b/plugins/woocommerce-blocks/tests/e2e/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Blocks End-to-End Tests
+# WooCommerce Blocks End-to-End Tests.
 
 This document provides an overview of the WooCommerce Blocks end-to-end testing process. For detailed instructions and comprehensive guidelines, please refer to the [contributor guidelines document](../../docs/contributors/e2e-guidelines.md).
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix the undefined artifacts path for blocks e2e.

With https://github.com/woocommerce/woocommerce/pull/50267 the `Resolve artifacts path` step moved to execute before the tests run step. The artifacts path for blocks e2e doesn't exists yet and realpath is returning `undefined`, making the `ARTIFACTS_PATH` env variable `undefined`.

Fixed by creating the path if it doesn't exist. 

### How to test the changes in this Pull Request:

Test run passed: https://github.com/woocommerce/woocommerce/actions/runs/10280225536/job/28447327051?pr=50432 