### PR TITLE
[testing workflows] Disable Metrics job in CI

### DIFF
--- a/plugins/woocommerce/changelog/ci-disable-metrics-job
+++ b/plugins/woocommerce/changelog/ci-disable-metrics-job
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -529,7 +529,7 @@
 						".wp-env.json"
 					],
 					"events": [
-						"push"
+						"disabled"
 					],
 					"report": {
 						"resultsBlobName": "core-metrics-report",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Metrics job is broken again on trunk runs. Disabling for now.

Context: p1723123258778329/1722607961.575119-slack-C03CPM3UXDJ


### How to test the changes in this Pull Request:

CI is green.