### PR TITLE
Blueprint - Add busy state on the import btn

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/pages/BuilderIntro.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BuilderIntro.tsx
@@ -25,6 +25,7 @@ export const BuilderIntro = ( {
 } ) => {
 	const [ file, setFile ] = useState( null );
 	const [ message, setMessage ] = useState( '' );
+	const [ importing, setImporting ] = useState( false );
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const handleFileChange = ( event: any ) => {
@@ -36,6 +37,8 @@ export const BuilderIntro = ( {
 			setMessage( 'Please select a file first.' );
 			return;
 		}
+
+		setImporting( true );
 
 		const formData = new FormData();
 		formData.append( 'file', file );
@@ -61,11 +64,14 @@ export const BuilderIntro = ( {
 							data.data.redirect
 					);
 
+					setImporting( false );
+
 					window.setTimeout( () => {
 						// @ts-expect-error tmp
 						window.location.href = data.data.redirect;
 					}, 2000 );
 				} else {
+					setImporting( false );
 					// @ts-expect-error tmp
 					setMessage( `Error: ${ data.message }` );
 					// @ts-expect-error tmp
@@ -78,6 +84,7 @@ export const BuilderIntro = ( {
 				}
 			} )
 			.catch( ( error ) => {
+				setImporting( false );
 				setMessage( `Error: ${ error.message }` );
 			} );
 	};
@@ -106,7 +113,11 @@ export const BuilderIntro = ( {
 					type="file"
 					onChange={ handleFileChange }
 				/>
-				<Button variant="primary" onClick={ handleUpload }>
+				<Button
+					variant="primary"
+					onClick={ handleUpload }
+					isBusy={ importing }
+				>
 					{ __( 'Import', 'woocommerce' ) }
 				</Button>
 				<div>

--- a/plugins/woocommerce/changelog/50716-update-import-btn-loading-state
+++ b/plugins/woocommerce/changelog/50716-update-import-btn-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This feature is behind a feature flag.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While testing the Blueprint build on a Playground instance, I noticed that clicking the Import button didn't seem to do anything. It turned out that Playground was just a bit slow, so I've added a busy state to the button to make the UI feel more responsive.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch and enable `blueprint` feature.
2. Navigate to `WooCommerce -> Settings -> Advanced -> Blueprint`
3. Export the current site and save the file locally.
4. Click on the `builder setup page` link on the same page.
5. Choose the exported JSON and click on the `Import` button.
6. Notice the button has `busy` state.

[woo-blueprint.json](https://github.com/user-attachments/files/16631179/woo-blueprint.json)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


This feature is behind a feature flag.
</details>
