### PR TITLE
[e2e tests] Fix flaky navigation to editor

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-waitForResponse-editor-navigation
+++ b/plugins/woocommerce/changelog/e2e-fix-waitForResponse-editor-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -39,12 +39,13 @@ const getCanvas = async ( page ) => {
 };
 
 const goToPageEditor = async ( { page } ) => {
-	await page.goto( 'wp-admin/post-new.php?post_type=page' );
-	await disableWelcomeModal( { page } );
-	await page.waitForResponse(
+	const responsePromise = page.waitForResponse(
 		( response ) =>
 			response.url().includes( '//page' ) && response.status() === 200
 	);
+	await page.goto( 'wp-admin/post-new.php?post_type=page' );
+	await disableWelcomeModal( { page } );
+	await responsePromise;
 };
 
 const goToPostEditor = async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -49,12 +49,13 @@ const goToPageEditor = async ( { page } ) => {
 };
 
 const goToPostEditor = async ( { page } ) => {
-	await page.goto( 'wp-admin/post-new.php' );
-	await disableWelcomeModal( { page } );
-	await page.waitForResponse(
+	const responsePromise = page.waitForResponse(
 		( response ) =>
 			response.url().includes( '//single' ) && response.status() === 200
 	);
+	await page.goto( 'wp-admin/post-new.php' );
+	await disableWelcomeModal( { page } );
+	await responsePromise;
 };
 
 const fillPageTitle = async ( page, title ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the incorrect usage of `page.waitForResponse` when navigating to page editor.

Fixes https://github.com/woocommerce/woocommerce/issues/50742
Fixes https://github.com/woocommerce/woocommerce/issues/50570
Fixes https://github.com/woocommerce/woocommerce/issues/50509
Fixes https://github.com/woocommerce/woocommerce/issues/50413

### How to test the changes in this Pull Request:

- CI green
- Locally:
```
pnpm test:e2e cart-block-calculate-shipping.spec.js create-post.spec.js create-cart-block.spec.js checkout-block-coupons.spec.js create-woocommerce-blocks.spec.js
```