### PR TITLE
Tweak stalebot settings for flaky tests issues

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/stale@v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-labels: 'metric: flaky e2e test'
+          only-issue-labels: 'metric: flaky e2e test'
           days-before-stale: -1
           days-before-close: -1
           days-before-issue-stale: 5

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,45 +1,48 @@
 name: 'Process stale needs-feedback issues'
 on:
-    schedule:
-        - cron: '21 0 * * *'
+  schedule:
+    - cron: '21 0 * * *'
+  workflow_dispatch:
 
-permissions: {}
+permissions: { }
 
 jobs:
-    stale:
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-            issues: write
-            pull-requests: write
-        steps:
-            - name: Scan issues
-              uses: actions/stale@v9.0.0
-              with:
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
-                  close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
-                  operations-per-run: 140
-                  days-before-stale: -1
-                  days-before-close: -1
-                  days-before-issue-stale: 7
-                  days-before-issue-close: 7
-                  stale-issue-label: 'status: stale'
-                  stale-pr-label: 'status: stale'
-                  exempt-issue-labels: 'type: enhancement'
-                  only-issue-labels: 'needs: author feedback'
-                  close-issue-label: "status: can't reproduce"
-                  ascending: true
-            - name: Close Stale Flaky Test Issues
-              uses: actions/stale@v9.0.0
-              with:
-                  only-labels: 'metric: flaky e2e test, team: Vortex'
-                  days-before-stale: 5
-                  days-before-close: 2
-                  stale-issue-label: 'metric: stale flaky e2e test report'
-                  stale-issue-message: 'This test may have been a one-time failure. It will be auto-closed if no further activity occurs within the next 2 days.'
-                  close-issue-message: 'Auto-closed due to inactivity. Please re-open if you believe this issue is still valid.'
-                  close-issue-reason: 'not_planned'
-                  remove-stale-when-updated: true
-                  exempt-all-assignees: true
-                  enable-statistics: true
+  stale:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Scan issues
+        uses: actions/stale@v9.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
+          close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
+          operations-per-run: 140
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-issue-stale: 7
+          days-before-issue-close: 7
+          stale-issue-label: 'status: stale'
+          stale-pr-label: 'status: stale'
+          exempt-issue-labels: 'type: enhancement'
+          only-issue-labels: 'needs: author feedback'
+          close-issue-label: "status: can't reproduce"
+          ascending: true
+      - name: Close Stale Flaky Test Issues
+        uses: actions/stale@v9.0.0
+        with:
+          only-labels: 'metric: flaky e2e test'
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-issue-stale: 5
+          days-before-issue-close: 2
+          stale-issue-label: 'status: stale'
+          stale-issue-message: 'This issue is being marked as stale due to inactivity. It will be auto-closed if no further activity occurs within the next 2 days.'
+          close-issue-message: 'Auto-closed due to inactivity. Please re-open if you believe this issue is still valid.'
+          close-issue-reason: 'not_planned'
+          remove-stale-when-updated: true
+          exempt-all-assignees: false
+          enable-statistics: true

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -47,4 +47,5 @@ jobs:
           remove-stale-when-updated: true
           exempt-all-assignees: false
           enable-statistics: true
+          ascending: true
           operations-per-run: 120

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -31,9 +31,10 @@ jobs:
           only-issue-labels: 'needs: author feedback'
           close-issue-label: "status: can't reproduce"
           ascending: true
-      - name: Close Stale Flaky Test Issues
+      - name: Process Stale Flaky Test Issues
         uses: actions/stale@v9.0.0
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           only-labels: 'metric: flaky e2e test'
           days-before-stale: -1
           days-before-close: -1
@@ -46,3 +47,4 @@ jobs:
           remove-stale-when-updated: true
           exempt-all-assignees: false
           enable-statistics: true
+          operations-per-run: 120


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated the stalebot configuration for flaky tests issues. Issues are not processed in time or at all.

- removed the `team: Vortex` label so that issues assigned to other teams will also be marked as stale
- added a `workflow_dispatch` trigger so we can also trigger it manually
- disabled default `days-before-stale` and `days-before-close` and added configs for issues only, to make sure PRs are not included
- updated the status label to be `status: stale` for consistency with the other stale issues
- updated the stale message. I have seen issues with tens of flaky reports over multiple days and the message "This test may have been a one-time failure." did not seem to right
- Set `exempt-all-assignees` to false so that assigned issues can also be marked as stale
- Increased `operations-per-run` value. Many issues remain unprocessed because the default operations value of 30 is not enough. [Example](https://github.com/woocommerce/woocommerce/actions/runs/10361554521/job/28682090587#step:3:1952).
- Set `ascending: true` to fetch the issues in asc order. This should also help with operations-per-run limit

### How to test the changes in this Pull Request:

Check if config updates make sense. We'll need to test it live.