### PR TITLE
Site visibility settings add documentation link and copy changes

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/constants.ts
+++ b/plugins/woocommerce-admin/client/launch-your-store/constants.ts
@@ -8,7 +8,7 @@ export const COMING_SOON_PAGE_EDITOR_LINK = getAdminLink(
 );
 
 export const SITE_VISIBILITY_DOC_LINK =
-	'https://woocommerce.com/document/woocommerce-launch-your-store/';
+	'https://woocommerce.com/document/configuring-woocommerce-settings/coming-soon-mode/';
 
 export const LAUNCH_YOUR_STORE_DOC_LINK =
 	'https://woocommerce.com/document/configuring-woocommerce-settings/#site-visibility';

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -132,9 +132,18 @@ const SiteVisibility = () => {
 			/>
 			<h2>{ __( 'Site visibility', 'woocommerce' ) }</h2>
 			<p className="site-visibility-settings-slotfill-description">
-				{ __(
-					'Manage how your site appears to visitors.',
-					'woocommerce'
+				{ createInterpolateElement(
+					__(
+						'Manage how your site appears to visitors. <a>Learn more</a>',
+						'woocommerce'
+					),
+					{
+						a: createElement( 'a', {
+							target: '_blank',
+							rel: 'noreferrer',
+							href: SITE_VISIBILITY_DOC_LINK,
+						} ),
+					}
 				) }
 			</p>
 			<div className="site-visibility-settings-slotfill-section">
@@ -162,6 +171,7 @@ const SiteVisibility = () => {
 								),
 								{
 									a: createElement( 'a', {
+										target: '_blank',
 										href: COMING_SOON_PAGE_EDITOR_LINK,
 									} ),
 								}
@@ -183,20 +193,13 @@ const SiteVisibility = () => {
 						label={
 							<>
 								{ __(
-									'Restrict to store pages only',
+									'Apply to store pages only',
 									'woocommerce'
 								) }
 								<p>
-									{ createInterpolateElement(
-										__(
-											'Display a "coming soon" message on your <a>store pages</a> — the rest of your site will remain visible.',
-											'woocommerce'
-										),
-										{
-											a: createElement( 'a', {
-												href: SITE_VISIBILITY_DOC_LINK,
-											} ),
-										}
+									{ __(
+										'Display a “coming soon” message on your store pages — the rest of your site will remain visible.',
+										'woocommerce'
 									) }
 								</p>
 							</>

--- a/plugins/woocommerce/changelog/fix-50779-site-visibility-settings-add-documentation-link-and-copy-changes
+++ b/plugins/woocommerce/changelog/fix-50779-site-visibility-settings-add-documentation-link-and-copy-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add link to title, remove link from a description, minor copy changes to site visibility settings page

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -198,7 +198,7 @@ class ExportWCSettings implements StepExporter, HasAlias {
 
 		$option_info['woocommerce_store_pages_only'] = array(
 			'location' => 'site_visibility.general',
-			'title'    => 'Restrict to store pages only',
+			'title'    => 'Apply to store pages only',
 		);
 
 		return compact( 'options', 'pages', 'option_info' );

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -113,7 +113,7 @@ class ComingSoonRequestHandler {
 			return false;
 		}
 
-		// Do not show coming soon on 404 pages when restrict to store pages only.
+		// Do not show coming soon on 404 pages when applied to store pages only.
 		if ( $this->coming_soon_helper->is_store_coming_soon() && is_404() ) {
 			return false;
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
@@ -132,7 +132,7 @@ test.describe(
 			// The store only checkbox should not be on the page.
 			await expect(
 				page.getByRole( 'checkbox', {
-					name: 'Restrict to store pages only',
+					name: 'Apply to store pages only',
 				} )
 			).toHaveCount( 0 );
 
@@ -156,14 +156,14 @@ test.describe(
 			// The store only checkbox should be visible.
 			await expect(
 				page.getByRole( 'checkbox', {
-					name: 'Restrict to store pages only',
+					name: 'Apply to store pages only',
 				} )
 			).toBeVisible();
 
 			// The store only checkbox should not be checked.
 			await expect(
 				page.getByRole( 'checkbox', {
-					name: 'Restrict to store pages only',
+					name: 'Apply to store pages only',
 				} )
 			).not.toBeChecked();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #50779

Minor copy changes and add documentation link.

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/3dc3f851-ecb2-4b13-aebe-9f3069a7ac5b">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to `WooCommerce > Settings > Site visibility`
2. Observe the copy changes highlighted in screenshot:
    - `Manage how your site appears to visitors. Learn more`
    - `Apply to store pages only`
    - Removed link from `store pages`
3. Click on `Learn more`
4. Observe `https://woocommerce.com/document/configuring-woocommerce-settings/coming-soon-mode/` is opened in a new tab
5. Click on `Editor`
6. Observe it opens up site editor in a new tab

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
