### PR TITLE
[e2e tests] Fixed broken logo picker tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-logo-picker-tests
+++ b/plugins/woocommerce/changelog/e2e-fix-logo-picker-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixed broken logo picker tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
@@ -43,7 +43,7 @@ export class LogoPickerPage {
 			.getByRole( 'tab', { name: 'Media Library' } )
 			.click();
 
-		await assemblerLocator.getByLabel( 'image-03' ).click();
+		await assemblerLocator.getByLabel( 'image-03' ).first().click();
 		await assemblerLocator
 			.getByRole( 'button', { name: 'Select', exact: true } )
 			.click();

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -168,7 +168,7 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 		const emptyLogoLocator =
 			logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
 		await expect( emptyLogoLocator ).toBeHidden();
-		await assembler.getByLabel( 'Options' ).click();
+		await assembler.getByLabel( 'Options', { exact: true } ).click();
 		await assembler.getByText( 'Delete' ).click();
 		await expect( emptyLogoLocator ).toBeVisible();
 	} );
@@ -182,7 +182,7 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 			logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
 		await emptyLogoPicker.click();
 		await logoPickerPageObject.pickImage( assembler );
-		await assembler.getByLabel( 'Options' ).click();
+		await assembler.getByLabel( 'Options', { exact: true } ).click();
 		await assembler.getByText( 'Replace' ).click();
 		await expect( assembler.getByText( 'Media Library' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes 2 broken logo picker tests. The locator for the Options button was not unique and resolved to more elements.

```
customize-store/assembler/logo-picker/logo-picker.spec.js:158:2 › Assembler -> Logo Picker › Clicking the Delete button should remove the selected image 
customize-store/assembler/logo-picker/logo-picker.spec.js:176:2 › Assembler -> Logo Picker › Clicking the replace image should open the media gallery
```

### How to test the changes in this Pull Request:

CI should be green
Locally you can run

```
pnpm test:e2e logo-picker.spec.js
```