### PR TITLE
Exclude privacy page from the store pages -- it is a core page

### DIFF
--- a/plugins/woocommerce/changelog/50608-update-exlude-privacy-page-from-store-page
+++ b/plugins/woocommerce/changelog/50608-update-exlude-privacy-page-from-store-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Removed the privacy page from the store pages list to make it accessible when the 'Coming Soon' mode is enabled with the 'Restrict to store pages only' option.
+

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -155,7 +155,6 @@ class WCAdminHelper {
 			'shop'        => wc_get_page_id( 'shop' ),
 			'cart'        => wc_get_page_id( 'cart' ),
 			'checkout'    => wc_get_page_id( 'checkout' ),
-			'privacy'     => wc_privacy_policy_page_id(),
 			'terms'       => wc_terms_and_conditions_page_id(),
 			'coming_soon' => wc_get_page_id( 'coming_soon' ),
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -44,7 +44,6 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 		wp_delete_post( get_option( 'woocommerce_cart_page_id' ), true );
 		wp_delete_post( get_option( 'woocommerce_checkout_page_id' ), true );
 		wp_delete_post( get_option( 'woocommerce_myaccount_page_id' ), true );
-		wp_delete_post( wc_privacy_policy_page_id(), true );
 		wp_delete_post( wc_terms_and_conditions_page_id(), true );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50161

This PR removes the privacy page from the store pages list to make it accessible when the 'Coming Soon' mode is enabled with the 'Restrict to store pages only' option.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Go to `Pages` and publish `Privacy Policy` page.
3. Go to `WooCommerce -> Settings -> Site Visibility`
4. Turn on `Coming soon` and `Restrict to store pages only`.
5. Open a new incognito window and visit https://JN-site/privacy-policy
6. Confirm the page renders without an issue.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Removed the privacy page from the store pages list to make it accessible when the 'Coming Soon' mode is enabled with the 'Restrict to store pages only' option.

</details>
