### PR TITLE
fix: core profiler sticky footer button variable vh breakpoints

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
@@ -7,6 +7,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 import { Extension, ExtensionList } from '@woocommerce/data';
 import { useState } from 'react';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import { Heading } from '../components/heading/heading';
 import { Navigation } from '../components/navigation/navigation';
 import { PluginCard } from '../components/plugin-card/plugin-card';
 import { getAdminSetting } from '~/utils/admin-settings';
-import clsx from 'clsx';
 
 const locale = ( getAdminSetting( 'locale' )?.siteLocale || 'en_US' ).replace(
 	'_',

--- a/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
@@ -21,6 +21,7 @@ import { Heading } from '../components/heading/heading';
 import { Navigation } from '../components/navigation/navigation';
 import { PluginCard } from '../components/plugin-card/plugin-card';
 import { getAdminSetting } from '~/utils/admin-settings';
+import clsx from 'clsx';
 
 const locale = ( getAdminSetting( 'locale' )?.siteLocale || 'en_US' ).replace(
 	'_',
@@ -146,6 +147,10 @@ export const Plugins = ( {
 		].includes( plugin.key )
 	);
 
+	const pluginsCardRowCount = Math.ceil(
+		context.pluginsAvailable.length / 2
+	);
+
 	return (
 		<div
 			className="woocommerce-profiler-plugins"
@@ -170,7 +175,12 @@ export const Plugins = ( {
 				{ errorMessage && (
 					<p className="plugin-error">{ errorMessage }</p>
 				) }
-				<div className="woocommerce-profiler-plugins__list">
+				<div
+					className={ clsx(
+						'woocommerce-profiler-plugins__list',
+						`rows-${ pluginsCardRowCount }`
+					) }
+				>
 					{ context.pluginsAvailable.map( ( plugin ) => {
 						const learnMoreLink = plugin.learn_more_link ? (
 							<Link
@@ -219,7 +229,12 @@ export const Plugins = ( {
 						);
 					} ) }
 				</div>
-				<div className="woocommerce-profiler-plugins__footer">
+				<div
+					className={ clsx(
+						'woocommerce-profiler-plugins__footer',
+						`rows-${ pluginsCardRowCount }`
+					) }
+				>
 					<div className="woocommerce-profiler-plugins-continue-button-container">
 						<Button
 							className="woocommerce-profiler-plugins-continue-button"

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -345,12 +345,44 @@
 			margin-top: 12px !important;
 		}
 	}
+
+	$sticky-footer-height: 140px;
+
 	.woocommerce-profiler-plugins__list {
 		display: flex;
 		flex-direction: row;
 		flex-wrap: wrap;
 		gap: 16px;
 		flex: 50%;
+
+		@mixin sticky-footer-scroll-padding {
+			padding-bottom: $sticky-footer-height;
+		}
+	
+		@include breakpoint(">782px") {// sticky footer shouldn't apply to mobile layout
+			// since the height of each card is more or less fixed (actually its variable but we limit text to 2 lines), 
+			// we can estimate the visual breakpoints that are required to "unstick" the footer from the bottom of the page. 
+			&.rows-1 {
+				@media screen and ( max-height: 520px ) {
+					@include sticky-footer-scroll-padding;
+				}
+			}
+			&.rows-2 {
+				@media screen and ( max-height: 650px ) {
+					@include sticky-footer-scroll-padding;
+				}
+			}
+			&.rows-3 {
+				@media screen and ( max-height: 780px ) {
+					@include sticky-footer-scroll-padding;
+				}
+			}
+			&.rows-4 {
+				@media screen and ( max-height: 910px ) {
+					@include sticky-footer-scroll-padding;
+				}
+			}
+		}
 	}
 
 	.woocommerce-profiler-plugins-continue-button {
@@ -392,12 +424,38 @@
 		flex-direction: column;
 		align-items: center;
 
-		@media screen and ( max-height: 900px ) {
+		@mixin plugins-sticky-footer {
 			background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 44.69%);
 			height: 140px;
 			position: fixed;
 			bottom: 0;
 		}
+
+		@include breakpoint(">782px") { // sticky footer shouldn't apply to mobile layout
+			// since the height of each card is more or less fixed (actually its variable but we limit text to 2 lines), 
+			// we can estimate the visual breakpoints that are required to "unstick" the footer from the bottom of the page.
+			&.rows-1 {
+				@media screen and ( max-height: 520px ) {
+					@include plugins-sticky-footer;
+				}
+			}
+			&.rows-2 {
+				@media screen and ( max-height: 650px ) {
+					@include plugins-sticky-footer;
+				}
+			}
+			&.rows-3 {
+				@media screen and ( max-height: 780px ) {
+					@include plugins-sticky-footer;
+				}
+			}
+			&.rows-4 {
+				@media screen and ( max-height: 910px ) {
+					@include plugins-sticky-footer;
+				}
+			}
+		}
+		
 	}
 
 	.woocommerce-profiler-plugins-continue-button-container {

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -358,10 +358,10 @@
 		@mixin sticky-footer-scroll-padding {
 			padding-bottom: $sticky-footer-height;
 		}
-	
+
 		@include breakpoint(">782px") {// sticky footer shouldn't apply to mobile layout
-			// since the height of each card is more or less fixed (actually its variable but we limit text to 2 lines), 
-			// we can estimate the visual breakpoints that are required to "unstick" the footer from the bottom of the page. 
+			// since the height of each card is more or less fixed (actually its variable but we limit text to 2 lines),
+			// we can estimate the visual breakpoints that are required to "unstick" the footer from the bottom of the page.
 			&.rows-1 {
 				@media screen and ( max-height: 520px ) {
 					@include sticky-footer-scroll-padding;
@@ -432,7 +432,7 @@
 		}
 
 		@include breakpoint(">782px") { // sticky footer shouldn't apply to mobile layout
-			// since the height of each card is more or less fixed (actually its variable but we limit text to 2 lines), 
+			// since the height of each card is more or less fixed (actually its variable but we limit text to 2 lines),
 			// we can estimate the visual breakpoints that are required to "unstick" the footer from the bottom of the page.
 			&.rows-1 {
 				@media screen and ( max-height: 520px ) {
@@ -455,7 +455,7 @@
 				}
 			}
 		}
-		
+
 	}
 
 	.woocommerce-profiler-plugins-continue-button-container {

--- a/plugins/woocommerce/changelog/fix-core-profiler-plugins-sticky-footer-button
+++ b/plugins/woocommerce/changelog/fix-core-profiler-plugins-sticky-footer-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed Core Profiler's sticky footer button problem


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50178, #50719.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Launch a JN site with this branch and go to the core profiler
2. Set country to one of these: { fiji: 2 rows, indonesia: 3 rows, france: 4 rows } for the required number of plugin rows that you want to test
3. Go through the core profiler to the plugins page and test around. 
 
The continue button should not be sticky unless the viewport height is insufficient to show all the cards, and all the cards should be fully visible when scrolling. This should also not apply in the mobile view.


https://github.com/user-attachments/assets/5ee46691-fbd4-411f-83aa-50730610cf71



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
