### PR TITLE
Add 'Show tab title' attribute to the Product Details block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.json
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.json
@@ -5,6 +5,12 @@
 	"title": "Product Details",
 	"description": "Display a product's description, attributes, and reviews.",
 	"category": "woocommerce-product-elements",
+	"attributes": {
+		"hideTabTitle": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"keywords": [
 		"WooCommerce"
 	],

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/block.tsx
@@ -8,7 +8,7 @@ interface SingleProductTab {
 	id: string;
 	title: string;
 	active: boolean;
-	content: string | undefined;
+	content: React.JSX.Element | undefined;
 }
 
 const ProductTabTitle = ( {
@@ -46,15 +46,28 @@ const ProductTabContent = ( {
 	);
 };
 
-export const SingleProductDetails = () => {
+export const SingleProductDetails = ( {
+	hideTabTitle,
+}: {
+	hideTabTitle: boolean;
+} ) => {
 	const productTabs = [
 		{
 			id: 'description',
 			title: 'Description',
 			active: true,
-			content: __(
-				'This block lists description, attributes and reviews for a single product.',
-				'woocommerce'
+			content: (
+				<>
+					{ ! hideTabTitle && (
+						<h2>{ __( 'Description', 'woocommerce' ) }</h2>
+					) }
+					<p>
+						{ __(
+							'This block lists description, attributes and reviews for a single product.',
+							'woocommerce'
+						) }
+					</p>
+				</>
 			),
 		},
 		{

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/edit.tsx
@@ -1,9 +1,18 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	BlockControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
+import {
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 import type { BlockEditProps } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,8 +21,8 @@ import Block from './block';
 import { Attributes } from './types';
 import './editor.scss';
 
-const Edit = ( { attributes }: BlockEditProps< Attributes > ) => {
-	const { className } = attributes;
+const Edit = ( { attributes, setAttributes }: BlockEditProps< Attributes > ) => {
+	const { className, hideTabTitle } = attributes;
 	const blockProps = useBlockProps( {
 		className,
 	} );
@@ -21,8 +30,21 @@ const Edit = ( { attributes }: BlockEditProps< Attributes > ) => {
 	return (
 		<>
 			<div { ...blockProps }>
+				<InspectorControls key="inspector">
+					<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+						<ToggleControl
+							label={ __( 'Show tab title in content', 'woocommerce' ) }
+							checked={ ! hideTabTitle }
+							onChange={ () =>
+								setAttributes( {
+									hideTabTitle: ! hideTabTitle,
+								} )
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
 				<Disabled>
-					<Block />
+					<Block hideTabTitle={ hideTabTitle } />
 				</Disabled>
 			</div>
 		</>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/edit.tsx
@@ -1,16 +1,8 @@
 /**
  * External dependencies
  */
-import {
-	InspectorControls,
-	BlockControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
-import {
-	PanelBody,
-	ToggleControl,
-} from '@wordpress/components';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -21,7 +13,10 @@ import Block from './block';
 import { Attributes } from './types';
 import './editor.scss';
 
-const Edit = ( { attributes, setAttributes }: BlockEditProps< Attributes > ) => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+}: BlockEditProps< Attributes > ) => {
 	const { className, hideTabTitle } = attributes;
 	const blockProps = useBlockProps( {
 		className,
@@ -33,7 +28,10 @@ const Edit = ( { attributes, setAttributes }: BlockEditProps< Attributes > ) => 
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
 						<ToggleControl
-							label={ __( 'Show tab title in content', 'woocommerce' ) }
+							label={ __(
+								'Show tab title in content',
+								'woocommerce'
+							) }
 							checked={ ! hideTabTitle }
 							onChange={ () =>
 								setAttributes( {

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-details/types.ts
@@ -1,3 +1,4 @@
 export interface Attributes {
 	className?: string;
+	hideTabTitle?: boolean;
 }

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -80,7 +80,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 		} );
 
 		const block = await editor.getBlockByName( blockData.slug );
-		await block.click();
+		await editor.selectBlocks( block );
 
 		// Verify the "Description" h2 heading is visible by default.
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -55,4 +55,57 @@ test.describe( `${ blockData.slug } Block`, () => {
 			/This block lists description, attributes and reviews for a single product./
 		);
 	} );
+
+	test( 'block hides tab title in content when toggle is off', async ( {
+		admin,
+		requestUtils,
+		editor,
+		page,
+		frontendUtils,
+	} ) => {
+		const template = await requestUtils.createTemplate( 'wp_template', {
+			slug: 'single-product-v-neck-t-shirt',
+			title: 'Product Details Test',
+			content: '',
+		} );
+
+		await admin.visitSiteEditor( {
+			postId: template.id,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		await editor.insertBlock( {
+			name: blockData.slug,
+		} );
+
+		const block = await editor.getBlockByName( blockData.slug );
+		await block.click();
+
+		// Verify the "Description" h2 heading is visible by default.
+		await expect(
+			editor.canvas.locator( 'h2:has-text("Description")' )
+		).toBeVisible();
+
+		await editor.openDocumentSettingsSidebar();
+		await page.getByText( "Show tab title in content" ).click();
+
+		// Verify the "Description" h2 heading has been hidden from the canvas.
+		await expect(
+			editor.canvas.locator( 'h2:has-text("Description")' )
+		).toBeHidden();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		// Visit the product page in the frontend.
+		await frontendUtils.goToShop();
+		await page.getByText( "V-Neck T-Shirt" ).click();
+
+		// Verify the "Description" h2 heading is not in the page.
+		await expect(
+			page.locator( 'h2:has-text("Description")' )
+		).toBeHidden();
+	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -88,7 +88,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 		).toBeVisible();
 
 		await editor.openDocumentSettingsSidebar();
-		await page.getByText( "Show tab title in content" ).click();
+		await page.getByText( 'Show tab title in content' ).click();
 
 		// Verify the "Description" h2 heading has been hidden from the canvas.
 		await expect(
@@ -99,9 +99,8 @@ test.describe( `${ blockData.slug } Block`, () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 
-		// Visit the product page in the frontend.
 		await frontendUtils.goToShop();
-		await page.getByText( "V-Neck T-Shirt" ).click();
+		await page.getByText( 'V-Neck T-Shirt' ).click();
 
 		// Verify the "Description" h2 heading is not in the page.
 		await expect(

--- a/plugins/woocommerce/changelog/add-47895-show-tab-title-attribute-product-details
+++ b/plugins/woocommerce/changelog/add-47895-show-tab-title-attribute-product-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add 'Show tab title' attribute to the Product Details block

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductDetails.php
@@ -70,7 +70,6 @@ class ProductDetails extends AbstractBlock {
 			$tabs_html = new WP_HTML_Tag_Processor( $tabs );
 			while ( $tabs_html->next_tag( array( 'class_name' => 'wc-tab' ) ) ) {
 				if ( $tabs_html->next_tag( 'h2' ) ) {
-					var_dump( $tabs_html->get_tag( array( 'tag_name' => 'h2' ) ) );
 					$tabs_html->set_attribute( 'hidden', 'true' );
 				}
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductDetails.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use WP_HTML_Tag_Processor;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
@@ -50,7 +51,31 @@ class ProductDetails extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		$hide_tab_title = isset( $attributes['hideTabTitle'] ) ? $attributes['hideTabTitle'] : false;
+
+		if ( $hide_tab_title ) {
+			add_filter( 'woocommerce_product_description_heading', '__return_empty_string' );
+			add_filter( 'woocommerce_product_additional_information_heading', '__return_empty_string' );
+			add_filter( 'woocommerce_reviews_title', '__return_empty_string' );
+		}
+
 		$tabs = $this->render_tabs();
+
+		if ( $hide_tab_title ) {
+			remove_filter( 'woocommerce_product_description_heading', '__return_empty_string' );
+			remove_filter( 'woocommerce_product_additional_information_heading', '__return_empty_string' );
+			remove_filter( 'woocommerce_reviews_title', '__return_empty_string' );
+
+			// Remove the first `h2` of every `.wc-tab`. This is required for the Reviews tabs when there are no reviews and for plugin tabs.
+			$tabs_html = new WP_HTML_Tag_Processor( $tabs );
+			while ( $tabs_html->next_tag( array( 'class_name' => 'wc-tab' ) ) ) {
+				if ( $tabs_html->next_tag( 'h2' ) ) {
+					var_dump( $tabs_html->get_tag( array( 'tag_name' => 'h2' ) ) );
+					$tabs_html->set_attribute( 'hidden', 'true' );
+				}
+			}
+			$tabs = $tabs_html->get_updated_html();
+		}
 
 		$classname = $attributes['className'] ?? '';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #47895.

This PR adds a new _Show tab title in content_ attribute to the Product Details block, so the user can customize if the title will be displayed or not.

To accomplish this, we use two approaches:

* Filtering some filters so they return an empty array (`woocommerce_product_description_heading`, `woocommerce_product_additional_information_heading` and `woocommerce_reviews_title`).
* With `WP_HTML_Tag_Processor`, we hide the first `h2` inside `.wc-tab`.

### How to test the changes in this Pull Request:

1. With a block theme, go to Appearance > Editor > Templates > Single Product.
2. Convert the template to the blockified template if necessary, and select the Product Details block.
3. Verify that, by default, the title of each tab is displayed in the tab content.
![image](https://github.com/user-attachments/assets/9f9e2b77-0167-4223-898c-82b574343abd)
4. Toggle the _Show tab title in content_ attribute. Verify the title disappears/appears as expected.

https://github.com/user-attachments/assets/3a316d82-3420-4c9a-af4b-53f1ef4e1103

5. Save and visit the product page on the frontend. Verify the tab title is displayed in content when the toggle is on, and it's not displayed when the toggle is off.
