### PR TITLE
Make sure 'size' parameter is only used for input types that support it (product quantity selector)

### DIFF
--- a/plugins/woocommerce/changelog/bugfix-quantity-html-issue
+++ b/plugins/woocommerce/changelog/bugfix-quantity-html-issue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes a warning that only shows up when validating page content
+
+

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.3.0
+ * @version 9.4.0
  *
  * @var bool   $readonly If the input should be set to readonly mode.
  * @var string $type     The input type attribute.
@@ -42,7 +42,7 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 		name="<?php echo esc_attr( $input_name ); ?>"
 		value="<?php echo esc_attr( $input_value ); ?>"
 		aria-label="<?php esc_attr_e( 'Product quantity', 'woocommerce' ); ?>"
-		<?php if( in_array( $type, array( 'text', 'search', 'tel', 'url', 'email', 'password' ) ) ) : ?>
+		<?php if ( in_array( $type, array( 'text', 'search', 'tel', 'url', 'email', 'password' ), true ) ) : ?>
 			size="4"
 		<?php endif; ?>
 		min="<?php echo esc_attr( $min_value ); ?>"

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.1
+ * @version 9.3.0
  *
  * @var bool   $readonly If the input should be set to readonly mode.
  * @var string $type     The input type attribute.

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 7.8.1
  *
  * @var bool   $readonly If the input should be set to readonly mode.
  * @var string $type     The input type attribute.
@@ -42,7 +42,9 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 		name="<?php echo esc_attr( $input_name ); ?>"
 		value="<?php echo esc_attr( $input_value ); ?>"
 		aria-label="<?php esc_attr_e( 'Product quantity', 'woocommerce' ); ?>"
-		size="4"
+		<?php if( in_array( $type, array( 'text', 'search', 'tel', 'url', 'email', 'password' ) ) ) : ?>
+			size="4"
+		<?php endif; ?>
 		min="<?php echo esc_attr( $min_value ); ?>"
 		max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
 		<?php if ( ! $readonly ) : ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The attribute `size` is not allowed on input type `number` elements. https://screenshot.sunlime.at/6c130f56a61a652a730124ace6f98329.png 

This PR aims to get rid of that html issue. 

https://www.w3schools.com/tags/att_input_size.asp

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product in WooCommerce > Products > Add Product.
2. Go to the product page.
3. Using your browser dev tools inspect the HTML for the quantity selector and confirm that it doesn't have a `size` attribute:
   <img width="236" alt="Screenshot 2024-08-29 at 08 49 24" src="https://github.com/user-attachments/assets/26821d67-1331-4561-94cd-bd668d4a28c7">
   <img width="719" alt="Screenshot 2024-08-29 at 08 49 19" src="https://github.com/user-attachments/assets/80f0cf56-338d-49e6-a32d-3695134b7e1e">
4. Enable the following snippet on your site by using the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/) or dropping the following as a .php file inside `wp-content/mu-plugins/`:
   ```php
   <?php
   add_filter( 'woocommerce_quantity_input_type', fn() => 'text' );
   ```
5. Refresh the product page.
6. As in step 3, inspect the quantity selector with the devtools, but this time confirm that the HTML contains a `size="4"` attribute:
   <img width="705" alt="Screenshot 2024-08-29 at 08 49 09" src="https://github.com/user-attachments/assets/99f5e689-055b-427b-9a5b-92978999cd35">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

fixed html error by having attribute size on input type number. 

</details>
