### PR TITLE
[e2e tests] Add BuildKite reporter to Blocks e2e tests

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -190,6 +190,7 @@
 		"babel-plugin-explicit-exports-references": "^1.0.2",
 		"babel-plugin-react-docgen": "4.2.1",
 		"babel-plugin-transform-react-remove-prop-types": "0.4.24",
+		"buildkite-test-collector": "^1.7.1",
 		"chalk": "4.1.2",
 		"circular-dependency-plugin": "5.2.2",
 		"copy-webpack-plugin": "11.0.0",

--- a/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/playwright.config.ts
@@ -30,6 +30,7 @@ const config: PlaywrightTestConfig = {
 						outputFolder: `${ __dirname }/artifacts/test-results/allure-results`,
 					},
 				],
+				[ 'buildkite-test-collector/playwright/reporter' ],
 		  ]
 		: 'list',
 	use: {

--- a/plugins/woocommerce/changelog/e2e-add-buildkite-reporter-for-blocks-e2e
+++ b/plugins/woocommerce/changelog/e2e-add-buildkite-reporter-for-blocks-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: add buildkite-test-collector for blocks e2e tests

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4350,6 +4350,9 @@ importers:
       babel-plugin-transform-react-remove-prop-types:
         specifier: 0.4.24
         version: 0.4.24
+      buildkite-test-collector:
+        specifier: ^1.7.1
+        version: 1.7.1
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -21804,7 +21807,7 @@ packages:
   react-with-direction@1.4.0:
     resolution: {integrity: sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==}
     peerDependencies:
-      react: ^17.0.2
+      react: ^0.14 || ^15 || ^16
       react-dom: ^0.14 || ^15 || ^16
 
   react-with-styles-interface-css@4.0.3:
@@ -37526,7 +37529,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.2)
-      debug: 4.3.5
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.55.0
     optionalDependencies:
       typescript: 5.3.2
@@ -43321,25 +43324,25 @@ snapshots:
 
   axios@0.21.4(debug@4.3.4):
     dependencies:
-      follow-redirects: 1.15.1(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.3.4)
     transitivePeerDependencies:
       - debug
 
   axios@0.24.0:
     dependencies:
-      follow-redirects: 1.15.1(debug@4.3.4)
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
 
   axios@0.25.0:
     dependencies:
-      follow-redirects: 1.15.1(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.3.4)
     transitivePeerDependencies:
       - debug
 
   axios@1.6.2:
     dependencies:
-      follow-redirects: 1.15.1(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -43347,7 +43350,7 @@ snapshots:
 
   axios@1.6.8:
     dependencies:
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -48524,11 +48527,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  follow-redirects@1.15.1(debug@4.3.4):
+  follow-redirects@1.15.1: {}
+
+  follow-redirects@1.15.6(debug@4.3.4):
     optionalDependencies:
       debug: 4.3.4(supports-color@9.4.0)
-
-  follow-redirects@1.15.6: {}
 
   follow-redirects@1.5.10:
     dependencies:
@@ -48771,7 +48774,7 @@ snapshots:
       react: 17.0.2
       react-dom: 18.3.1(react@17.0.2)
       style-value-types: 5.0.0
-      tslib: 2.6.3
+      tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
 
@@ -48784,7 +48787,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       style-value-types: 5.0.0
-      tslib: 2.6.3
+      tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
 
@@ -49929,7 +49932,7 @@ snapshots:
   http-proxy@1.18.1(debug@4.3.4):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.3.4)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds the BuildKite test reporter to Blocks e2e tests.
It should report all Blocks e2e runs in BuildKite Analytics.

### How to test the changes in this Pull Request:

Check BuildKite Analytics for one of the runs of this PR ([example](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/runs/4d8c25b7-2483-82ce-b1a6-5a2350bf5cfc)). It should include the blocks e2e tests.