### PR TITLE
[testing workflows] Fix undefined BuildKite Analytics message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           else
             MESSAGE="${{ github.event_name }}"
           fi
-          echo "BUILDKITE_ANALYTICS_MESSAGE=$MESSAGE" >> "$GITHUB_OUTPUT"
+          echo "BUILDKITE_ANALYTICS_MESSAGE=$MESSAGE" >> "$GITHUB_ENV"
         shell: bash
 
       - name: 'Resolve artifacts path'

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End-to-End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and `wp-env`.
+This is the documentation for the e2e testing setup based on Playwright and `wp-env`...
 
 ## Table of contents
 

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Playwright End-to-End Tests
 
-This is the documentation for the e2e testing setup based on Playwright and `wp-env`...
+This is the documentation for the e2e testing setup based on Playwright and `wp-env`.
 
 ## Table of contents
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/50267 updated the steps used to determine the value of `BUILDKITE_ANALYTICS_MESSAGE`, but it set the value in `$GITHUB_OUTPUT` instead of `$GITHUB_ENV`, making it unavailable for the following steps.
As a result the runs in BuildKite have the fallback name, which a generated unique ID.

### How to test the changes in this Pull Request:

Check BuildKite Analytics for [the run of this PR](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/runs/7b399af3-1f0b-804d-824e-b49e93a5b0f2). Its name should be the title of the PR.