### PR TITLE
Remove remote API call in "Grow your business" task

### DIFF
--- a/plugins/woocommerce/changelog/fix-marketing-task
+++ b/plugins/woocommerce/changelog/fix-marketing-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove remote API call from marketing task

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -68,54 +68,28 @@ class Marketing extends Task {
 	/**
 	 * Get the marketing plugins.
 	 *
+	 * @deprecated 9.3.0 Removed to improve performance.
 	 * @return array
 	 */
 	public static function get_plugins() {
-		$bundles = RemoteFreeExtensions::get_extensions(
-			array(
-				'task-list/reach',
-				'task-list/grow',
-			)
+		wc_deprecated_function(
+			__METHOD__,
+			'9.3.0'
 		);
-
-		return array_reduce(
-			$bundles,
-			function( $plugins, $bundle ) {
-				$visible = array();
-				foreach ( $bundle['plugins'] as $plugin ) {
-					if ( $plugin->is_visible ) {
-						$visible[] = $plugin;
-					}
-				}
-				return array_merge( $plugins, $visible );
-			},
-			array()
-		);
+		return array();
 	}
 
 	/**
 	 * Check if the store has installed marketing extensions.
 	 *
+	 * @deprecated 9.3.0 Removed to improve performance.
 	 * @return bool
 	 */
 	public static function has_installed_extensions() {
-		$plugins   = self::get_plugins();
-		$remaining = array();
-		$installed = array();
-
-		foreach ( $plugins as $plugin ) {
-			if ( ! $plugin->is_installed ) {
-				$remaining[] = $plugin;
-			} else {
-				$installed[] = $plugin;
-			}
-		}
-
-		// Make sure the task has been actioned and a marketing extension has been installed.
-		if ( count( $installed ) > 0 && Task::is_task_actioned( 'marketing' ) ) {
-			return true;
-		}
-
+		wc_deprecated_function(
+			__METHOD__,
+			'9.3.0'
+		);
 		return false;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -57,25 +57,12 @@ class Marketing extends Task {
 	}
 
 	/**
-	 * Task completion.
-	 *
-	 * @return bool
-	 */
-	public function is_complete() {
-		if ( null === $this->is_complete_result ) {
-			$this->is_complete_result = self::has_installed_extensions();
-		}
-
-		return $this->is_complete_result;
-	}
-
-	/**
 	 * Task visibility.
 	 *
 	 * @return bool
 	 */
 	public function can_view() {
-		return Features::is_enabled( 'remote-free-extensions' ) && count( self::get_plugins() ) > 0;
+		return Features::is_enabled( 'remote-free-extensions' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50453

The "Grow your business" task previously makes PHP-based REST API requests to WooCommerce.com to fetch list of recommendations, however does not have any error handling when the API is unavailable. This is used to determine its view and completed states. A compounding issue was discovered where the Home navigation badge queries this task for its completion state and subsequently causes a REST API request to fire. As a result, every admin page had a performance issue while rendering the navigation.

This PR simplifies the task by

* Removes the check for recommendations on WooCommerce.com before showing the task. This may mean the task is visible in periods of WooCommerce.com downtime, but users will see the task with the core fallback recommendations.
* Uses the actioned state to determine completion. The actioned state is already set when users install an extension from the task screen.

Additionally, the now unused helper methods for fetching recommendations have been deprecated.

<img width="1792" alt="grow your store visibility" src="https://github.com/user-attachments/assets/ead408b2-5ac9-48dc-89c1-768ec0d35772">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Home
2. See that "Grow your business" task is visible
3. Click "Grow your business" task
4. See available recommendations
5. Go to WooCommerce > Home
6. See that "Grow your business" task is incomplete
7.  Click "Grow your business" task
8. Install any extension by clicking "Get started"
9. Go to WooCommerce > Home
10. See that "Grow your business" task is complete
11. Block this request to WooCommerce.com, eg using WC Admin Test Helper or this snippet
```
function block_specific_woocommerce_request($preempt, $parsed_args, $url) {
    // The URL to block
    $blocked_url = 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.3/recommendations.json';

    // Check if the URL matches the blocked URL
    if ($url === $blocked_url) {
        return new WP_Error('woocommerce_blocked', __('Request to woocommerce.com marketing recommendations is blocked.', 'your-text-domain'));
    }

    // If not, return the original response
    return $preempt;
}

// Hook into the HTTP API before the request is made
add_filter('pre_http_request', 'block_specific_woocommerce_request', 10, 3);
```
13. Delete transient `woocommerce_admin_free_extensions_specs`, e.g. `wp transient delete --all`
14. On jurassic ninja you may need to clear the cache using `wp cache flush`
15. Click "Grow your business" task
16. See that task renders with fallback recommendations

<img width="1792" alt="gys fallback state" src="https://github.com/user-attachments/assets/87bd100b-79e2-4eb5-904a-7db6758d01c5">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
