### PR TITLE
Log deprecation warnings for Query class

### DIFF
--- a/plugins/woocommerce/changelog/50969-dev-deprecate-query
+++ b/plugins/woocommerce/changelog/50969-dev-deprecate-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Log deprecation warnings for `Query` class usage.

--- a/plugins/woocommerce/changelog/50969-dev-deprecate-query
+++ b/plugins/woocommerce/changelog/50969-dev-deprecate-query
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Log deprecation warnings for analytic reports `Automattic\WooCommerce\Admin\API\Reports\Query` class usage.
+Log deprecation warnings for `Query` class usage.

--- a/plugins/woocommerce/changelog/50969-dev-deprecate-query
+++ b/plugins/woocommerce/changelog/50969-dev-deprecate-query
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Log deprecation warnings for `Query` class usage.
+Log deprecation warnings for analytic reports `Automattic\WooCommerce\Admin\API\Reports\Query` class usage.

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -32,7 +32,7 @@ class Controller extends GenericController implements ExportableInterface {
 	protected $rest_base = 'reports/categories';
 
 	/**
-	 * Get data from `'categories'` Query.
+	 * Get data from `'categories'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Query.php
@@ -23,7 +23,7 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Categories\Query
  *
- * @deprecated 9.3.0 Categories\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Categories\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
@@ -32,22 +32,26 @@ class Query extends ReportsQuery {
 	/**
 	 * Valid fields for Categories report.
 	 *
-	 * @deprecated 9.3.0 Categories\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Categories\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get categories data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Categories\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Categories\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args    = apply_filters( 'woocommerce_analytics_categories_query_args', $this->get_query_vars() );
 		$results = \WC_Data_Store::load( self::REPORT_NAME )->get_data( $args );
 		return apply_filters( 'woocommerce_analytics_categories_select_query', $results, $args );

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -31,7 +31,7 @@ class Controller extends GenericController implements ExportableInterface {
 	protected $rest_base = 'reports/coupons';
 
 	/**
-	 * Get data from `'coupons'` Query.
+	 * Get data from `'coupons'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Query.php
@@ -22,29 +22,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Coupons\Query
  *
- * @deprecated 9.3.0 Coupons\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Coupons\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Products report.
 	 *
-	 * @deprecated 9.3.0 Coupons\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Coupons\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Coupons\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Coupons\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_coupons_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-coupons' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -54,7 +54,7 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get data from `'coupons-stats'` Query.
+	 * Get data from `'coupons-stats'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Query.php
@@ -22,29 +22,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Coupons\Stats\Query
  *
- * @deprecated 9.3.0 Coupons\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Coupons\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Products report.
 	 *
-	 * @deprecated 9.3.0 Coupons\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Coupons\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Coupons\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Coupons\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_coupons_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-coupons-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -34,7 +34,7 @@ class Controller extends GenericController implements ExportableInterface {
 	protected $rest_base = 'reports/customers';
 
 	/**
-	 * Get data from Query.
+	 * Get data from Customers\Query.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Query.php
@@ -23,18 +23,20 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Customers\Stats\Query
  *
- * @deprecated 9.3.0 Customers\Stats\Query class is deprecated, please use Reports\Customers\Query with a custom name, GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Customers\Stats\Query class is deprecated, please use `Reports\Customers\Query` with a custom name, `GenericQuery`, `\WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Customers report.
 	 *
-	 * @deprecated 9.3.0 Customers\Stats\Query class is deprecated, please use Reports\Customers\Query with a custom name, GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Customers\Stats\Query class is deprecated, please use `Reports\Customers\Query` with a custom name, `GenericQuery`, `\WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`Reports\Customers\Query` with a custom name, `GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array(
 			'per_page' => get_option( 'posts_per_page' ), // not sure if this should be the default.
 			'page'     => 1,
@@ -47,11 +49,13 @@ class Query extends ReportsQuery {
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Customers\Stats\Query class is deprecated, please use Reports\Customers\Query with a custom name, GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Customers\Stats\Query class is deprecated, please use `Reports\Customers\Query` with a custom name, `GenericQuery`, `\WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, 'x.x.x', '`Reports\Customers\Query` with a custom name, `GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_customers_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-customers-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
@@ -32,7 +32,7 @@ class Controller extends GenericController implements ExportableInterface {
 	protected $rest_base = 'reports/downloads';
 
 	/**
-	 * Get data from `'downloads'` Query.
+	 * Get data from `'downloads'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Query.php
@@ -22,29 +22,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Downloads\Query
  *
- * @deprecated 9.3.0 Downloads\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Downloads\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for downloads report.
 	 *
-	 * @deprecated 9.3.0 Downloads\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Downloads\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get downloads data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Downloads\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Downloads\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_downloads_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-downloads' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -60,7 +60,7 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get data from `'downloads-stats'` Query.
+	 * Get data from `'downloads-stats'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Query.php
@@ -12,29 +12,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Downloads\Stats\Query
  *
- * @deprecated 9.3.0 Downloads\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Downloads\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Orders report.
 	 *
-	 * @deprecated 9.3.0 Downloads\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Downloads\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get revenue data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Downloads\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Downloads\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_downloads_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-downloads-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericController.php
@@ -175,7 +175,7 @@ abstract class GenericController extends \WC_REST_Reports_Controller {
 	/**
 	 * Get the report data.
 	 *
-	 * Prepares query params, fetches the report data from the Query object,
+	 * Prepares query params, fetches the report data from the data store,
 	 * prepares it for the response, and packs it into the convention-conforming response object.
 	 *
 	 * @throws \WP_Error When the queried data is invalid.
@@ -237,7 +237,7 @@ abstract class GenericController extends \WC_REST_Reports_Controller {
 	}
 
 	/**
-	 * Maps query arguments from the REST request, to be fed to Query.
+	 * Maps query arguments from the REST request, to be used to query the datastore.
 	 *
 	 * `WP_REST_Request` does not expose a method to return all params covering defaults,
 	 * as it does for `$request['param']` accessor.

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
@@ -207,7 +207,7 @@ abstract class GenericStatsController extends GenericController {
 	/**
 	 * Get the report data.
 	 *
-	 * Prepares query params, fetches the report data from the Query object,
+	 * Prepares query params, fetches the report data from the data store,
 	 * prepares it for the response, and packs it into the convention-conforming response object.
 	 *
 	 * @override GenericController::get_items()

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -31,7 +31,7 @@ class Controller extends GenericController implements ExportableInterface {
 	protected $rest_base = 'reports/orders';
 
 	/**
-	 * Get data from Query.
+	 * Get data from Orders\Query.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -31,7 +31,7 @@ class Controller extends GenericStatsController {
 	protected $rest_base = 'reports/orders/stats';
 
 	/**
-	 * Get data from Query.
+	 * Get data from Orders\Stats\Query.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -478,7 +478,7 @@ class Controller extends GenericController {
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @param object $object data
+	 * @param object $object data.
 	 * @return array
 	 */
 	protected function prepare_links( $object ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -478,7 +478,7 @@ class Controller extends GenericController {
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @param \Automattic\WooCommerce\Admin\API\Reports\Query $object Object data.
+	 * @param object $object data
 	 * @return array
 	 */
 	protected function prepare_links( $object ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -42,7 +42,7 @@ class Controller extends GenericController implements ExportableInterface {
 	);
 
 	/**
-	 * Get data from `'products'` Query.
+	 * Get data from `'products'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Query.php
@@ -23,29 +23,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Products\Query
  *
- * @deprecated 9.3.0 Products\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Products\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Products report.
 	 *
-	 * @deprecated 9.3.0 Products\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Products\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Products\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Products\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_products_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-products' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -48,7 +48,7 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get data from `'products-stats'` Query.
+	 * Get data from `'products-stats'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *
@@ -61,7 +61,7 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Maps query arguments from the REST request, to be fed to Query.
+	 * Maps query arguments from the REST request to be used to query the datastore.
 	 *
 	 * @param \WP_REST_Request $request Full request object.
 	 * @return array Simplified array of params.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Query.php
@@ -23,29 +23,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Products\Stats\Query
  *
- * @deprecated 9.3.0 Products\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Products\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Products report.
 	 *
-	 * @deprecated 9.3.0 Products\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Products\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Products\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Products\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_products_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-products-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Query.php
@@ -10,17 +10,31 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Admin\API\Reports\Query
  *
- * @deprecated 9.3.0 Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 abstract class Query extends \WC_Object_Query {
+
+	/**
+	 * Create a new query.
+	 *
+	 * @deprecated 9.3.0 Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
+	 *
+	 * @param array $args Criteria to query on in a format similar to WP_Query.
+	 */
+	public function __construct( $args = array() ) {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+		parent::__construct( $args );
+	}
+
 	/**
 	 * Get report data matching the current query vars.
 	 *
-	 * @deprecated 9.3.0 Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array|object of WC_Product objects
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
 		/* translators: %s: Method name */
 		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be overridden in subclass.", 'woocommerce' ), __METHOD__ ), array( 'status' => 405 ) );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -36,7 +36,7 @@ class Controller extends GenericController implements ExportableInterface {
 	protected $rest_base = 'reports/taxes';
 
 	/**
-	 * Get data from `'taxes'` Query.
+	 * Get data from `'taxes'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Query.php
@@ -22,29 +22,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Taxes\Query
  *
- * @deprecated 9.3.0 Taxes\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Taxes\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Taxes report.
 	 *
-	 * @deprecated 9.3.0 Taxes\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Taxes\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Taxes\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Taxes\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_taxes_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-taxes' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -84,7 +84,7 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get data from `'taxes-stats'` Query.
+	 * Get data from `'taxes-stats'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Query.php
@@ -23,29 +23,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Taxes\Stats\Query
  *
- * @deprecated 9.3.0 Taxes\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Taxes\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Taxes report.
 	 *
-	 * @deprecated 9.3.0 Taxes\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Taxes\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get tax stats data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Taxes\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Taxes\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_taxes_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-taxes-stats' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -50,7 +50,7 @@ class Controller extends GenericController implements ExportableInterface {
 	);
 
 	/**
-	 * Get data from `'variations'` Query.
+	 * Get data from `'variations'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Query.php
@@ -23,29 +23,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Variations\Query
  *
- * @deprecated 9.3.0 Variations\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Variations\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Products report.
 	 *
-	 * @deprecated 9.3.0 Variations\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Variations\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get product data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Variations\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Variations\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_variations_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-variations' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -46,7 +46,7 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get data from `'variations-stats'` Query.
+	 * Get data from `'variations-stats'` GenericQuery.
 	 *
 	 * @override GenericController::get_datastore_data()
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Query.php
@@ -23,29 +23,33 @@ use Automattic\WooCommerce\Admin\API\Reports\Query as ReportsQuery;
 /**
  * API\Reports\Variations\Stats\Query
  *
- * @deprecated 9.3.0 Variations\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+ * @deprecated 9.3.0 Variations\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
  */
 class Query extends ReportsQuery {
 
 	/**
 	 * Valid fields for Products report.
 	 *
-	 * @deprecated 9.3.0 Variations\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Variations\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	protected function get_default_query_vars() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		return array();
 	}
 
 	/**
 	 * Get variations data based on the current query vars.
 	 *
-	 * @deprecated 9.3.0 Variations\Stats\Query class is deprecated, please use GenericQuery or \WC_Object_Query instead.
+	 * @deprecated 9.3.0 Variations\Stats\Query class is deprecated. Please use `GenericQuery`, \WC_Object_Query`, or use `DataStore` directly.
 	 *
 	 * @return array
 	 */
 	public function get_data() {
+		wc_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '9.3.0', '`GenericQuery`, `\WC_Object_Query`, or direct `DataStore` use' );
+
 		$args = apply_filters( 'woocommerce_analytics_variations_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-variations-stats' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Log deprecation warnings for Query class
deprecated in https://github.com/woocommerce/woocommerce/pull/49425

We introduced `GenericQuery` as a replacement for redundant `Query` classes, https://github.com/woocommerce/woocommerce/pull/49425 also added the support for Querry-less connection between a Controller and its DataStore.
As 9.2 is already prepared for the release with some developer advisory on how to 
With the new implementation, we can now start throwing warnings to motivate the community to stop using the classes so we can eventually remove them.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install an extension that uses the legacy `Query` class, like
   - woocommerce-product-bundles
   - woocommerce-gift-cards
   - sales-report-email-pro
3. Open the page that uses it (analytic reports)
4. Check the PHP log, look for `deprecated since version 9.3.0`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Log deprecation warnings for `Query` class usage.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
