### PR TITLE
Fix flaky remote logging PHP unit test

### DIFF
--- a/plugins/woocommerce/changelog/fix-flaky-remote-logging-test
+++ b/plugins/woocommerce/changelog/fix-flaky-remote-logging-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky remote logging PHP unit test

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -423,7 +423,7 @@ class RemoteLoggerTest extends \WC_Unit_Test_Case {
 		add_filter( 'option_woocommerce_remote_variant_assignment', fn() => 5 );
 		add_filter(
 			'plugins_api',
-			function ( $result, $action, $args ) {
+			function ( $result, $action, $args ) use ( $enabled ) {
 				if ( 'plugin_information' === $action && 'woocommerce' === $args->slug ) {
 					return (object) array( 'version' => $enabled ? WC()->version : '9.0.0' );
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1724420990201099-slack-C03CPM3UXDJ

This PR fixes the flaky `Automattic\WooCommerce\Tests\Internal\Logging\RemoteLoggerTest::test_remote_logging_allowed` PHP test.

I wasn't able to reproduce the issue locally and also, running the test multiple times on the [CI with only PHP actions](https://github.com/woocommerce/woocommerce/actions/runs/10553558015/job/29236048692) didn't reproduce the issue. This issue seems only to happen when the test with [full CI actions](https://github.com/woocommerce/woocommerce/actions/runs/10554270299/job/29236222044) and the test fails because the [`is_latest_woocommerce_version()`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php#L153) returns `false` when it should return `true`. 

I think something is wrong with the mock version in the test, and after WC 9.2 was released, the test started to fail in the CI. Before this PR, we changed the `WC()->version` to test different scenarios. In this PR, I decided not to modify the `WC()->version`, and instead, I updated the transient and filter to return the expected value based on the `WC()->version` value to ensure the test is stable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


Review the changes in the PR and ensure the PHP CI checks have passed. 

Try restarting the CI a few times to confirm that the CI checks are stable.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>