### PR TITLE
Product Gallery: add defensive check

### DIFF
--- a/plugins/woocommerce/changelog/50495-50460-fatal-call-to-a-member-function-get_gallery_image_ids-on-bool
+++ b/plugins/woocommerce/changelog/50495-50460-fatal-call-to-a-member-function-get_gallery_image_ids-on-bool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Product Gallery: add defensive check to avoid fatal errors.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
@@ -74,6 +74,10 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 
 		$product = wc_get_product( $post_id );
 
+		if ( ! $product instanceof \WC_Product ) {
+			return '';
+		}
+
 		$product_gallery = $product->get_gallery_image_ids();
 
 		if ( empty( $product_gallery ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50460. This PR implements a defensive check to ensure that WordPress doesn't throw a fatal error if `wc_get_product` doesn't return a `WC_Product` instance.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit the Site Editor
2. Edit the Single Product template
3. Remove the `Product Image Gallery`
4. Add `Product Gallery (Beta)`
5. Save
6. Visit a product page.
7. Smoke test the gallery.
8. Ensure that any fatal error is thrown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Product Gallery: add defensive check to avoid fatal errors.

</details>
