### PR TITLE
[Remote Logging] Use `wcAssetUrl` to check if the stack frame is from WooCommerce

### DIFF
--- a/packages/js/remote-logging/changelog/fix-remote-logging-asset-path
+++ b/packages/js/remote-logging/changelog/fix-remote-logging-asset-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc asset url check

--- a/packages/js/remote-logging/src/remote-logger.ts
+++ b/packages/js/remote-logging/src/remote-logger.ts
@@ -334,7 +334,7 @@ export class RemoteLogger {
 	) {
 		const containsWooCommerceFrame = stackFrames.some(
 			( frame ) =>
-				frame.url && frame.url.includes( '/woocommerce/assets/' )
+				frame.url && frame.url.startsWith( getSetting( 'wcAssetUrl' ) )
 		);
 
 		/**

--- a/packages/js/remote-logging/src/test/index.ts
+++ b/packages/js/remote-logging/src/test/index.ts
@@ -32,6 +32,17 @@ jest.mock( 'tracekit', () => ( {
 	} ),
 } ) );
 
+jest.mock( '@woocommerce/settings', () => {
+	return {
+		getSetting: jest.fn().mockImplementation( ( key ) => {
+			if ( key === 'wcAssetUrl' ) {
+				return 'http://example.com/woocommerce/assets';
+			}
+			return null;
+		} ),
+	};
+} );
+
 describe( 'RemoteLogger', () => {
 	const originalConsoleWarn = console.warn;
 	let logger: RemoteLogger;
@@ -222,7 +233,7 @@ describe( 'RemoteLogger', () => {
 			const error = new Error( 'Test error' );
 			const stackFrames = [
 				{
-					url: 'http://example.com/wp-content/plugins/woocommerce/assets/js/admin/app.min.js',
+					url: 'http://example.com/woocommerce/assets/js/admin/app.min.js',
 					func: 'testFunction',
 					args: [],
 					line: 1,
@@ -241,6 +252,13 @@ describe( 'RemoteLogger', () => {
 			const stackFrames = [
 				{
 					url: 'http://example.com/other/script.js',
+					func: 'testFunction',
+					args: [],
+					line: 1,
+					column: 1,
+				},
+				{
+					url: 'http://example.com/other/plugin/woocommerce/assets/js/app.min.js',
 					func: 'testFunction',
 					args: [],
 					line: 1,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We're currently using `/woocommerce/assets/` to check if the stack frame is from WooCommerce. This is not a reliable since the plugin can be installed in a different directory and some plugins might have a similar directory structure. This PR changes the check to use `wcAssetUrl` which is the url of the WooCommerce assets directory.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a JN site with this branch
2. Go to `Tools -> WCA Test Helper -> Remote Logging`
3. Enable remote logging
4. Open dev tools and run `window.localStorage.setItem( 'debug', 'wc:remote-logging')` in the console
5. Click on JS Simulate Core Exception
6. Go to a WooCommerce page and confirm it throws an error in the console
7. Confirm the debug log shows `wc:remote-logging Sending error to API`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
