### PR TITLE
[e2e tests] Ignore Playwright focused tests in CI

### DIFF
--- a/plugins/woocommerce/changelog/e2e-add-forbidOnly-config
+++ b/plugins/woocommerce/changelog/e2e-add-forbidOnly-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -74,6 +74,7 @@ const config = {
 	reportSlowTests: { max: 5, threshold: 30 * 1000 }, // 30 seconds threshold
 	reporter,
 	maxFailures: E2E_MAX_FAILURES ? Number( E2E_MAX_FAILURES ) : 0,
+	forbidOnly: !! CI,
 	use: {
 		baseURL: BASE_URL,
 		screenshot: { mode: 'only-on-failure', fullPage: true },


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `forbidOnly` property ignores [focused tests](https://playwright.dev/docs/api/class-test#test-only). If there are focused tests, only those will run, skipping all the others.
Setting this property to true for CI helps in cases when a focused test was accidentally committed, so that in CI all tests run, not only the focused test.

### How to test the changes in this Pull Request:

CI green?
Locally:
1. make a test focused using `test.only` 
2. Run tests with `pnpm test:e2e`. Only the focused test should run.
3. Run tests with `CI=true pnpm test:e2e`. ~All the tests should run.~ An error is expected: `Error: item focused with '.only' is not allowed due to the 'forbidOnly' option`