### PR TITLE
Reintroduce get_all_active_valid_plugins public function after revert

### DIFF
--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -68,6 +68,34 @@ class PluginUtil {
 	}
 
 	/**
+	 * Wrapper for WP's private `wp_get_active_and_valid_plugins` and `wp_get_active_network_plugins` functions.
+	 *
+	 * This combines the results of the two functions to get a list of all plugins that are active within a site.
+	 * It's more useful than just retrieving the option values because it also validates that the plugin files exist.
+	 * This wrapper is also a hedge against backward-incompatible changes since both of the WP methods are marked as
+	 * being "@access private", so if need be we can update our methods here to preserve functionality.
+	 *
+	 * Note that the doc block for `wp_get_active_and_valid_plugins` says it returns "Array of paths to plugin files
+	 * relative to the plugins directory", but it actually returns absolute paths.
+	 *
+	 * @return string[] Array of absolute paths to plugin files.
+	 */
+	public function get_all_active_valid_plugins() {
+		$local = wp_get_active_and_valid_plugins();
+
+		if ( is_multisite() ) {
+			require_once ABSPATH . WPINC . '/ms-load.php';
+			$network = wp_get_active_network_plugins();
+		} else {
+			$network = array();
+		}
+
+		$all = array_merge( $local, $network );
+
+		return array_unique( $all );
+	}
+
+	/**
 	 * Get a list with the names of the WordPress plugins that are WooCommerce aware
 	 * (they have a "WC tested up to" header).
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reintroduces `get_all_active_valid_plugins` public function after revert https://github.com/woocommerce/woocommerce/pull/50881

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Make sure all the tests pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
