### PR TITLE
Fix `Single product` translations on edit mode

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/block.json
@@ -17,12 +17,12 @@
 		"productId": {
 		   "type": "number"
 		}
-	 },
-	 "example": {
+	},
+	"example": {
 		"attributes": {
-		  "isPreview": true
+  			"isPreview": true
 		}
-	  },
+	},
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"textdomain": "woocommerce",
 	"apiVersion": 2,

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
@@ -53,6 +53,10 @@ const Editor = ( {
 	const [ isEditing, setIsEditing ] = useState( ! productId );
 	const blockProps = useBlockProps();
 
+	const block = useSelect( ( select ) =>
+		select( 'core/blocks' ).getBlockType( metadata.name )
+	);
+
 	const productPreview = useSelect( ( select ) => {
 		if ( ! isPreview ) {
 			return null;
@@ -102,10 +106,10 @@ const Editor = ( {
 				{ isEditing ? (
 					<Placeholder
 						icon={ BLOCK_ICON }
-						label={ metadata.title }
+						label={ block.title }
 						className="wc-block-editor-single-product"
 					>
-						{ metadata.description }
+						{ block.description }
 						<div className="wc-block-editor-single-product__selection">
 							<SharedProductControl
 								attributes={ attributes }

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
@@ -53,8 +53,9 @@ const Editor = ( {
 	const [ isEditing, setIsEditing ] = useState( ! productId );
 	const blockProps = useBlockProps();
 
-	const block = useSelect( ( select ) =>
-		select( 'core/blocks' ).getBlockType( metadata.name )
+	const block = useSelect(
+		( select ) => select( 'core/blocks' ).getBlockType( metadata.name ),
+		[]
 	);
 
 	const productPreview = useSelect( ( select ) => {

--- a/plugins/woocommerce/changelog/50599-50049-fix-single-product-translations
+++ b/plugins/woocommerce/changelog/50599-50049-fix-single-product-translations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Single product block - Fix translation for title and description in edit mode.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50049

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `wp-admin/options-general.php` and change the language to a 100% translated one (like Spanish or Italian).
2. Create a new page or post.
3. Insert the `Single Product` block.
4. Check that the title and description of the block in edit mode are translated.

| Before | After |
|--------|--------|
| <img width="661" alt="Screenshot 2024-08-12 at 16 00 32" src="https://github.com/user-attachments/assets/0f126829-5e99-40d0-bdf1-98b91ff94c30"> | <img width="678" alt="Screenshot 2024-08-12 at 15 58 48" src="https://github.com/user-attachments/assets/f16f2284-230d-4160-8729-a3cb27d40423"> |


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Single product block - Fix translation for title and description in edit mode.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
