### PR TITLE
Add `woocommerce_coming_soon` option for all sites

### DIFF
--- a/plugins/woocommerce/changelog/add-coming-soon-options-for-all-sites
+++ b/plugins/woocommerce/changelog/add-coming-soon-options-for-all-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add woocommerce_coming_soon option for all sites

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -295,6 +295,7 @@ class WC_Install {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'maybe_enable_hpos' ), 20 );
+		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'add_coming_soon_option' ), 20 );
 		add_action( 'admin_init', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'add_admin_note_after_page_created' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
@@ -987,6 +988,17 @@ class WC_Install {
 			$feature_controller = wc_get_container()->get( FeaturesController::class );
 			$feature_controller->change_feature_enable( 'custom_order_tables', true );
 		}
+	}
+
+	/**
+	 * Add the woocommerce_coming_soon option for new shops.
+	 *
+	 * Ensure that the option is set for all shops, even if core profiler is disabled on the host.
+	 *
+	 * @since 9.3.0
+	 */
+	public static function add_coming_soon_option() {
+		add_option( 'woocommerce_coming_soon', 'no' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -262,6 +262,9 @@ class WC_Install {
 		'9.2.0' => array(
 			'wc_update_920_add_wc_hooked_blocks_version_option',
 		),
+		'9.3.0' => array(
+			'wc_update_930_add_woocommerce_coming_soon_option',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2779,14 +2779,16 @@ function wc_update_920_add_wc_hooked_blocks_version_option() {
 function wc_update_910_remove_obsolete_user_meta() {
 	global $wpdb;
 
-	$deletions = $wpdb->query( "
+	$deletions = $wpdb->query(
+		"
 		DELETE FROM $wpdb->usermeta
 		WHERE meta_key IN (
 			'_last_order',
 			'_order_count',
 			'_money_spent'
 		)
-	" );
+	"
+	);
 
 	$logger = wc_get_logger();
 
@@ -2814,4 +2816,11 @@ function wc_update_910_remove_obsolete_user_meta() {
 			)
 		);
 	}
+}
+
+/**
+ * Add woocommerce_coming_soon option when it is not currently present.
+ */
+function wc_update_930_add_woocommerce_coming_soon_option() {
+	add_option( 'woocommerce_coming_soon', 'no' );
 }

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -133,7 +133,7 @@ class LaunchYourStore {
 		$private_link     = 'no';
 		$share_key        = wp_generate_password( 32, false );
 
-		add_option( 'woocommerce_coming_soon', $coming_soon );
+		update_option( 'woocommerce_coming_soon', $coming_soon );
 		add_option( 'woocommerce_store_pages_only', $store_pages_only );
 		add_option( 'woocommerce_private_link', $private_link );
 		add_option( 'woocommerce_share_key', $share_key );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Could you describe the changes made to this Pull Request and the reason for thes -->

Closes https://github.com/woocommerce/woocommerce/issues/50367.

For optimal performance, all sites should have the `woocommerce_coming_soon` option value set. This would allow the value to be retrieved with get_option() without requiring an extra query. 

Changes:

- Add a db update routine to add the `woocommerce_coming_soon` option when it is not currently present using `add_option()`
- Add `woocommerce_coming_soon` option for new sites using `woocommerce_newly_installed` hook.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**New site stop at the core profiler**

1. Create a new site with this branch
2. Stop at the core profiler intro screen
3. Confirm `woocommerce_coming_soon ` option is set to `no`

**New site completes core profiler**

1. Create a new site with this branch
2. Complete the core profiler
3. On the homescreen see that the site visibility badge says site coming soon


**Existing Live Site**

1. Create a new site with WC 9.1 or 9.2 and WC beta tester
2. Run `wp option set woocommerce_onboarding_profile --json '{"skipped": true}'` to skip core profiler
3. Upload and activate this branch build zip, or switch to this branch using the live branch feature (/wp-admin/admin.php?page=wc-admin&path=%2Flive-branches)
4. Go to `WooCommerce > Home`, click on `Update WooCommerce Database ` and wait for it to complete
5. Confirm `woocommerce_coming_soon` option is set to `no`

**Existing site in coming soon mode**

1. Create a new site with WC 9.1 or 9.2 and WC beta tester
2. Upload and activate this branch build zip, or switch to this branch using the live branch feature (/wp-admin/admin.php?page=wc-admin&path=%2Flive-branches)
3. Go to WooCommerce > Home, click on Update WooCommerce Database and wait for it to complete
4. On the homescreen see that the site visibility badge says site coming soon

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
