### PR TITLE
REST: Update product stock when removing line item from order

### DIFF
--- a/plugins/woocommerce/changelog/50606-fix-49651-rest-remove-line-item-stock
+++ b/plugins/woocommerce/changelog/50606-fix-49651-rest-remove-line-item-stock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure that the orders REST endpoint behaves the same as the UI when updating an order to remove a line item.

--- a/plugins/woocommerce/changelog/50606-fix-49651-rest-remove-line-item-stock
+++ b/plugins/woocommerce/changelog/50606-fix-49651-rest-remove-line-item-stock
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Ensure that the orders REST endpoint behaves the same as the UI when updating an order to remove a line item.
+In respect of restoring stock levels, ensure that the orders REST endpoint behaves the same as the UI when removing line items.

--- a/plugins/woocommerce/changelog/50606-fix-49651-rest-remove-line-item-stock
+++ b/plugins/woocommerce/changelog/50606-fix-49651-rest-remove-line-item-stock
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-In respect of restoring stock levels, ensure that the orders REST endpoint behaves the same as the UI when removing line items.
+Ensure that the orders REST endpoint behaves the same as the UI when updating an order to remove a line item.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -188,7 +188,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		if ( ! $item ) {
 			throw new WC_REST_Exception(
 				'woocommerce_rest_invalid_item_id',
-				__( 'Order item ID provided is not associated with order.', 'woocommerce' ),
+				esc_html__( 'Order item ID provided is not associated with order.', 'woocommerce' ),
 				400
 			);
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -131,7 +131,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 							foreach ( $value as $item ) {
 								if ( is_array( $item ) ) {
 									if ( $this->item_is_null( $item ) || ( isset( $item['quantity'] ) && 0 === $item['quantity'] ) ) {
-										$order->remove_item( $item['id'] );
+										$this->remove_item( $order, $key, $item['id'] );
 									} else {
 										$this->set_item( $order, $key, $item );
 									}
@@ -168,6 +168,46 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		 * @param bool            $creating If is creating a new object.
 		 */
 		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $order, $request, $creating );
+	}
+
+	/**
+	 * Wrapper method to remove order items.
+	 * When updating, the item ID provided is checked to ensure it is associated
+	 * with the order.
+	 *
+	 * @param WC_Order $order     The order to remove the item from.
+	 * @param string   $item_type The item type (from the request, not from the item, e.g. 'line_items' rather than 'line_item').
+	 * @param int      $item_id   The ID of the item to remove.
+	 *
+	 * @return void
+	 * @throws WC_REST_Exception If item ID is not associated with order.
+	 */
+	protected function remove_item( WC_Order $order, string $item_type, int $item_id ) {
+		$item = $order->get_item( $item_id );
+
+		if ( ! $item ) {
+			throw new WC_REST_Exception(
+				'woocommerce_rest_invalid_item_id',
+				__( 'Order item ID provided is not associated with order.', 'woocommerce' ),
+				400
+			);
+		}
+
+		if ( 'line_items' === $item_type ) {
+			require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
+			wc_maybe_adjust_line_item_product_stock( $item, 0 );
+		}
+
+		/**
+		 * Allow extensions be notified before the item is removed.
+		 *
+		 * @param WC_Order_Item $item The item object.
+		 *
+		 * @since 9.3.0.
+		 */
+		do_action( 'woocommerce_rest_remove_order_item', $item );
+
+		$order->remove_item( $item_id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -182,7 +182,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 * @return void
 	 * @throws WC_REST_Exception If item ID is not associated with order.
 	 */
-	protected function remove_item( WC_Order $order, string $item_type, int $item_id ) {
+	protected function remove_item( WC_Order $order, string $item_type, int $item_id ): void {
 		$item = $order->get_item( $item_id );
 
 		if ( ! $item ) {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -424,14 +424,16 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 6, $product->get_stock_quantity() );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() );
-		$request->set_body_params( array(
-			'line_items' => array(
-				array(
-					'id'       => $item->get_id(),
-					'quantity' => 5
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'id'       => $item->get_id(),
+						'quantity' => 5,
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -459,14 +461,16 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 6, $product->get_stock_quantity() );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() );
-		$request->set_body_params( array(
-			'line_items' => array(
-				array(
-					'id'       => $item->get_id(),
-					'quantity' => 0
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'id'       => $item->get_id(),
+						'quantity' => 0,
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -403,4 +403,77 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$this->assertIsArray( $decoded_data_object[0]->meta_data );
 	}
+
+	/**
+	 * @testdox When a line item quantity in an order is updated via REST API, the product's stock should also be updated.
+	 */
+	public function test_order_update_line_item_quantity_updates_product_stock() {
+		require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product, array( 'status' => 'on-hold' ) ); // Initial qty of 4.
+		$items = $order->get_items();
+		$item  = reset( $items );
+		wc_maybe_adjust_line_item_product_stock( $item );
+
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 6, $product->get_stock_quantity() );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_body_params( array(
+			'line_items' => array(
+				array(
+					'id'       => $item->get_id(),
+					'quantity' => 5
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$product = wc_get_product( $product );
+		$this->assertEquals( 5, $product->get_stock_quantity() );
+	}
+
+	/**
+	 * @testdox When a line item in an order is removed via REST API, the product's stock should also be updated.
+	 */
+	public function test_order_remove_line_item_updates_product_stock() {
+		require_once WC_ABSPATH . 'includes/admin/wc-admin-functions.php';
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product, array( 'status' => 'on-hold' ) ); // Initial qty of 4.
+		$items = $order->get_items();
+		$item  = reset( $items );
+		wc_maybe_adjust_line_item_product_stock( $item );
+
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 6, $product->get_stock_quantity() );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() );
+		$request->set_body_params( array(
+			'line_items' => array(
+				array(
+					'id'       => $item->get_id(),
+					'quantity' => 0
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$order = wc_get_order( $order );
+		$this->assertEmpty( $order->get_items() );
+
+		$product = wc_get_product( $product );
+		$this->assertEquals( 10, $product->get_stock_quantity() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This ensures that the REST endpoint behaves the same as the UI when updating an order to remove a line item.

The new `remove_item` wrapper method introduced here tries to use a similar pattern to the existing [`set_item`](https://github.com/woocommerce/woocommerce/blob/0468bdbe82b2ebb0d3c8ec04bdb7c840b3e7de3b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php#L1014-L1064) method, which is why it contains the new `woocommerce_rest_remove_order_item` action hook.

Fixes #49651

### How to test the changes in this Pull Request:

1. Create a product. Under Product Data > Inventory, check the box for Stock management and then set the Quantity to 50.
2. Create an order. Add the new product to the order with a quantity of 1. Set the order status to On Hold. Note the ID of the order.
3. Back on the Products list table view, note that the new product should now show as "In stock (49)" since 1 has now been reserved for the On Hold order.
4. Make a REST API request to get the data about the new order, so you can get the ID of the line item (which is different than the product ID):
    ```
    curl --request GET \
      --url http://localhost:8888/wp-json/wc/v3/orders/{order ID}
    ```
5. Now make another REST API request to update the order and remove the line item by setting the quantity to `0`.
    ```
    POST /wp-json/wc/v3/orders/{order ID} HTTP/1.1
    Host: localhost:8888

    {
      "line_items": [
        {
          "id": {line item ID},
          "quantity": 0
        }
      ]
    }
    ```
6. Check back on the Products list table view. The product should now show 50 in stock instead of 49. If you view the order, the line item should be gone.
7. If you try this on trunk rather than the branch for this PR, the number of in stock for the product will not be updated when you update the order via REST API.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure that the orders REST endpoint behaves the same as the UI when updating an order to remove a line item.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
