### PR TITLE
Address some styling conflicts in the description block editor toolbar on small viewports

### DIFF
--- a/packages/js/product-editor/changelog/fix-49697_settings_button_on_mobile
+++ b/packages/js/product-editor/changelog/fix-49697_settings_button_on_mobile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Tweak header styling in description modal editor to address issues with smaller viewports.

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -31,8 +31,8 @@
 		align-items: center;
 		display: flex;
 
-		.woocommerce-iframe-editor-document-tools {
-			&__left {
+		.components-accessible-toolbar {
+			.woocommerce-iframe-editor-document-tools__left {
 				align-items: center;
 				display: inline-flex;
 				gap: 8px;

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
@@ -75,4 +75,10 @@
 			display: none;
 		}
 	}
+
+	.woocommerce-iframe-editor__header-right
+		.interface-pinned-items
+		.components-button {
+		display: flex;
+	}
 }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -30,7 +30,6 @@ import {
 // eslint-disable-next-line @woocommerce/dependency-group
 import {
 	ComplementaryArea,
-	store as interfaceStore,
 	// @ts-expect-error No types for this exist yet.
 } from '@wordpress/interface';
 
@@ -118,18 +117,12 @@ export function IframeEditor( {
 		return select( blockEditorStore ).getSettings();
 	}, [] );
 
-	const { hasFixedToolbar, isRightSidebarOpen } = useSelect( ( select ) => {
+	const { hasFixedToolbar } = useSelect( ( select ) => {
 		// @ts-expect-error These selectors are available in the block data store.
 		const { get: getPreference } = select( preferencesStore );
 
-		// @ts-expect-error These selectors are available in the interface data store.
-		const { getActiveComplementaryArea } = select( interfaceStore );
-
 		return {
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
-			isRightSidebarOpen: getActiveComplementaryArea(
-				SIDEBAR_COMPLEMENTARY_AREA_SCOPE
-			),
 		};
 	}, [] );
 
@@ -264,11 +257,9 @@ export function IframeEditor( {
 								 bounds. */ }
 							<div className="woocommerce-iframe-editor__content-inserter-clipper" />
 						</BlockTools>
-						{ isRightSidebarOpen && (
-							<ComplementaryArea.Slot
-								scope={ SIDEBAR_COMPLEMENTARY_AREA_SCOPE }
-							/>
-						) }
+						<ComplementaryArea.Slot
+							scope={ SIDEBAR_COMPLEMENTARY_AREA_SCOPE }
+						/>
 					</div>
 					{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
 					<PluginArea scope="woocommerce-product-editor-modal-block-editor" />


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Made one small change to address this issue in particular and another change around an issue I noticed with Gutenberg enabled, I left comments inline with more context.

Closes #49697 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch on a new WooCommerce store and enable the new product form ( **WooCommerce > Settings > Advanced > Features** )
2. Go to **Products > Add new**
3. Scroll down to the description field and click **Full Editor** in the toolbar
4. Open your console and set the window to a device with like **iPhone 14 Pro Max** or **Samsung Galaxy S20 Ultra**
5. Notice how the block settings is still present and toggleable
![Screenshot 2024-08-07 at 11 05 07 AM](https://github.com/user-attachments/assets/0eb0d76d-a269-4a17-967a-590259441b52)
6. Install the latest version of Gutenberg and enable it
7. Navigate to the description modal editor again and check if the header still looks correctly.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
