### PR TITLE
[Beta Tester] Flush cache after deleting option and resetting PHP rate limit

### DIFF
--- a/plugins/woocommerce-beta-tester/api/options/rest-api.php
+++ b/plugins/woocommerce-beta-tester/api/options/rest-api.php
@@ -61,6 +61,7 @@ function wca_test_helper_delete_option( $request ) {
 		)
 	);
 
+	wp_cache_flush();
 	return new WP_REST_RESPONSE( null, 204 );
 }
 

--- a/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
+++ b/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
@@ -119,8 +119,7 @@ function reset_php_rate_limit() {
 	$wpdb->query(
 		"DELETE FROM {$wpdb->prefix}wc_rate_limits"
 	);
-
-	WC_Cache_Helper::invalidate_cache_group( WC_Rate_Limiter::CACHE_GROUP );
+	wp_cache_flush();
 
 	return new WP_REST_Response( array( 'success' => true ), 200 );
 }

--- a/plugins/woocommerce-beta-tester/changelog/fix-remote-logging-tool-cache
+++ b/plugins/woocommerce-beta-tester/changelog/fix-remote-logging-tool-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Flush cache after deleting option and resetting PHP rate limit


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I added the remote logging tool to beta tester in https://github.com/woocommerce/woocommerce/pull/50425.

However, I found that the cache might not flushed after deleting the option and resetting the PHP rate limit on JN sites which caused the incorrect behavior. This PR adds the cache flushing to ensure the cache is cleared after these actions.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally.
2. cd to `plugins/woocommerce-beta-tester` and run `pnpm run build:zip`
3. Create a new JN site with this branch
4. Upload and activate `woocommerce-beta-tester.zip`
5. Go to `Tools -> WCA Test Helper -> Remote Logging`
6. Enable remote logging
7.  Click on PHP `Log Event` and confirm notice shows it log the event successfully
8. Click again on PHP `Log Event` and confirm the `Failed to log remote event.` error message is shown
9. Click on PHP `Reset Rate Limit` and click on PHP `Log Event` to confirm rate limit is reset
10. Repeat steps 9 and confirm it works consistently
11. Click on JS `Simulate Beta Tester Exception`, refresh the page, and confirm it throws an error in the console
12. Repeat steps 11-12, confirm it works consistently



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
