### PR TITLE
[e2e tests] Fix flaky product-attributes-block-editor -> can add existing attributes

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-product-attributes-block-editor-tests
+++ b/plugins/woocommerce/changelog/e2e-fix-product-attributes-block-editor-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix flakiness in product attributes test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -282,7 +282,10 @@ test(
 		} );
 
 		await test.step( 'add an existing attribute', async () => {
-			await page.getByRole( 'button', { name: 'Add new' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Add new' } )
+				.first()
+				.click();
 
 			await page.waitForLoadState( 'domcontentloaded' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated locator for "Add new" button. It was being resolved to multiple elements when Custom fields Add new was also being displayed.

```
[ui] › merchant/products/block-editor/product-attributes-block-editor.spec.js:273:1 › can add existing attributes
      Error: locator.click: Error: strict mode violation: getByRole('button', { name: 'Add new' }) resolved to 2 elements:
        1) <button type="button" class="components-button woocommerce-add-attribute-list-item__add-button is-secondary">Add new</button> aka getByRole('button', { name: 'Add new' }).first()
        2) <button type="button" class="components-button is-secondary">Add new</button> aka getByLabel('Block: Product custom fields toggle control').getByRole('button', { name: 'Add new' })
```

### How to test the changes in this Pull Request:

CI should be green.
Locally you can run
```
pnpm test:e2e product-attributes-block-editor.spec.js
```