### PR TITLE
Flag slow phpunit tests

### DIFF
--- a/plugins/woocommerce/phpunit.xml
+++ b/plugins/woocommerce/phpunit.xml
@@ -49,4 +49,7 @@
 			<file>./includes/wc-widget-functions.php</file>
 		</exclude>
 	</coverage>
+	<extensions>
+		<extension class="Automattic\WooCommerce\Tests\SlowTests" />
+	</extensions>
 </phpunit>

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -287,6 +287,9 @@ class WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/traits/trait-wc-rest-api-complex-meta.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/HPOSToggleTrait.php';
 		require_once dirname( $this->tests_dir ) . '/php/helpers/SerializingCacheTrait.php';
+
+		// Extensions.
+		require_once dirname( $this->tests_dir ) . '/php/helpers/SlowTests.php';
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/helpers/SlowTests.php
+++ b/plugins/woocommerce/tests/php/helpers/SlowTests.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests;
+
+use Automattic\Jetpack\IdentityCrisis\Exception;
+use PHPUnit\Runner\AfterTestHook;
+
+/**
+ *
+ */
+class SlowTests implements AfterTestHook {
+	/**
+	 * Threshold of what's considered "slow".
+	 */
+	protected const MAX_SECONDS_ALLOWED = 3;
+
+	/**
+	 *
+	 *
+	 * @param string $test Name of the test.
+	 * @param float  $time Elapsed time in seconds of the test.
+	 *
+	 * @return void
+	 */
+	public function executeAfterTest( string $test, float $time ): void {
+		if ( $time > self::MAX_SECONDS_ALLOWED ) {
+			fwrite( STDERR, sprintf( "\nThe %s test took %s seconds!\n", $test, $time ) );
+		}
+	}
+}


### PR DESCRIPTION
**This is not intended to be merged.**

Recently while trying to figure out why a bunch of tests were failing in [my PR](https://github.com/woocommerce/woocommerce/pull/50692), I ran the whole test suite locally (normally I just filter for specific tests), and I noticed that there were a bunch of tests that seem to take a loooooong time. I wondered if there was a good way to identify which tests these were, and after some searching I found [this article](https://aaronsaray.com/2021/finding-slow-tests-in-phpunit-9/).

So the changeset in this PR is an implementation of the extension discussed in the article, with a "slow test" threshold of 3 seconds. I ran the full test suite with this extension active and there are **80 tests** that surpass the threshold. Although, nearly all of them are way past 3 seconds, with an average of 9.2 seconds, and a few above 15 seconds. Obviously the timing of these tests can be variable, and may be faster/slower in other environments like CI. But with the numbers shown below, these tests collectively take over **12 minutes** to run.

As you can see, every single one of them is related to reports.

```
The WC_Admin_Tests_API_ProductsLowInStock::test_low_stock test took 7.651859379 seconds!
The WC_Admin_Tests_API_Reports_Categories::test_get_reports test took 7.171513003 seconds!
The WC_Admin_Tests_API_Reports_Categories::test_get_reports_categories_param test took 7.252111754 seconds!
The WC_Admin_Tests_API_Reports_Categories::test_get_reports_categories_sort test took 7.397390503 seconds!
The WC_Admin_Tests_API_Reports_Coupons_Stats::test_get_reports test took 7.481947712 seconds!
The WC_Admin_Tests_API_Reports_Coupons::test_get_reports test took 7.871677503 seconds!
The WC_Admin_Tests_API_Reports_Coupons::test_get_reports_coupons_param test took 7.299858211 seconds!
The WC_Admin_Tests_API_Reports_Customers_Stats::test_get_reports test took 8.172190212 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_user_creation test took 10.030503713 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_get_reports test took 8.114017628 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_search test took 7.903302921 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_get_reports_with_filter_empty test took 7.838757171 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_user_profile_name test took 7.860637462 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_billing_name test took 7.833468962 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_shipping_name test took 7.996129795 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_user_deletion test took 7.916966753 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_sync_order_customer test took 8.029619212 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_sync_latest_order_customer test took 8.123112295 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_sync_latest_order_customer_with_multiple_customers test took 8.398171461 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_get_last_order test took 8.931760879 seconds!
The WC_Admin_Tests_API_Reports_Downloads_Stats::test_get_report_with_user_filter test took 9.627980422 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_date_filter test took 10.651628046 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_product_filter test took 9.665541088 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_order_filter test took 9.893068547 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_user_filter test took 8.571670837 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_ip_address_filter test took 7.943404795 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_deleted_product test took 7.946299962 seconds!
The WC_Admin_Tests_API_Reports_Export::test_taxes_report_export test took 15.031257007 seconds!
The WC_Admin_Tests_API_Reports_Import::test_import_params test took 8.063384254 seconds!
The WC_Admin_Tests_API_Reports_Import::test_delete_stats test took 9.087046588 seconds!
The WC_Admin_Tests_API_Reports_Import::test_import_status test took 8.217980795 seconds!
The WC_Admin_Tests_API_Reports_Orders_Stats::test_product_attributes_filter test took 8.972321213 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_get_reports test took 8.138717879 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_get_reports_with_orphaned_refund test took 8.069469296 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_product_attributes_filter test took 9.011540129 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_custom_product_attributes_filter test took 10.849896172 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_product_variation_exclusion_filter test took 8.413865088 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_order_price_formatting_with_different_base_currency test took 8.303399503 seconds!
The WC_Admin_Tests_API_Reports_Performance_Indicators::test_get_indicators test took 8.399841962 seconds!
The WC_Admin_Tests_API_Reports_Products_Stats::test_get_reports test took 8.224058129 seconds!
The WC_Admin_Tests_API_Reports_Products::test_get_reports test took 16.177644423 seconds!
The WC_Admin_Tests_API_Reports_Products::test_get_reports_products_param test took 12.135282089 seconds!
The WC_Admin_Tests_API_Reports_Taxes_Stats::test_get_reports test took 8.405378587 seconds!
The WC_Admin_Tests_API_Reports_Taxes::test_get_reports test took 8.46526442 seconds!
The WC_Admin_Tests_API_Reports_Taxes::test_get_reports_taxes_param test took 8.68503738 seconds!
The WC_Admin_Tests_API_Reports_Variations::test_get_reports test took 8.529748004 seconds!
The WC_Admin_Tests_API_Reports_Variations::test_simple_products_excluded_from_variations_reports_by_default test took 8.571996753 seconds!
The WC_Admin_Tests_API_Reports_Variations::test_get_reports_variations_param test took 8.63920942 seconds!
The WC_Admin_Tests_Reports_Regenerate_Batching::test_queue_dependent_action test took 8.490106004 seconds!
The WC_Admin_Tests_Reports_Coupons_Stats::test_populate_and_query test took 8.771648129 seconds!
The WC_Admin_Tests_Reports_Coupons_Stats::test_deleted_coupon test took 11.856961006 seconds!
The WC_Admin_Tests_Reports_Coupons::test_populate_and_query test took 8.863062837 seconds!
The WC_Admin_Tests_Reports_Coupons::test_deleted_coupons test took 8.724935212 seconds!
The WC_Admin_Tests_Reports_Customer::test_customer_order_count test took 17.058729383 seconds!
The WC_Admin_Tests_Reports_Customer::test_order_deletion_removes_customer test took 8.787423711 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query test took 8.706576712 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_statuses test took 9.297790338 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_refunds test took 8.957721212 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_multiple_coupons test took 9.091193004 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_multiple_intervals test took 20.346302217 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_order_deletion test took 9.074559296 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_segmenting_by_product_and_variation test took 9.149284505 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_zero_fill_order_by_date test took 9.367587254 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_zero_fill_order_by_orders_count test took 9.400743462 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_guest_returning_customer test took 10.155412755 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_registered_returning_customer test took 10.465344547 seconds!
The WC_Admin_Tests_Reports_Orders::test_extended_info test took 9.114539754 seconds!
The WC_Admin_Tests_Reports_Orders::test_products_in_orders test took 9.687378838 seconds!
The WC_Admin_Tests_Reports_Orders::test_product_and_variation_includes_count test took 9.351572879 seconds!
The WC_Admin_Tests_Reports_Orders::test_coupon_exclusion_includes_orders_without_coupons test took 9.274998629 seconds!
The WC_Admin_Tests_Reports_Products::test_populate_and_query test took 9.383748921 seconds!
The WC_Admin_Tests_Reports_Products::test_order_by_product_name test took 11.760081589 seconds!
The WC_Admin_Tests_Reports_Products::test_extended_info test took 9.357908128 seconds!
The WC_Admin_Tests_Reports_Products::test_variable_product_extended_info test took 9.406975005 seconds!
The WC_Admin_Tests_Reports_Products::test_populate_and_refund test took 9.572978837 seconds!
The WC_Admin_Tests_Reports_Products::test_report_export_arguments test took 9.397020545 seconds!
The WC_Admin_Tests_Reports_Revenue_Stats::test_populate_and_query test took 9.469328796 seconds!
The WC_Admin_Tests_Reports_Variations::test_populate_and_query test took 9.530857088 seconds!
The WC_Admin_Tests_Reports_Variations::test_extended_info test took 9.507518254 seconds!
The WC_Admin_Tests_Reports_Variations::test_attribute_filtering test took 9.766785004 seconds!
```