### PR TITLE
Update the link color in legal disclaimers on core profiler

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -196,9 +196,6 @@
 			margin-left: 10px;
 		}
 
-		a {
-			color: $gray-700;
-		}
 	}
 }
 // Business location page
@@ -413,9 +410,6 @@
 	.woocommerce-profiler-plugins-jetpack-agreement {
 		color: $gray-700;
 		font-size: 12px;
-		a {
-			color: inherit;
-		}
 	}
 
 	.woocommerce-profiler-plugins__footer {

--- a/plugins/woocommerce/changelog/update-tc-link-color
+++ b/plugins/woocommerce/changelog/update-tc-link-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use standard link color in legal disclaimers on core profiler


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50831.

Updates the color of links in legal copy on core profiler screens.

<img width="1792" alt="legal link core profiler into" src="https://github.com/user-attachments/assets/4a6455e8-6f61-4a3d-b881-324701dad3a9">

<img width="1792" alt="legal link core profiler extensions" src="https://github.com/user-attachments/assets/c2f0cb26-de44-4219-9f9c-a2581c63e2f5">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start Core profiler on a fresh install
2. On intro screen, see that "Learn more about usage tracking" link is in blue (assuming normal color scheme selected)
3. Continue to free extensions screen
4. See that the Jetpack "terms of service" link is in blue (assuming normal color scheme selected)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
