### PR TITLE
Revert "Prevent initializing coming soon feature if it's already initialized"

### DIFF
--- a/plugins/woocommerce/changelog/update-lys-init-coming-soon
+++ b/plugins/woocommerce/changelog/update-lys-init-coming-soon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Prevent initializing coming soon feature if it's already initialized

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -128,11 +128,6 @@ class LaunchYourStore {
 			return;
 		}
 
-		if ( false === get_option( 'woocommerce_store_pages_only', false ) ) {
-			// Coming soon already initialized.
-			return false;
-		}
-
 		$coming_soon      = 'yes';
 		$store_pages_only = WCAdminHelper::is_site_fresh() ? 'no' : 'yes';
 		$private_link     = 'no';


### PR DESCRIPTION
Reverts woocommerce/woocommerce#50668 as it's causing Coming Soon to not be enabled after going through Core Profiler