### PR TITLE
Conditionally initialize block template compatibility classes

### DIFF
--- a/plugins/woocommerce/changelog/fix-46527-compatibility-layer-init
+++ b/plugins/woocommerce/changelog/fix-46527-compatibility-layer-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Conditionally initialize block template compatibility classes

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -132,8 +132,27 @@ class Bootstrap {
 				$is_store_api_request = wc()->is_store_api_request();
 
 				if ( ! $is_store_api_request && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
+
 					$this->container->get( BlockTemplatesRegistry::class )->init();
 					$this->container->get( BlockTemplatesController::class )->init();
+
+					if ( wc_current_theme_is_fse_theme() ) {
+						$this->container->register(
+							ArchiveProductTemplatesCompatibility::class,
+							function () {
+								return new ArchiveProductTemplatesCompatibility();
+							}
+						);
+						$this->container->register(
+							SingleProductTemplateCompatibility::class,
+							function () {
+								return new SingleProductTemplateCompatibility();
+							}
+						);
+
+						$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
+						$this->container->get( SingleProductTemplateCompatibility::class )->init();
+					}
 				}
 			},
 			999
@@ -169,8 +188,6 @@ class Bootstrap {
 			$this->container->get( BlockPatterns::class );
 			$this->container->get( BlockTypesController::class );
 			$this->container->get( ClassicTemplatesCompatibility::class );
-			$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
-			$this->container->get( SingleProductTemplateCompatibility::class )->init();
 			$this->container->get( Notices::class )->init();
 			$this->container->get( PTKPatternsStore::class );
 			$this->container->get( TemplateOptions::class )->init();
@@ -274,18 +291,6 @@ class Bootstrap {
 			function ( Container $container ) {
 				$asset_data_registry = $container->get( AssetDataRegistry::class );
 				return new ClassicTemplatesCompatibility( $asset_data_registry );
-			}
-		);
-		$this->container->register(
-			ArchiveProductTemplatesCompatibility::class,
-			function () {
-				return new ArchiveProductTemplatesCompatibility();
-			}
-		);
-		$this->container->register(
-			SingleProductTemplateCompatibility::class,
-			function () {
-				return new SingleProductTemplateCompatibility();
 			}
 		);
 		$this->container->register(

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -132,27 +132,8 @@ class Bootstrap {
 				$is_store_api_request = wc()->is_store_api_request();
 
 				if ( ! $is_store_api_request && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
-
 					$this->container->get( BlockTemplatesRegistry::class )->init();
 					$this->container->get( BlockTemplatesController::class )->init();
-
-					if ( wc_current_theme_is_fse_theme() ) {
-						$this->container->register(
-							ArchiveProductTemplatesCompatibility::class,
-							function () {
-								return new ArchiveProductTemplatesCompatibility();
-							}
-						);
-						$this->container->register(
-							SingleProductTemplateCompatibility::class,
-							function () {
-								return new SingleProductTemplateCompatibility();
-							}
-						);
-
-						$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
-						$this->container->get( SingleProductTemplateCompatibility::class )->init();
-					}
 				}
 			},
 			999

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -21,10 +21,6 @@ abstract class AbstractTemplateCompatibility {
 	 * Initialization method.
 	 */
 	public function init() {
-		if ( ! wc_current_theme_is_fse_theme() ) {
-			return;
-		}
-
 		$this->set_hook_data();
 
 		add_filter(

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -62,11 +62,13 @@ class ProductAttributeTemplate extends AbstractTemplate {
 		}
 
 		if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) ) {
+			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+			$compatibility_layer->init();
+
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
-				$compatibility_layer->init();
+			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -61,10 +62,12 @@ class ProductAttributeTemplate extends AbstractTemplate {
 		}
 
 		if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) ) {
+
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+				$compatibility_layer->init();
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -62,7 +62,6 @@ class ProductAttributeTemplate extends AbstractTemplate {
 		}
 
 		if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) ) {
-
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
 			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -50,12 +50,13 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) ) {
+			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+			$compatibility_layer->init();
 
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
-				$compatibility_layer->init();
+			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -49,10 +50,12 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) ) {
+
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+				$compatibility_layer->init();
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
@@ -56,11 +56,13 @@ class ProductCategoryTemplate extends AbstractTemplate {
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_cat' ) ) {
+			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+			$compatibility_layer->init();
+
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
-				$compatibility_layer->init();
+			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -57,8 +58,9 @@ class ProductCategoryTemplate extends AbstractTemplate {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_cat' ) ) {
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+				$compatibility_layer->init();
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -49,11 +49,13 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_post_type_archive( 'product' ) && is_search() ) {
+			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+			$compatibility_layer->init();
+
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
-				$compatibility_layer->init();
+			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -50,8 +51,9 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 		if ( ! is_embed() && is_post_type_archive( 'product' ) && is_search() ) {
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+				$compatibility_layer->init();
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -57,8 +58,9 @@ class ProductTagTemplate extends AbstractTemplate {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_tag' ) ) {
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+				$compatibility_layer->init();
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
@@ -56,11 +56,13 @@ class ProductTagTemplate extends AbstractTemplate {
 	 */
 	public function render_block_template() {
 		if ( ! is_embed() && is_product_taxonomy() && is_tax( 'product_tag' ) ) {
+			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
+			$compatibility_layer->init();
+
 			$templates = get_block_templates( array( 'slug__in' => array( self::SLUG ) ) );
 
-			if ( isset( $templates[0] ) && ! BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
-				$compatibility_layer = new ArchiveProductTemplatesCompatibility();
-				$compatibility_layer->init();
+			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -76,7 +76,8 @@ class SingleProductTemplate extends AbstractTemplate {
 			}
 
 			if ( isset( $template ) && BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+				$compatibility_layer = new SingleProductTemplateCompatibility();
+				$compatibility_layer->init();
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -51,6 +51,9 @@ class SingleProductTemplate extends AbstractTemplate {
 		if ( ! is_embed() && is_singular( 'product' ) ) {
 			global $post;
 
+			$compatibility_layer = new SingleProductTemplateCompatibility();
+			$compatibility_layer->init();
+
 			$valid_slugs         = array( self::SLUG );
 			$single_product_slug = 'product' === $post->post_type && $post->post_name ? 'single-product-' . $post->post_name : '';
 			if ( $single_product_slug ) {
@@ -76,8 +79,7 @@ class SingleProductTemplate extends AbstractTemplate {
 			}
 
 			if ( isset( $template ) && BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-				$compatibility_layer = new SingleProductTemplateCompatibility();
-				$compatibility_layer->init();
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -14,7 +14,6 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	const IS_FIRST_BLOCK = '__wooCommerceIsFirstBlock';
 	const IS_LAST_BLOCK  = '__wooCommerceIsLastBlock';
 
-
 	/**
 	 * Inject hooks to rendered content of corresponding blocks.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/46527.

This PR makes it so we only initialize the `ArchiveProductTemplatesCompatibility` and the `SingleProductTemplateCompatibility` classes when they are going to be used. That means the site is using a block theme, the current page is the Single Product or a Product Archive template, etc.

### How to test the changes in this Pull Request:

No functionality is added in this PR, so testing means making sure there are no regressions:

1. With a block theme, make sure you are using the blockified templates. You can make sure by going to Appearance > Site Editor > Templates, opening the Single Product and Product Catalog templates and making sure they are made of smaller blocks and there is the "Revert to Classic Template" button in the sidebar.
2. Add some code that hooks into PHP hooks (you can use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin if necessary). Ie:

```PHP
add_action('woocommerce_before_single_product', function() {
	echo 'woocommerce_before_single_product';
});
add_action('woocommerce_before_single_product_summary', function() {
	echo 'woocommerce_before_single_product_summary';
});
add_action('woocommerce_before_main_content', function() {
	echo 'woocommerce_before_main_content';
});
add_action('woocommerce_before_shop_loop_item', function() {
	echo 'woocommerce_before_shop_loop_item';
});
```

3. Visit the frontend of a single product and the _Shop_ page. Verify the hooks are being applied:

![Screenshot of the Shop page with the hooks being in use](https://github.com/user-attachments/assets/cb688cf6-f137-476c-9dfd-4efda9d49305)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
