### PR TITLE
[e2e tests] Add an option to skip the env setup script when running tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-env-setup-add-option-to-skip-setup-script
+++ b/plugins/woocommerce/changelog/e2e-env-setup-add-option-to-skip-setup-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: add an option to skip the env setup script running before test execution

--- a/plugins/woocommerce/tests/e2e-pw/run-tests-with-env.sh
+++ b/plugins/woocommerce/tests/e2e-pw/run-tests-with-env.sh
@@ -2,6 +2,22 @@
 
 set -eo pipefail
 
+skipEnvSetup=False
+
+while getopts "x" opt; do
+  case $opt in
+    x)
+      skipEnvSetup=True
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
 envName=$1
 shift
 
@@ -12,7 +28,6 @@ SCRIPT_PATH=$(
 
 echo "Setting up environment: $envName"
 
-
 if [ -f "$SCRIPT_PATH/envs/$envName/.env.enc" ]; then
 	echo "Found encrypted .env file for environment '$envName'"
 	"$SCRIPT_PATH/bin/dotenv.sh" -d "$envName"
@@ -22,7 +37,12 @@ else
 	rm -f "$SCRIPT_PATH/.env"
 fi
 
-"$SCRIPT_PATH/envs/$envName/env-setup.sh"
+if [ "$skipEnvSetup" == "True" ]; then
+	echo "Skipping environment setup"
+else
+	echo "Executing environment setup script(s)"
+	"$SCRIPT_PATH/envs/$envName/env-setup.sh"
+fi
 
 echo "Running tests with environment: '$envName'"
 echo "Arguments: $*"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When running e2e tests with an env (this is default now) an env setup script is executed. With repeated local runs during development this can take too long and it's not necessary to re-install everything with each run.
Added the `-x` option to the `run-tests-with-env.sh` script which is the entry point. Using this option will skip the execution of the env's setup script.

The option needs to be added before the environment name, e.g. `test:e2e:with-env -x env-name`

### How to test the changes in this Pull Request:

Run tests locally and check the console output. Example usage with `gutenberg-stable` env:


A first run, without the option will run the setup script and install the Gutenberg plugin.
```
pnpm test:e2e:with-env gutenberg-stable
```
Expected output:
```
Setting up environment: gutenberg-stable
No encrypted .env file found for environment 'gutenberg-stable'.
Removing .env file if it exists.
Executing environment setup script(s)
Installing Gutenberg from WordPress/gutenberg
...
Running tests with environment: 'gutenberg-stable'
```


A second run, with the -x option will skip the setup script and leave the env as it is.

```
pnpm test:e2e:with-env -x gutenberg-stable
```
Expected output:
```
Setting up environment: gutenberg-stable
No encrypted .env file found for environment 'gutenberg-stable'.
Removing .env file if it exists.
Skipping environment setup
Running tests with environment: 'gutenberg-stable'

```