### PR TITLE
Track product and tax rates importer view triggered from WP importer/exporter

### DIFF
--- a/plugins/woocommerce/changelog/50769-add-tracking-to-wp-import-export-screen
+++ b/plugins/woocommerce/changelog/50769-add-tracking-to-wp-import-export-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracks for WordPress Importer/Export pages.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -333,7 +333,7 @@ class WC_Admin_Importers {
 	public function track_importer_exporter_view() {
 		$screen = get_current_screen();
 
-		if ( ! isset( $screen ) ) {
+		if ( ! isset( $screen->id ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -337,6 +337,11 @@ class WC_Admin_Importers {
 			return;
 		}
 
+		// Don't track if we're in a specific import screen.
+		if ( isset( $_GET['import'] ) ) {
+			return;
+		}
+
 		if ( 'import' === $screen->id || 'export' === $screen->id ) {
 			wc_admin_record_tracks_event( 'wordpress_' . $screen->id . '_view' );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -34,7 +34,7 @@ class WC_Admin_Importers {
 		add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 		add_action( 'wp_ajax_woocommerce_do_ajax_product_import', array( $this, 'do_ajax_product_import' ) );
-		add_action( 'in_admin_footer', array( __CLASS__, 'track_importer_exporter_view' ) );
+		add_action( 'in_admin_footer', array( $this, 'track_importer_exporter_view' ) );
 
 		// Register WooCommerce importers.
 		$this->importers['product_importer'] = array(

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -1,4 +1,4 @@
-<?php
+<?php //phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
 /**
  * Init WooCommerce data importers.
  *
@@ -34,6 +34,7 @@ class WC_Admin_Importers {
 		add_action( 'admin_head', array( $this, 'hide_from_menus' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 		add_action( 'wp_ajax_woocommerce_do_ajax_product_import', array( $this, 'do_ajax_product_import' ) );
+		add_action( 'in_admin_footer', array( __CLASS__, 'track_importer_exporter_view' ) );
 
 		// Register WooCommerce importers.
 		$this->importers['product_importer'] = array(
@@ -96,8 +97,13 @@ class WC_Admin_Importers {
 	 */
 	public function product_importer() {
 		if ( Constants::is_defined( 'WP_LOAD_IMPORTERS' ) ) {
-			wp_safe_redirect( admin_url( 'edit.php?post_type=product&page=product_importer' ) );
+			wp_safe_redirect( admin_url( 'edit.php?post_type=product&page=product_importer&source=wordpress-importer' ) );
 			exit;
+		}
+
+		// phpcs:ignore
+		if ( isset( $_GET['source'] ) && 'wordpress-importer' === sanitize_text_field( wp_unslash( $_GET['source'] ) ) ) {
+			wc_admin_record_tracks_event( 'product_importer_view_from_wp_importer' );
 		}
 
 		include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
@@ -132,7 +138,9 @@ class WC_Admin_Importers {
 			}
 		}
 
-		require dirname( __FILE__ ) . '/importers/class-wc-tax-rate-importer.php';
+		wc_admin_record_tracks_event( 'tax_rates_importer_view_from_wp_importer' );
+
+		require __DIR__ . '/importers/class-wc-tax-rate-importer.php';
 
 		$importer = new WC_Tax_Rate_Importer();
 		$importer->dispatch();
@@ -182,7 +190,9 @@ class WC_Admin_Importers {
 								// Register the taxonomy now so that the import works!
 								register_taxonomy(
 									$term['domain'],
+									// phpcs:ignore
 									apply_filters( 'woocommerce_taxonomy_objects_' . $term['domain'], array( 'product' ) ),
+									// phpcs:ignore
 									apply_filters(
 										'woocommerce_taxonomy_args_' . $term['domain'],
 										array(
@@ -229,7 +239,7 @@ class WC_Admin_Importers {
 			 *
 			 * @param int $size Batch size.
 			 *
-			 * @since
+			 * @since 3.1.0
 			 */
 			'lines'              => apply_filters( 'woocommerce_product_import_batch_size', 30 ),
 			'parse'              => true,
@@ -312,6 +322,23 @@ class WC_Admin_Importers {
 					'skipped'             => is_countable( $results['skipped'] ) ? count( $results['skipped'] ) : 0,
 				)
 			);
+		}
+	}
+
+	/**
+	 * Track importer/exporter view.
+	 *
+	 * @return void
+	 */
+	public function track_importer_exporter_view() {
+		$screen = get_current_screen();
+
+		if ( ! isset( $screen ) ) {
+			return;
+		}
+
+		if ( 'import' === $screen->id || 'export' === $screen->id ) {
+			wc_admin_record_tracks_event( 'wordpress_' . $screen->id . '_view' );
 		}
 	}
 }

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -338,6 +338,7 @@ class WC_Admin_Importers {
 		}
 
 		// Don't track if we're in a specific import screen.
+		// phpcs:ignore
 		if ( isset( $_GET['import'] ) ) {
 			return;
 		}


### PR DESCRIPTION
…screen

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50757 

This PR adds the following tracks 

**product_importer_view_from_wp_importer:** Triggered when a user clicks on `Run importer` for `WooCommerce products (CSV)` on the Tools -> Import page.

**tax_rates_importer_view_from_wp_importer:** Triggered when a user clicks on `Run importer` for `WooCommerce tax rates (CS)` on the Tools -> Import page.

**wordpress_export_view**: Triggered when a user views `Tools -> Export` page.
**wordpress_import_view**: Triggered when a user views `Tools -> Import` page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Make sure `Allow usage of WooCommerce to be tracked` is checked on `WooCommerce -> Settings -> Advanced -> WooCommerce.com`
3. Open your browser's inspector and click on the `Network` tab and search for `t.gif`
4. Navigate to `Tools -> Export`.
5. Confirm the `wordpress_export_view` event.
6. Navigate to `Tools -> Import`.
7. Confirm the `wordpress_import_view` event.
8. Click on `Run Importer` for `WooCommerce products (CSV)`
9. Confirm the `product_importer_view_from_wp_importer` event.
10. Go back to the importer screen.
11. Click on `Run Importer` for `WooCommerce tax rates (CSV)`
12. Confirm the `tax_rates_importer_view_from_wp_importer` event.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add tracks for WordPress Importer/Export pages.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
