### PR TITLE
Update Continue button container on core profiler extension screen

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
@@ -219,51 +219,53 @@ export const Plugins = ( {
 						);
 					} ) }
 				</div>
-				<div className="woocommerce-profiler-plugins-continue-button-container">
-					<Button
-						className="woocommerce-profiler-plugins-continue-button"
-						variant="primary"
-						onClick={
-							selectedPlugins.length
-								? submitInstallationRequest
-								: skipPluginsPage
-						}
-					>
-						{ __( 'Continue', 'woocommerce' ) }
-					</Button>
-				</div>
-				{ pluginsWithAgreement.length > 0 && (
-					<p className="woocommerce-profiler-plugins-jetpack-agreement">
-						{ interpolateComponents( {
-							mixedString: sprintf(
-								/* translators: %s: a list of plugins, e.g. Jetpack */
-								_n(
-									'By installing %s plugin for free you agree to our {{link}}Terms of Service{{/link}}.',
-									'By installing %s plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
-									pluginsWithAgreement.length,
-									'woocommerce'
-								),
-								joinWithAnd(
-									pluginsWithAgreement.map(
-										( plugin ) => plugin.name
+				<div className="woocommerce-profiler-plugins__footer">
+					<div className="woocommerce-profiler-plugins-continue-button-container">
+						<Button
+							className="woocommerce-profiler-plugins-continue-button"
+							variant="primary"
+							onClick={
+								selectedPlugins.length
+									? submitInstallationRequest
+									: skipPluginsPage
+							}
+						>
+							{ __( 'Continue', 'woocommerce' ) }
+						</Button>
+					</div>
+					{ pluginsWithAgreement.length > 0 && (
+						<p className="woocommerce-profiler-plugins-jetpack-agreement">
+							{ interpolateComponents( {
+								mixedString: sprintf(
+									/* translators: %s: a list of plugins, e.g. Jetpack */
+									_n(
+										'By installing %s plugin for free you agree to our {{link}}Terms of Service{{/link}}.',
+										'By installing %s plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
+										pluginsWithAgreement.length,
+										'woocommerce'
+									),
+									joinWithAnd(
+										pluginsWithAgreement.map(
+											( plugin ) => plugin.name
+										)
 									)
-								)
-									.map( composeListFormatParts )
-									.join( '' )
-							),
-							components: {
-								span: <span />,
-								link: (
-									<Link
-										href="https://wordpress.com/tos/"
-										target="_blank"
-										type="external"
-									/>
+										.map( composeListFormatParts )
+										.join( '' )
 								),
-							},
-						} ) }
-					</p>
-				) }
+								components: {
+									span: <span />,
+									link: (
+										<Link
+											href="https://wordpress.com/tos/"
+											target="_blank"
+											type="external"
+										/>
+									),
+								},
+							} ) }
+						</p>
+					) }
+				</div>
 			</div>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -392,7 +392,7 @@
 		align-items: center;
 
 		@media screen and ( max-height: 900px ) {
-			background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%);
+			background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%); // transparent to white gradient from top to bottom.
 			height: 140px;
 			position: fixed;
 			bottom: 0;

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -385,6 +385,20 @@
 		}
 	}
 
+	.woocommerce-profiler-plugins__footer {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		@media screen and ( max-height: 900px ) {
+			background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%);
+			height: 140px;
+			position: fixed;
+			bottom: 0;
+		}
+	}
+
 	.woocommerce-profiler-plugins-continue-button-container {
 		@include breakpoint("<782px") {
 			width: 100%;

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -392,7 +392,7 @@
 		align-items: center;
 
 		@media screen and ( max-height: 900px ) {
-			background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%); // transparent to white gradient from top to bottom.
+			background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 44.69%);
 			height: 140px;
 			position: fixed;
 			bottom: 0;

--- a/plugins/woocommerce/changelog/update-core-profiler-sticky-continue-button
+++ b/plugins/woocommerce/changelog/update-core-profiler-sticky-continue-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update core profiler continue button container on extension screen


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50497.

On 1440x900 screens, the continue button isn't visible above the fold. To improve the UX for these users, stick the continue button at the bottom of the viewport and a white gradient background behind it.


- On desktop screens 900px and smaller, add a 140px tall container stuck to the bottom of the viewport
- Add a transparent to solid white gradient to the container (top to bottom)
- Vertically center align the continue button and dislaimer text inside the container



https://github.com/user-attachments/assets/6f41cce9-93e3-4da9-ab9a-80f3ee93f979



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch
2. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=plugins
3. Resize the browser window to 1440x900 or smaller (height) and confirm the continue button is visible above the fold
4. Confirm the continue button is stuck to the bottom of the viewport and the background is a white gradient

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
