### PR TITLE
[e2e tests] Transform Classic Checkout: add an extra check of API response before checking the UI

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-create-checkout-block-gutenberg
+++ b/plugins/woocommerce/changelog/e2e-fix-create-checkout-block-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
@@ -92,9 +92,10 @@ test.describe(
 			await publishPage( page, testPage.title );
 
 			// add additional payment option after page creation
-			await api.put( 'payment_gateways/bacs', {
+			const r = await api.put( 'payment_gateways/bacs', {
 				enabled: true,
 			} );
+			expect( r.data.enabled ).toBe( true );
 			await page.reload();
 
 			// Mandatory to wait for the editor content, to ensure the iframe is loaded (if Gutenberg is active)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Attempt to better understand https://github.com/woocommerce/woocommerce/issues/49316. This will most probably not fix the flakiness, but help understand the payment configuration state before the failing assertion.

### How to test the changes in this Pull Request:

- CI green?
- Locally, run the test with 
```
pnpm test:e2e:with-env gutenberg-stable create-checkout-block.spec.js
```