### PR TITLE
Product Price block: prevent price amounts from breaking into multiple lines

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/product-price/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-price/style.scss
@@ -23,6 +23,10 @@
 	ins {
 		text-decoration: none;
 	}
+
+	.woocommerce-Price-amount {
+		white-space: nowrap;
+	}
 }
 
 .wc-block-components-product-price__value {

--- a/plugins/woocommerce/changelog/fix-50659-product-price-nowrap
+++ b/plugins/woocommerce/changelog/fix-50659-product-price-nowrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Price block: prevent price amounts from breaking into multiple lines


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/50659.

### How to test the changes in this Pull Request:

1. Edit the Single Product template and make it so the Product Title and Product Price are rendered next to each other. Ie, inside a Row block:

![imatge](https://github.com/user-attachments/assets/91f9f961-af65-4ccc-adc2-69d66f739b5e)

```HTML
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"bottom"}} -->
<div class="wp-block-group"><!-- wp:post-title {"level":1,"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->

<!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"fontSize":"large"} /--></div>
<!-- /wp:group -->
```

2. Go to Single Product page in the frontend.
3. Make sure no matter what the price never breaks into multiple lines:

Before | After
--- | ---
![Screenshot 2024-08-14 at 09-13-35 Hoodie with Logo – 202408](https://github.com/user-attachments/assets/96b21dcc-05b4-4384-9858-93f81478bcec) | ![Screenshot 2024-08-14 at 09-14-11 Hoodie with Logo – 202408](https://github.com/user-attachments/assets/9ae9d435-51db-4294-9854-1798be1b2ddf)