### PR TITLE
Store API: Do not resume orders with `pending` status

### DIFF
--- a/plugins/woocommerce/changelog/fix-50429-store-api-resuming-exclude-pending
+++ b/plugins/woocommerce/changelog/fix-50429-store-api-resuming-exclude-pending
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API: Do not resume pending orders--create a new order instead

--- a/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
@@ -60,8 +60,9 @@ trait DraftOrderTrait {
 			return true;
 		}
 
-		// Pending and failed orders can be retried if the cart hasn't changed.
-		if ( $order_object->needs_payment() && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
+		// Failed orders and those needing payment can be retried if the cart hasn't changed.
+		// Pending orders are excluded from this check since they may be awaiting an update from the payment processor.
+		if ( $order_object->needs_payment() && ! $order_object->has_status( 'pending' ) && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Store API determines if an order can be resumed by looking at the draft order ID in session's status. Before this patch it uses `pending`, `draft`, and `failed` as valid statuses (using `$order->needs_payment()`).

The legacy checkout does not do this which has caused some confusion with payment gateway developers who use `pending` status while waiting for authorization. Even though they should be using `on hold` status which was made for that purpose, we should follow what classic checkout does and create a duplicate order instead.

Closes #50429

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open 2 browsers and in one be logged in as admin, and in the other visit the store as a guest.
2. Place an order as the guest by adding 1 item to the cart. Pay using COD or BACs. Leave thanks page open. Note down the order ID.
3. As the admin, edit the new order and change the order status from processing or on-hold (depending on gateway) to `pending`. Save the order.
4. Back as the customer, click through to the product from the thanks page and add it to the cart again. Go through the checkout process again with the same details and same payment method. Ensure the items in the cart are identical to the last order.
5. After placing the order, check that the order ID does not match the ID of the original order.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
