### PR TITLE
[e2e test] Fix strict mode violation in delete variation test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-delete-variation-test-strict-mode-violation
+++ b/plugins/woocommerce/changelog/e2e-fix-delete-variation-test-strict-mode-violation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -368,7 +368,9 @@ test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
 			await page.getByLabel( 'Delete variation' ).click();
 
 			await expect(
-				page.getByText( '1 variation deleted.' )
+				page
+					.getByLabel( 'Dismiss this notice' )
+					.getByText( '1 variation deleted.' )
 			).toBeVisible();
 
 			await page.waitForSelector(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/50807 fixed a flaky test issue but introduced a strict mode violation. 

```
Error: expect.toBeVisible: Error: strict mode violation: getByText('1 variation deleted.') resolved to 2 elements:
        1) <div class="components-snackbar__content">1 variation deleted.</div> aka getByLabel('Dismiss this notice')
        2) <div aria-live="polite" aria-atomic="true" id="a11y-speak-polite" class="a11y-speak-region" aria-relevant="additions text">1 variation deleted.</div> aka locator('#a11y-speak-polite')
```

Resolved by updating the locator to look for the text in getByLabel('Dismiss this notice') element.

Also fixes https://github.com/woocommerce/woocommerce/issues/50269

### How to test the changes in this Pull Request:

- CI green
- Locally: `pnpm test:e2e create-variable-product-block-editor.spec.js`