### PR TITLE
Fix LYS tour is shown again after closing it

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
@@ -40,7 +40,8 @@ export const useSiteVisibilityTour = () => {
 				woocommerce_launch_your_store_tour_hidden: 'yes',
 			},
 		} );
-
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
 		dispatch( 'core' ).invalidateResolution( 'getCurrentUser' );
 	};
 

--- a/plugins/woocommerce-admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
@@ -31,15 +31,17 @@ export const useSiteVisibilityTour = () => {
 		};
 	} );
 
-	const onClose = () => {
+	const onClose = async () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		dispatch( 'core' ).saveUser( {
+		await dispatch( 'core' ).saveUser( {
 			id: window?.wcSettings?.currentUserId,
 			meta: {
 				woocommerce_launch_your_store_tour_hidden: 'yes',
 			},
 		} );
+
+		dispatch( 'core' ).invalidateResolution( 'getCurrentUser' );
 	};
 
 	return {

--- a/plugins/woocommerce-admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
+++ b/plugins/woocommerce-admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
@@ -37,7 +37,7 @@ export const useSiteVisibilityTour = () => {
 		await dispatch( 'core' ).saveUser( {
 			id: window?.wcSettings?.currentUserId,
 			meta: {
-				woocommerce_launch_your_store_tour_hidden: 'yes',
+				[ LYS_TOUR_HIDDEN ]: 'yes',
 			},
 		} );
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/plugins/woocommerce/changelog/fix-lys-tour-show-again
+++ b/plugins/woocommerce/changelog/fix-lys-tour-show-again
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix LYS tour is shown again after closing it


### PR DESCRIPTION
a### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49126.

Invalidating the tour state after closing it, so it won't be shown again.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch
2. Set `woocommerce_show_lys_tour` option to yes.
3. Go to `WooCommerce > Home`
4. Confirm the tour is shown and close it
5. Click on the product task
6. Click on the back icon
7. Confirm the tour is not shown again


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
