### PR TITLE
Enhance Remote Logging to Include `request_uri`

### DIFF
--- a/packages/js/remote-logging/changelog/update-remote-logging-data
+++ b/packages/js/remote-logging/changelog/update-remote-logging-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add request_uri prop to remote logging data

--- a/packages/js/remote-logging/src/remote-logger.ts
+++ b/packages/js/remote-logging/src/remote-logger.ts
@@ -103,6 +103,11 @@ export class RemoteLogger {
 				message: error.message,
 				severity: 'error',
 				...extraData,
+				properties: {
+					...extraData?.properties,
+					request_uri:
+						window.location.pathname + window.location.search,
+				},
 			} ),
 			trace: this.getFormattedStackFrame(
 				TraceKit.computeStackTrace( error )
@@ -206,6 +211,10 @@ export class RemoteLogger {
 				message: error.message,
 				severity: 'critical',
 				tags: [ 'js-unhandled-error' ],
+				properties: {
+					request_uri:
+						window.location.pathname + window.location.search,
+				},
 			} ),
 			trace: this.getFormattedStackFrame( trace ),
 		};

--- a/plugins/woocommerce/changelog/update-remote-logging-data
+++ b/plugins/woocommerce/changelog/update-remote-logging-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add request_uri prop to remote logging data

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -71,6 +71,7 @@ class RemoteLogger extends \WC_Log_Handler {
 				'wc_version'  => WC()->version,
 				'php_version' => phpversion(),
 				'wp_version'  => get_bloginfo( 'version' ),
+				'request_uri' => filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL ),
 			),
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50669.

Enhance the logging functionality to include the full REQUEST_URI in addition to the host.
This will allow for more precise deduplication and identification of individual WordPress installs, especially in cases where they exist in subdirectories under the same domain.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:



1. Create a new JN site with this branch
2.  SSH into JN site and rename the wc plugin folder to `woocommerce` (There is a bug we need to fix in remote logging package that we're checking for the `woocommerce` folder to determine if error is from WC Core)
3. Go to `Tools -> WCA Test Helper -> Remote Logging`
4. Enable remote logging
5. Click on PHP `Simulate Core Exception`, refresh the page and confirm it throws an error
6. Click on JS `Simulate Core Exception`, go to a WooCommerce page and confirm it throws an error in the console
7. Check the log server page for the log entry (See test plan in D155228-code to see how to check the log entry)
8. Confirm the log properties include `request_uri`.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
