### PR TITLE
[testing workflow] Disable shards when re-running failed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
             # Only if there are failed tests, we want to use the --last-failed flag. 
             # The run will fail if we're using the flag and there are no failed tests.
             if [ "$failedTests" -gt 0 ]; then
-              if [ "$LAST_FAILED_RUN" == "1" ]; then
+              if [ "$LAST_FAILED_RUN" == "2" ]; then
                 echo "Found failed tests, running only failed tests"
                 # Add shard 1/1 to override the default shard value. No tests will run for shards > 1.
                 # The clean way would be to replace the shard flag from the command, but this also works.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,9 @@ jobs:
             if [ "$failedTests" -gt 0 ]; then
               if [ "$LAST_FAILED_RUN" == "1" ]; then
                 echo "Found failed tests, running only failed tests"
-                lastRunFlag="--last-failed"
+                # Add shard 1/1 to override the default shard value. No tests will run for shards > 1.
+                # The clean way would be to replace the shard flag from the command, but this also works.
+                lastRunFlag="--last-failed --shard=1/1"
               else
                 echo "Found failed tests, but LAST_FAILED_RUN is switched off. Running all tests."
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
             # Only if there are failed tests, we want to use the --last-failed flag. 
             # The run will fail if we're using the flag and there are no failed tests.
             if [ "$failedTests" -gt 0 ]; then
-              if [ "$LAST_FAILED_RUN" == "2" ]; then
+              if [ "$LAST_FAILED_RUN" == "1" ]; then
                 echo "Found failed tests, running only failed tests"
                 # Add shard 1/1 to override the default shard value. No tests will run for shards > 1.
                 # The clean way would be to replace the shard flag from the command, but this also works.

--- a/plugins/woocommerce/changelog/ci-dont-use-sharding-for-last-failed
+++ b/plugins/woocommerce/changelog/ci-dont-use-sharding-for-last-failed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: Use a single shard when re-running failed tests in CI

--- a/plugins/woocommerce/tests/e2e-pw/.gitignore
+++ b/plugins/woocommerce/tests/e2e-pw/.gitignore
@@ -1,3 +1,4 @@
 /.state
 /test-results
 /envs/_default
+/playwright-report

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -92,11 +92,7 @@ const config = {
 		{
 			name: 'ui',
 			use: { ...devices[ 'Desktop Chrome' ] },
-			testMatch: [
-				'**basic.spec.js',
-				'**/product-*spec.js',
-				'**/wordpress-post.spec.js',
-			],
+			testIgnore: '**/api-tests/**',
 		},
 		{
 			name: 'api',

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -15,7 +15,6 @@ const {
 	CI,
 	DEFAULT_TIMEOUT_OVERRIDE,
 	E2E_MAX_FAILURES,
-	PLAYWRIGHT_HTML_REPORT,
 	REPEAT_EACH,
 } = process.env;
 
@@ -54,9 +53,7 @@ if ( process.env.CI ) {
 	reporter.push( [
 		'html',
 		{
-			outputFolder:
-				PLAYWRIGHT_HTML_REPORT ??
-				`${ testsResultsPath }/reports/playwright-report`,
+			outputFolder: `${ testsResultsPath }/playwright-report`,
 			open: 'on-failure',
 		},
 	] );

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -92,7 +92,11 @@ const config = {
 		{
 			name: 'ui',
 			use: { ...devices[ 'Desktop Chrome' ] },
-			testIgnore: '**/api-tests/**',
+			testMatch: [
+				'**basic.spec.js',
+				'**/product-*spec.js',
+				'**/wordpress-post.spec.js',
+			],
 		},
 		{
 			name: 'api',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
@@ -8,6 +8,7 @@ test(
 	'logged-in customer can comment on a post',
 	{ tag: [ '@gutenberg', '@payments', '@services' ] },
 	async ( { page } ) => {
+		expect( process.env.GITHUB_RUN_ATTEMPT ).toBe( '2' );
 		await page.goto( 'hello-world/' );
 		await expect(
 			page.getByRole( 'heading', { name: 'Hello world!', exact: true } )

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
@@ -8,7 +8,6 @@ test(
 	'logged-in customer can comment on a post',
 	{ tag: [ '@gutenberg', '@payments', '@services' ] },
 	async ( { page } ) => {
-		expect( process.env.GITHUB_RUN_ATTEMPT ).toBe( '2' );
 		await page.goto( 'hello-world/' );
 		await expect(
 			page.getByRole( 'heading', { name: 'Hello world!', exact: true } )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/50267
When re-running only the failed Playwright tests using a shard > 1 will run 0 tests.
This is a quick fix by adding the `--shard=1/1` argument together with `--last-failed` to basically disable sharding and ensure tests are actually being run.

### How to test the changes in this Pull Request:

Have a failed test in a shard > 1. Re-run the job. All failed tests and only those should run.

Test runs: 
- [run 1](https://github.com/woocommerce/woocommerce/actions/runs/10305647279/job/28527030109?pr=50492): failed test in shard 6/6
- [run 2](https://github.com/woocommerce/woocommerce/actions/runs/10305647279/job/28527514300?pr=50492#step:9:133): re-run of shard 6/6 - only the failed test ran and it passed
- [run 3](https://github.com/woocommerce/woocommerce/actions/runs/10305647279/job/28527768529?pr=50492): re-run of shard 6/6 after the test passed, all tests ran again