### PR TITLE
Register block settings from transient settings instead of reading JSON file

### DIFF
--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractInnerBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractInnerBlock.php
@@ -30,10 +30,11 @@ abstract class AbstractInnerBlock extends AbstractBlock {
 			$block_settings['api_version'] = 2;
 		}
 
-		$metadata_path = $this->asset_api->get_block_metadata_path( $this->block_name, 'inner-blocks/' );
-		// Prefer to register with metadata if the path is set in the block's class.
-		register_block_type_from_metadata(
-			$metadata_path,
+		$metadata_path  = $this->asset_api->get_block_metadata_path( $this->block_name, 'inner-blocks/' );
+		$block_settings = array_merge( $block_settings, $this->get_block_settings_from_metadata_path( $metadata_path ) );
+
+		register_block_type(
+			$this->get_block_type(),
 			$block_settings
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR attempts to improve the TTFB issue note in https://github.com/woocommerce/woocommerce/issues/50714 by storing block settings in a transient and reading from that transient instead of the metadata file path each time.

While this improves TTFB by approximately `~2ms`, it comes with a number of drawbacks:
* Unnecessary waste of storage and transactions using transients
* Bypassing the file path passed to `register_block_type_from_metadata` means we miss out on block hooks

A better solution would be to combine (via build process) blocks into a single PHP file and read directly from there as core implemented [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/blocks/blocks-json.php), though changes will be needed upstream to make sure the block hooks features still get added to blocks without file paths.

There are probably still higher impact areas for performance around blocks given the `24ms` time added to TTFB from blocks in general.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open up the non-logged in homepage of your site with only WooCommerce active and the Twenty Twenty Four theme using the default homepage template.
2. Using a program like [this](https://github.com/jaygooby/ttfb.sh), run TTFB tests (I ran 100x) to determine median TTFB time compared to trunk.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
