### PR TITLE
[Filter Products by Price]: Update view when changing the min/max value

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
@@ -170,6 +170,22 @@ const PriceSlider = ( {
 	] );
 
 	/**
+	 * Selects the price field when it is clicked.
+	 *
+	 * @param {Object} event event data.
+	 */
+	const handleSelectOnClick = (
+		event:
+			| React.FocusEvent< HTMLInputElement >
+			| React.MouseEvent< HTMLInputElement >
+	) => {
+		const target = event.currentTarget;
+		if ( target ) {
+			target.select();
+		}
+	};
+
+	/**
 	 * Works around an IE issue where only one range selector is visible by changing the display order
 	 * based on the mouse position.
 	 *
@@ -284,7 +300,7 @@ const PriceSlider = ( {
 			);
 			onChange( values );
 		},
-		400
+		1000
 	);
 
 	const debouncedUpdateQuery = useDebouncedCallback( onSubmit, 600 );
@@ -395,6 +411,7 @@ const PriceSlider = ( {
 		displayType: 'input',
 		allowNegative: false,
 		disabled: isLoading || ! hasValidConstraints,
+		onClick: handleSelectOnClick,
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
@@ -251,7 +251,7 @@ const PriceSlider = ( {
 	);
 
 	/**
-	 * Handles price change logic and calls onChange if necessary.
+	 * Handles price change logic and calls onChange.
 	 */
 	const handlePriceChange = useDebouncedCallback(
 		(
@@ -285,35 +285,6 @@ const PriceSlider = ( {
 			onChange( values );
 		},
 		400
-	);
-
-	/**
-	 * Called when a price input loses focus - commit changes to slider.
-	 */
-	const priceInputOnBlur = useCallback(
-		( event: React.FocusEvent< HTMLInputElement > ) => {
-			// Only refresh when finished editing the min and max fields.
-			if (
-				event.relatedTarget &&
-				( event.relatedTarget as Element ).classList &&
-				( event.relatedTarget as Element ).classList.contains(
-					'wc-block-price-filter__amount'
-				)
-			) {
-				return;
-			}
-
-			const isMin = event.target.classList.contains(
-				'wc-block-price-filter__amount--min'
-			);
-
-			handlePriceChange(
-				minPriceInput as number,
-				maxPriceInput as number,
-				isMin
-			);
-		},
-		[ onChange, stepValue, minPriceInput, maxPriceInput, handlePriceChange ]
 	);
 
 	const debouncedUpdateQuery = useDebouncedCallback( onSubmit, 600 );
@@ -424,7 +395,6 @@ const PriceSlider = ( {
 		displayType: 'input',
 		allowNegative: false,
 		disabled: isLoading || ! hasValidConstraints,
-		onBlur: priceInputOnBlur,
 	};
 
 	return (
@@ -479,13 +449,11 @@ const PriceSlider = ( {
 									return;
 								}
 								setMaxPriceInput( value );
-								// handlePriceChange( false );
 								handlePriceChange(
 									minPriceInput as number,
 									value,
-									true
+									false
 								);
-								// onChange( [ minPriceInput as number, value ] );
 							} }
 							value={ maxPriceInput }
 						/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
@@ -251,6 +251,43 @@ const PriceSlider = ( {
 	);
 
 	/**
+	 * Handles price change logic and calls onChange if necessary.
+	 */
+	const handlePriceChange = useDebouncedCallback(
+		(
+			minInsertedPrice: number,
+			maxInsertedPrice: number,
+			isMin: boolean
+		) => {
+			// When the user inserts in the max price input a value less or equal than the current minimum price,
+			// we set to 0 the minimum price.
+			if ( minInsertedPrice >= maxInsertedPrice ) {
+				const values = constrainRangeSliderValues(
+					[ 0, maxInsertedPrice ],
+					null,
+					null,
+					stepValue,
+					isMin
+				);
+				return onChange( [
+					parseInt( values[ 0 ], 10 ),
+					parseInt( values[ 1 ], 10 ),
+				] );
+			}
+
+			const values = constrainRangeSliderValues(
+				[ minInsertedPrice, maxInsertedPrice ],
+				null,
+				null,
+				stepValue,
+				isMin
+			);
+			onChange( values );
+		},
+		400
+	);
+
+	/**
 	 * Called when a price input loses focus - commit changes to slider.
 	 */
 	const priceInputOnBlur = useCallback(
@@ -270,32 +307,13 @@ const PriceSlider = ( {
 				'wc-block-price-filter__amount--min'
 			);
 
-			// When the user inserts in the max price input a value less or equal than the current minimum price,
-			// we set to 0 the minimum price.
-			if ( minPriceInput >= maxPriceInput ) {
-				const values = constrainRangeSliderValues(
-					[ 0, maxPriceInput ],
-					null,
-					null,
-					stepValue,
-					isMin
-				);
-				return onChange( [
-					parseInt( values[ 0 ], 10 ),
-					parseInt( values[ 1 ], 10 ),
-				] );
-			}
-
-			const values = constrainRangeSliderValues(
-				[ minPriceInput, maxPriceInput ],
-				null,
-				null,
-				stepValue,
+			handlePriceChange(
+				minPriceInput as number,
+				maxPriceInput as number,
 				isMin
 			);
-			onChange( values );
 		},
-		[ onChange, stepValue, minPriceInput, maxPriceInput ]
+		[ onChange, stepValue, minPriceInput, maxPriceInput, handlePriceChange ]
 	);
 
 	const debouncedUpdateQuery = useDebouncedCallback( onSubmit, 600 );
@@ -432,6 +450,11 @@ const PriceSlider = ( {
 									return;
 								}
 								setMinPriceInput( value );
+								handlePriceChange(
+									value,
+									maxPriceInput as number,
+									true
+								);
 							} }
 							value={ minPriceInput }
 						/>
@@ -456,6 +479,13 @@ const PriceSlider = ( {
 									return;
 								}
 								setMaxPriceInput( value );
+								// handlePriceChange( false );
+								handlePriceChange(
+									minPriceInput as number,
+									value,
+									true
+								);
+								// onChange( [ minPriceInput as number, value ] );
 							} }
 							value={ maxPriceInput }
 						/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
@@ -170,7 +170,7 @@ const PriceSlider = ( {
 	] );
 
 	/**
-	 * Selects the price field when it is clicked.
+	 * Selects the price field when clicked.
 	 *
 	 * @param {Object} event event data.
 	 */

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/frontend.ts
@@ -4,6 +4,7 @@
 import { store, getContext, getElement } from '@woocommerce/interactivity';
 import { formatPrice, getCurrency } from '@woocommerce/price-format';
 import { HTMLElementEvent } from '@woocommerce/types';
+import { debounce } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -35,6 +36,46 @@ const getUrl = ( context: PriceFilterContext ) => {
 	return url.href;
 };
 
+const debounceUpdate = debounce( ( context, element, event ) => {
+	const { decimalSeparator } = getCurrency();
+	const { minRange, minPrice, maxPrice, maxRange } = context;
+	const type = event.target.name;
+	const value = parseInt(
+		event.target.value
+			.replace( new RegExp( `[^0-9\\${ decimalSeparator }]+`, 'g' ), '' )
+			.replace( new RegExp( `\\${ decimalSeparator }`, 'g' ), '.' ),
+		10
+	);
+
+	const currentMinPrice =
+		type === 'min'
+			? Math.min( Number.isNaN( value ) ? minRange : value, maxPrice )
+			: minPrice;
+
+	const currentMaxPrice =
+		type === 'max'
+			? Math.max( Number.isNaN( value ) ? maxRange : value, minPrice )
+			: maxPrice;
+
+	if ( type === 'min' ) {
+		element.ref.value = currentMinPrice;
+	} else if ( type === 'max' ) {
+		element.ref.value = currentMaxPrice;
+	}
+
+	context.minPrice = currentMinPrice;
+	context.maxPrice = currentMaxPrice;
+
+	navigate(
+		getUrl( {
+			minRange,
+			maxRange,
+			minPrice: currentMinPrice,
+			maxPrice: currentMaxPrice,
+		} )
+	);
+}, 1000 );
+
 store< PriceFilterStore >( 'woocommerce/product-filter-price', {
 	state: {
 		rangeStyle: () => {
@@ -61,60 +102,19 @@ store< PriceFilterStore >( 'woocommerce/product-filter-price', {
 	},
 	actions: {
 		updateProducts: ( event: HTMLElementEvent< HTMLInputElement > ) => {
-			const { decimalSeparator } = getCurrency();
 			const context = getContext< PriceFilterContext >();
-			const { minRange, minPrice, maxPrice, maxRange } = context;
-			const type = event.target.name;
-			const value = parseInt(
-				event.target.value
-					.replace(
-						new RegExp( `[^0-9\\${ decimalSeparator }]+`, 'g' ),
-						''
-					)
-					.replace(
-						new RegExp( `\\${ decimalSeparator }`, 'g' ),
-						'.'
-					),
-				10
-			);
-
-			const currentMinPrice =
-				type === 'min'
-					? Math.min(
-							Number.isNaN( value ) ? minRange : value,
-							maxPrice
-					  )
-					: minPrice;
-			const currentMaxPrice =
-				type === 'max'
-					? Math.max(
-							Number.isNaN( value ) ? maxRange : value,
-							minPrice
-					  )
-					: maxPrice;
 
 			// In some occasions the input element is updated with the incorrect value.
 			// By using the element that triggered the event, we can ensure the correct value is used for the input.
 			const element = getElement();
-			if ( type === 'min' ) {
-				element.ref.value = currentMinPrice;
+
+			debounceUpdate( context, element, event );
+		},
+		selectInputContent: () => {
+			const element = getElement();
+			if ( element && element.ref ) {
+				element.ref.select();
 			}
-
-			if ( type === 'max' ) {
-				element.ref.value = currentMaxPrice;
-			}
-
-			context.minPrice = currentMinPrice;
-			context.maxPrice = currentMaxPrice;
-
-			navigate(
-				getUrl( {
-					minRange,
-					maxRange,
-					minPrice: currentMinPrice,
-					maxPrice: currentMaxPrice,
-				} )
-			);
 		},
 		reset: () => {
 			navigate(

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/price-filter/types.ts
@@ -32,6 +32,7 @@ export type PriceFilterStore = {
 	state: PriceFilterState;
 	actions: {
 		updateProducts: ( event: HTMLElementEvent< HTMLInputElement > ) => void;
+		selectInputContent: () => void;
 		reset: () => void;
 	};
 };

--- a/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/filter-blocks/price-filter.block_theme.spec.ts
@@ -93,7 +93,10 @@ test.describe( 'Product Filter: Price Filter Block', () => {
 			);
 			const minPriceInput = leftInputContainer.locator( '.min' );
 			await minPriceInput.fill( String( defaultMinRange ) );
-			await minPriceInput.blur();
+
+			await page.waitForURL(
+				( url ) => ! url.href.includes( 'min_price' )
+			);
 
 			// Max price input field
 			const rightInputContainer = page.locator(
@@ -101,7 +104,10 @@ test.describe( 'Product Filter: Price Filter Block', () => {
 			);
 			const maxPriceInput = rightInputContainer.locator( '.max' );
 			await maxPriceInput.fill( String( defaultMaxRange ) );
-			await maxPriceInput.blur();
+
+			await page.waitForURL(
+				( url ) => ! url.href.includes( 'max_price' )
+			);
 
 			const button = page.getByRole( 'button', { name: 'Clear' } );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
@@ -359,6 +359,12 @@ test.describe( `${ blockData.name } Block - with Product Collection`, () => {
 
 		await maxPriceInput.dblclick();
 		await maxPriceInput.fill( '$5' );
+
+		const resetPriceFilterButton = page.getByRole( 'button', {
+			name: 'Reset price filter',
+		} );
+		await expect( resetPriceFilterButton ).toBeVisible();
+
 		await page
 			.getByRole( 'button', { name: 'Apply price filter' } )
 			.click();

--- a/plugins/woocommerce/changelog/dev-42636_update_view_when_changing_input
+++ b/plugins/woocommerce/changelog/dev-42636_update_view_when_changing_input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+[Filter Products by Price]: Update view when changing the min/max value #50651

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -171,7 +171,8 @@ final class ProductFilterPrice extends AbstractBlock {
 					type="text"
 					value="%s"
 					data-wc-bind--value="state.formattedMinPrice"
-					data-wc-on--change="actions.updateProducts"
+					data-wc-on--input="actions.updateProducts"
+					data-wc-on--focus="actions.selectInputContent"
 					pattern=""
 				/>',
 				wp_strip_all_tags( $formatted_min_price )
@@ -189,7 +190,8 @@ final class ProductFilterPrice extends AbstractBlock {
 					type="text"
 					value="%s"
 					data-wc-bind--value="state.formattedMaxPrice"
-					data-wc-on--change="actions.updateProducts"
+					data-wc-on--input="actions.updateProducts"
+					data-wc-on--focus="actions.selectInputContent"
 				/>',
 				wp_strip_all_tags( $formatted_max_price )
 			) : sprintf(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the code to immediately apply changes to the `min` and `max` price range as soon as they are entered.
Previously, the shopper had to leave the input field before the price range was updated.

https://github.com/user-attachments/assets/50877781-940f-4e27-b5d7-411074ee2a3b

Closes #42636.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a few products.
2. Go to Posts > Add New Post.
3. Add a `Product Collection` block and select `create your own`.
4. Add a `Filter by price` block below.
5. Preview the post.
6. You will see a list of products and the `Filter by price` section below.
7. Verify that it's not possible to add a `max` price higher than the highest product price.

![Screenshot 2024-08-15 at 11 16 40 AM](https://github.com/user-attachments/assets/11c76a21-92ee-4ba5-bddf-beadd7ac9b73)

8. Verify that the `min` price resets to zero when the entered `max` price is lower than the entered `min` price.

https://github.com/user-attachments/assets/3ef15521-5a76-4546-a16d-bfff0aa9ad3b

9. Enter a valid `max` price; the products should automatically filter based on the new price.
10. Similarly, entering a valid `min` price should trigger the same behavior.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
