### PR TITLE
Fixed permission issue while editing orders

### DIFF
--- a/plugins/woocommerce/changelog/50764-origin-fix-48124-edit-order-permission
+++ b/plugins/woocommerce/changelog/50764-origin-fix-48124-edit-order-permission
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed edit order permission issue for custom user roles.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -67,7 +67,7 @@ class PageController {
 			wp_die( esc_html__( 'Order type mismatch.', 'woocommerce' ) );
 		}
 
-		if ( ! current_user_can( get_post_type_object( $this->order_type )->cap->edit_post, $this->order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ! current_user_can( get_post_type_object( $this->order_type )->cap->edit_post, $this->order->get_id() ) && ! current_user_can( 'edit_shop_orders' ) ) {
 			wp_die( esc_html__( 'You do not have permission to edit this order', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

See related issue #48124, users logged in with a custom user role are unable to edit orders with permission `edit_shop_orders`.
Generic `manage_woocommerce` user role is used to check permissions. See: https://github.com/woocommerce/woocommerce/blob/99d8b9bf42a0a949cf65228ed377e277cc945d98/plugins/woocommerce/includes/class-wc-ajax.php#L577 where `edit_shop_orders` is already widely used.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a custom role
2. Add the `read`, `read_shop_order` and `edit_shop_orders` capabilities
3. Create a new user with the custom role
4. Login as the new user
5. Go to Orders->Edit order page

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Fixed edit order permission issue for custom user roles.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
