### PR TITLE
Add lost password e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/50611-add-lost-password-e2e-test
+++ b/plugins/woocommerce/changelog/50611-add-lost-password-e2e-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add lost password e2e tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/lost-password.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/lost-password.spec.js
@@ -19,11 +19,20 @@ test.describe( 'Can go to lost password page and submit the form', () => {
 			.fill( admin.username );
 		await page.getByRole( 'button', { name: 'Get New Password' } ).click();
 
-		// Expect that email could not be sent because the test site is not configured to send emails.
-		await expect(
-			page.getByText(
-				/The email could not be sent. Your site may not be correctly configured to send emails/i
-			)
-		).toBeVisible();
+		try {
+			await page.waitForURL( '**/wp-login.php?checkemail=confirm' );
+			await expect(
+				page.getByText( /Check your email for the confirmation link/i )
+			).toBeVisible();
+		} catch ( e ) {
+			// For local testing, the email might not be sent, so we can ignore this error.
+
+			// eslint-disable-next-line jest/no-try-expect
+			await expect(
+				page.getByText(
+					/The email could not be sent. Your site may not be correctly configured to send emails/i
+				)
+			).toBeVisible();
+		}
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/lost-password.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/lost-password.spec.js
@@ -1,0 +1,29 @@
+const { test, expect } = require( '@playwright/test' );
+const { admin } = require( '../../test-data/data' );
+
+test.describe( 'Can go to lost password page and submit the form', () => {
+	test( 'can visit the lost password page from the login page', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-login.php' );
+		await page.getByRole( 'link', { name: 'Lost your password?' } ).click();
+		expect( page.url() ).toContain( '/wp-login.php?action=lostpassword' );
+		await expect( page.getByText( 'Get New Password' ) ).toBeVisible();
+	} );
+
+	test( 'can submit the lost password form', async ( { page } ) => {
+		await page.goto( '/wp-login.php?action=lostpassword' );
+		await page.getByLabel( 'Username or Email Address' ).click();
+		await page
+			.getByLabel( 'Username or Email Address' )
+			.fill( admin.username );
+		await page.getByRole( 'button', { name: 'Get New Password' } ).click();
+
+		// Expect that email could not be sent because the test site is not configured to send emails.
+		await expect(
+			page.getByText(
+				/The email could not be sent. Your site may not be correctly configured to send emails/i
+			)
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50381.

Add e2e test for lost password flow

- Visits /wp-login.php as a logged-out user
- Clicks "Lost your password?"
- Confirms the next screen is default WP admin screen
- Successfully submits the form (but email couldn't be sent)

The [`wp_email()`](https://developer.wordpress.org/reference/functions/wp_mail/) default [uses wordpress@$sitename as the from email address](https://github.com/WordPress/wordpress-develop/blob/6.6/src/wp-includes/pluggable.php#L369-L387), but the test site is using localhost:8086 so the from email address is not valid. This is why the email couldn't be sent. If we want to test the email sending functionality, we need to use a different domain name or use a Email plugin to configure the email sending. I think it's not necessary to test the email sending functionality in this test since we want to ensure the default WP lost password screen is shown properly.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Review the test spec and confirm the e2e tests pass


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add lost password e2e tests

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
