### PR TITLE
Fix broken beta tester release GH action

### DIFF
--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -28,11 +28,11 @@ jobs:
               working-directory: plugins/woocommerce-beta-tester
               run: pnpm build:zip
 
-            # - name: Create release
-            #   id: create_release
-            #   uses: woocommerce/action-gh-release@master
-            #   with:
-            #       tag_name: wc-beta-tester-${{ inputs.version }}
-            #       name: WooCommerce Beta Tester Release ${{ inputs.version }}
-            #       draft: false
-            #       files: plugins/woocommerce-beta-tester/woocommerce-beta-tester.zip
+            - name: Create release
+              id: create_release
+              uses: woocommerce/action-gh-release@master
+              with:
+                  tag_name: wc-beta-tester-${{ inputs.version }}
+                  name: WooCommerce Beta Tester Release ${{ inputs.version }}
+                  draft: false
+                  files: plugins/woocommerce-beta-tester/woocommerce-beta-tester.zip

--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -20,13 +20,9 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                install: '@woocommerce/plugin-woocommerce-beta-tester'
-                build: '@woocommerce/plugin-woocommerce-beta-tester'
+                install: '@woocommerce/plugin-woocommerce-beta-tester...'
+                build: '@woocommerce/plugin-woocommerce-beta-tester...'
                 pull-package-deps: '@woocommerce/plugin-woocommerce-beta-tester'
-
-            - name: Lint
-              working-directory: plugins/woocommerce-beta-tester
-              run: composer run phpcs
 
             - name: Build WooCommerce Beta Tester Zip
               working-directory: plugins/woocommerce-beta-tester

--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -20,8 +20,8 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                install: '@woocommerce/plugin-woocommerce'
-                build: '@woocommerce/plugin-woocommerce'
+                install: '@woocommerce/plugin-woocommerce-beta-tester'
+                build: '@woocommerce/plugin-woocommerce-beta-tester'
                 pull-package-deps: '@woocommerce/plugin-woocommerce-beta-tester'
 
             - name: Lint
@@ -32,11 +32,11 @@ jobs:
               working-directory: plugins/woocommerce-beta-tester
               run: pnpm build:zip
 
-            - name: Create release
-              id: create_release
-              uses: woocommerce/action-gh-release@master
-              with:
-                  tag_name: wc-beta-tester-${{ inputs.version }}
-                  name: WooCommerce Beta Tester Release ${{ inputs.version }}
-                  draft: false
-                  files: plugins/woocommerce-beta-tester/woocommerce-beta-tester.zip
+            # - name: Create release
+            #   id: create_release
+            #   uses: woocommerce/action-gh-release@master
+            #   with:
+            #       tag_name: wc-beta-tester-${{ inputs.version }}
+            #       name: WooCommerce Beta Tester Release ${{ inputs.version }}
+            #       draft: false
+            #       files: plugins/woocommerce-beta-tester/woocommerce-beta-tester.zip


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


The Beta tester release action [failed](https://github.com/woocommerce/woocommerce/actions/runs/10297010099/job/28499488054
) with the following error:

```bash
Error: ../../packages/js/notices build:project:cjs: src/store/actions.ts(4,26): error TS7016: Could not find a declaration file for module 'lodash'. '/home/runner/work/woocommerce/woocommerce/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/lodash.js' implicitly has an 'any' type.
../../packages/js/notices build:project:cjs:   Try `npm i --save-dev @types/lodash` if it exists or add a new declaration (.d.ts) file containing `declare module 'lodash';`
Error: ../../packages/js/notices build:project:cjs: src/store/actions.ts(5,50): error TS2307: Cannot find module '@wordpress/notices' or its corresponding type declarations.
Error: ../../packages/js/notices build:project:cjs: src/store/actions.ts(19,15): error TS2503: Cannot find namespace 'JSX'.
Error: ../../packages/js/notices build:project:cjs: src/store/controls.ts(4,23): error TS2307: Cannot find module '@wordpress/a11y' or its corresponding type declarations.
Error: ../../packages/js/notices build:project:cjs: src/store/index.ts(4,31): error TS7016: Could not find a declaration file for module '@wordpress/data'. '/home/runner/work/woocommerce/woocommerce/node_modules/.pnpm/@wordpress+data@6.6.1_react@17.0.2/node_modules/@wordpress/data/build/index.js' implicitly has an 'any' type.
../../packages/js/notices build:project:cjs:   Try `npm i --save-dev @types/wordpress__data` if it exists or add a new declaration (.d.ts) file containing `declare module '@wordpress/data';`
```

It seems related to recent changes in the [`setup-woocommerce-monorepo/action.yml`](https://github.com/woocommerce/woocommerce/blob/464a8a898f78fd25a3b09244a239dbffc048e839/.github/actions/setup-woocommerce-monorepo/action.yml#L89-L97) file. Previously it [ran `pnpm install` command](https://github.com/woocommerce/woocommerce/actions/runs/9673412243/job/26687300761#step:3:113) but now it runs `pnpm install --filter='@woocommerce/plugin-woocommerce' --frozen-lockfile --config.dedupe-peer-dependents=false` and dependencies are not installed properly. This PR fixes the issue by changing the filter option to `@woocommerce/plugin-woocommerce-beta-tester...` so that all the dependencies are correctly installed. 

I also removed the lint step, which IMO is not required for this action. We should check the lint before merging the feature branch to the main branch.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- Make sure everything looks good.
- Go to https://github.com/woocommerce/woocommerce/actions/workflows/release-wc-beta-tester.yml and click on Run workflow
- Change branch to `test/beta-tester-release-action`
- Enter 2.4.0 and run the job.

I've also tested it here: https://github.com/woocommerce/woocommerce/actions/runs/10297707167


The `test/beta-tester-release-action` branch has the same changes, without `Create release workflow` for testing purposes.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
