### PR TITLE
Only count published products in productCount

### DIFF
--- a/plugins/woocommerce/changelog/fix-48380_blocks_config_product_count
+++ b/plugins/woocommerce/changelog/fix-48380_blocks_config_product_count
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Only count published products in productCount

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -450,9 +450,9 @@ abstract class AbstractBlock {
 				'wordCountType' => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 			];
 			if ( is_admin() && ! WC()->is_rest_api_request() ) {
-				$product_counts = wp_count_posts( 'product' );
+				$product_counts     = wp_count_posts( 'product' );
 				$published_products = isset( $product_counts->publish ) ? $product_counts->publish : 0;
-				$wc_blocks_config = array_merge(
+				$wc_blocks_config    = array_merge(
 					$wc_blocks_config,
 					[
 						// Note that while we don't have a consolidated way of doing feature-flagging

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -452,7 +452,7 @@ abstract class AbstractBlock {
 			if ( is_admin() && ! WC()->is_rest_api_request() ) {
 				$product_counts     = wp_count_posts( 'product' );
 				$published_products = isset( $product_counts->publish ) ? $product_counts->publish : 0;
-				$wc_blocks_config    = array_merge(
+				$wc_blocks_config   = array_merge(
 					$wc_blocks_config,
 					[
 						// Note that while we don't have a consolidated way of doing feature-flagging

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -450,6 +450,8 @@ abstract class AbstractBlock {
 				'wordCountType' => _x( 'words', 'Word count type. Do not translate!', 'woocommerce' ),
 			];
 			if ( is_admin() && ! WC()->is_rest_api_request() ) {
+				$product_counts = wp_count_posts( 'product' );
+				$published_products = isset( $product_counts->publish ) ? $product_counts->publish : 0;
 				$wc_blocks_config = array_merge(
 					$wc_blocks_config,
 					[
@@ -457,7 +459,7 @@ abstract class AbstractBlock {
 						// we are borrowing from the WC Admin Features implementation. Also note we cannot
 						// use the wcAdminFeatures global because it's not always enqueued in the context of blocks.
 						'experimentalBlocksEnabled' => Features::is_enabled( 'experimental-blocks' ),
-						'productCount'              => array_sum( (array) wp_count_posts( 'product' ) ),
+						'productCount'              => $published_products,
 					]
 				);
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We use `wcBlocksConfig.productCount` to display a UI suggesting to create a new product when there are no products (like the `All Products` or `Filter by price` blocks.


![Screenshot 2024-08-08 at 5 16 17 PM](https://github.com/user-attachments/assets/7486a2e7-d4ab-4854-bc00-2f424fecfd21)


However, if there isn't any published product (with draft products or in the trash can) `productCount` is higher than 0, preventing the Add products screen to be shown.

![Screenshot 2024-08-08 at 5 16 41 PM](https://github.com/user-attachments/assets/801fba83-1274-482d-98d0-85ac8395e2fa)


This PR adds the changes needed to set `productCount` only with the count of published products.

Expected behavior: `wcBlocksConfig.productCount` should be 0 if there are only trashed (or draft) products.

Closes #48380.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before checking out this branch.
2. Make sure you have some products in your store.
3. Trash all of them (without deleting them permanently).
4. Go to the post or page editor and add the `All Products` block.
5. Verify that no product message is visible


![Screenshot 2024-08-08 at 4 58 39 PM](https://github.com/user-attachments/assets/f0c56785-9ed4-4213-870b-fd9a7746bc1e)

6. Now checkout this branch.
7. Refresh the post or page you were creating.
8. The placeholder to add a new product should be visible.

![image](https://github.com/woocommerce/woocommerce/assets/3616980/8eca0a14-9c5f-433d-af31-ce3df3ab156b)

9.  Verify that the `Filter by price` block shows the same messages as well.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
