### PR TITLE
Metrics: Use utils provided by `@wordpress/e2e-test-utils-playwright`

### DIFF
--- a/plugins/woocommerce/changelog/update-metrics-tests-utils-usage
+++ b/plugins/woocommerce/changelog/update-metrics-tests-utils-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make the Metrics tests use utilities provided by the updated @wordpress/e2e-test-utils-playwright package.

--- a/plugins/woocommerce/tests/metrics/specs/editor.spec.js
+++ b/plugins/woocommerce/tests/metrics/specs/editor.spec.js
@@ -16,35 +16,6 @@ const BROWSER_IDLE_WAIT = 1000;
 
 const results = {};
 
-async function setPreferences( page, context, preferences ) {
-	await page.waitForFunction( () => window?.wp?.data );
-
-	await page.evaluate(
-		async ( props ) => {
-			for ( const [ key, value ] of Object.entries(
-				props.preferences
-			) ) {
-				await window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( props.context, key, value );
-			}
-		},
-		{ context, preferences }
-	);
-}
-
-async function editPost( admin, page, postId ) {
-	const query = new URLSearchParams();
-	query.set( 'post', String( postId ) );
-	query.set( 'action', 'edit' );
-
-	await admin.visitAdminPage( 'post.php', query.toString() );
-	await setPreferences( page, 'core/edit-post', {
-		welcomeGuide: false,
-		fullscreenMode: false,
-	} );
-}
-
 test.describe( 'Editor Performance', () => {
 	test.use( {
 		perfUtils: async ( { page }, use ) => {
@@ -86,7 +57,7 @@ test.describe( 'Editor Performance', () => {
 				metrics,
 			} ) => {
 				// Open the test draft.
-				await editPost( admin, page, draftId );
+				await admin.editPost( draftId );
 				const canvas = await perfUtils.getCanvas();
 
 				// Wait for the first block.
@@ -148,8 +119,8 @@ test.describe( 'Editor Performance', () => {
 			draftId = await perfUtils.saveDraft();
 		} );
 
-		test( 'Run the test', async ( { admin, page, perfUtils, metrics } ) => {
-			await editPost( admin, page, draftId );
+		test( 'Run the test', async ( { admin, perfUtils, metrics } ) => {
+			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
 			const canvas = await perfUtils.getCanvas();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since we updated the `@wordpress/e2e-test-utils-playwright` package (#50274), we can now use the utils provided with the new version.

### How to test the changes in this Pull Request:

Metrics job runs only in CI against trunk, but it can also be locally tested by running the following:

```sh
cd tools/compare-perf
pnpm install
node index.js "perf" "8aba7eebde3f4cc412972e4e518cc5f9b340b28c" "3d7d7f02017383937f1a4158d433d0e5d44b3dc9" "--tests-branch" "8aba7eebde3f4cc412972e4e518cc5f9b340b28c" "--wp-version" "6.6"
```