### PR TITLE
Fix navigation badge decreases when installing extension in "Grow your business task"

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/components/task.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task.tsx
@@ -9,7 +9,7 @@ import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { ONBOARDING_STORE_NAME, TaskType } from '@woocommerce/data';
 import { useCallback } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect, resolveSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -31,25 +31,28 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 	const { invalidateResolutionForStoreSelector, optimisticallyCompleteTask } =
 		useDispatch( ONBOARDING_STORE_NAME );
 
-	const updateBadge = useCallback( () => {
-		const badgeElements: Array< HTMLElement > | null = Array.from(
-			document.querySelectorAll(
-				'#adminmenu .woocommerce-task-list-remaining-tasks-badge'
-			)
+	const updateBadge = useCallback( async () => {
+		const badgeElements = document.querySelectorAll(
+			'#adminmenu .woocommerce-task-list-remaining-tasks-badge'
 		);
 
 		if ( ! badgeElements?.length ) {
 			return;
 		}
 
-		badgeElements.forEach( ( badgeElement ) => {
-			const currentBadgeCount = Number( badgeElement.innerText );
+		const setupTaskList = await resolveSelect(
+			ONBOARDING_STORE_NAME
+		).getTaskList( 'setup' );
+		if ( ! setupTaskList ) {
+			return;
+		}
 
-			if ( currentBadgeCount === 1 ) {
-				badgeElement.remove();
-			} else {
-				badgeElement.innerHTML = String( currentBadgeCount - 1 );
-			}
+		const remainingTasksCount = setupTaskList.tasks.filter(
+			( _task ) => ! _task.isComplete
+		).length;
+
+		badgeElements.forEach( ( badge ) => {
+			badge.textContent = remainingTasksCount.toString();
 		} );
 	}, [] );
 
@@ -64,7 +67,12 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 			invalidateResolutionForStoreSelector( 'getTaskLists' );
 			updateBadge();
 		},
-		[ id ]
+		[
+			id,
+			invalidateResolutionForStoreSelector,
+			optimisticallyCompleteTask,
+			updateBadge,
+		]
 	);
 
 	return (

--- a/plugins/woocommerce-admin/client/task-lists/components/task.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task.tsx
@@ -9,7 +9,7 @@ import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { ONBOARDING_STORE_NAME, TaskType } from '@woocommerce/data';
 import { useCallback } from '@wordpress/element';
-import { useDispatch, useSelect, resolveSelect } from '@wordpress/data';
+import { useDispatch, resolveSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */

--- a/plugins/woocommerce/changelog/fix-badge-decrease-marketing-task
+++ b/plugins/woocommerce/changelog/fix-badge-decrease-marketing-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix navigation badge decreases when installing extension in "Grow your business task"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50513

The navigation badge count decreases whenever extensions are installed in the "Grow your business" task.

This is because we decrease the count of the navigation badge whenever onComplete() is called in the task. This PR updates the logic to set the badge count based on active set up tasks to ensure the badge count is accurate.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Skip Core Profiler and choose `Afghanistan` as store country
3. Open "Grow your business" task
4. Note the count of incomplete tasks in the WooCommerce > Home navigation badge
5. Install an extension by clicking "Get started"
6. See that the badge count doesn't change
7. Go to Payment task
8. Enable cash on delivery
9. See that the badge count decreases by 1


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
