### PR TITLE
fix: missing TreeSelectControl styles

### DIFF
--- a/packages/js/components/changelog/fix-tree-select-control-missing-wpcom-styles
+++ b/packages/js/components/changelog/fix-tree-select-control-missing-wpcom-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Fixed missing styles on TreeSelectControl by copying from @wordpress/components/CheckboxControl and importing @wordpress/base-styles

--- a/packages/js/components/src/tree-select-control/index.scss
+++ b/packages/js/components/src/tree-select-control/index.scss
@@ -1,3 +1,5 @@
+@import "node_modules/@wordpress/base-styles/mixins";
+
 $gap-largest: 40px;
 $gap-larger: 36px;
 $gap-large: 24px;
@@ -206,6 +208,78 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgb(0 0 0 / 20%),
 
 				&:focus {
 					box-shadow: 0 0 0 1px #fff, 0 0 0 3px var(--wp-admin-theme-color);
+				}
+			}
+		}
+
+		// At the time of this comment, it was discovered that this component has
+		// the same classnames as the WP Components Checkbox, without it being a code depedency.
+		// This caused some visual breakages when changes happened in WP 6.6, and
+		// the rules have been copied over from WP Components styles of 6.5.1.
+		// https://github.com/WordPress/gutenberg/blob/403b4b8d014ef7f6edc15c822e455e109bf49c6d/packages/components/src/checkbox-control/style.scss#L4
+		// mixins were imported from @wordpress/base-styles as there's a significant amount of rules if
+		// it were to be copied. I think the risk of them changing is lower than the chance we decide to upstream this component.
+		.components-checkbox-control__input-container {
+			$checkbox-input-size: 20px;
+			$checkbox-input-size-sm: 24px; // Width & height for small viewports.
+
+			height: $checkbox-input-size-sm;
+			width: $checkbox-input-size-sm;
+			display: inline-block;
+			margin-right: 12px;
+			position: relative;
+			vertical-align: middle;
+
+			@include break-small() {
+				height: $checkbox-input-size;
+				width: $checkbox-input-size;
+			}
+
+			.components-checkbox-control__input[type="checkbox"] {
+				@include checkbox-control;
+				background: $white;
+				color: $gray-900;
+				clear: none;
+				cursor: pointer;
+				display: inline-block;
+				line-height: 0;
+				margin: 0 $grid-unit-05 0 0;
+				outline: 0;
+				padding: 0 !important;
+				text-align: center;
+				vertical-align: top;
+				width: $checkbox-input-size-sm;
+				height: $checkbox-input-size-sm;
+			
+				@include break-small() {
+					height: $checkbox-input-size;
+					width: $checkbox-input-size;
+				}
+			
+				appearance: none;
+				transition: 0.1s border-color ease-in-out;
+				@include reduce-motion("transition");
+			
+				&:checked,
+				&:indeterminate {
+					$components-color-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+					background: $components-color-accent;
+					border-color: $components-color-accent;
+			
+					// Hide default checkbox styles in IE.
+					&::-ms-check {
+						opacity: 0;
+					}
+				}
+			
+				&:checked::before {
+					content: none;
+				}
+
+				
+				@include break-small {
+					height: $checkbox-input-size;
+					width: $checkbox-input-size;
 				}
 			}
 		}

--- a/packages/js/components/src/tree-select-control/index.scss
+++ b/packages/js/components/src/tree-select-control/index.scss
@@ -207,6 +207,7 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgb(0 0 0 / 20%),
 					box-shadow: 0 0 0 1px #1e1e1e;
 					
 					&:focus {
+						border-color: $white;
 						box-shadow: 0 0 0 1px #fff, 0 0 0 3px var(--wp-admin-theme-color);
 					}
 				}

--- a/packages/js/components/src/tree-select-control/index.scss
+++ b/packages/js/components/src/tree-select-control/index.scss
@@ -200,14 +200,15 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgb(0 0 0 / 20%),
 		}
 
 		&.is-partially-checked {
-
-			.components-checkbox-control__input {
-				background: var(--wp-admin-theme-color);
-				border: $gap-smallest solid $white;
-				box-shadow: 0 0 0 1px #1e1e1e;
-
-				&:focus {
-					box-shadow: 0 0 0 1px #fff, 0 0 0 3px var(--wp-admin-theme-color);
+			.components-checkbox-control__input-container {
+				.components-checkbox-control__input[type="checkbox"] {
+					background: var(--wp-admin-theme-color);
+					border: $gap-smallest solid $white;
+					box-shadow: 0 0 0 1px #1e1e1e;
+					
+					&:focus {
+						box-shadow: 0 0 0 1px #fff, 0 0 0 3px var(--wp-admin-theme-color);
+					}
 				}
 			}
 		}
@@ -257,7 +258,6 @@ $muriel-box-shadow-8dp: 0 5px 5px -3px rgb(0 0 0 / 20%),
 				}
 			
 				appearance: none;
-				transition: 0.1s border-color ease-in-out;
 				@include reduce-motion("transition");
 			
 				&:checked,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/issues/50349

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce and go to shipping settings (./wp-admin/admin.php?page=wc-settings&tab=shipping)
2. Add a shipping zone (./wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new)
3. Zone regions checkboxes should look correct
4. Devs reviewing this can also check that the styles are being loaded from WooCommerce plugin assets. The WordPress styles should also be loaded but they will be overriden completely.

![image](https://github.com/user-attachments/assets/97ee6acf-bbb7-4364-8028-14f2ef64b786)
![image](https://github.com/user-attachments/assets/704fac05-ba67-4faa-8569-c1cc0808376f)
![image](https://github.com/user-attachments/assets/7c9724a7-ec07-44bd-9737-be04053f6668)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
