### PR TITLE
Rename woocommerce_is_store_page to woocommerce_is_extension_store_page

### DIFF
--- a/plugins/woocommerce/changelog/50771-update-rename-woocommerce_is_store_page_filter
+++ b/plugins/woocommerce/changelog/50771-update-rename-woocommerce_is_store_page_filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Rename woocommerce_is_store_page to woocommerce_is_extension_store_page

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -236,7 +236,7 @@ class WCAdminHelper {
 		 * @param bool   $is_store_page Whether or not the URL is a store page.
 		 * @param string $url           URL to check.
 		 */
-		$is_store_page = apply_filters( 'woocommerce_is_store_page', false, $url );
+		$is_store_page = apply_filters( 'woocommerce_is_extension_store_page', false, $url );
 
 		return filter_var( $is_store_page, FILTER_VALIDATE_BOOL );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50621  

This PR renames `woocommerce_is_store_page to` to `woocommerce_is_extension_store_page`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch and complete/skip the core profiler.
2. Navigate to `WooCommerce -> Settings -> Site visibility` 
3. Turn on `Coming soon` and make sure to turn on `Restrict to store pages only`
4. Click on `Save changes`
5. Install and activate [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
6. Navigate to `Snippets -> Add new` and past the following code

```
add_filter('woocommerce_is_extension_store_page', function($is_store_page, $url) {
	return $url === get_site_url();
}, 10, 2);
```

7. Open an incognito window and visit the site home.
8. Confirm the home renders a coming soon page.
9. Go back to the snippet and return `false` and save the change.
10. Go back to the home page and refresh.
11. It should display the home page now.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Rename woocommerce_is_store_page to woocommerce_is_extension_store_page

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
