### PR TITLE
CYS: avoid to enqueue Jetpack scripts

### DIFF
--- a/plugins/woocommerce/changelog/50679-fix-cys-ai-flow
+++ b/plugins/woocommerce/changelog/50679-fix-cys-ai-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: avoid to enqueue Jetpack scripts

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -238,11 +238,6 @@ class CustomizeStore extends Task {
 		 * @since 8.0.3
 		*/
 		do_action( 'enqueue_block_editor_assets' );
-
-		// Load Jetpack's block editor assets because they are not enqueued by default.
-		if ( class_exists( 'Jetpack_Gutenberg' ) ) {
-			Jetpack_Gutenberg::enqueue_block_editor_assets();
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -3,7 +3,6 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use Jetpack_Gutenberg;
 use WP_Post;
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We noticed that when JetPack is installed, there are two issues on the Assembler page:
- Some blocks aren't registered correctly
- The block toolbar has a black border.

| Without Jetpack installed | With Jetpack installed |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/386e94df-2b47-4388-ae29-267442d7af44" /> | <video src="https://github.com/user-attachments/assets/ebc8bd37-3d63-42b0-a7ab-565f8936f575" /> | 


For some reason, Jetpack scripts are included on this page. @moon0326, do you recall why it is necessary? (https://github.com/woocommerce/woocommerce/pull/40140)  Do you see any issue with merging this change?


Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Head over to WooCommerce > Home > Customize your store.
2. Follow the flow.
3. Smoke test the Assembler
5. Ensure that you don't see any regression.
6. Install Jetpack plugin
7. Repeat 1-5 steps.
8. Repeat 1-7 steps with Core flow and AI flow.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: avoid to enqueue Jetpack scripts

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>