### PR TITLE
Improve `setup_tasks_remaining()` performance to make `menu_task_count` safer

### DIFF
--- a/plugins/woocommerce/changelog/update-improve-setup-task-count
+++ b/plugins/woocommerce/changelog/update-improve-setup-task-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve setup_tasks_remaining performance

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -297,7 +297,6 @@ class TaskLists {
 				$task_list->add_task( $task );
 			}
 		}
-
 	}
 
 	/**
@@ -318,7 +317,7 @@ class TaskLists {
 	public static function get_lists_by_ids( $ids ) {
 		return array_filter(
 			self::$lists,
-			function( $list ) use ( $ids ) {
+			function ( $list ) use ( $ids ) {
 				return in_array( $list->get_list_id(), $ids, true );
 			}
 		);
@@ -404,25 +403,28 @@ class TaskLists {
 	/**
 	 * Return number of setup tasks remaining
 	 *
-	 * @return number
+	 * This is not updated immediately when a task is completed, but rather when task is marked as complete in the database to reduce performance impact.
+	 *
+	 * @return int|null
 	 */
 	public static function setup_tasks_remaining() {
 		$setup_list = self::get_list( 'setup' );
 
-		if ( ! $setup_list || $setup_list->is_hidden() || $setup_list->has_previously_completed() || $setup_list->is_complete() ) {
+		if ( ! $setup_list || $setup_list->is_hidden() || $setup_list->has_previously_completed() ) {
 			return;
 		}
 
-		$remaining_tasks = array_values(
+		$viewable_tasks  = $setup_list->get_viewable_tasks();
+		$completed_tasks = get_option( Task::COMPLETED_OPTION, array() );
+
+		return count(
 			array_filter(
-				$setup_list->get_viewable_tasks(),
-				function( $task ) {
-					return ! $task->is_complete();
+				$viewable_tasks,
+				function ( $task ) use ( $completed_tasks ) {
+					return ! in_array( $task->get_id(), $completed_tasks, true );
 				}
 			)
 		);
-
-		return count( $remaining_tasks );
 	}
 
 	/**
@@ -443,7 +445,6 @@ class TaskLists {
 				break;
 			}
 		}
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -317,8 +317,8 @@ class TaskLists {
 	public static function get_lists_by_ids( $ids ) {
 		return array_filter(
 			self::$lists,
-			function ( $list ) use ( $ids ) {
-				return in_array( $list->get_list_id(), $ids, true );
+			function ( $task_list ) use ( $ids ) {
+				return in_array( $task_list->get_list_id(), $ids, true );
 			}
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -416,6 +416,9 @@ class TaskLists {
 
 		$viewable_tasks  = $setup_list->get_viewable_tasks();
 		$completed_tasks = get_option( Task::COMPLETED_OPTION, array() );
+		if ( ! is_array( $completed_tasks ) ) {
+			$completed_tasks = array();
+		}
 
 		return count(
 			array_filter(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50533.

Counting unfinished tasks by calling `is_complete()` on each task is expensive and potentially dangerous. This PR calculates the count of completed tasks by fetching the completed tasks from the `woocommerce_task_list_tracked_completed_tasks` option and subtracting them from the total number of viewable tasks instead.

This will make the method faster and safer but lose the ability to reflect the real-time status of the setup list since the completion check is done asynchronously. This is a trade-off that we are willing to make.

Potential future improvements: we can further improve this by updating the badge number via JS to reflect the real-time status of the setup list if needed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch.
2. Complete or skip the core profiler
3. Go to `WooCommerce > Home`
4. Check the number of unfinished tasks in the setup list matches the badge number on the `WooCommerce > Home` menu item.
5. Complete any of task
6. Go to `WooCommerce > Home` 
7. Check the badge number is updated after the page is reloaded. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
