### PR TITLE
Add/clear theme info cache

### DIFF
--- a/plugins/woocommerce/changelog/50803-add-clear-theme-info-cache
+++ b/plugins/woocommerce/changelog/50803-add-clear-theme-info-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add function to clear system status theme info cache

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -1068,7 +1068,6 @@ if ( 0 < $mu_plugins_count ) :
 						<?php esc_html_e( 'Clear system status theme info cache', 'woocommerce' ); ?>
 					</a>
 				</td>
-				</td>
 			</tr>
 		<?php endif; ?>
 	</tbody>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -1060,7 +1060,14 @@ if ( 0 < $mu_plugins_count ) :
 					</mark>
 					<a href="https://woocommerce.com/document/fix-outdated-templates-woocommerce/" target="_blank">
 						<?php esc_html_e( 'Learn how to update', 'woocommerce' ); ?>
+					</a> |
+					<mark class="info">
+						<span class="dashicons dashicons-info"></span>
+					</mark>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=tools' ) ); ?>">
+						<?php esc_html_e( 'Clear system status theme info cache', 'woocommerce' ); ?>
 					</a>
+				</td>
 				</td>
 			</tr>
 		<?php endif; ?>

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -123,42 +123,42 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 	 */
 	public function get_tools() {
 		$tools = array(
-			'clear_transients'                   => array(
+			'clear_transients'                     => array(
 				'name'   => __( 'WooCommerce transients', 'woocommerce' ),
 				'button' => __( 'Clear transients', 'woocommerce' ),
 				'desc'   => __( 'This tool will clear the product/shop transients cache.', 'woocommerce' ),
 			),
-			'clear_expired_transients'           => array(
+			'clear_expired_transients'             => array(
 				'name'   => __( 'Expired transients', 'woocommerce' ),
 				'button' => __( 'Clear transients', 'woocommerce' ),
 				'desc'   => __( 'This tool will clear ALL expired transients from WordPress.', 'woocommerce' ),
 			),
-			'delete_orphaned_variations'         => array(
+			'delete_orphaned_variations'           => array(
 				'name'   => __( 'Orphaned variations', 'woocommerce' ),
 				'button' => __( 'Delete orphaned variations', 'woocommerce' ),
 				'desc'   => __( 'This tool will delete all variations which have no parent.', 'woocommerce' ),
 			),
-			'clear_expired_download_permissions' => array(
+			'clear_expired_download_permissions'   => array(
 				'name'   => __( 'Used-up download permissions', 'woocommerce' ),
 				'button' => __( 'Clean up download permissions', 'woocommerce' ),
 				'desc'   => __( 'This tool will delete expired download permissions and permissions with 0 remaining downloads.', 'woocommerce' ),
 			),
-			'regenerate_product_lookup_tables'   => array(
+			'regenerate_product_lookup_tables'     => array(
 				'name'   => __( 'Product lookup tables', 'woocommerce' ),
 				'button' => __( 'Regenerate', 'woocommerce' ),
 				'desc'   => __( 'This tool will regenerate product lookup table data. This process may take a while.', 'woocommerce' ),
 			),
-			'recount_terms'                      => array(
+			'recount_terms'                        => array(
 				'name'   => __( 'Term counts', 'woocommerce' ),
 				'button' => __( 'Recount terms', 'woocommerce' ),
 				'desc'   => __( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', 'woocommerce' ),
 			),
-			'reset_roles'                        => array(
+			'reset_roles'                          => array(
 				'name'   => __( 'Capabilities', 'woocommerce' ),
 				'button' => __( 'Reset capabilities', 'woocommerce' ),
 				'desc'   => __( 'This tool will reset the admin, customer and shop_manager roles to default. Use this if your users cannot access all of the WooCommerce admin pages.', 'woocommerce' ),
 			),
-			'clear_sessions'                     => array(
+			'clear_sessions'                       => array(
 				'name'   => __( 'Clear customer sessions', 'woocommerce' ),
 				'button' => __( 'Clear', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -167,7 +167,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'This tool will delete all customer session data from the database, including current carts and saved carts in the database.', 'woocommerce' )
 				),
 			),
-			'clear_template_cache'               => array(
+			'clear_template_cache'                 => array(
 				'name'   => __( 'Clear template cache', 'woocommerce' ),
 				'button' => __( 'Clear', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -176,7 +176,16 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'This tool will empty the template cache.', 'woocommerce' )
 				),
 			),
-			'install_pages'                      => array(
+			'clear_system_status_theme_info_cache' => array(
+				'name'   => __( 'Clear system status theme info cache', 'woocommerce' ),
+				'button' => __( 'Clear', 'woocommerce' ),
+				'desc'   => sprintf(
+					'<strong class="red">%1$s</strong> %2$s',
+					__( 'Note:', 'woocommerce' ),
+					__( 'This tool will empty the system status theme info cache.', 'woocommerce' )
+				),
+			),
+			'install_pages'                        => array(
 				'name'   => __( 'Create default WooCommerce pages', 'woocommerce' ),
 				'button' => __( 'Create pages', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -185,7 +194,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'This tool will install all the missing WooCommerce pages. Pages already defined and set up will not be replaced.', 'woocommerce' )
 				),
 			),
-			'delete_taxes'                       => array(
+			'delete_taxes'                         => array(
 				'name'   => __( 'Delete WooCommerce tax rates', 'woocommerce' ),
 				'button' => __( 'Delete tax rates', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -194,12 +203,12 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'This option will delete ALL of your tax rates, use with caution. This action cannot be reversed.', 'woocommerce' )
 				),
 			),
-			'regenerate_thumbnails'              => array(
+			'regenerate_thumbnails'                => array(
 				'name'   => __( 'Regenerate shop thumbnails', 'woocommerce' ),
 				'button' => __( 'Regenerate', 'woocommerce' ),
 				'desc'   => __( 'This will regenerate all shop thumbnails to match your theme and/or image settings.', 'woocommerce' ),
 			),
-			'db_update_routine'                  => array(
+			'db_update_routine'                    => array(
 				'name'   => __( 'Update database', 'woocommerce' ),
 				'button' => __( 'Update database', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -565,6 +574,11 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					$message = __( 'The active version of WooCommerce does not support template cache clearing.', 'woocommerce' );
 					$ran     = false;
 				}
+				break;
+
+			case 'clear_system_status_theme_info_cache':
+				wc_clear_system_status_theme_info_cache();
+				$message = __( 'System status theme info cache cleared.', 'woocommerce' );
 				break;
 
 			case 'verify_db_tables':

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -457,6 +457,15 @@ function wc_clear_template_cache() {
 }
 
 /**
+ * Clear the system status theme info cache.
+ *
+ * @since 9.4.0
+ */
+function wc_clear_system_status_theme_info_cache() {
+	delete_transient( 'wc_system_status_theme_info' );
+}
+
+/**
  * Get Base Currency Code.
  *
  * @return string


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49891

This PR adds a clear system status theme info cache function and a tooltip to use this function in the system status template override section.

![Google Chrome - WooCommerce status ‹ woo-blocks-dev — WordPress 2024-08-20 at 12 05 17 PM](https://github.com/user-attachments/assets/f987ca3c-c09b-47e7-934e-78f8e42d8e09)
![Google Chrome - WooCommerce status ‹ woo-blocks-dev — WordPress 2024-08-20 at 12 04 36 PM](https://github.com/user-attachments/assets/65019266-6be2-4c58-8533-24d0492f6c2e)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a template override i.e. `order-again.php` template to your theme/child-theme. Example path `wp-content/themes/child-theme/woocommerce/order/order-again.php`. Change the template version to an older version (any). Ie. 7.5.0
2. Go to the system status report and scroll down to `Templates` section. You should see an outdated template message for that template.
3. Change the template version back to what it was originally.
4. Go back to the system status report and scroll down to `Template` section. Notice the outdated template message is still there.
5. Click on the link that says `Clear system status theme info cache`.
6. You should be taken to the System Status Tools tab. Clear the cache for `Clear system status theme info cache`.
7. Go back to the system status report and scroll down to `Templates` section. You should no longer see the outdated template message.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add function to clear system status theme info cache

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
