### PR TITLE
Conditionally set new order email sent meta field

### DIFF
--- a/plugins/woocommerce/changelog/fix-conditionally-set-new-order-metafield
+++ b/plugins/woocommerce/changelog/fix-conditionally-set-new-order-metafield
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Conditionally set new order email sent meta field

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -109,10 +109,11 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 			}
 
 			if ( $this->is_enabled() && $this->get_recipient() ) {
-				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
-
-				$order->update_meta_data( '_new_order_email_sent', 'true' );
-				$order->save();
+				$email_sent_successfully = $this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+				if ( $email_sent_successfully ) {
+					$order->update_meta_data( '_new_order_email_sent', 'true' );
+					$order->save();
+				}
 			}
 
 			$this->restore_locale();


### PR DESCRIPTION
Check the result from the send email before updating the  '_new_order_email_sent' order metafield to true. We're having issues on our orders where emails are not being sent to, but upon checking on the database the '_new_order_email_sent' is set to true.


### Changes proposed in this Pull Request:

1. Check if the new order email is actually sent out correctly.
2. If so then update the meta data.

Closes #49886

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Send out a new order email by placing an order, from the order page on your test server
2. Ensure that the new order email was actually received in the inbox
3. Now search the database for a newly entered `_new_order_email_sent` meta data
4. If the email had failed then this database entry should not occur.

 
#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
