### PR TITLE
Checkout: prevent error from get_value method when WC has not been properly initialized

### DIFF
--- a/plugins/woocommerce/changelog/fix-50245-fatal-error-checkout-customer
+++ b/plugins/woocommerce/changelog/fix-50245-fatal-error-checkout-customer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent an error in the WC_Checkout class when WooCommerce has not been properly initialized yet

--- a/plugins/woocommerce/changelog/fix-50245-fatal-error-checkout-customer
+++ b/plugins/woocommerce/changelog/fix-50245-fatal-error-checkout-customer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Address a fatal error that could happen if certain properties of the main WooCommerce class were accessed before WooCommerce had finished initializing

--- a/plugins/woocommerce/changelog/fix-50245-fatal-error-checkout-customer
+++ b/plugins/woocommerce/changelog/fix-50245-fatal-error-checkout-customer
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Address a fatal error that could happen if certain properties of the main WooCommerce class were accessed before WooCommerce had finished initializing

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1357,7 +1357,7 @@ class WC_Checkout {
 
 		if ( is_callable( array( $customer_object, "get_$input" ) ) ) {
 			$value = $customer_object->{"get_$input"}();
-		} elseif ( $customer_object->meta_exists( $input ) ) {
+		} elseif ( is_callable( array( $customer_object, 'meta_exists' ) ) && $customer_object->meta_exists( $input ) ) {
 			$value = $customer_object->get_meta( $input, true );
 		}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -113,14 +113,14 @@ final class WooCommerce {
 	 *
 	 * @var WC_Cart
 	 */
-	public $cart = null;
+	private $cart = null;
 
 	/**
 	 * Customer instance.
 	 *
 	 * @var WC_Customer
 	 */
-	public $customer = null;
+	private $customer = null;
 
 	/**
 	 * Order factory instance.
@@ -199,7 +199,7 @@ final class WooCommerce {
 			return $this->api;
 		}
 
-		if ( in_array( $key, array( 'payment_gateways', 'shipping', 'mailer', 'checkout' ), true ) ) {
+		if ( in_array( $key, array( 'payment_gateways', 'shipping', 'mailer', 'checkout', 'customer', 'cart' ), true ) ) {
 			return $this->$key();
 		}
 	}
@@ -213,6 +213,8 @@ final class WooCommerce {
 	public function __set( string $key, $value ) {
 		if ( 'api' === $key ) {
 			$this->api = $value;
+		} elseif ( in_array( $key, array( 'customer', 'cart' ), true ) ) {
+			$this->$key = $value;
 		} elseif ( property_exists( $this, $key ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( 'Cannot access private property WooCommerce::$' . esc_html( $key ), E_USER_ERROR );
@@ -1152,6 +1154,28 @@ final class WooCommerce {
 	 */
 	public function shipping() {
 		return WC_Shipping::instance();
+	}
+
+	/**
+	 * Get customer class.
+	 *
+	 * @return WC_Customer
+	 */
+	public function customer() {
+		$this->initialize_cart();
+
+		return $this->customer;
+	}
+
+	/**
+	 * Get cart class.
+	 *
+	 * @return WC_Cart
+	 */
+	public function cart() {
+		$this->initialize_cart();
+
+		return $this->cart;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -113,14 +113,14 @@ final class WooCommerce {
 	 *
 	 * @var WC_Cart
 	 */
-	private $cart = null;
+	public $cart = null;
 
 	/**
 	 * Customer instance.
 	 *
 	 * @var WC_Customer
 	 */
-	private $customer = null;
+	public $customer = null;
 
 	/**
 	 * Order factory instance.
@@ -199,7 +199,7 @@ final class WooCommerce {
 			return $this->api;
 		}
 
-		if ( in_array( $key, array( 'payment_gateways', 'shipping', 'mailer', 'checkout', 'customer', 'cart' ), true ) ) {
+		if ( in_array( $key, array( 'payment_gateways', 'shipping', 'mailer', 'checkout' ), true ) ) {
 			return $this->$key();
 		}
 	}
@@ -213,8 +213,6 @@ final class WooCommerce {
 	public function __set( string $key, $value ) {
 		if ( 'api' === $key ) {
 			$this->api = $value;
-		} elseif ( in_array( $key, array( 'customer', 'cart' ), true ) ) {
-			$this->$key = $value;
 		} elseif ( property_exists( $this, $key ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			trigger_error( 'Cannot access private property WooCommerce::$' . esc_html( $key ), E_USER_ERROR );
@@ -1154,28 +1152,6 @@ final class WooCommerce {
 	 */
 	public function shipping() {
 		return WC_Shipping::instance();
-	}
-
-	/**
-	 * Get customer class.
-	 *
-	 * @return WC_Customer
-	 */
-	public function customer() {
-		$this->initialize_cart();
-
-		return $this->customer;
-	}
-
-	/**
-	 * Get cart class.
-	 *
-	 * @return WC_Cart
-	 */
-	public function cart() {
-		$this->initialize_cart();
-
-		return $this->cart;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -202,5 +202,20 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			$errors->get_error_message( 'shipping' )
 		);
 	}
+
+	/**
+	 * @testdox If the WooCommerce class's customer object is null (like if WC has not been fully initialized yet),
+	 *          calling WC_Checkout::get_value should not throw an error.
+	 */
+	public function test_get_value_no_error_on_null_customer() {
+		$sut = WC_Checkout::instance();
+
+		$orig_customer = WC()->customer;
+		WC()->customer = null;
+
+		$this->assertNull( $sut->get_value( 'billing_country' ) );
+
+		WC()->customer = $orig_customer;
+	}
 }
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -46,12 +46,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	 * @param bool $expect_error_message_for_shipping_country True to expect an error to be generated for the shipping country.
 	 */
 	public function test_validate_posted_data_adds_error_for_non_existing_country( $ship_to_different_address, $expect_error_message_for_shipping_country ) {
-		$_POST = array(
+		$data = array(
 			'billing_country'           => 'XX',
 			'shipping_country'          => 'YY',
 			'ship_to_different_address' => $ship_to_different_address,
 		);
-		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		add_filter(
 			'woocommerce_cart_needs_shipping_address',
@@ -75,12 +74,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	 * @testdox the customer notes are correctly sanitized.
 	 */
 	public function test_order_notes() {
-		$_POST = array(
+		$data = array(
 			'ship_to_different_address' => false,
 			'order_comments'             => '<a href="http://attackerpage.com/csrf.html">This text should not save inside an anchor.</a><script>alert("alert")</script>',
 			'payment_method'            => 'bacs',
 		);
-		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$errors = new WP_Error();
 
@@ -108,12 +106,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	 * @param bool $ship_to_different_address True to simulate shipping to a different address than the billing address.
 	 */
 	public function test_validate_posted_data_does_not_add_error_for_existing_country( $ship_to_different_address ) {
-		$_POST = array(
+		$data = array(
 			'billing_country'           => 'ES',
 			'shipping_country'          => 'ES',
 			'ship_to_different_address' => $ship_to_different_address,
 		);
-		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$errors = new WP_Error();
 
@@ -132,12 +129,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	 * @param bool $ship_to_different_address True to simulate shipping to a different address than the billing address.
 	 */
 	public function test_validate_posted_data_does_not_add_error_for_empty_country( $ship_to_different_address ) {
-		$_POST = array(
+		$data = array(
 			'billing_country'           => '',
 			'shipping_country'          => '',
 			'ship_to_different_address' => $ship_to_different_address,
 		);
-		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$errors = new WP_Error();
 
@@ -186,12 +182,11 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			)
 		);
 
-		$_POST = array(
+		$data = array(
 			'billing_country'           => $country,
 			'shipping_country'          => $country,
 			'ship_to_different_address' => false,
 		);
-		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$errors = new WP_Error();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If the `customer` property of the main `WooCommerce` class is accessed before the `woocommerce_init` action has fired, the property will be `null` instead of containing a class instance, which can cause a fatal error if you then try to access a method on it. This simply adds a check in WC_Checkout::get_value to ensure the class instance exists before trying to invoke a method.

Previously this PR tried to take a holistic approach and make sure that the `customer` property always contained a class instance when it was accessed. However, this ended up breaking a lot of other stuff. After other such attempts in the past to make things more robust, and failing spectacularly, I should know better, but here we are. So instead we're going with the band-aid approach.

Fixes #50245

### How to test the changes in this Pull Request:

1. First replicate the problem on the trunk branch with [these instructions](https://github.com/woocommerce/woocommerce/issues/50245#issuecomment-2287300027).
2. Switch to this branch and reload the logged out tab. With this changeset there should not be any errors.
