### PR TITLE
Clear global_unique_id when restoring a product with an existing global_unique_id

### DIFF
--- a/plugins/woocommerce/changelog/update-clear-unique-id
+++ b/plugins/woocommerce/changelog/update-clear-unique-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Clear global_unique_id when restoring a product that doesn't have an unique id

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -405,10 +405,24 @@ class WC_Post_Data {
 			$data_store->untrash_variations( $id );
 
 			wc_product_force_unique_sku( $id );
+			self::clear_global_unique_id_if_necessary( $id );
 
 			wc_get_container()->get( ProductAttributesLookupDataStore::class )->on_product_changed( $id );
 		} elseif ( 'product_variation' === $post_type ) {
 			wc_get_container()->get( ProductAttributesLookupDataStore::class )->on_product_changed( $id );
+		}
+	}
+
+	/**
+	 * Clear global unique id if it's not unique.
+	 *
+	 * @param mixed $id Post ID.
+	 */
+	private static function clear_global_unique_id_if_necessary( $id ) {
+		$product = wc_get_product( $id );
+		if ( ! wc_product_has_global_unique_id( $id, $product->get_global_unique_id() ) ) {
+			$product->set_global_unique_id( '' );
+			$product->save();
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -420,7 +420,7 @@ class WC_Post_Data {
 	 */
 	private static function clear_global_unique_id_if_necessary( $id ) {
 		$product = wc_get_product( $id );
-		if ( ! wc_product_has_global_unique_id( $id, $product->get_global_unique_id() ) ) {
+		if ( $product && ! wc_product_has_global_unique_id( $id, $product->get_global_unique_id() ) ) {
 			$product->set_global_unique_id( '' );
 			$product->save();
 		}


### PR DESCRIPTION
…unique id

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Clear global_unique_id when restoring a product with an existing global_unique_id

Closes #50442 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

(copied from original issue)

1. Create a simple product with a GTIN, UPC, EAN or ISBN value of `012345678905`. The GTIN, UPC, EAN or ISBN field can be found in the Inventory tab of the product editor.
2. Trash that product.
3. Create another simple product that also has the same GTIN, UPC, EAN or ISBN (`012345678905`).
4. Restore the first product from trash.
5.  Verify that the field was cleared on the restored product

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
