### PR TITLE
[Beta Tester] Fix build:zip script to make sure dependencies are built first

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/50508-fix-beta-tester-build-deps
+++ b/plugins/woocommerce-beta-tester/changelog/50508-fix-beta-tester-build-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Adjustment to the build step.
+

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -17,7 +17,6 @@
 		"@types/wordpress__plugins": "3.0.0",
 		"@woocommerce/dependency-extraction-webpack-plugin": "workspace:*",
 		"@woocommerce/eslint-plugin": "workspace:*",
-		"@woocommerce/remote-logging": "workspace:*",
 		"@wordpress/env": "^9.7.0",
 		"@wordpress/prettier-config": "2.17.0",
 		"@wordpress/scripts": "^19.2.4",
@@ -36,6 +35,7 @@
 		"@woocommerce/data": "workspace:*",
 		"@woocommerce/expression-evaluation": "workspace:*",
 		"@woocommerce/product-editor": "workspace:*",
+		"@woocommerce/remote-logging": "workspace:*",
 		"@wordpress/api-fetch": "wp-6.0",
 		"@wordpress/components": "wp-6.0",
 		"@wordpress/compose": "wp-6.0",
@@ -64,7 +64,8 @@
 		"build_step": "pnpm run build:zip"
 	},
 	"scripts": {
-		"build": "pnpm build:admin && pnpm uglify",
+		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
+		"build:project": "pnpm build:admin && pnpm uglify",
 		"build:admin": "wp-scripts build",
 		"build:dev": "pnpm lint:js && pnpm build",
 		"build:zip": "./bin/build-zip.sh",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3858,6 +3858,9 @@ importers:
       '@woocommerce/product-editor':
         specifier: workspace:*
         version: link:../../packages/js/product-editor
+      '@woocommerce/remote-logging':
+        specifier: workspace:*
+        version: link:../../packages/js/remote-logging
       '@wordpress/api-fetch':
         specifier: wp-6.0
         version: 6.3.1
@@ -3916,9 +3919,6 @@ importers:
       '@woocommerce/eslint-plugin':
         specifier: workspace:*
         version: link:../../packages/js/eslint-plugin
-      '@woocommerce/remote-logging':
-        specifier: workspace:*
-        version: link:../../packages/js/remote-logging
       '@wordpress/env':
         specifier: ^9.7.0
         version: 9.7.0


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/50425#discussion_r1709054657 it was noticed that dependencies weren't getting built when trying to build a zip. This will cause problems if your environment hasn't fully built all dependencies. 

This PR changes the `build` command to the same as the others in the monorepo. It seems to build everything, which is heavy handed, but the`start` script remains unchanged for development purposes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Locally, force a package to be unbuilt, `rm -rf packages/js/remote-logging/build-types`
2. Remove the cache just in case, `rm -rf ${pnpm store path}`
3. Build a zip and see no errors occur, ` pnpm --filter='@woocommerce/plugin-woocommerce-beta-tester' build:zip`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Adjustment to the build step.

</details>
