### PR TITLE
Reset password form: Fix regression which prevents new logged in accounts from setting initial password

### DIFF
--- a/plugins/woocommerce/changelog/fix-set-new-password-regression-49670
+++ b/plugins/woocommerce/changelog/fix-set-new-password-regression-49670
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow new accounts to set new password even if logged in.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -41,11 +41,8 @@ class WC_Shortcode_My_Account {
 
 		self::my_account_add_notices();
 
-		$is_lost_password      = isset( $wp->query_vars['lost-password'] );
-		$is_new_account_action = 'newaccount' === wc_clean( wp_unslash( $_GET['action'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		// Show the lost password page only if the user is logged out, or they are setting a password for a new account.
-		if ( $is_lost_password && ( ! is_user_logged_in() || $is_new_account_action ) ) {
+		// Show the lost password page. This can still be accessed directly by logged in accounts which is important for the initial create password links sent via email.
+		if ( isset( $wp->query_vars['lost-password'] ) ) {
 			self::lost_password();
 			return;
 		}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -34,7 +34,7 @@ class WC_Shortcode_My_Account {
 	public static function output( $atts ) {
 		global $wp;
 
-		// Check cart class is loaded, or abort.
+		// Check cart class is loaded or abort.
 		if ( is_null( WC()->cart ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -34,11 +34,39 @@ class WC_Shortcode_My_Account {
 	public static function output( $atts ) {
 		global $wp;
 
-		// Check cart class is loaded or abort.
+		// Check cart class is loaded, or abort.
 		if ( is_null( WC()->cart ) ) {
 			return;
 		}
 
+		self::my_account_add_notices();
+
+		$is_lost_password      = isset( $wp->query_vars['lost-password'] );
+		$is_new_account_action = 'newaccount' === wc_clean( wp_unslash( $_GET['action'] ?? '' ) );
+
+		// Show the lost password page only if the user is logged out, or they are setting a password for a new account.
+		if ( $is_lost_password && ( ! is_user_logged_in() || $is_new_account_action ) ) {
+			self::lost_password();
+			return;
+		}
+
+		// Show login form if not logged in.
+		if ( ! is_user_logged_in() ) {
+			wc_get_template( 'myaccount/form-login.php' );
+			return;
+		}
+
+		// Output the my account page.
+		self::my_account( $atts );
+	}
+
+	/**
+	 * Add notices to the my account page.
+	 *
+	 * Historically a filter has existed to render a message above the my account page content while the user is
+	 * logged out. See `woocommerce_my_account_message`.
+	 */
+	private static function my_account_add_notices() {
 		if ( ! is_user_logged_in() ) {
 			/**
 			 * Filters the message shown on the 'my account' page when the user is not logged in.
@@ -50,27 +78,18 @@ class WC_Shortcode_My_Account {
 			if ( ! empty( $message ) ) {
 				wc_add_notice( $message );
 			}
-
-			// After password reset, add confirmation message.
-			if ( ! empty( $_GET['password-reset'] ) ) { // WPCS: input var ok, CSRF ok.
-				wc_add_notice( __( 'Your password has been reset successfully.', 'woocommerce' ) );
-			}
-
-			if ( isset( $wp->query_vars['lost-password'] ) ) {
-				self::lost_password();
-			} else {
-				wc_get_template( 'myaccount/form-login.php' );
-			}
-			return;
 		}
 
-		if ( isset( $wp->query_vars['customer-logout'] ) ) {
+		// After password reset, add confirmation message.
+		if ( ! empty( $_GET['password-reset'] ) ) {
+			wc_add_notice( __( 'Your password has been reset successfully.', 'woocommerce' ) );
+		}
+
+		// After logging out without a nonce, add confirmation message.
+		if ( isset( $wp->query_vars['customer-logout'] ) && is_user_logged_in() ) {
 			/* translators: %s: logout url */
 			wc_add_notice( sprintf( __( 'Are you sure you want to log out? <a href="%s">Confirm and log out</a>', 'woocommerce' ), wc_logout_url() ) );
 		}
-
-		// Output the my account page.
-		self::my_account( $atts );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -42,7 +42,7 @@ class WC_Shortcode_My_Account {
 		self::my_account_add_notices();
 
 		$is_lost_password      = isset( $wp->query_vars['lost-password'] );
-		$is_new_account_action = 'newaccount' === wc_clean( wp_unslash( $_GET['action'] ?? '' ) );
+		$is_new_account_action = 'newaccount' === wc_clean( wp_unslash( $_GET['action'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Show the lost password page only if the user is logged out, or they are setting a password for a new account.
 		if ( $is_lost_password && ( ! is_user_logged_in() || $is_new_account_action ) ) {
@@ -81,7 +81,7 @@ class WC_Shortcode_My_Account {
 		}
 
 		// After password reset, add confirmation message.
-		if ( ! empty( $_GET['password-reset'] ) ) {
+		if ( ! empty( $_GET['password-reset'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			wc_add_notice( __( 'Your password has been reset successfully.', 'woocommerce' ) );
 		}
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -46,12 +46,6 @@ function wc_template_redirect() {
 		exit;
 	}
 
-	// Redirect to edit account if trying to recover password whilst logged in.
-	if ( isset( $wp->query_vars['lost-password'] ) && is_user_logged_in() ) {
-		wp_safe_redirect( esc_url_raw( wc_get_endpoint_url( 'edit-account', '', wc_get_page_permalink( 'myaccount' ) ) ) );
-		exit;
-	}
-
 	// Trigger 404 if trying to access an endpoint on wrong page.
 	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() && apply_filters( 'woocommerce_account_endpoint_page_not_found', true ) ) {
 		$wp_query->set_404();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/issues/28956 reported that logged in accounts could access the lost-password form. This was undesirable and considered a bug. 

This was fixed in https://github.com/woocommerce/woocommerce/pull/49670/files which prevented access to those forms while logged in.

This however caused a regression because new customer account emails contain a link that says "Click here to set your new password". This may be clicked by a user who was logged in automatically.

When checkout generates passwords automatically, logged in users still need to be able to access this flow, because they cannot change their password from the edit account page without knowing the original. Therefore this PR reverts that change.

I have included docblocks in the shortcode explaining why this is needed so this is not regressed again in the future. Other related improvements to the readability of the code, and the removal of deprecated account page handling, have been left in place.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Please smoke test functionality around this to reduce likelihood of other regressions. I will list the main flows I can think of.

1. As a logged in user go to the my account page
2. Navigate between each section and ensure things look correct
3. Navigate directly to /my-account/lost-password. **You can see the form.** You can interact with the form like a logged out user could.

_Logged out behaviour_

1. Ensure you are logged out
2. On the account page click "lost password"
3. Ensure the lost password form is shown
4. Enter your email and reset your password
5. Use the link sent to you via email
6. Ensure you can update the password successfully and log in afterwards

_**New account behaviour**_

1. In settings, WooCommerce > Settings > Accounts and Privacy, enable the "Send password setup link (recommended)" option
2. Log out
3. Go through checkout as a guest and check the "create account" checkbox
4. After placing the order confirm you are logged in
5. Find the "your XXX account has been created" email
6. Inside is a link that says "Click here to set your new password". Use that link and confirm you see the new password form, and you can set a new password using this form.
7. After setting the password, log out and log back in using your new password.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
