### PR TITLE
Avoid fatal in `wc_get_chosen_shipping_method_ids`

### DIFF
--- a/plugins/woocommerce/changelog/fix-50283-fatal-shipping-methods
+++ b/plugins/woocommerce/changelog/fix-50283-fatal-shipping-methods
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure session object is initialized before attempting to get chosen shipping methods

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -413,7 +413,12 @@ function wc_cart_round_discount( $value, $precision ) {
  */
 function wc_get_chosen_shipping_method_ids() {
 	$method_ids     = array();
-	$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+	$chosen_methods = array();
+
+	if ( is_callable( array( WC()->session, 'get' ) ) ) {
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+	}
+
 	foreach ( $chosen_methods as $chosen_method ) {
 		if ( ! is_string( $chosen_method ) ) {
 			continue;
@@ -421,6 +426,7 @@ function wc_get_chosen_shipping_method_ids() {
 		$chosen_method = explode( ':', $chosen_method );
 		$method_ids[]  = current( $chosen_method );
 	}
+
 	return $method_ids;
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This ensures the WC() session object is initialized before attempting to get chosen shipping methods. If it's not initialized, `wc_get_chosen_shipping_method_ids` will return an empty array.

Fixes #50283

### How to test the changes in this Pull Request:

1. Follow the "Steps to reproduce" in #50283. With this PR branch, there should not be any fatal errors.