### PR TITLE
Fix wcadmin-product-usage-notice-modal react18 createroot

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/woo-product-usage-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/woo-product-usage-notice/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ const {
 const container = document.createElement( 'div' );
 container.setAttribute( 'id', 'woo-product-usage-notice' );
 
-render(
+createRoot( document.body.appendChild( container ) ).render(
 	<ProductUsageNoticeModal
 		renewUrl={ renewUrl }
 		subscribeUrl={ subscribeUrl }
@@ -41,6 +41,5 @@ render(
 		colorScheme={ colorScheme }
 		subscriptionState={ subscriptionState }
 		screenId={ screenId }
-	/>,
-	document.body.appendChild( container )
+	/>
 );

--- a/plugins/woocommerce/changelog/fix-wcadmin-react18-product-usage-notice-modal
+++ b/plugins/woocommerce/changelog/fix-wcadmin-react18-product-usage-notice-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Changed from using React.render to React.createRoot for product-usage-notice-modal as it has been deprecated since React 18


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change how we render the `ProductUsageNoticeModal` component onto the page. We did it with `ReactDOM.render` but that's no longer supported after React 18. This PR updates it to `createRoot().render()`.

### How to test the changes in this Pull Request:

> [!NOTE]  
> Nothing changes other than way initiating a React tree. Therefore same instruction tests from #47697 are copied below

##### Overview

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout the branch on wccom's repo that serves the new endpoint
2. Install and activate either AW or WCS on the store without active subscription
3. Go to any screen IDs defined in the wccom's endpoint response, for example—with AW—go to `/wp-admin/edit.php?post_type=aw_workflow`.
4. Modal should be displayed like following:

   <img width="971" alt="image" src="https://github.com/woocommerce/woocommerce/assets/78313/ee1013aa-ca10-4420-bc59-7e933c192385">


5. Clicking any buttons or outside the modal will dismiss the modal. It will be counted as one and persisted in the user meta.
6. Last time dismissed (globally and per-product) and count of dismissals are stored as user meta

##### Tracks events

* Clicking "maybe later" should fire Tracks event `wcadmin_product_usage_notice_maybe_later_clicked` with props `product_id` and `screen_id` passed
* Dismissing the modal (clicking 'x' or outside the modal) should fire Tracks event `wcadmin_product_usage_notice_dismissed` with props `product_id` and `screen_id` passed
* When the modal shown, it should fire Tracks event `wcadmin_product_usage_notice_opened` with props `product_id` and `screen_id` passed

##### UTM params

The CTA should have UTM params in the URL

```
'utm_source'    => 'pu',
'utm_medium'    => 'product',
'utm_campaign'  => 'pu_modal_(subscribe|renew)',
```


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
