### PR TITLE
[Remote Specs] Treat empty arrays as valid cached values

### DIFF
--- a/plugins/woocommerce/changelog/50521-fix-DataPoller-valid-result
+++ b/plugins/woocommerce/changelog/50521-fix-DataPoller-valid-result
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+In Remote Specs, treat empty arrays as valid cached values so individual engines can return default values.

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
@@ -106,7 +106,7 @@ abstract class DataSourcePoller {
 	public function get_specs_from_data_sources() {
 		$locale      = get_user_locale();
 		$specs_group = get_transient( $this->args['transient_name'] ) ?? array();
-		$specs       = isset( $specs_group[ $locale ] ) ? $specs_group[ $locale ] : array();
+		$specs       = isset( $specs_group[ $locale ] ) ? $specs_group[ $locale ] : null;
 
 		if ( ! is_array( $specs ) ) {
 			$this->read_specs_from_data_sources();

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
@@ -107,7 +107,7 @@ abstract class DataSourcePoller {
 		$locale      = get_user_locale();
 		$specs_group = get_transient( $this->args['transient_name'] ) ?? array();
 		$specs       = isset( $specs_group[ $locale ] ) ? $specs_group[ $locale ] : null;
-		
+
 		if ( ! is_array( $specs ) ) {
 			$this->read_specs_from_data_sources();
 			$specs_group = get_transient( $this->args['transient_name'] );

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
@@ -108,7 +108,7 @@ abstract class DataSourcePoller {
 		$specs_group = get_transient( $this->args['transient_name'] ) ?? array();
 		$specs       = isset( $specs_group[ $locale ] ) ? $specs_group[ $locale ] : array();
 
-		if ( ! is_array( $specs ) || empty( $specs ) ) {
+		if ( ! is_array( $specs ) ) {
 			$this->read_specs_from_data_sources();
 			$specs_group = get_transient( $this->args['transient_name'] );
 			$specs       = isset( $specs_group[ $locale ] ) ? $specs_group[ $locale ] : array();

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
@@ -107,7 +107,7 @@ abstract class DataSourcePoller {
 		$locale      = get_user_locale();
 		$specs_group = get_transient( $this->args['transient_name'] ) ?? array();
 		$specs       = isset( $specs_group[ $locale ] ) ? $specs_group[ $locale ] : null;
-
+		
 		if ( ! is_array( $specs ) ) {
 			$this->read_specs_from_data_sources();
 			$specs_group = get_transient( $this->args['transient_name'] );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/InitTest.php
@@ -140,9 +140,15 @@ class InitTest extends WC_Unit_Test_Case {
 		);
 
 		$bundles           = RemoteFreeExtensions::get_extensions();
+		$defaults          = DefaultFreeExtensions::get_all();
 		$stored_transients = get_transient( 'woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
+
+		$this->assertTrue( count( $stored_transients['en_US'] ) === 0 );
 		$this->assertTrue( count( $bundles ) > 1 );
-		$this->assertEquals( count( $bundles ), count( DefaultFreeExtensions::get_all() ) );
+		$this->assertEquals( count( $bundles ), count( $defaults ) );
+		foreach ( $bundles as $key => $bundle ) {
+			$this->assertEquals( $defaults[ $key ]->key, $bundle['key'] );
+		}
 
 		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
 		$this->assertTrue( ( $expires - time() ) < 3 * HOUR_IN_SECONDS );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/RemoteFreeExtensions/InitTest.php
@@ -142,7 +142,7 @@ class InitTest extends WC_Unit_Test_Case {
 		$bundles           = RemoteFreeExtensions::get_extensions();
 		$stored_transients = get_transient( 'woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
 		$this->assertTrue( count( $bundles ) > 1 );
-		$this->assertEquals( count( $stored_transients['en_US'] ), count( DefaultFreeExtensions::get_all() ) );
+		$this->assertEquals( count( $bundles ), count( DefaultFreeExtensions::get_all() ) );
 
 		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . RemoteFreeExtensionsDataSourcePoller::ID . '_specs' );
 		$this->assertTrue( ( $expires - time() ) < 3 * HOUR_IN_SECONDS );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/WCPayPromotion/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/WCPayPromotion/InitTest.php
@@ -303,7 +303,6 @@ class InitTest extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $default_promotions, $promotions );
 
-		$this->assertEquals( $stored_specs_in_transient['en_US'], $default_specs );
 		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . WCPayPromotionDataSourcePoller::ID . '_specs' );
 		$this->assertTrue( ( $expires - time() ) <= 3 * HOUR_IN_SECONDS );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/WCPayPromotion/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/WCPayPromotion/InitTest.php
@@ -301,6 +301,7 @@ class InitTest extends WC_Unit_Test_Case {
 		$default_specs      = DefaultPromotions::get_all();
 		$default_promotions = EvaluateSuggestion::evaluate_specs( $default_specs )['suggestions'];
 
+		$this->assertTrue( count( $stored_specs_in_transient['en_US'] ) === 0 );
 		$this->assertEquals( $default_promotions, $promotions );
 
 		$expires = (int) get_transient( '_transient_timeout_woocommerce_admin_' . WCPayPromotionDataSourcePoller::ID . '_specs' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Errors in `wp_remote_get` such as timeouts cause an empty array to be cached for remote specs. The empty array is read as invalid and and another request is kicked off, sometimes producing the same result.

If an error occurs in `wp_remote_get` an `array()` is returned.

https://github.com/woocommerce/woocommerce/blob/c406f1991efb62cd77cc8550357cb79d63635250/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php#L210-L219

The empty array is then stored in the transient after some manipulation.

https://github.com/woocommerce/woocommerce/blob/c406f1991efb62cd77cc8550357cb79d63635250/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php#L149-L162

In the next call the transient is `empty` and another request is kicked off. 

https://github.com/woocommerce/woocommerce/blob/c406f1991efb62cd77cc8550357cb79d63635250/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php#L111-L115

This PR treats the empty array as valid to prevent another request. In the case of RemoteFreeExtensions, this case is handled and default values returned.

https://github.com/woocommerce/woocommerce/blob/c406f1991efb62cd77cc8550357cb79d63635250/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php#L85-L87

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Simulate an error when calling `wp_remote_get` in the data poller. You can use a number of tools such as hosts file entry `127.0.0.1 woocommerce.com` but I just returned the empty array early and added logging to simulate the error. 
```diff
diff --git a/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php b/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
index c585771060..f85d3d8ac8 100644
--- a/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/DataSourcePoller.php
@@ -194,6 +194,8 @@ abstract class DataSourcePoller {
         * @return array The specs that have been read from the data source.
         */
        protected static function read_data_source( $url ) {
+               error_log( 'Polling the data source: ' . $url );
+               return array();
                $logger_context = array( 'source' => $url );
                $logger         = self::get_logger();
                $response       = wp_remote_get(
```
2. Clear your cached transients, `wp transient delete --all`
3. Go to a task, `/wp-admin/admin.php?page=wc-admin&task=marketing` and check the logs.
4. You should see a few endpoints being called (although they should probably not be in this case). They should be called only once. You can perform these steps on `trunk` and see multiple requests, sometimes 20-30.
5. Refresh the page, there should be no logs because the `array()` cached value is being returned.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

In Remote Specs, treat empty arrays as valid cached values so individual engines can return default values.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
