### PR TITLE
Run Checkout block coupon filter on empty array

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
@@ -49,8 +49,6 @@ const TotalsDiscount = ( {
 	} = values;
 	const discountValue = parseInt( totalDiscount, 10 );
 
-	// We need to run the filter even if we don't have coupons.
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const filteredCartCoupons = applyCheckoutFilter( {
 		arg: filteredCartCouponsFilterArg,
 		filterName: 'coupons',

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
@@ -49,6 +49,14 @@ const TotalsDiscount = ( {
 	} = values;
 	const discountValue = parseInt( totalDiscount, 10 );
 
+	// We need to run the filter even if we don't have coupons.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const filteredCartCoupons = applyCheckoutFilter( {
+		arg: filteredCartCouponsFilterArg,
+		filterName: 'coupons',
+		defaultValue: cartCoupons,
+	} );
+
 	if ( ! discountValue && cartCoupons.length === 0 ) {
 		return null;
 	}
@@ -60,12 +68,6 @@ const TotalsDiscount = ( {
 	)
 		? discountValue + discountTaxValue
 		: discountValue;
-
-	const filteredCartCoupons = applyCheckoutFilter( {
-		arg: filteredCartCouponsFilterArg,
-		filterName: 'coupons',
-		defaultValue: cartCoupons,
-	} );
 
 	return (
 		<TotalsItem

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
@@ -57,7 +57,7 @@ const TotalsDiscount = ( {
 		defaultValue: cartCoupons,
 	} );
 
-	if ( ! discountValue && cartCoupons.length === 0 ) {
+	if ( ! discountValue && filteredCartCoupons.length === 0 ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/changelog/50876-fix-run-coupon-filter-on-empty
+++ b/plugins/woocommerce/changelog/50876-fix-run-coupon-filter-on-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make Checkout block `coupons` filter consistent by always running.


### PR DESCRIPTION
Sometime ago we introduced a coupon filter that allows people to filter out coupons or possibly add coupons. The filter would only run there coupons, meaning the filter wouldn't run if you remove the last coupon, and it won't on mount.

This fixes it by making sure it always run. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following code in console:
```js
const { registerCheckoutFilters } = window.wc.blocksCheckout;

    const modifyCoupons = ( coupons, extensions, args ) => {
        console.log(coupons);
        return coupons;
}
registerCheckoutFilters( 'example-extension', {
        coupons: modifyCoupons,
    } );
```
2. Add a coupon, notice that it logs a single item.
3. Remove the coupon, notice it logs an empty array.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Make Checkout block `coupons` filter consistent by always running.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
