### PR TITLE
Fix the PHP warning in which the null was passed to json_decode

### DIFF
--- a/plugins/woocommerce/changelog/fix-php-warning
+++ b/plugins/woocommerce/changelog/fix-php-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Product Collection: fix the PHP deprecated warning

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -226,7 +226,7 @@ class ProductCollection extends AbstractBlock {
 				'data-wc-navigation-id',
 				'wc-product-collection-' . $this->parsed_block['attrs']['queryId']
 			);
-			$current_context = json_decode( $p->get_attribute( 'data-wc-context' ), true ) ?? [];
+			$current_context = json_decode( $p->get_attribute( 'data-wc-context' ) ?? '{}', true );
 			$p->set_attribute(
 				'data-wc-context',
 				wp_json_encode(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/50166 I introduced the code in which there was possibility to pass the `null` to `json_decode` [here](https://github.com/woocommerce/woocommerce/pull/50166/files#diff-933825fdae3edb1301562e70acef6627856dd1c39c7475056ef21ac4f0ee9941R229) which is deprecated.

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/688e5e80-e2ea-4a3b-a768-3ce5dd6045dc">

This PR fixes it by passing a string with an empty object as a fallback (`'{}'`) instead.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your store operates on PHP 8.3 and have Query Monitor or similar installed
2. Create new post
3. Add Product Collection block
4. Choose "create your own"
5. Save and go to frontend
6. Make sure there is no PHP warning

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
