### PR TITLE
Fixed the order of elements on the Order Confirmation screen

### DIFF
--- a/plugins/woocommerce/changelog/50395-the-title-on-the-confirmation-page-is-below-the-subtitle
+++ b/plugins/woocommerce/changelog/50395-the-title-on-the-confirmation-page-is-below-the-subtitle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue that caused the page title and content text to display in the incorrect order on the Order Confirmation page.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -50,10 +50,10 @@ class Status extends AbstractOrderConfirmationBlock {
 
 		if ( $additional_content ) {
 			$block = $block . sprintf(
-					'<div class="wc-block-order-confirmation-status-description %1$s">%2$s</div>',
-					esc_attr( trim( $classname ) ),
-					$additional_content
-				);
+				'<div class="wc-block-order-confirmation-status-description %1$s">%2$s</div>',
+				esc_attr( trim( $classname ) ),
+				$additional_content
+			);
 		}
 
 		return $block;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -40,14 +40,20 @@ class Status extends AbstractOrderConfirmationBlock {
 			return '';
 		}
 
-		$additional_content = $this->render_account_notice( $order ) . $this->render_confirmation_notice( $order );
+		$account_notice = $this->render_account_notice( $order );
+
+		if ( $account_notice ) {
+			$block = $account_notice . $block;
+		}
+
+		$additional_content = $this->render_confirmation_notice( $order );
 
 		if ( $additional_content ) {
-			return sprintf(
-				'<div class="wc-block-order-confirmation-status-description %1$s">%2$s</div>',
-				esc_attr( trim( $classname ) ),
-				$additional_content
-			) . $block;
+			$block = $block . sprintf(
+					'<div class="wc-block-order-confirmation-status-description %1$s">%2$s</div>',
+					esc_attr( trim( $classname ) ),
+					$additional_content
+				);
 		}
 
 		return $block;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -43,7 +43,11 @@ class Status extends AbstractOrderConfirmationBlock {
 		$account_notice = $this->render_account_notice( $order );
 
 		if ( $account_notice ) {
-			$block = $account_notice . $block;
+			$block = sprintf(
+				'<div class="wc-block-order-confirmation-status-notices %1$s">%2$s</div>',
+				esc_attr( trim( $classname ) ),
+				$account_notice
+			) . $block;
 		}
 
 		$additional_content = $this->render_confirmation_notice( $order );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50395 

This PR fixes the order of elements on the Order Confirmation page, namely h1 and sub-heading that was changed accidentally in #48673 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. As a guest, add something to your cart and checkout using the block-based checkout.
2. Ensure you toggle the "create an account" box.
3. After placing the order, assuming you're using the block based order confirmation, you'll see a notice at the top of the screen indicating the account was created. Leave this page open in a browser window.
4. Go find the account email your new account received and click the link to reset/set a password.
5. Set the password for the account and log in.
6. Refresh the order confirmation page from earlier and confirm the notice is now hidden.
7. Visit the order confirmation page in an incognito window and verify that the title appears before the additional information text.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/10286be9-6338-4974-b7d8-7286e222bdff">

8. Change the URL, namely the order number to an invalid one, and check the title appears before the additional information text.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/576e16d5-08c2-45d5-a480-9e50c3bd8de6">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Resolved an issue that caused the page title and content text to display in the incorrect order on the Order Confirmation page.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
