### PR TITLE
Improve reset password check using or locator

### DIFF
--- a/plugins/woocommerce/changelog/tweak-improve-reset-password-check
+++ b/plugins/woocommerce/changelog/tweak-improve-reset-password-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update reset password e2e to use or locator to check reset status

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/lost-password.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/lost-password.spec.js
@@ -19,20 +19,16 @@ test.describe( 'Can go to lost password page and submit the form', () => {
 			.fill( admin.username );
 		await page.getByRole( 'button', { name: 'Get New Password' } ).click();
 
-		try {
-			// For local testing, the email might not be sent, so we can ignore this error.
-			await expect(
-				page.getByText(
-					/The email could not be sent. Your site may not be correctly configured to send emails/i
-				)
-			).toBeVisible();
-		} catch ( e ) {
-			// eslint-disable-next-line jest/no-try-expect
-			await page.waitForURL( '**/wp-login.php?checkemail=confirm' );
-			// eslint-disable-next-line jest/no-try-expect
-			await expect(
-				page.getByText( /Check your email for the confirmation link/i )
-			).toBeVisible();
-		}
+		const emailSentMessage = page.getByText(
+			'check your email for the confirmation link'
+		);
+		const emailNotSentMessage = page.getByText(
+			'the email could not be sent'
+		);
+
+		// We don't have to care if the email was sent, we just want to know the button click attempts a reset.
+		await expect(
+			emailSentMessage.or( emailNotSentMessage )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As suggested by @WunderBart here: https://github.com/woocommerce/woocommerce/pull/50666/files#r1721421087, we can improve the reset password check by using an or locator instead of a try catch block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check the code
2. Ensure e2e passes

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
