### PR TITLE
Blocks\Assets\Api: Do not attempt to update script_data transient with the same data

### DIFF
--- a/plugins/woocommerce/changelog/50962-dont-update-transient-with-same-data
+++ b/plugins/woocommerce/changelog/50962-dont-update-transient-with-same-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Don't update the script data transient for the same data

--- a/plugins/woocommerce/changelog/50962-dont-update-transient-with-same-data
+++ b/plugins/woocommerce/changelog/50962-dont-update-transient-with-same-data
@@ -1,4 +1,4 @@
 Significance: patch
-Type: tweak
+Type: performance
 
 Don't update the script data transient for the same data

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -42,6 +42,13 @@ class Api {
 	private $script_data = null;
 
 	/**
+	 * Tracks whether script_data was modified during the current request.
+	 *
+	 * @var boolean
+	 */
+	private $script_data_modified = false;
+
+	/**
 	 * Stores the hash for the script data, made up of the site url, plugin version and package path.
 	 *
 	 * @var string
@@ -171,6 +178,9 @@ class Api {
 		if ( is_null( $this->script_data ) || $this->disable_cache ) {
 			return;
 		}
+		if ( ! $this->script_data_modified ) {
+			return;
+		}
 		set_transient(
 			$this->script_data_transient_key,
 			wp_json_encode(
@@ -216,6 +226,7 @@ class Api {
 				'version'      => ! empty( $asset['version'] ) ? $asset['version'] : $this->get_file_version( $relative_src ),
 				'dependencies' => ! empty( $asset['dependencies'] ) ? $asset['dependencies'] : [],
 			);
+			$this->script_data_modified = true;
 		}
 
 		// Return asset details as well as the requested dependencies array.

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -226,7 +226,7 @@ class Api {
 				'version'      => ! empty( $asset['version'] ) ? $asset['version'] : $this->get_file_version( $relative_src ),
 				'dependencies' => ! empty( $asset['dependencies'] ) ? $asset['dependencies'] : [],
 			);
-			$this->script_data_modified = true;
+			$this->script_data_modified         = true;
 		}
 
 		// Return asset details as well as the requested dependencies array.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**On the shutdown hook created by `Blocks\Assets\Api`, only run `set_transient()` if we have new or changed data to put in the transient.** Currently, this is being run on every request, even if the data is exactly the same.

This change aims to improve performance by increasing the TTLB (time to last byte) - which does delay the browser response.

In the overall timeline of a request, this shutdown hook shows near the end:
![2024-08-26_09-15](https://github.com/user-attachments/assets/89124aa1-08be-43b2-a8d3-626a9b6b273d)

A closer look:
![2024-08-26_09-15_1](https://github.com/user-attachments/assets/f53027b0-3ab3-47af-8f13-876552daee84)



If we log every SQL query being run, we can see this `set_transient()` call results in 3 queries being run when the data is exactly the same:
```
SELECT autoload FROM wp_options WHERE option_name = '_transient_timeout_woocommerce_blocks_asset_api_script_data' LIMIT 1
SHOW FULL COLUMNS FROM `wp_options`
UPDATE `wp_options` SET `option_value` = '1727274701' WHERE `option_name` = '_transient_timeout_woocommerce_blocks_asset_api_script_data'
```

WP is smart enough to not run the update on the transient option, but this is still 3 queries that don't need to happen.

The timing is variable, but it can take up to 12-15ms in my testing:

![2024-08-26_09-34](https://github.com/user-attachments/assets/32904602-6865-4b07-b6ae-75cbeac46740)

Shutdown hooks do impact the browser response. This can be verified by adding a `sleep(10)` to the shutdown hook.

### How to test the changes in this Pull Request:


#### Inspect correctness 

Inspect the `$script_data` attribute of the Api.php closely. Besides being pulled out the cache, it is a private attribute, and it is only updated in one place:
https://github.com/woocommerce/woocommerce/blob/30ae60b27336ce050bd69ecf6e2707e7f593a76a/plugins/woocommerce/src/Blocks/Assets/Api.php#L214-L218

Therefore, we only need to set a flag in this one spot to know if `$this->script_data` changed outside the cache and needs to be updated.

#### Verify fewer DB queries

Log out every query being run:
```diff
diff --git a/class-wpdb.php b/class-wpdb.php
index aeb9679..9b20f37 100644
--- a/class-wpdb.php
+++ b/class-wpdb.php
@@ -2255,6 +2255,7 @@ class wpdb {
                // Keep track of the last query for debug.
                $this->last_query = $query;
 
+               error_log($query);
                $this->_do_query( $query );
 
                // Database server has gone away, try to reconnect.
```

Visit the homepage. Notice 3 fewer queries at the very end while using this branch.

#### Verify Script Data

Add: 
```php
		error_log(json_encode([
			'src'          => $this->script_data[ $relative_src ]['src'],
			'version'      => $this->script_data[ $relative_src ]['version'],
			'dependencies' => array_merge( $this->script_data[ $relative_src ]['dependencies'], $dependencies ),
		]));
```
Just before the return statement in `get_script_data()`. Before and after the patch, there should be no changes.

#### Verify cache still working

Add:
```php
		error_log("Found cached script data");
		error_log(json_encode($transient_value['script_data']));
```
Just before the return statement in `get_cached_script_data()`. See that data is being pulled out of the cache.

#### Verify cache updates still happen

Change the return value of `get_script_data_hash()` (can just add a ` . '_v2'` at the end), while logging all DB queries. Your next request should contain a `UPDATE `wp_options` SET `option_value` = '{\"script_data\"...` query. Note that if you used a browser to request, you might have to scroll up in the query log, since your browser made 2 requests and only the first one updated it.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
