### PR TITLE
Fix flaky product variations test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-variations-test
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-variations-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixes a flaky product variations e2e test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -367,10 +367,14 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 
 			await page.getByLabel( 'Delete variation' ).click();
 
-			const element = page.locator( 'div.components-snackbar__content' );
-			await expect( await element.innerText() ).toMatch(
-				'1 variation deleted.'
-			);
+			await expect(
+				page.getByText( '1 variation deleted.' )
+			).toBeVisible();
+
+			await page.waitForSelector(
+				'div.woocommerce-product-variations-pagination__info',
+				{ timeout: 20000 }
+			); // test was timing out before page loaded
 
 			await expect(
 				await page


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change addresses the flakiness in the [product variations test](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-core-e2e-tests/tests/f4909eae-9d5d-8965-8282-6ca38c374ed8?branch=refs/heads/trunk) by having the page wait for a selector to load before trying to assert the number of variations present.

Running locally, I had the test fail 4 times out of 100 runs.  After this change, I ran the test another 200 times and there were no failures.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure CI passes
2. `pnpm env:restart && pnpm test:e2e merchant/products/block-editor/create-variable-product-block-editor.spec.js --repeat-each 50` (or however many times you want to run it locally)

<!-- End testing instructions -->
