### PR TITLE
Fix `store-title` endpoint - Pass default value to `get_option`

### DIFF
--- a/plugins/woocommerce/changelog/50673-fix-store-title-error
+++ b/plugins/woocommerce/changelog/50673-fix-store-title-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix `store-title` endpoint - Pass default value to `get_option`.

--- a/plugins/woocommerce/src/Admin/API/AI/StoreTitle.php
+++ b/plugins/woocommerce/src/Admin/API/AI/StoreTitle.php
@@ -86,8 +86,8 @@ class StoreTitle extends AIEndpoint {
 			);
 		}
 
-		$store_title                 = html_entity_decode( get_option( self::STORE_TITLE_OPTION_NAME ) );
-		$previous_ai_generated_title = html_entity_decode( get_option( self::AI_STORE_TITLE_OPTION_NAME ) );
+		$store_title                 = html_entity_decode( get_option( self::STORE_TITLE_OPTION_NAME, '' ) );
+		$previous_ai_generated_title = html_entity_decode( get_option( self::AI_STORE_TITLE_OPTION_NAME, '' ) );
 
 		if ( strtolower( trim( self::DEFAULT_TITLE ) ) === strtolower( trim( $store_title ) ) || ( ! empty( $store_title ) && $previous_ai_generated_title !== $store_title ) ) {
 			return rest_ensure_response( array( 'ai_content_generated' => false ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an error that was happening on the `store-title` endpoint due to not passing a default value to the `get_option` function.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In a WooExpress store, go to wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store.
2. Start designing a new store and write the description.
3. Confirm the flow finishes without errors and you see a store title related to your description in the assembler.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix `store-title` endpoint - Pass default value to `get_option`.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
