### PR TITLE
Vertically center product meta box elements

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-product-meta-box-minor-adjustment
+++ b/plugins/woocommerce/changelog/fix-add-product-meta-box-minor-adjustment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Vertically center product meta elements

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5579,7 +5579,7 @@ img.help_tip {
 
 		input,
 		select {
-			margin-top: -3px;
+			margin-top: -2px;
 			vertical-align: middle;
 		}
 
@@ -8086,7 +8086,7 @@ table.bar_chart {
 	#woocommerce-product-data {
 		.hndle {
 			display: block;
-			line-height: 24px;
+			line-height: 28px;
 
 			.type_box {
 				display: inline;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses a slight misalignment in product meta box elements.

#### Before:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/c75c5184-4213-41c9-a94b-931dc82adc24">

#### After:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/7a5c2de8-b849-4d7a-8728-623b4f3535bf">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to `Products > Add new`
2. Observe the `Product data` title, dropdown and checkboxes are vertically centered

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
