### PR TITLE
[e2e tests] Update locators for Customers page in page-loads spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-improve-page-loads-customers-test
+++ b/plugins/woocommerce/changelog/e2e-improve-page-loads-customers-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix flakiness in page-loads customer page test

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -53,7 +53,7 @@ if ( process.env.CI ) {
 	reporter.push( [
 		'html',
 		{
-			outputFolder: `${ testsResultsPath }/playwright-report`,
+			outputFolder: `${ testsRootPath }/playwright-report`,
 			open: 'on-failure',
 		},
 	] );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -22,8 +22,8 @@ const wcPages = [
 			{
 				name: 'Customers',
 				heading: 'Customers',
-				element: '#search-inline-input-0',
-				text: 'Move backward for selected items',
+				element: '.woocommerce-dropdown-button__labels',
+				text: 'All Customers',
 			},
 			{
 				name: 'Reports',
@@ -206,8 +206,7 @@ for ( const currentPage of wcPages ) {
 				} ) => {
 					await page
 						.locator(
-							`li.wp-menu-open > ul.wp-submenu > li:has-text("${ currentPage.subpages[ i ].name }")`,
-							{ waitForLoadState: 'networkidle' }
+							`li.wp-menu-open > ul.wp-submenu > li:has-text("${ currentPage.subpages[ i ].name }")`
 						)
 						.click();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/50272

Attempt for fix flakiness of `merchant/page-loads.spec.js:204:5 › WooCommerce Page Load > Load WooCommerce sub pages › Can load Customers`

Updated the locators to check on page.

### How to test the changes in this Pull Request:

- CI should be green.
- Locally, run:
```
pnpm test:e2e page-loads.spec.js
```