### PR TITLE
fix: shipping region zone decode html entities

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
@@ -8,20 +8,27 @@ import { createRoot } from '@wordpress/element';
  */
 import { RegionPicker } from './region-picker';
 import { ShippingCurrencyContext } from './currency-context';
+import { recursivelyTransformLabels, decodeHTMLEntities } from './utils';
 
 const shippingZoneRegionPickerRoot = document.getElementById(
 	'wc-shipping-zone-region-picker-root'
 );
 
-const options = window.shippingZoneMethodsLocalizeScript?.region_options ?? [];
+const options =
+	recursivelyTransformLabels(
+		window.shippingZoneMethodsLocalizeScript?.region_options,
+		decodeHTMLEntities
+	) ?? [];
 const initialValues = window.shippingZoneMethodsLocalizeScript?.locations ?? [];
 
-const ShippingApp = () => (
-	<div>
-		<ShippingCurrencyContext />
-		<RegionPicker options={ options } initialValues={ initialValues } />
-	</div>
-);
+const ShippingApp = () => {
+	return (
+		<div>
+			<ShippingCurrencyContext />
+			<RegionPicker options={ options } initialValues={ initialValues } />
+		</div>
+	);
+};
 
 if ( shippingZoneRegionPickerRoot ) {
 	createRoot( shippingZoneRegionPickerRoot ).render( <ShippingApp /> );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { createRoot } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
 import { RegionPicker } from './region-picker';
 import { ShippingCurrencyContext } from './currency-context';
-import { recursivelyTransformLabels, decodeHTMLEntities } from './utils';
+import { recursivelyTransformLabels } from './utils';
 
 const shippingZoneRegionPickerRoot = document.getElementById(
 	'wc-shipping-zone-region-picker-root'
@@ -17,7 +18,7 @@ const shippingZoneRegionPickerRoot = document.getElementById(
 const options =
 	recursivelyTransformLabels(
 		window.shippingZoneMethodsLocalizeScript?.region_options,
-		decodeHTMLEntities
+		decodeEntities
 	) ?? [];
 const initialValues = window.shippingZoneMethodsLocalizeScript?.locations ?? [];
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/test/utils.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/test/utils.js
@@ -1,0 +1,173 @@
+/**
+ * Internal dependencies
+ */
+import { recursivelyTransformLabels, decodeHTMLEntities } from '../utils';
+
+describe( 'recursivelyTransformLabels', () => {
+	function toUpperCase( label ) {
+		return label.toUpperCase();
+	}
+
+	test( 'Single node with label', () => {
+		const node = { label: 'test' };
+		const result = recursivelyTransformLabels( node, toUpperCase );
+		expect( result.label ).toBe( 'TEST' );
+	} );
+
+	test( 'Single node without label', () => {
+		const node = { value: 42 };
+		const result = recursivelyTransformLabels( node, toUpperCase );
+		expect( result.value ).toBe( 42 );
+		expect( result.label ).toBeUndefined();
+	} );
+
+	test( 'Nested nodes', () => {
+		const node = {
+			label: 'parent',
+			value: 'par',
+			children: [
+				{ label: 'child1', value: 'ch1' },
+				{ label: 'child2', value: 'ch2' },
+			],
+		};
+		const result = recursivelyTransformLabels( node, toUpperCase );
+		expect( result.label ).toBe( 'PARENT' );
+		expect( result.value ).toBe( 'par' );
+		expect( result.children[ 0 ].label ).toBe( 'CHILD1' );
+		expect( result.children[ 0 ].value ).toBe( 'ch1' );
+		expect( result.children[ 1 ].label ).toBe( 'CHILD2' );
+		expect( result.children[ 1 ].value ).toBe( 'ch2' );
+	} );
+
+	test( 'Nested nodes with mixed children', () => {
+		const node = {
+			label: 'parent',
+			children: [
+				{ label: 'child1' },
+				{ value: 42 },
+				{ label: 'child2' },
+			],
+		};
+		const result = recursivelyTransformLabels( node, toUpperCase );
+		expect( result.label ).toBe( 'PARENT' );
+		expect( result.children[ 0 ].label ).toBe( 'CHILD1' );
+		expect( result.children[ 1 ].value ).toBe( 42 );
+		expect( result.children[ 1 ].label ).toBeUndefined();
+		expect( result.children[ 2 ].label ).toBe( 'CHILD2' );
+	} );
+
+	test( 'Array of nodes', () => {
+		const node = [ { label: 'node1' }, { label: 'node2' } ];
+		const result = recursivelyTransformLabels( node, toUpperCase );
+		expect( result[ 0 ].label ).toBe( 'NODE1' );
+		expect( result[ 1 ].label ).toBe( 'NODE2' );
+	} );
+
+	test( 'Deeply nested nodes', () => {
+		const node = {
+			label: 'root',
+			children: [
+				{
+					label: 'branch1',
+					value: 'br1',
+					children: [
+						{ label: 'leaf1', value: 'le1' },
+						{ label: 'leaf2' },
+					],
+				},
+				{ label: 'branch2' },
+			],
+		};
+		const result = recursivelyTransformLabels( node, toUpperCase );
+		expect( result.label ).toBe( 'ROOT' );
+		expect( result.children[ 0 ].label ).toBe( 'BRANCH1' );
+		expect( result.children[ 0 ].value ).toBe( 'br1' );
+		expect( result.children[ 0 ].children[ 0 ].label ).toBe( 'LEAF1' );
+		expect( result.children[ 0 ].children[ 0 ].value ).toBe( 'le1' );
+		expect( result.children[ 0 ].children[ 1 ].label ).toBe( 'LEAF2' );
+		expect( result.children[ 1 ].label ).toBe( 'BRANCH2' );
+	} );
+} );
+
+describe( 'decodeHTMLEntities', () => {
+	test( 'should return the same string if there are no HTML entities', () => {
+		const input = 'Hello, World!';
+		const expectedOutput = 'Hello, World!';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+	test( 'should decode HTML entity for é', () => {
+		const input = '&eacute;';
+		const expectedOutput = 'é';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode HTML entity for à', () => {
+		const input = '&agrave;';
+		const expectedOutput = 'à';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode HTML entity for ñ', () => {
+		const input = '&ntilde;';
+		const expectedOutput = 'ñ';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode HTML entity for ü', () => {
+		const input = '&uuml;';
+		const expectedOutput = 'ü';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode multiple HTML entities with accents', () => {
+		const input = '&eacute;&agrave;&ntilde;&uuml;';
+		const expectedOutput = 'éàñü';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode a string with HTML entities representing the word Curaçao', () => {
+		const input = 'Cura&ccedil;ao';
+		const expectedOutput = 'Curaçao';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode a string with mixed content including HTML entities with accents', () => {
+		const input =
+			'Café &eacute;clair &agrave; la carte &ntilde; and pi&ntilde;a colada';
+		const expectedOutput = 'Café éclair à la carte ñ and piña colada';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+
+	test( 'should decode a string with multiple HTML entities of the same character with accents', () => {
+		const input = '&eacute;&eacute;&eacute;';
+		const expectedOutput = 'ééé';
+		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
+	} );
+} );
+
+describe( 'recursivelyTransformLabels and decodeHTMLEntities should work together', () => {
+	test( 'Deeply nested nodes', () => {
+		const node = {
+			label: 'root',
+			children: [
+				{
+					label: 'branch1',
+					value: 'br1',
+					children: [
+						{ label: 'Cura&ccedil;ao', value: 'le1' },
+						{ label: 'leaf2' },
+					],
+				},
+				{ label: 'branch2' },
+			],
+		};
+		const result = recursivelyTransformLabels( node, decodeHTMLEntities );
+		expect( result.label ).toBe( 'root' );
+		expect( result.children[ 0 ].label ).toBe( 'branch1' );
+		expect( result.children[ 0 ].value ).toBe( 'br1' );
+		expect( result.children[ 0 ].children[ 0 ].label ).toBe( 'Curaçao' );
+		expect( result.children[ 0 ].children[ 0 ].value ).toBe( 'le1' );
+		expect( result.children[ 0 ].children[ 1 ].label ).toBe( 'leaf2' );
+		expect( result.children[ 1 ].label ).toBe( 'branch2' );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/test/utils.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/test/utils.js
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+/**
  * Internal dependencies
  */
-import { recursivelyTransformLabels, decodeHTMLEntities } from '../utils';
+import { recursivelyTransformLabels } from '../utils';
 
 describe( 'recursivelyTransformLabels', () => {
 	function toUpperCase( label ) {
@@ -89,63 +93,7 @@ describe( 'recursivelyTransformLabels', () => {
 	} );
 } );
 
-describe( 'decodeHTMLEntities', () => {
-	test( 'should return the same string if there are no HTML entities', () => {
-		const input = 'Hello, World!';
-		const expectedOutput = 'Hello, World!';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-	test( 'should decode HTML entity for é', () => {
-		const input = '&eacute;';
-		const expectedOutput = 'é';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode HTML entity for à', () => {
-		const input = '&agrave;';
-		const expectedOutput = 'à';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode HTML entity for ñ', () => {
-		const input = '&ntilde;';
-		const expectedOutput = 'ñ';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode HTML entity for ü', () => {
-		const input = '&uuml;';
-		const expectedOutput = 'ü';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode multiple HTML entities with accents', () => {
-		const input = '&eacute;&agrave;&ntilde;&uuml;';
-		const expectedOutput = 'éàñü';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode a string with HTML entities representing the word Curaçao', () => {
-		const input = 'Cura&ccedil;ao';
-		const expectedOutput = 'Curaçao';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode a string with mixed content including HTML entities with accents', () => {
-		const input =
-			'Café &eacute;clair &agrave; la carte &ntilde; and pi&ntilde;a colada';
-		const expectedOutput = 'Café éclair à la carte ñ and piña colada';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-
-	test( 'should decode a string with multiple HTML entities of the same character with accents', () => {
-		const input = '&eacute;&eacute;&eacute;';
-		const expectedOutput = 'ééé';
-		expect( decodeHTMLEntities( input ) ).toBe( expectedOutput );
-	} );
-} );
-
-describe( 'recursivelyTransformLabels and decodeHTMLEntities should work together', () => {
+describe( 'recursivelyTransformLabels and decodeEntities should work together', () => {
 	test( 'Deeply nested nodes', () => {
 		const node = {
 			label: 'root',
@@ -161,7 +109,7 @@ describe( 'recursivelyTransformLabels and decodeHTMLEntities should work togethe
 				{ label: 'branch2' },
 			],
 		};
-		const result = recursivelyTransformLabels( node, decodeHTMLEntities );
+		const result = recursivelyTransformLabels( node, decodeEntities );
 		expect( result.label ).toBe( 'root' );
 		expect( result.children[ 0 ].label ).toBe( 'branch1' );
 		expect( result.children[ 0 ].value ).toBe( 'br1' );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/utils.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/utils.js
@@ -1,10 +1,3 @@
-export const decodeHTMLEntities = ( text ) => {
-	const parser = new window.DOMParser();
-	const decodedString = parser.parseFromString( text, 'text/html' )
-		.documentElement.textContent;
-	return decodedString;
-};
-
 export const recursivelyTransformLabels = ( node, transform ) => {
 	if ( Array.isArray( node ) ) {
 		return node.map( ( element ) => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/utils.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/utils.js
@@ -1,0 +1,21 @@
+export const decodeHTMLEntities = ( text ) => {
+	const parser = new window.DOMParser();
+	const decodedString = parser.parseFromString( text, 'text/html' )
+		.documentElement.textContent;
+	return decodedString;
+};
+
+export const recursivelyTransformLabels = ( node, transform ) => {
+	if ( Array.isArray( node ) ) {
+		return node.map( ( element ) => {
+			return recursivelyTransformLabels( element, transform );
+		} );
+	}
+	if ( node.label ) {
+		node.label = transform( node.label );
+	}
+	if ( node.children ) {
+		node.children = recursivelyTransformLabels( node.children, transform );
+	}
+	return node;
+};

--- a/plugins/woocommerce/changelog/fix-shipping-zone-region-selector-decode-html-entities
+++ b/plugins/woocommerce/changelog/fix-shipping-zone-region-selector-decode-html-entities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Transform labels in shipping zone region selector to decode html entities


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/issues/50349

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce and go to shipping settings (./wp-admin/admin.php?page=wc-settings&tab=shipping)
2. Add a shipping zone (./wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new)
3. Zone regions with special accents should now render correctly without encoded html entities.
4. Note that no changes have been made to the persistence logic, since it is using the `.value` of the nodes and not the `.label` which is what is being transformed. 
5. Also note that the filtering works as expected since that functionality was added in #41495 . I suspect something might have happened between then and now that introduced HTML encoding.

![image](https://github.com/user-attachments/assets/0e399e61-8d67-47ff-88a6-419be8ca077a)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
