### PR TITLE
Set timeout to 2 seconds for helper product-usage-notice-rules endpoint request

### DIFF
--- a/plugins/woocommerce/changelog/update-explicit-timeout-for-get_product_usage_notice_rules
+++ b/plugins/woocommerce/changelog/update-explicit-timeout-for-get_product_usage_notice_rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Set timeout to 2 seconds for helper product-usage-notice-rules endpoint request

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1590,6 +1590,7 @@ class WC_Helper {
 			'product-usage-notice-rules',
 			array(
 				'authenticated' => false,
+				'timeout'       => 2,
 			)
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Set the timeout to 2 seconds when requesting helper endpoint `/product-usage-notice-rules`. This endpoint can serve 1423.1680 requests / sec with avg response time 0.02 sec. The response is cached for 1h, however a request can happen when loading an admin screen, therefore reducing a slowness factor when a user in a slownet.

Here's a summary of a simple load tests:

```
hey -n 1000 -c 50 https://woocommerce.com/wp-json/helper/1.0/product-usage-notice-rules

Summary:
  Total:	0.7027 secs
  Slowest:	0.1728 secs
  Fastest:	0.0166 secs
  Average:	0.0257 secs
  Requests/sec:	1423.1680
```



### How to test the changes in this Pull Request:

Use `wp shell`

```
wp> delete_transient( '_woocommerce_helper_product_usage_notice_rules' )
wp> WP_Helper::get_product_usage_notice_rules()

=> array(3) {
  ["wait_in_seconds_after_any_dismisses"]=>
  int(259200)
  ["products"]=> ...
  ["restricted_products"]=> ...
```

If your WC tests site is connected to WooCommerce.com dev env, put a delay (i.e. `sleep( 3 )`) in the endpoint handler and retest:

```
wp> delete_transient( '_woocommerce_helper_product_usage_notice_rules' )
wp> WC_Helper::get_product_usage_notice_rules()
=> array(0) {
}
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
