### PR TITLE
Classic cart: Remove common query string variables which affect cart contents

### DIFF
--- a/plugins/woocommerce/changelog/50725-fix-cart-url-with-query-string
+++ b/plugins/woocommerce/changelog/50725-fix-cart-url-with-query-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Removes querystrings from cart URL introduced in #50524.
+

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1476,8 +1476,9 @@ function wc_transaction_query( $type = 'start', $force = false ) {
  */
 function wc_get_cart_url() {
 	if ( is_cart() && isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
-		$protocol = is_ssl() ? 'https' : 'http';
-		$cart_url = esc_url_raw( $protocol . '://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$protocol    = is_ssl() ? 'https' : 'http';
+		$current_url = esc_url_raw( $protocol . '://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$cart_url    = remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), $current_url );
 	} else {
 		$cart_url = wc_get_page_permalink( 'cart' );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses the comment in https://github.com/woocommerce/woocommerce/pull/50524#issuecomment-2293282355 in which we found that if a query string param is present that changes the cart, this is used in the form action on the classic cart page. This makes it so when you update the cart, the query string action repeats.

Fix is to remove common parameters like `?add-to-cart=`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In settings > products turn off "Enable AJAX add to cart buttons on archives"
2. Add an item to the cart. Ensure this item has some cross-sells configured. 
3. Go to the classic cart page.
4. See products in cross-sells area. Add one to cart. Note the query string contains `?add-to-cart=x`
5. Edit the qty of a line item and "update"
6. Ensure only that change occurred and the upsell product was not added to the cart again.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
Removes querystrings from cart URL introduced in #50524.

</details>
