### PR TITLE
[e2e tests] Replace hardcoded default wp-env credentials

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-hardcoded-default-creds
+++ b/plugins/woocommerce/changelog/e2e-remove-hardcoded-default-creds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
@@ -6,6 +6,7 @@ const { encodeCredentials } = require( '../../../utils/plugin-utils' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 const { setOption } = require( '../../../utils/options' );
+const { admin } = require( '../../../test-data/data' );
 
 const test = base.extend( {
 	assemblerPageObject: async ( { page }, use ) => {
@@ -528,8 +529,8 @@ test.describe( 'Assembler -> Color Pickers', { tag: '@gutenberg' }, () => {
 			baseURL,
 			extraHTTPHeaders: {
 				Authorization: `Basic ${ encodeCredentials(
-					'admin',
-					'password'
+					admin.username,
+					admin.password
 				) }`,
 				cookie: '',
 			},

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -4,6 +4,7 @@ const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 const { setOption } = require( '../../../utils/options' );
 const { encodeCredentials } = require( '../../../utils/plugin-utils' );
+const { admin } = require( '../../../test-data/data' );
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {
@@ -179,8 +180,8 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 			baseURL,
 			extraHTTPHeaders: {
 				Authorization: `Basic ${ encodeCredentials(
-					'admin',
-					'password'
+					admin.username,
+					admin.password
 				) }`,
 				cookie: '',
 			},

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.page.js
@@ -1,4 +1,5 @@
 const { encodeCredentials } = require( '../../../../utils/plugin-utils' );
+const { admin } = require( '../../../../test-data/data' );
 
 export class LogoPickerPage {
 	page;
@@ -58,8 +59,8 @@ export class LogoPickerPage {
 			baseURL,
 			extraHTTPHeaders: {
 				Authorization: `Basic ${ encodeCredentials(
-					'admin',
-					'password'
+					admin.username,
+					admin.password
 				) }`,
 				cookie: '',
 			},

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/customize-store.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/customize-store.page.js
@@ -1,4 +1,5 @@
 const { encodeCredentials } = require( '../../utils/plugin-utils' );
+const { admin } = require( '../../test-data/data' );
 
 export class CustomizeStorePage {
 	request;
@@ -11,8 +12,8 @@ export class CustomizeStorePage {
 			baseURL,
 			extraHTTPHeaders: {
 				Authorization: `Basic ${ encodeCredentials(
-					'admin',
-					'password'
+					admin.username,
+					admin.password
 				) }`,
 				cookie: '',
 			},

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
@@ -1,5 +1,5 @@
 const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
-const { customer } = require( '../../test-data/data' );
+const { admin, customer } = require( '../../test-data/data' );
 
 const emailContent = '#wp-mail-logging-modal-content-body-content';
 const emailContentHtml = '#wp-mail-logging-modal-format-html';
@@ -250,10 +250,10 @@ test.describe(
 				await page.goto( 'wp-login.php' );
 				await page
 					.getByLabel( 'Username or Email Address' )
-					.fill( 'admin' );
+					.fill( admin.username );
 				await page
 					.getByLabel( 'Password', { exact: true } )
-					.fill( 'password' );
+					.fill( admin.password );
 				await page.getByRole( 'button', { name: 'Log In' } ).click();
 				await page.goto(
 					`wp-admin/tools.php?page=wpml_plugin_log&s=${ encodeURIComponent(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { admin } = require( '../../test-data/data' );
 
 const productPrice = '18.16';
 const simpleProductName = 'Simple single product';
@@ -100,8 +101,8 @@ test.describe(
 			page,
 		} ) => {
 			await page.goto( 'my-account' );
-			await page.locator( '#username' ).fill( 'admin' );
-			await page.locator( '#password' ).fill( 'password' );
+			await page.locator( '#username' ).fill( admin.username );
+			await page.locator( '#password' ).fill( admin.password );
 			await page.locator( 'text=Log in' ).click();
 
 			await page.goto( `product/${ simpleProductSlug }` );

--- a/plugins/woocommerce/tests/e2e-pw/utils/features.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/features.js
@@ -1,12 +1,13 @@
 const { encodeCredentials } = require( './plugin-utils' );
+const { admin } = require( '../test-data/data' );
 
 const setFeatureFlag = async ( request, baseURL, flagName, enable ) => {
 	const apiContext = await request.newContext( {
 		baseURL,
 		extraHTTPHeaders: {
 			Authorization: `Basic ${ encodeCredentials(
-				'admin',
-				'password'
+				admin.username,
+				admin.password
 			) }`,
 			cookie: '',
 		},
@@ -23,8 +24,8 @@ const resetFeatureFlags = async ( request, baseURL ) => {
 		baseURL,
 		extraHTTPHeaders: {
 			Authorization: `Basic ${ encodeCredentials(
-				'admin',
-				'password'
+				admin.username,
+				admin.password
 			) }`,
 			cookie: '',
 		},

--- a/plugins/woocommerce/tests/e2e-pw/utils/options.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/options.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { encodeCredentials } from './plugin-utils';
+const { admin } = require( '../test-data/data' );
 
 export const setOption = async (
 	request,
@@ -13,8 +14,8 @@ export const setOption = async (
 		baseURL,
 		extraHTTPHeaders: {
 			Authorization: `Basic ${ encodeCredentials(
-				'admin',
-				'password'
+				admin.username,
+				admin.password
 			) }`,
 			cookie: '',
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some tests and utils are hardcoding the default wp-env credentials. Replaced them to use the test data values so they can also work with other environments.

### How to test the changes in this Pull Request:

CI green?