### PR TITLE
Optimize Blocks Registration: Compile block.json to PHP for OPcache and Runtime Performance

### DIFF
--- a/plugins/woocommerce-blocks/bin/blocks-json-to-php.js
+++ b/plugins/woocommerce-blocks/bin/blocks-json-to-php.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const json2php = require('json2php');
+
+const blocksDir = path.join(__dirname, '../assets/js/blocks');
+const outputFile = path.join(__dirname, '../build/blocks-json.php');
+
+const blocks = {};
+
+glob.sync(`${blocksDir}/**/block.json`).forEach(file => {
+  const blockJson = JSON.parse(fs.readFileSync(file, 'utf8'));
+  blocks[blockJson.name] = blockJson;
+});
+
+const phpContent = `<?php
+// This file is generated. Do not modify it manually.
+return ${json2php(blocks)};
+`;
+
+fs.writeFileSync(outputFile, phpContent);
+
+console.log('blocks-json.php has been generated.');

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -49,6 +49,7 @@
 		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
 		"build:project": "pnpm --if-present '/^build:project:.*$/'",
 		"build:project:bundle": "wireit",
+		"build:project:blocks-json-to-php": "wireit",
 		"build:check-assets": "rimraf build/* && cross-env ASSET_CHECK=true BABEL_ENV=default NODE_ENV=production webpack",
 		"prebuild:docs": "rimraf docs/extensibility/actions.md & rimraf docs/extensibility/filters.md",
 		"build:docs": "./vendor/bin/wp-hooks-generator --input=src --output=bin/hook-docs/data && node ./bin/hook-docs && pnpm build:docs:block-references",
@@ -394,6 +395,15 @@
 		"watch:build:project:bundle": {
 			"command": "webpack --watch",
 			"service": true
+		},
+		"build:project:blocks-json-to-php": {
+			"command": "node ./bin/blocks-json-to-php.js",
+			"files": [
+				"assets/js/blocks/**/block.json"
+			],
+			"output": [
+				"build/blocks-json.php"
+			]
 		},
 		"dependencyOutputs": {
 			"allowUsuallyExcludedPaths": true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Performance optimization for WooCommerce Blocks by compiling block.json files into a single PHP file, similar to the approach taken by WordPress core in version 6.1. 

See: https://make.wordpress.org/core/2022/10/07/improved-php-performance-for-core-blocks-registration/

* New build script: Added a script (`bin/blocks-json-to-php.js`) that compiles all block.json files into a single PHP file (`build/blocks-json.php`).
* OPcache utilization: The resulting PHP file can be cached by OPcache, unlike JSON files. This leads to faster access times and reduced memory usage.
* Eliminated runtime JSON decoding: By pre-compiling JSON to PHP arrays, we eliminate the need for repetitive JSON decoding at runtime, further improving performance.
* Updated block registration: Modified AbstractBlock and AbstractInnerBlock classes to use the compiled PHP data when available, falling back to the traditional block.json method when necessary.

### Blocked

I am only able to get half of the benefit while this core bug exists: https://core.trac.wordpress.org/ticket/61910 .

### How to test the changes in this Pull Request:

* Verify that all existing blocks continue to function correctly after the change.
* Check performance metrics before and after the change, mainly TTFB.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
