### PR TITLE
Remove deprecation warnings

### DIFF
--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Query.php
@@ -37,8 +37,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -50,8 +48,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args    = apply_filters( 'woocommerce_analytics_categories_query_args', $this->get_query_vars() );
 		$results = \WC_Data_Store::load( self::REPORT_NAME )->get_data( $args );
 		return apply_filters( 'woocommerce_analytics_categories_select_query', $results, $args );

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Query.php
@@ -34,8 +34,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -47,8 +45,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_coupons_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-coupons' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Query.php
@@ -34,8 +34,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -47,8 +45,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_coupons_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-coupons-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Query.php
@@ -35,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array(
 			'per_page' => get_option( 'posts_per_page' ), // not sure if this should be the default.
 			'page'     => 1,
@@ -54,8 +52,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use Reports\Customers\Query with a custom name, GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_customers_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-customers-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Query.php
@@ -34,8 +34,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -47,8 +45,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_downloads_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-downloads' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Query.php
@@ -24,8 +24,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -37,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_downloads_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-downloads-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Query.php
@@ -35,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -48,8 +46,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_products_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-products' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Query.php
@@ -35,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -48,8 +46,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_products_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-products-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Query.php
@@ -13,18 +13,6 @@ defined( 'ABSPATH' ) || exit;
  * @deprecated x.x.x Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
  */
 abstract class Query extends \WC_Object_Query {
-
-	/**
-	 * Create a new query.
-	 *
-	 * @deprecated x.x.x Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
-	 *
-	 * @param array $args Criteria to query on in a format similar to WP_Query.
-	 */
-	public function __construct( $args = array() ) {
-		parent::__construct( $args );
-	}
-
 	/**
 	 * Get report data matching the current query vars.
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Query.php
@@ -22,7 +22,6 @@ abstract class Query extends \WC_Object_Query {
 	 * @param array $args Criteria to query on in a format similar to WP_Query.
 	 */
 	public function __construct( $args = array() ) {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Use GenericQuery or \WC_Object_Query instead' );
 		parent::__construct( $args );
 	}
 
@@ -34,7 +33,6 @@ abstract class Query extends \WC_Object_Query {
 	 * @return array|object of WC_Product objects
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
 		/* translators: %s: Method name */
 		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be overridden in subclass.", 'woocommerce' ), __METHOD__ ), array( 'status' => 405 ) );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Query.php
@@ -34,8 +34,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -47,8 +45,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_taxes_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-taxes' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Query.php
@@ -35,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -48,8 +46,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_taxes_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-taxes-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Query.php
@@ -35,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -48,8 +46,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_variations_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-variations' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Query.php
@@ -35,8 +35,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		return array();
 	}
 
@@ -48,8 +46,6 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', 'Query class is deprecated, please use GenericQuery or \WC_Object_Query instead' );
-
 		$args = apply_filters( 'woocommerce_analytics_variations_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-variations-stats' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove deprecation warnings
To make the improvements more gradual. Give developers alternative & time first, before throwing warnings.

As we are in no rush to remove those classes, and https://github.com/woocommerce/woocommerce/pull/49425 is the first moment when we deliver alternative to Query for 3PDs, to make the migration process more gracefully I think we could start with
1. In version `x` (9.3)
   - Ship `GenericQuery`
   - PHPDoc with `@deprecated`
   - Announce in release post that `Query` classes are no longer used and are about to be deprecated
   - Prepare migration guidelines for devs to follow
2. In version `x+1` ship `wc_deprecated` warnings, once devs had time to read the docs.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR reverts part of https://github.com/woocommerce/woocommerce/pull/48964

1. Run automated tests
2. Smokte test analytics for regression
3. Make an extension that uses Query. For example make AutomateWoo use Query and `Query::get_default_query_vars` in https://github.com/woocommerce/automatewoo/blob/develop/admin/Analytics/Rest_API/Upstream/Generic_Query.php. Make sure no deprecations warnings are logged.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
