### PR TITLE
Fix translations - Avoid registering blocks in the wrong context

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -44,13 +44,14 @@ export const registerBlockSingleProductTemplate = ( {
 		blockMetadata = blockName;
 	}
 
+	const editSiteStore = select( 'core/edit-site' );
+
 	subscribe( () => {
 		const previousTemplateId = currentTemplateId;
-		const store = select( 'core/edit-site' );
 
 		// With GB 16.3.0 the return type can be a number: https://github.com/WordPress/gutenberg/issues/53230
 		currentTemplateId = parseTemplateId(
-			store?.getEditedPostId< string | number | undefined >()
+			editSiteStore?.getEditedPostId< string | number | undefined >()
 		);
 		const hasChangedTemplate = previousTemplateId !== currentTemplateId;
 		const hasTemplateId = Boolean( currentTemplateId );
@@ -108,7 +109,11 @@ export const registerBlockSingleProductTemplate = ( {
 		// This subscribe callback could be invoked with the core/blocks store
 		// which would cause infinite registration loops because of the `registerBlockType` call.
 		// This local cache helps prevent that.
-		if ( ! isBlockRegistered && isAvailableOnPostEditor ) {
+		if (
+			! isBlockRegistered &&
+			isAvailableOnPostEditor &&
+			! editSiteStore
+		) {
 			if ( isVariationBlock ) {
 				blocksRegistered.add( variationName );
 				registerBlockVariation(

--- a/plugins/woocommerce/changelog/50615-fix-product-rating-translations
+++ b/plugins/woocommerce/changelog/50615-fix-product-rating-translations
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix "Related products translations" - Avoid registering blocks in the wrong context.
+Fix translation - Avoid registering blocks in the wrong context.

--- a/plugins/woocommerce/changelog/50615-fix-product-rating-translations
+++ b/plugins/woocommerce/changelog/50615-fix-product-rating-translations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix "Related products translations" - Avoid registering blocks in the wrong context.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the translations of some blocks, like `Related products` or `Product ratings` . It seems the issue comes from the block getting registered with the 'core/edit-post' subscribe even if we were in the site editor context.
This change uses the fact that the 'core/edit-site' store is undefined when we are on the site editor, so we check that before registering the block on the 'core/edit-post' subscribe.

Closes https://github.com/woocommerce/woocommerce/issues/50050

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout trunk.
2. Switch to the Italian or Spanish language (or some language that has 100% of string translated).
3. Visit `wp-admin/site-editor.php?postId=woocommerce%2Fwoocommerce%2F%2Fsingle-product&postType=wp_template&canvas=edit`.
4. Check the `Product Rating`.
5. Ensure that the block isn't translated.
6. Checkout this branch.
7. Repeat 2-4.
8. Ensure that the block is translated.
9. Create a new page or post and insert the `Single Product` block.
10. Click on the `Product Rating` inner block and check is also translated here.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix translation - Avoid registering blocks in the wrong context.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
