### PR TITLE
Store API: Add test coverage for Product Reviews endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-42064-product-reviews-endpoint-tests
+++ b/plugins/woocommerce/changelog/fix-42064-product-reviews-endpoint-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Store API: Add test coverage for Product Reviews endpoint
+
+

--- a/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
@@ -195,6 +195,22 @@ class FixtureData {
 	}
 
 	/**
+	 * Create a product category and return the result.
+	 *
+	 * @param array $props Category props.
+	 * @return array
+	 */
+	public function get_product_category( $props ) {
+		$category_name = $props['name'] ?? 'Test Category';
+
+		return wp_insert_term(
+			$category_name,
+			'product_cat',
+			$props
+		);
+	}
+
+	/**
 	 * Create a coupon and return the result.
 	 *
 	 * @param array $props Product props.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -47,8 +47,8 @@ class ProductReviews extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		// Assert correct response format.
-		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertEquals( 2, count( $data ), 'Unexpected item count.' );
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 2, count( $data ), 'Unexpected item count.' );
 
 		// Assert response items contain the correct properties.
 		$this->assertArrayHasKey( 'id', $data[0] );
@@ -67,10 +67,10 @@ class ProductReviews extends ControllerTestCase {
 		$this->assertArrayHasKey( 'reviewer_avatar_urls', $data[0] );
 
 		// Assert response items contain the correct review data.
-		$this->assertEquals( 'Test Product 2', $data[0]['product_name'] );
-		$this->assertEquals( 4, $data[0]['rating'] );
-		$this->assertEquals( 'Test Product 1', $data[1]['product_name'] );
-		$this->assertEquals( 5, $data[1]['rating'] );
+		$this->assertSame( 'Test Product 2', $data[0]['product_name'] );
+		$this->assertSame( 4, $data[0]['rating'] );
+		$this->assertSame( 'Test Product 1', $data[1]['product_name'] );
+		$this->assertSame( 5, $data[1]['rating'] );
 	}
 
 	/**
@@ -84,9 +84,9 @@ class ProductReviews extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
 		$this->assertCount( 1, $data, 'Unexpected item count.' );
-		$this->assertEquals( 5, $data[0]['rating'] );
+		$this->assertSame( 5, $data[0]['rating'] );
 	}
 
 	/**
@@ -98,9 +98,9 @@ class ProductReviews extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
 		$this->assertCount( 1, $data, 'Unexpected item count.' );
-		$this->assertEquals( 5, $data[0]['rating'] );
+		$this->assertSame( 5, $data[0]['rating'] );
 	}
 
 	/**
@@ -119,9 +119,9 @@ class ProductReviews extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
 		$this->assertCount( 2, $data, 'Unexpected item count.' );
-		$this->assertEquals( 4, $data[0]['rating'] );
-		$this->assertEquals( 5, $data[1]['rating'] );
+		$this->assertSame( 4, $data[0]['rating'] );
+		$this->assertSame( 5, $data[1]['rating'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -23,6 +23,12 @@ class ProductReviews extends ControllerTestCase {
 
 		$fixtures = new FixtureData();
 
+		$this->product_category = $fixtures->get_product_category(
+			array(
+				'name' => 'Test Category 1',
+			)
+		);
+
 		$this->products = array(
 			$fixtures->get_simple_product(
 				array(
@@ -34,6 +40,7 @@ class ProductReviews extends ControllerTestCase {
 				array(
 					'name'          => 'Test Product 2',
 					'regular_price' => 100,
+					'category_ids'  => array( $this->product_category['term_id'] ),
 				)
 			),
 		);
@@ -110,21 +117,13 @@ class ProductReviews extends ControllerTestCase {
 	 * Test getting reviews from a specific category.
 	 */
 	public function test_get_items_with_category_id_param() {
-		$request            = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
-		$product_categories = wp_get_post_terms(
-			$this->products[1]->get_id(),
-			'product_cat',
-			array(
-				'fields' => 'ids',
-			)
-		);
-		$request->set_param( 'category_id', (string) $product_categories[0] );
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$request->set_param( 'category_id', (string) $this->product_category['term_id'] );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertSame( 200, $response->get_status(), 'Unexpected status code.' );
-		$this->assertCount( 2, $data, 'Unexpected item count.' );
+		$this->assertCount( 1, $data, 'Unexpected item count.' );
 		$this->assertSame( 4, $data[0]['rating'] );
-		$this->assertSame( 5, $data[1]['rating'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Controller Tests.
+ */
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
+
+use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\ControllerTestCase;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+
+/**
+ * Product Reviews Controller Tests.
+ */
+class ProductReviews extends ControllerTestCase {
+
+	/**
+	 * Setup test review data. Called before every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$fixtures = new FixtureData();
+
+		$this->products = array(
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 1',
+					'regular_price' => 10,
+				)
+			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 2',
+					'regular_price' => 100,
+				)
+			),
+		);
+
+		$fixtures->add_product_review( $this->products[0]->get_id(), 5 );
+		$fixtures->add_product_review( $this->products[1]->get_id(), 4 );
+	}
+
+	/**
+	 * Test getting reviews.
+	 */
+	public function test_get_items() {
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' ) );
+		$data     = $response->get_data();
+
+		// Assert correct response format.
+		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertEquals( 2, count( $data ), 'Unexpected item count.' );
+
+		// Assert response items contain the correct properties.
+		$this->assertArrayHasKey( 'id', $data[0] );
+		$this->assertArrayHasKey( 'date_created', $data[0] );
+		$this->assertArrayHasKey( 'formatted_date_created', $data[0] );
+		$this->assertArrayHasKey( 'date_created_gmt', $data[0] );
+		$this->assertArrayHasKey( 'product_id', $data[0] );
+		$this->assertArrayHasKey( 'product_name', $data[0] );
+		$this->assertArrayHasKey( 'product_permalink', $data[0] );
+		$this->assertArrayHasKey( 'product_image', $data[0] );
+		$this->assertArrayHasKey( 'product_permalink', $data[0] );
+		$this->assertArrayHasKey( 'reviewer', $data[0] );
+		$this->assertArrayHasKey( 'review', $data[0] );
+		$this->assertArrayHasKey( 'rating', $data[0] );
+		$this->assertArrayHasKey( 'verified', $data[0] );
+		$this->assertArrayHasKey( 'reviewer_avatar_urls', $data[0] );
+
+		// Assert response items contain the correct review data.
+		$this->assertEquals( 'Test Product 2', $data[0]['product_name'] );
+		$this->assertEquals( 4, $data[0]['rating'] );
+		$this->assertEquals( 'Test Product 1', $data[1]['product_name'] );
+		$this->assertEquals( 5, $data[1]['rating'] );
+	}
+
+	/**
+	 * Test getting reviews with specific order and per_page parameters.
+	 */
+	public function test_get_items_with_order_params() {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$request->set_param( 'per_page', 1 );
+		$request->set_param( 'orderby', 'rating' );
+		$request->set_param( 'order', 'desc' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertCount( 1, $data, 'Unexpected item count.' );
+		$this->assertEquals( 5, $data[0]['rating'] );
+	}
+
+	/**
+	 * Test getting reviews from a specific product.
+	 */
+	public function test_get_items_with_product_id_param() {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$request->set_param( 'product_id', (string) $this->products[0]->get_id() );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertCount( 1, $data, 'Unexpected item count.' );
+		$this->assertEquals( 5, $data[0]['rating'] );
+	}
+
+	/**
+	 * Test getting reviews from a specific category.
+	 */
+	public function test_get_items_with_category_id_param() {
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$product_categories = wp_get_post_terms(
+			$this->products[1]->get_id(),
+			'product_cat',
+			array(
+				'fields' => 'ids'
+			)
+		);
+		$request->set_param( 'category_id', (string) $product_categories[0] );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status(), 'Unexpected status code.' );
+		$this->assertCount( 2, $data, 'Unexpected item count.' );
+		$this->assertEquals( 4, $data[0]['rating'] );
+		$this->assertEquals( 5, $data[1]['rating'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductReviews.php
@@ -2,6 +2,9 @@
 /**
  * Controller Tests.
  */
+
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes;
 
 use Automattic\WooCommerce\Tests\Blocks\StoreApi\Routes\ControllerTestCase;
@@ -107,12 +110,12 @@ class ProductReviews extends ControllerTestCase {
 	 * Test getting reviews from a specific category.
 	 */
 	public function test_get_items_with_category_id_param() {
-		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
+		$request            = new \WP_REST_Request( 'GET', '/wc/store/v1/products/reviews' );
 		$product_categories = wp_get_post_terms(
 			$this->products[1]->get_id(),
 			'product_cat',
 			array(
-				'fields' => 'ids'
+				'fields' => 'ids',
 			)
 		);
 		$request->set_param( 'category_id', (string) $product_categories[0] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds some PHP tests to the Product Reviews endpoint.

Closes #42064.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass.
2. If you have access to the code, you can optionally reintroduce [this bug](https://github.com/woocommerce/woocommerce-blocks/pull/11913/files) or make any other change that would make the endpoint to return and error and verify tests fail appropriately.
