### PR TITLE
[WIP][Accessibility] Fix inline documentation typos in woocommerce-blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -118,7 +118,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 };
 
 export default ( props: Props ) => {
-	// It is necessary because this block has to support serveral contexts:
+	// It is necessary because this block has to support several contexts:
 	// - Inside `All Products Block` -> `withProductDataContext` HOC
 	// - Inside `Products Block` -> Gutenberg Context
 	// - Inside `Single Product Template` -> Gutenberg Context

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -60,7 +60,7 @@ const Edit = ( {
 			<div
 				{ ...blockProps }
 				/**
-				 * If block is decendant of the All Products block, we don't want to
+				 * If block is descendant of the All Products block, we don't want to
 				 * apply style here because it will be applied inside Block using
 				 * useColors, useTypography, and useSpacing hooks.
 				 */

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/edit.tsx
@@ -43,7 +43,7 @@ const Edit = ( {
 		<div
 			{ ...blockProps }
 			/**
-			 * If block is decendant of the All Products block, we don't want to
+			 * If block is descendant of the All Products block, we don't want to
 			 * apply style here because it will be applied inside Block using
 			 * useColors, useTypography, and useSpacing hooks.
 			 */

--- a/plugins/woocommerce-blocks/assets/js/base/components/block-error-boundary/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/block-error-boundary/types.ts
@@ -18,7 +18,7 @@ interface BlockErrorBase {
 	 */
 	text?: React.ReactNode | undefined;
 	/**
-	 * Text preceeding the error message.
+	 * Text preceding the error message.
 	 */
 	errorMessagePrefix?: string | undefined;
 	/**
@@ -26,7 +26,7 @@ interface BlockErrorBase {
 	 */
 	button?: React.ReactNode;
 	/**
-	 * Controls wether to show the error block or fail silently
+	 * Controls whether to show the error block or fail silently
 	 */
 	showErrorBlock?: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/price-slider/index.tsx
@@ -78,7 +78,7 @@ export interface PriceSliderProps {
 	 */
 	step?: number;
 	/**
-	 * Wheter we're in the editor or not.
+	 * Whether we're in the editor or not.
 	 */
 	isEditor?: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/collections/use-collection.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/collections/use-collection.ts
@@ -13,7 +13,7 @@ import { isError } from '@woocommerce/types';
  * kept up to date with the collection matching that query in the store state.
  *
  * @throws {Object} Throws an exception object if there was a problem with the
- * 					API request, to be picked up by BlockErrorBoundry.
+ * 					API request, to be picked up by BlockErrorBoundary.
  *
  * @param {Object}  options                  An object declaring the various
  *                                           collection arguments.

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/test/use-query-state.jsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/test/use-query-state.jsx
@@ -63,7 +63,7 @@ describe( 'Testing Query State Hooks', () => {
 	 * arguments.
 	 *
 	 * @param {Function} hookTested      The hook being tested to use in the
-	 *                                   test comopnent.
+	 *                                   test component.
 	 * @param {Array}    propKeysForArgs An array of keys for the props that
 	 *                                   will be used on the test component that
 	 *                                   will have values fed to the tested

--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/block.tsx
@@ -212,7 +212,7 @@ const ActiveFiltersBlock = ( {
 	] );
 
 	/**
-	 * Parse the filter URL to set the active rating fitlers.
+	 * Parse the filter URL to set the active rating filters.
 	 * This code should be moved to Rating Filter block once it's implemented.
 	 */
 	useEffect( () => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/hacks.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/hacks.ts
@@ -142,7 +142,7 @@ const useLockedChildren = ( {
 
 			const clientId = targetNode.dataset.block;
 			const isLocked = isBlockLocked( clientId );
-			// Prevent the keyboard event from propogating if it supports locking.
+			// Prevent the keyboard event from propagating if it supports locking.
 			if ( isLocked ) {
 				event.preventDefault();
 				event.stopPropagation();

--- a/plugins/woocommerce-blocks/assets/js/data/checkout/actions.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/checkout/actions.ts
@@ -63,7 +63,7 @@ export const __internalSetRedirectUrl = ( redirectUrl: string ) => ( {
 /**
  * Set whether the checkout has an error or not
  *
- * @param hasError Wether the checkout has an error or not
+ * @param hasError Whether the checkout has an error or not
  */
 export const __internalSetHasError = ( hasError = true ) => ( {
 	type: types.SET_HAS_ERROR,

--- a/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/test/hierarchy.js
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/search-list-control/test/hierarchy.js
@@ -153,7 +153,7 @@ describe( 'buildTermsTree', () => {
 		] );
 	} );
 
-	test( 'should return a tree of items, with orphan categories appended to the end, with children of thier own', () => {
+	test( 'should return a tree of items, with orphan categories appended to the end, with children of their own', () => {
 		const filteredList = [
 			{ id: 1, name: 'Apricots', parent: 0 },
 			{ id: 3, name: 'Elderberry', parent: 2 },

--- a/plugins/woocommerce-blocks/assets/js/interactivity/vdom.js
+++ b/plugins/woocommerce-blocks/assets/js/interactivity/vdom.js
@@ -21,7 +21,7 @@ const directiveParser = new RegExp(
 		// segments. It excludes underscore intentionally to prevent confusion.
 		// E.g., "custom-directive".
 		'([a-z0-9]+(?:-[a-z0-9]+)*)' +
-		// (Optional) Match '--' followed by any alphanumeric charachters. It
+		// (Optional) Match '--' followed by any alphanumeric characters. It
 		// excludes underscore intentionally to prevent confusion, but it can
 		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
 		'(?:--([a-z0-9_-]+))?$',

--- a/plugins/woocommerce-blocks/bin/gen-block-list-doc.js
+++ b/plugins/woocommerce-blocks/bin/gen-block-list-doc.js
@@ -103,12 +103,12 @@ function processObjWithInnerKeys( obj ) {
  * not disabled. So adding { color: 'link' } support also brings along
  * background and text.
  *
- * @param {Object} supports - keys supported by blokc
+ * @param {Object} supports - keys supported by block
  * @return {Object} supports augmented with defaults
  */
 function augmentSupports( supports ) {
 	if ( supports && 'color' in supports ) {
-		// If backgroud or text is not specified (true or false)
+		// If background or text is not specified (true or false)
 		// then add it as true.a
 		if (
 			typeof supports.color === 'object' &&

--- a/plugins/woocommerce-blocks/phpcs.xml
+++ b/plugins/woocommerce-blocks/phpcs.xml
@@ -9,7 +9,7 @@
 
 	<!-- Configs -->
 	<!--
-		It shoudld match the minimum WP version supported by WooCommerce Core
+		It should match the minimum WP version supported by WooCommerce Core
 		(see https://github.com/woocommerce/woocommerce-blocks/blob/trunk/.github/release-initial-checklist.md#initial-preparation)
 	-->
 	<config name="minimum_supported_wp_version" value="6.3" />

--- a/plugins/woocommerce-blocks/readme.txt
+++ b/plugins/woocommerce-blocks/readme.txt
@@ -2723,7 +2723,7 @@ This release fixes an error that some users experienced when their site automati
 
 - Fix - Ensure empty categories are correctly hidden in the product categories block. ([3765](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3765))
 - Fix - Added missing wrapper div within FeaturedCategory and FeatureProduct blocks. ([3746](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3746))
-- Fix - Set correct text color in BlockErrorBoundry notices. ([3738](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3738))
+- Fix - Set correct text color in BlockErrorBoundary notices. ([3738](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3738))
 - Hidden cart item meta data will not be rendered in the Cart and Checkout blocks. ([3732](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3732))
 - Fix - Improved accessibility of product image links in the products block by using correct aria tags and hiding empty image placeholders. ([3722](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3722))
 - Add missing aria-label for stars image in the review-list-item component. ([3706](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3706))

--- a/plugins/woocommerce-blocks/storybook/main.js
+++ b/plugins/woocommerce-blocks/storybook/main.js
@@ -35,7 +35,7 @@ module.exports = {
 	},
 	// webpackFinal field was added in following PR: https://github.com/woocommerce/woocommerce-blocks/pull/7514
 	// This fixes "storybook build issue" related to framer-motion library.
-	// Solution is from this commment: https://github.com/storybookjs/storybook/issues/16690#issuecomment-971579785
+	// Solution is from this comment: https://github.com/storybookjs/storybook/issues/16690#issuecomment-971579785
 	webpackFinal: async ( config ) => {
 		config.module.rules.push( {
 			test: /\.mjs$/,

--- a/plugins/woocommerce/changelog/50737-fix-37502-inline-doc-typos-in-woo-blocks
+++ b/plugins/woocommerce/changelog/50737-fix-37502-inline-doc-typos-in-woo-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Fix inline documentation typos in woocommerce-blocks.
+

--- a/plugins/woocommerce/changelog/fix-37502-inline-doc-typos-in-woo-blocks
+++ b/plugins/woocommerce/changelog/fix-37502-inline-doc-typos-in-woo-blocks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Fix inline documentation typos in woocommerce-blocks.

--- a/plugins/woocommerce/changelog/fix-37502-inline-doc-typos-in-woo-blocks
+++ b/plugins/woocommerce/changelog/fix-37502-inline-doc-typos-in-woo-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Fix inline documentation typos in woocommerce-blocks.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes part of the #37502 issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

NA.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix inline documentation typos in woocommerce-blocks.

</details>
