### PR TITLE
Fix: Allow verified parameter to be set by REST API request

### DIFF
--- a/plugins/woocommerce/changelog/fix-45609
+++ b/plugins/woocommerce/changelog/fix-45609
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow verified parameter to be set by REST API request

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
@@ -472,6 +472,10 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 
 		update_comment_meta( $review_id, 'rating', ! empty( $request['rating'] ) ? $request['rating'] : '0' );
 
+		if ( isset( $request['verified'] ) && ! empty( $request['verified'] ) ) {
+			update_comment_meta( $review_id, 'verified', $request['verified'] );
+		}
+
 		$review = get_comment( $review_id );
 
 		/**
@@ -584,6 +588,10 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 
 		if ( ! empty( $request['rating'] ) ) {
 			update_comment_meta( $id, 'rating', $request['rating'] );
+		}
+
+		if ( isset( $request['verified'] ) && ! empty( $request['verified'] ) ) {
+			update_comment_meta( $id, 'verified', $request['verified'] );
 		}
 
 		$review = get_comment( $id );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Cherry-picked from: https://github.com/woocommerce/woocommerce/pull/47132, added changelog and testing instructions.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product if you don't already have.
2. Send the following payload to the endpoint: `wp-json/wc/v3/products/reviews`
```json
{
  "product_id": 1927,
  "review": "Nice album asdaasassds123!",
  "reviewer": "John Doe",
  "reviewer_email": "john.doe@example.com",
  "rating": 5,
  "verified": true
}
```
3. Replace the product id.
4. Make sure the returned object has a `verified` set parameter as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
