### PR TITLE
Update woocommerce shipping promo banner [wc-shipping-188]

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -184,6 +184,11 @@ export class ShippingBanner extends Component {
 		const jsPath = assets.wcshipping_create_label_script;
 		const stylePath = assets.wcshipping_create_label_style;
 
+		const shipmentTrackingJsPath =
+			assets.wcshipping_shipment_tracking_script;
+		const shipmentTrackingStylePath =
+			assets.wcshipping_shipment_tracking_style;
+
 		if ( undefined === window.wcsPluginData ) {
 			const assetPath = jsPath.substring(
 				0,
@@ -241,11 +246,34 @@ export class ShippingBanner extends Component {
 				document.body.appendChild( script );
 			} ),
 			new Promise( ( resolve, reject ) => {
+				const script = document.createElement( 'script' );
+				script.src = shipmentTrackingJsPath;
+				script.async = true;
+				script.onload = resolve;
+				script.onerror = reject;
+				document.body.appendChild( script );
+			} ),
+			new Promise( ( resolve, reject ) => {
 				if ( stylePath !== '' ) {
 					const link = document.createElement( 'link' );
 					link.rel = 'stylesheet';
 					link.type = 'text/css';
 					link.href = stylePath;
+					link.media = 'all';
+					link.onload = resolve;
+					link.onerror = reject;
+					link.id = 'wcshipping-injected-styles';
+					document.head.appendChild( link );
+				} else {
+					resolve();
+				}
+			} ),
+			new Promise( ( resolve, reject ) => {
+				if ( shipmentTrackingStylePath !== '' ) {
+					const link = document.createElement( 'link' );
+					link.rel = 'stylesheet';
+					link.type = 'text/css';
+					link.href = shipmentTrackingStylePath;
 					link.media = 'all';
 					link.onload = resolve;
 					link.onerror = reject;

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Button, ExternalLink } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
@@ -23,6 +23,7 @@ import { getWcsAssets, acceptWcsTos } from '../wcs-api';
 
 const wcAssetUrl = getSetting( 'wcAssetUrl', '' );
 const wcsPluginSlug = 'woocommerce-shipping';
+const wcstPluginSlug = 'woocommerce-services';
 
 export class ShippingBanner extends Component {
 	constructor( props ) {
@@ -259,7 +260,7 @@ export class ShippingBanner extends Component {
 	}
 
 	getInstallText = () => {
-		const { activePlugins } = this.props;
+		const { activePlugins, actionButtonLabel } = this.props;
 		if ( activePlugins.includes( wcsPluginSlug ) ) {
 			// If WCS is active, then the only remaining step is to agree to the ToS.
 			return __(
@@ -267,9 +268,12 @@ export class ShippingBanner extends Component {
 				'woocommerce'
 			);
 		}
-		return __(
-			'By clicking "Create shipping label", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
-			'woocommerce'
+		return sprintf(
+			__(
+				'By clicking "%s", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
+				'woocommerce'
+			),
+			actionButtonLabel
 		);
 	};
 
@@ -394,6 +398,7 @@ export class ShippingBanner extends Component {
 			return null;
 		}
 
+		const { actionButtonLabel } = this.props;
 		return (
 			<div>
 				<div className="wc-admin-shipping-banner-container">
@@ -445,7 +450,7 @@ export class ShippingBanner extends Component {
 						isBusy={ isShippingLabelButtonBusy }
 						onClick={ this.createShippingLabelClicked }
 					>
-						{ __( 'Create shipping label', 'woocommerce' ) }
+						{ actionButtonLabel }
 					</Button>
 
 					<button
@@ -487,11 +492,16 @@ export default compose(
 		const isRequesting =
 			isPluginsRequesting( 'activatePlugins' ) ||
 			isPluginsRequesting( 'installPlugins' );
+		const activePlugins = getActivePlugins();
+		const actionButtonLabel = activePlugins.includes( wcstPluginSlug )
+			? __( 'Install WooCommerce Shipping', 'woocommerce' )
+			: __( 'Create shipping label', 'woocommerce' );
 
 		return {
 			isRequesting,
 			isJetpackConnected: isJetpackConnected(),
-			activePlugins: getActivePlugins(),
+			activePlugins,
+			actionButtonLabel,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -22,7 +22,7 @@ import SetupNotice, { setupErrorTypes } from '../setup-notice';
 import { getWcsAssets, acceptWcsTos } from '../wcs-api';
 
 const wcAssetUrl = getSetting( 'wcAssetUrl', '' );
-const wcsPluginSlug = 'woocommerce-services';
+const wcsPluginSlug = 'woocommerce-shipping';
 
 export class ShippingBanner extends Component {
 	constructor( props ) {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -293,7 +293,41 @@ export class ShippingBanner extends Component {
 		);
 	};
 
-	openWcsModal() {}
+	openWcsModal = () => {
+		// Since the button is dynamically added, we need to wait for it to become selectable and then click it.
+
+		const buttonSelector =
+			'#woocommerce-shipping-shipping-label-shipping_label button';
+		if ( MutationObserver ) {
+			const observer = new MutationObserver(
+				( mutationsList, observer ) => {
+					const button = document.querySelector( buttonSelector );
+					if ( button ) {
+						button.click();
+						observer.disconnect();
+					}
+				}
+			);
+
+			observer.observe(
+				document.getElementById(
+					'woocommerce-shipping-shipping-label-shipping_label'
+				),
+				{
+					childList: true,
+					subtree: true,
+				}
+			);
+		} else {
+			const interval = setInterval( () => {
+				const targetElement = document.querySelector( buttonSelector );
+				if ( targetElement ) {
+					targetElement.click();
+					clearInterval( interval );
+				}
+			}, 300 );
+		}
+	};
 
 	render() {
 		const {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -10,7 +10,8 @@ import PropTypes from 'prop-types';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { getSetting } from '@woocommerce/settings';
+import { getSetting, getAdminLink } from '@woocommerce/settings';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -370,10 +371,21 @@ export class ShippingBanner extends Component {
 			return (
 				<p>
 					<strong>
-						{ __(
-							'Please update the WooCommerce Shipping & Tax plugin to the latest version to ensure compatibility with WooCommerce Shipping.',
-							'woocommerce'
-						) }
+						{ interpolateComponents( {
+							mixedString: __(
+								'Please {{pluginPageLink}}update{{/pluginPageLink}} the WooCommerce Shipping & Tax plugin to the latest version to ensure compatibility with WooCommerce Shipping.',
+								'woocommerce'
+							),
+							components: {
+								pluginPageLink: (
+									<Link
+										href={ getAdminLink( 'plugins.php' ) }
+										target="_blank"
+										type="wp-admin"
+									/>
+								),
+							},
+						} ) }
 					</strong>
 				</p>
 			);

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -239,6 +239,13 @@ export class ShippingBanner extends Component {
 			window.jQuery( '#woocommerce-order-label' ).hide();
 		}
 
+		document
+			.querySelectorAll( 'script[src*="/woocommerce-services/"]' )
+			.forEach( ( node ) => node.remove?.() );
+		document
+			.querySelectorAll( 'link[href*="/woocommerce-services/"]' )
+			.forEach( ( node ) => node.remove?.() );
+
 		Promise.all( [
 			new Promise( ( resolve, reject ) => {
 				const script = document.createElement( 'script' );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -86,7 +86,8 @@ export class ShippingBanner extends Component {
 
 	async installAndActivatePlugins( pluginSlug ) {
 		// Avoid double activating.
-		const { installPlugins, activatePlugins, isRequesting } = this.props;
+		const { installPlugins, activatePlugins, isRequesting, activePlugins } =
+			this.props;
 		if ( isRequesting ) {
 			return false;
 		}
@@ -108,7 +109,16 @@ export class ShippingBanner extends Component {
 			return;
 		}
 
-		this.acceptTosAndGetWCSAssets();
+		if (
+			! activePlugins.includes( wcsPluginSlug ) &&
+			[ 1, '1' ].includes( wcShippingCoreData.is_wcst_compatible )
+		) {
+			this.acceptTosAndGetWCSAssets();
+		} else {
+			this.setState( {
+				showShippingBanner: false,
+			} );
+		}
 	}
 
 	woocommerceServiceLinkClicked = () => {
@@ -363,6 +373,26 @@ export class ShippingBanner extends Component {
 			showShippingBanner,
 			isShippingLabelButtonBusy,
 		} = this.state;
+		if (
+			! showShippingBanner &&
+			[ 0, '0' ].includes( wcShippingCoreData.is_wcst_compatible )
+		) {
+			document
+				.getElementById( 'woocommerce-admin-print-label' )
+				.classList.add( 'error' );
+
+			return (
+				<p>
+					<strong>
+						{ __(
+							'Please update the WooCommerce Shipping & Tax plugin to the latest version to ensure compatibility with WooCommerce Shipping.',
+							'woocommerce'
+						) }
+					</strong>
+				</p>
+			);
+		}
+
 		if ( ! showShippingBanner ) {
 			return null;
 		}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -7,7 +7,6 @@ import { Button, ExternalLink } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import interpolateComponents from '@automattic/interpolate-components';
 import PropTypes from 'prop-types';
-import { get, isArray } from 'lodash';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -37,7 +36,7 @@ export class ShippingBanner extends Component {
 			showShippingBanner: true,
 			isDismissModalOpen: false,
 			setupErrorReason: setupErrorTypes.SETUP,
-			orderId: parseInt( wcShippingCoreData.order_id, 10 ),
+			orderId: parseInt( window.wcShippingCoreData.order_id, 10 ),
 			wcsAssetsLoaded: false,
 			wcsAssetsLoading: false,
 			wcsSetupError: false,
@@ -111,7 +110,7 @@ export class ShippingBanner extends Component {
 
 		if (
 			! activePlugins.includes( wcsPluginSlug ) &&
-			[ 1, '1' ].includes( wcShippingCoreData.is_wcst_compatible )
+			[ 1, '1' ].includes( window.wcShippingCoreData.is_wcst_compatible )
 		) {
 			this.acceptTosAndGetWCSAssets();
 		} else {
@@ -155,14 +154,12 @@ export class ShippingBanner extends Component {
 			} )
 			.then( () => getWcsAssets() )
 			.then( ( wcsAssets ) => this.loadWcsAssets( wcsAssets ) )
-			.catch( ( err ) => {
+			.catch( () => {
 				this.setState( { wcsSetupError: true } );
 			} );
 	};
 
 	generateMetaBoxHtml( nodeId, title, args ) {
-		const argsJsonString = JSON.stringify( args ).replace( /"/g, '&quot;' ); // JS has no native html_entities so we just replace.
-
 		const togglePanelText = __( 'Toggle panel:', 'woocommerce' );
 
 		return `
@@ -323,6 +320,7 @@ export class ShippingBanner extends Component {
 			);
 		}
 		return sprintf(
+			// translators: %s is the action button label.
 			__(
 				'By clicking "%s", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
 				'woocommerce'
@@ -336,13 +334,13 @@ export class ShippingBanner extends Component {
 
 		const buttonSelector =
 			'#woocommerce-shipping-shipping-label-shipping_label button';
-		if ( MutationObserver ) {
-			const observer = new MutationObserver(
-				( mutationsList, observer ) => {
+		if ( window.MutationObserver ) {
+			const observer = new window.MutationObserver(
+				( mutationsList, observing ) => {
 					const button = document.querySelector( buttonSelector );
 					if ( button ) {
 						button.click();
-						observer.disconnect();
+						observing.disconnect();
 					}
 				}
 			);
@@ -375,7 +373,7 @@ export class ShippingBanner extends Component {
 		} = this.state;
 		if (
 			! showShippingBanner &&
-			[ 0, '0' ].includes( wcShippingCoreData.is_wcst_compatible )
+			[ 0, '0' ].includes( window.wcShippingCoreData.is_wcst_compatible )
 		) {
 			document
 				.getElementById( 'woocommerce-admin-print-label' )

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -198,16 +198,14 @@ export class ShippingBanner extends Component {
 		const shipmentTrackingStylePath =
 			assets.wcshipping_shipment_tracking_style;
 
-		const { itemsCount, orderId, activePlugins } = this.props;
+		const { activePlugins } = this.props;
 
 		document.getElementById( labelPurchaseMetaboxId )?.remove();
 		const shippingLabelContainerHtml = this.generateMetaBoxHtml(
 			labelPurchaseMetaboxId,
 			__( 'Shipping Label', 'woocommerce' ),
 			{
-				order: { id: orderId },
 				context: 'shipping_label',
-				items: itemsCount,
 			}
 		);
 		// Insert shipping label metabox just above main order details box.
@@ -220,9 +218,7 @@ export class ShippingBanner extends Component {
 			shipmentTrackingMetaboxId,
 			__( 'Shipment Tracking', 'woocommerce' ),
 			{
-				order: { id: orderId },
 				context: 'shipment_tracking',
-				items: itemsCount,
 			}
 		);
 		// Insert tracking metabox in the side after the order actions.
@@ -464,7 +460,6 @@ export class ShippingBanner extends Component {
 }
 
 ShippingBanner.propTypes = {
-	itemsCount: PropTypes.number.isRequired,
 	isJetpackConnected: PropTypes.bool.isRequired,
 	activePlugins: PropTypes.array.isRequired,
 	activatePlugins: PropTypes.func.isRequired,

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -318,7 +318,7 @@ export class ShippingBanner extends Component {
 		} );
 	}
 
-	openWcsModal = () => {
+	openWcsModal() {
 		// Since the button is dynamically added, we need to wait for it to become selectable and then click it.
 
 		const buttonSelector =
@@ -354,7 +354,7 @@ export class ShippingBanner extends Component {
 				}
 			}, 300 );
 		}
-	};
+	}
 
 	render() {
 		const {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -199,14 +199,6 @@ export class ShippingBanner extends Component {
 		const shipmentTrackingStylePath =
 			assets.wcshipping_shipment_tracking_style;
 
-		if ( undefined === window.wcsPluginData ) {
-			const assetPath = jsPath.substring(
-				0,
-				jsPath.lastIndexOf( '/' ) + 1
-			);
-			window.wcsPluginData = { assetPath };
-		}
-
 		const { itemsCount, orderId } = this.props;
 
 		document.getElementById( labelPurchaseMetaboxId )?.remove();

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -367,7 +367,7 @@ export class ShippingBanner extends Component {
 			return null;
 		}
 
-		const { actionButtonLabel } = this.props;
+		const { actionButtonLabel, headline } = this.props;
 		return (
 			<div>
 				<div className="wc-admin-shipping-banner-container">
@@ -377,12 +377,7 @@ export class ShippingBanner extends Component {
 						alt={ __( 'Shipping ', 'woocommerce' ) }
 					/>
 					<div className="wc-admin-shipping-banner-blob">
-						<h3>
-							{ __(
-								'Print discounted shipping labels with a click.',
-								'woocommerce'
-							) }
-						</h3>
+						<h3>{ headline }</h3>
 						<p>
 							{ interpolateComponents( {
 								mixedString: this.state.installText,
@@ -465,12 +460,21 @@ export default compose(
 		const actionButtonLabel = activePlugins.includes( wcstPluginSlug )
 			? __( 'Install WooCommerce Shipping', 'woocommerce' )
 			: __( 'Create shipping label', 'woocommerce' );
-
+		const headline = activePlugins.includes( wcstPluginSlug )
+			? __(
+					'Print discounted shipping labels with a click, now with the dedicated plugin!',
+					'woocommerce'
+			  )
+			: __(
+					'Print discounted shipping labels with a click.',
+					'woocommerce'
+			  );
 		return {
 			isRequesting,
 			isJetpackConnected: isJetpackConnected(),
 			activePlugins,
 			actionButtonLabel,
+			headline,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -337,7 +337,9 @@ export class ShippingBanner extends Component {
 			observer.observe(
 				document.getElementById(
 					'woocommerce-shipping-shipping-label-shipping_label'
-				),
+				) ??
+					document.getElementById( 'wpbody-content' ) ??
+					document.body,
 				{
 					childList: true,
 					subtree: true,

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -25,7 +25,7 @@ import {
 } from '../wcs-api';
 
 const wcAssetUrl = getSetting( 'wcAssetUrl', '' );
-const wcsPluginSlug = 'woocommerce-shipping';
+const wcShippingPluginSlug = 'woocommerce-shipping';
 const wcstPluginSlug = 'woocommerce-services';
 
 export class ShippingBanner extends Component {
@@ -74,8 +74,8 @@ export class ShippingBanner extends Component {
 		const { activePlugins } = this.props;
 		this.setState( { isShippingLabelButtonBusy: true } );
 		this.trackElementClicked( 'shipping_banner_create_label' );
-		if ( ! activePlugins.includes( wcsPluginSlug ) ) {
-			this.installAndActivatePlugins( wcsPluginSlug );
+		if ( ! activePlugins.includes( wcShippingPluginSlug ) ) {
+			this.installAndActivatePlugins( wcShippingPluginSlug );
 		} else {
 			this.acceptTosAndGetWCSAssets();
 		}
@@ -111,7 +111,10 @@ export class ShippingBanner extends Component {
 			return;
 		}
 
-		if ( ! activePlugins.includes( wcsPluginSlug ) && isWcstCompatible ) {
+		if (
+			! activePlugins.includes( wcShippingPluginSlug ) &&
+			isWcstCompatible
+		) {
 			this.acceptTosAndGetWCSAssets();
 		} else {
 			this.setState( {
@@ -130,7 +133,7 @@ export class ShippingBanner extends Component {
 			banner_name: 'wcadmin_install_wcs_prompt',
 			jetpack_installed: activePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
-			wcs_installed: activePlugins.includes( wcsPluginSlug ),
+			wcs_installed: activePlugins.includes( wcShippingPluginSlug ),
 			...customProps,
 		} );
 	};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -199,7 +199,7 @@ export class ShippingBanner extends Component {
 		const shipmentTrackingStylePath =
 			assets.wcshipping_shipment_tracking_style;
 
-		const { itemsCount, orderId } = this.props;
+		const { itemsCount, orderId, activePlugins } = this.props;
 
 		document.getElementById( labelPurchaseMetaboxId )?.remove();
 		const shippingLabelContainerHtml = this.generateMetaBoxHtml(
@@ -309,7 +309,13 @@ export class ShippingBanner extends Component {
 				'woocommerce-admin-print-label'
 			).style.display = 'none';
 
-			this.openWcsModal();
+			/**
+			 * We'll only get to this point if either WCS&T is not active or is active but compatible with WooCommerce Shipping
+			 * so once we check if the WCS&T is not active, we can open the label purchase modal immediately.
+			 */
+			if ( ! activePlugins.includes( wcstPluginSlug ) ) {
+				this.openWcsModal();
+			}
 		} );
 	}
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -189,6 +189,8 @@ export class ShippingBanner extends Component {
 
 		this.setState( { wcsAssetsLoading: true } );
 
+		const labelPurchaseMetaboxId = 'woocommerce-order-label';
+		const shipmentTrackingMetaboxId = 'woocommerce-order-shipment-tracking';
 		const jsPath = assets.wcshipping_create_label_script;
 		const stylePath = assets.wcshipping_create_label_style;
 
@@ -207,8 +209,9 @@ export class ShippingBanner extends Component {
 
 		const { itemsCount, orderId } = this.props;
 
+		document.getElementById( labelPurchaseMetaboxId )?.remove();
 		const shippingLabelContainerHtml = this.generateMetaBoxHtml(
-			'woocommerce-order-label',
+			labelPurchaseMetaboxId,
 			__( 'Shipping Label', 'woocommerce' ),
 			{
 				order: { id: orderId },
@@ -221,8 +224,9 @@ export class ShippingBanner extends Component {
 			.getElementById( 'woocommerce-order-data' )
 			.insertAdjacentHTML( 'beforebegin', shippingLabelContainerHtml );
 
+		document.getElementById( shipmentTrackingMetaboxId )?.remove();
 		const shipmentTrackingHtml = this.generateMetaBoxHtml(
-			'woocommerce-order-shipment-tracking',
+			shipmentTrackingMetaboxId,
 			__( 'Shipment Tracking', 'woocommerce' ),
 			{
 				order: { id: orderId },

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -90,6 +90,7 @@ export class ShippingBanner extends Component {
 			isRequesting,
 			activePlugins,
 			isWcstCompatible,
+			isIncompatibleWCShippingInstalled,
 		} = this.props;
 		if ( isRequesting ) {
 			return false;
@@ -109,6 +110,15 @@ export class ShippingBanner extends Component {
 				setupErrorReason: setupErrorTypes.ACTIVATE,
 				wcsSetupError: true,
 			} );
+			return;
+		}
+
+		/**
+		 * If a incompatible version of the WooCommerce Shipping plugin is installed, the necessary endpoints
+		 * are not available, so we need to reload the page to ensure to make the plugin usable.
+		 */
+		if ( isIncompatibleWCShippingInstalled ) {
+			window.location.reload( true );
 			return;
 		}
 
@@ -514,6 +524,9 @@ export default compose(
 			orderId: parseInt( window.wcShippingCoreData.order_id, 10 ),
 			isWcstCompatible: [ 1, '1' ].includes(
 				window.wcShippingCoreData.is_wcst_compatible
+			),
+			isIncompatibleWCShippingInstalled: [ 1, '1' ].includes(
+				window.wcShippingCoreData.is_incompatible_wcshipping_installed
 			),
 		};
 	} ),

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -40,7 +40,6 @@ export class ShippingBanner extends Component {
 			wcsAssetsLoading: false,
 			wcsSetupError: false,
 			isShippingLabelButtonBusy: false,
-			installText: this.getInstallText(),
 			isWcsModalOpen: false,
 		};
 	}
@@ -319,25 +318,6 @@ export class ShippingBanner extends Component {
 		} );
 	}
 
-	getInstallText = () => {
-		const { activePlugins, actionButtonLabel } = this.props;
-		if ( activePlugins.includes( wcsPluginSlug ) ) {
-			// If WCS is active, then the only remaining step is to agree to the ToS.
-			return __(
-				'You\'ve already installed WooCommerce Shipping. By clicking "Create shipping label", you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
-				'woocommerce'
-			);
-		}
-		return sprintf(
-			// translators: %s is the action button label.
-			__(
-				'By clicking "%s", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
-				'woocommerce'
-			),
-			actionButtonLabel
-		);
-	};
-
 	openWcsModal = () => {
 		// Since the button is dynamically added, we need to wait for it to become selectable and then click it.
 
@@ -415,7 +395,14 @@ export class ShippingBanner extends Component {
 						<h3>{ headline }</h3>
 						<p>
 							{ interpolateComponents( {
-								mixedString: this.state.installText,
+								mixedString: sprintf(
+									// translators: %s is the action button label.
+									__(
+										'By clicking "%s", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
+										'woocommerce'
+									),
+									actionButtonLabel
+								),
 								components: {
 									tosLink: (
 										<ExternalLink

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -525,8 +525,6 @@ describe( 'The message in the banner', () => {
 
 	const notActivatedMessage =
 		'By clicking "Create shipping label", WooCommerce Shipping(opens in a new tab) will be installed and you agree to its Terms of Service(opens in a new tab).';
-	const activatedMessage =
-		'You\'ve already installed WooCommerce Shipping. By clicking "Create shipping label", you agree to its Terms of Service(opens in a new tab).';
 
 	it( 'should show install text "By clicking "Create shipping label"..." when first loaded.', () => {
 		const { container } = createShippingBannerWrapper( {
@@ -554,6 +552,7 @@ describe( 'The message in the banner', () => {
 				itemsCount={ 1 }
 				orderId={ 1 }
 				isWcstCompatible={ true }
+				actionButtonLabel="Create shipping label"
 			/>
 		);
 
@@ -561,16 +560,5 @@ describe( 'The message in the banner', () => {
 			container.querySelector( '.wc-admin-shipping-banner-blob p' )
 				.textContent
 		).toBe( notActivatedMessage );
-	} );
-
-	it( 'should show install text "By clicking "You\'ve already installed WooCommerce Shipping."..." when WooCommerce Service is already installed.', () => {
-		const { container } = createShippingBannerWrapper( {
-			activePlugins: [ wcsPluginSlug ],
-		} );
-
-		expect(
-			container.querySelector( '.wc-admin-shipping-banner-blob p' )
-				.textContent
-		).toBe( activatedMessage );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -66,6 +66,16 @@
 	.components-external-link__icon {
 		display: none;
 	}
+
+	&.error {
+		min-height: auto;
+		.inside {
+			padding-bottom: 6px;
+				p {
+					font-size: 13px;
+				}
+		}
+	}
 }
 
 .components-modal__frame.wc-admin-shipping-banner__dismiss-modal {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -71,9 +71,9 @@
 		min-height: auto;
 		.inside {
 			padding-bottom: 6px;
-				p {
-					font-size: 13px;
-				}
+			p {
+				font-size: 13px;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/wcs-api.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/wcs-api.js
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 
 export function acceptWcsTos() {
-	const path = '/wc/v1/connect/tos';
+	const path = '/wcshipping/v1/tos';
 	return apiFetch( {
 		path,
 		method: 'POST',
@@ -13,7 +13,15 @@ export function acceptWcsTos() {
 }
 
 export function getWcsAssets() {
-	const path = '/wc/v1/connect/assets';
+	const path = '/wcshipping/v1/assets';
+	return apiFetch( {
+		path,
+		method: 'GET',
+	} );
+}
+
+export function getWcsLabelPurchaseConfigs(orderId) {
+	const path = `wcshipping/v1/config/label_purchase/${orderId}`;
 	return apiFetch( {
 		path,
 		method: 'GET',

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/wcs-api.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/wcs-api.js
@@ -20,8 +20,8 @@ export function getWcsAssets() {
 	} );
 }
 
-export function getWcsLabelPurchaseConfigs(orderId) {
-	const path = `wcshipping/v1/config/label_purchase/${orderId}`;
+export function getWcsLabelPurchaseConfigs( orderId ) {
+	const path = `wcshipping/v1/config/label_purchase/${ orderId }`;
 	return apiFetch( {
 		path,
 		method: 'GET',

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/wcs-api.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/wcs-api.js
@@ -21,7 +21,7 @@ export function getWcsAssets() {
 }
 
 export function getWcsLabelPurchaseConfigs( orderId ) {
-	const path = `wcshipping/v1/config/label_purchase/${ orderId }`;
+	const path = `wcshipping/v1/config/label-purchase/${ orderId }`;
 	return apiFetch( {
 		path,
 		method: 'GET',

--- a/plugins/woocommerce/changelog/update-woocommerce-shipping-promo-banner-188
+++ b/plugins/woocommerce/changelog/update-woocommerce-shipping-promo-banner-188
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Shipping Promo Banner to install the latest version of WooCommerce Shipping instead of WCS&T.

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * Shows print shipping label banner on edit order page.
@@ -84,9 +85,9 @@ class ShippingLabelBanner {
 	 * @param \WP_Post $post Current post object.
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
-		if ( 'shop_order' !== $post_type ) {
-			return;
-		}
+    if ( !OrderUtil::is_order_edit_screen() ) {
+      return;
+    }
 		$order = wc_get_order( $post );
 		if ( $this->should_show_meta_box() ) {
 			add_meta_box(

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -38,15 +38,15 @@ class ShippingLabelBanner {
 	private function should_show_meta_box() {
 		if ( ! $this->shipping_label_banner_display_rules ) {
 			$dotcom_connected = null;
-			$wcs_version       = null;
-			$wcs_tos_accepted  = null;
+			$wcs_version      = null;
+			$wcs_tos_accepted = null;
 
 			if ( class_exists( Jetpack_Connection_Manager::class ) ) {
 				$dotcom_connected = ( new Jetpack_Connection_Manager() )->has_connected_owner();
 			}
 
-			if ( class_exists( '\WC_Connect_Loader' ) ) {
-				$wcs_version = \WC_Connect_Loader::get_wcs_version();
+			if ( class_exists( '\Automattic\WCShipping\Utils' ) ) {
+				$wcs_version = \Automattic\WCShipping\Utils::get_wcshipping_version();
 			}
 
 			if ( class_exists( '\WC_Connect_Options' ) ) {
@@ -79,9 +79,9 @@ class ShippingLabelBanner {
 	 * @param \WP_Post $post Current post object.
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
-    if ( !OrderUtil::is_order_edit_screen() ) {
-      return;
-    }
+		if ( ! OrderUtil::is_order_edit_screen() ) {
+			return;
+		}
 		$order = wc_get_order( $post );
 		if ( $this->should_show_meta_box() ) {
 			add_meta_box(

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -37,17 +37,12 @@ class ShippingLabelBanner {
 	 */
 	private function should_show_meta_box() {
 		if ( ! $this->shipping_label_banner_display_rules ) {
-			$jetpack_version   = null;
-			$jetpack_connected = null;
+			$dotcom_connected = null;
 			$wcs_version       = null;
 			$wcs_tos_accepted  = null;
 
-			if ( defined( 'JETPACK__VERSION' ) ) {
-				$jetpack_version = JETPACK__VERSION;
-			}
-
 			if ( class_exists( Jetpack_Connection_Manager::class ) ) {
-				$jetpack_connected = ( new Jetpack_Connection_Manager() )->has_connected_owner();
+				$dotcom_connected = ( new Jetpack_Connection_Manager() )->has_connected_owner();
 			}
 
 			if ( class_exists( '\WC_Connect_Loader' ) ) {
@@ -67,8 +62,7 @@ class ShippingLabelBanner {
 
 			$this->shipping_label_banner_display_rules =
 				new ShippingLabelBannerDisplayRules(
-					$jetpack_version,
-					$jetpack_connected,
+					$dotcom_connected,
 					$wcs_version,
 					$wcs_tos_accepted,
 					$incompatible_plugins

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -56,9 +56,7 @@ class ShippingLabelBanner {
 			$incompatible_plugins = class_exists( '\WC_Shipping_Fedex_Init' ) ||
 				class_exists( '\WC_Shipping_UPS_Init' ) ||
 				class_exists( '\WC_Integration_ShippingEasy' ) ||
-				class_exists( '\WC_ShipStation_Integration' ) ||
-				class_exists( '\Automattic\WCShipping\Loader' ) ||
-				class_exists( '\Automattic\WCTax\Loader' );
+				class_exists( '\WC_ShipStation_Integration' );
 
 			$this->shipping_label_banner_display_rules =
 				new ShippingLabelBannerDisplayRules(

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -20,6 +20,8 @@ class ShippingLabelBanner {
 	 */
 	private $shipping_label_banner_display_rules;
 
+	private const MIN_COMPATIBLE_WCST_VERSION = '2.7.0';
+
 	/**
 	 * Constructor
 	 */
@@ -125,14 +127,18 @@ class ShippingLabelBanner {
 	public function add_print_shipping_label_script( $hook ) {
 		WCAdminAssets::register_style( 'print-shipping-label-banner', 'style', array( 'wp-components' ) );
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'print-shipping-label-banner', true );
+		$wcst_version = null;
+		$order        = wc_get_order();
+		if ( class_exists( '\WC_Connect_Loader' ) ) {
+			$wcst_version = \WC_Connect_Loader::get_wcs_version();
+		}
 
 		$payload = array(
-			'nonce'                 => wp_create_nonce( 'wp_rest' ),
-			'baseURL'               => get_rest_url(),
-			'wcs_server_connection' => true,
+			'is_wcst_compatible' => $wcst_version ? (int) version_compare( $wcst_version, self::MIN_COMPATIBLE_WCST_VERSION, '>=' ) : 0,
+			'order_id'           => $order ? $order->get_id() : null,
 		);
 
-		wp_localize_script( 'print-shipping-label-banner', 'wcConnectData', $payload );
+		wp_localize_script( 'wc-admin-print-shipping-label-banner', 'wcShippingCoreData', $payload );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -76,7 +76,7 @@ class ShippingLabelBanner {
 		if ( ! OrderUtil::is_order_edit_screen() ) {
 			return;
 		}
-		$order = wc_get_order( $post_or_order );
+
 		if ( $this->should_show_meta_box() ) {
 			add_meta_box(
 				'woocommerce-admin-print-label',
@@ -87,8 +87,6 @@ class ShippingLabelBanner {
 				'high',
 				array(
 					'context' => 'shipping_label',
-					'order'   => $order->get_id(),
-					'items'   => $this->count_shippable_items( $order ),
 				)
 			);
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_print_shipping_label_script' ) );

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -68,11 +68,8 @@ class ShippingLabelBanner {
 
 	/**
 	 * Add metabox to order page.
-	 *
-	 * @param string             $order_type current post type.
-	 * @param \WP_Post|\WC_Order $post_or_order Current post object.
 	 */
-	public function add_meta_boxes( $order_type, $post_or_order ) {
+	public function add_meta_boxes() {
 		if ( ! OrderUtil::is_order_edit_screen() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -41,7 +41,6 @@ class ShippingLabelBanner {
 		if ( ! $this->shipping_label_banner_display_rules ) {
 			$dotcom_connected = null;
 			$wcs_version      = null;
-			$wcs_tos_accepted = null;
 
 			if ( class_exists( Jetpack_Connection_Manager::class ) ) {
 				$dotcom_connected = ( new Jetpack_Connection_Manager() )->has_connected_owner();
@@ -49,10 +48,6 @@ class ShippingLabelBanner {
 
 			if ( class_exists( '\Automattic\WCShipping\Utils' ) ) {
 				$wcs_version = \Automattic\WCShipping\Utils::get_wcshipping_version();
-			}
-
-			if ( class_exists( '\WC_Connect_Options' ) ) {
-				$wcs_tos_accepted = \WC_Connect_Options::get_option( 'tos_accepted' );
 			}
 
 			$incompatible_plugins = class_exists( '\WC_Shipping_Fedex_Init' ) ||
@@ -64,7 +59,6 @@ class ShippingLabelBanner {
 				new ShippingLabelBannerDisplayRules(
 					$dotcom_connected,
 					$wcs_version,
-					$wcs_tos_accepted,
 					$incompatible_plugins
 				);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -69,14 +69,14 @@ class ShippingLabelBanner {
 	/**
 	 * Add metabox to order page.
 	 *
-	 * @param string   $post_type current post type.
-	 * @param \WP_Post $post Current post object.
+	 * @param string             $order_type current post type.
+	 * @param \WP_Post|\WC_Order $post_or_order Current post object.
 	 */
-	public function add_meta_boxes( $post_type, $post ) {
+	public function add_meta_boxes( $order_type, $post_or_order ) {
 		if ( ! OrderUtil::is_order_edit_screen() ) {
 			return;
 		}
-		$order = wc_get_order( $post );
+		$order = wc_get_order( $post_or_order );
 		if ( $this->should_show_meta_box() ) {
 			add_meta_box(
 				'woocommerce-admin-print-label',
@@ -87,7 +87,7 @@ class ShippingLabelBanner {
 				'high',
 				array(
 					'context' => 'shipping_label',
-					'order'   => $post->ID,
+					'order'   => $order->get_id(),
 					'items'   => $this->count_shippable_items( $order ),
 				)
 			);

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -134,7 +134,7 @@ class ShippingLabelBanner {
 		}
 
 		$payload = array(
-			// If WCS&T is not installed, it's considered compatible
+			// If WCS&T is not installed, it's considered compatible.
 			'is_wcst_compatible' => $wcst_version ? (int) version_compare( $wcst_version, self::MIN_COMPATIBLE_WCST_VERSION, '>=' ) : 1,
 			'order_id'           => $order ? $order->get_id() : null,
 		);

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -134,7 +134,8 @@ class ShippingLabelBanner {
 		}
 
 		$payload = array(
-			'is_wcst_compatible' => $wcst_version ? (int) version_compare( $wcst_version, self::MIN_COMPATIBLE_WCST_VERSION, '>=' ) : 0,
+			// If WCS&T is not installed, it's considered compatible
+			'is_wcst_compatible' => $wcst_version ? (int) version_compare( $wcst_version, self::MIN_COMPATIBLE_WCST_VERSION, '>=' ) : 1,
 			'order_id'           => $order ? $order->get_id() : null,
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -6,7 +6,7 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 /**
- * Determines whether or not the Shipping Label Banner should be displayed
+ * Determines whether the Shipping Label Banner should be displayed
  */
 class ShippingLabelBannerDisplayRules {
 
@@ -25,14 +25,14 @@ class ShippingLabelBannerDisplayRules {
 	private $wcs_version;
 
 	/**
-	 * Whether or not there're plugins installed incompatible with the banner.
+	 * Whether installed plugins are incompatible with the banner.
 	 *
 	 * @var bool
 	 */
 	private $no_incompatible_plugins_installed;
 
 	/**
-	 * Whether or not the WooCommerce Shipping & Tax ToS has been accepted.
+	 * Whether the WooCommerce Shipping & Tax ToS has been accepted.
 	 *
 	 * @var bool
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -18,13 +18,6 @@ class ShippingLabelBannerDisplayRules {
 	private $dotcom_connected;
 
 	/**
-	 * Holds the installed WooCommerce Shipping & Tax version.
-	 *
-	 * @var string
-	 */
-	private $wcs_version;
-
-	/**
 	 * Whether installed plugins are incompatible with the banner.
 	 *
 	 * @var bool
@@ -32,18 +25,18 @@ class ShippingLabelBannerDisplayRules {
 	private $no_incompatible_plugins_installed;
 
 	/**
+	 * Holds the installed WooCommerce Shipping & Tax version.
+	 *
+	 * @var string
+	 */
+	private $wcs_version;
+
+	/**
 	 * Whether the WooCommerce Shipping & Tax ToS has been accepted.
 	 *
 	 * @var bool
 	 */
 	private $wcs_tos_accepted;
-
-	/**
-	 * Minimum supported WooCommerce Shipping & Tax version.
-	 *
-	 * @var string
-	 */
-	private $min_wcs_version = '1.22.5';
 
 	/**
 	 * Supported countries by USPS, see: https://webpmt.usps.gov/pmt010.cfm
@@ -63,13 +56,12 @@ class ShippingLabelBannerDisplayRules {
 	/**
 	 * Constructor.
 	 *
-	 * @param bool   $dotcom_connected Is site connected to wordpress.com?.
-	 * @param string $wcs_version Installed WooCommerce Shipping & Tax version to check.
-	 * @param bool   $wcs_tos_accepted WooCommerce Shipping & Tax Terms of Service accepted?.
-	 * @param bool   $incompatible_plugins_installed Are there any incompatible plugins installed?.
+	 * @param bool $dotcom_connected Is site connected to wordpress.com?.
+	 * @param bool $wcs_tos_accepted WooCommerce Shipping & Tax Terms of Service accepted?.
+	 * @param bool $incompatible_plugins_installed Are there any incompatible plugins installed?.
 	 */
 	public function __construct( $dotcom_connected, $wcs_version, $wcs_tos_accepted, $incompatible_plugins_installed ) {
-		$this->dotcom_connected                 = $dotcom_connected;
+		$this->dotcom_connected                  = $dotcom_connected;
 		$this->wcs_version                       = $wcs_version;
 		$this->wcs_tos_accepted                  = $wcs_tos_accepted;
 		$this->no_incompatible_plugins_installed = ! $incompatible_plugins_installed;
@@ -84,9 +76,7 @@ class ShippingLabelBannerDisplayRules {
 			$this->no_incompatible_plugins_installed &&
 			$this->order_has_shippable_products() &&
 			$this->store_in_us_and_usd() &&
-			( $this->wcs_not_installed() || (
-				$this->wcs_up_to_date() && ! $this->wcs_tos_accepted
-			) );
+			$this->wcs_not_installed();
 	}
 
 	/**
@@ -154,12 +144,5 @@ class ShippingLabelBannerDisplayRules {
 	 */
 	private function wcs_not_installed() {
 		return ! $this->wcs_version;
-	}
-
-	/**
-	 * Checks if WooCommerce Shipping & Tax is up to date.
-	 */
-	private function wcs_up_to_date() {
-		return $this->wcs_version && version_compare( $this->wcs_version, $this->min_wcs_version, '>=' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -153,12 +153,7 @@ class ShippingLabelBannerDisplayRules {
 	 * @return bool
 	 */
 	private function order_has_shippable_products() {
-		$post = get_post();
-		if ( ! $post ) {
-			return false;
-		}
-
-		$order = wc_get_order( get_post()->ID );
+		$order = wc_get_order();
 
 		if ( ! $order ) {
 			return false;

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -11,11 +11,11 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class ShippingLabelBannerDisplayRules {
 
 	/**
-	 * Whether or not the installed Jetpack is connected.
+	 * Whether the site is connected to wordpress.com.
 	 *
 	 * @var bool
 	 */
-	private $jetpack_connected;
+	private $dotcom_connected;
 
 	/**
 	 * Holds the installed WooCommerce Shipping & Tax version.
@@ -63,15 +63,13 @@ class ShippingLabelBannerDisplayRules {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $jetpack_version Installed Jetpack version to check.
-	 * @param bool   $jetpack_connected Is Jetpack connected?.
+	 * @param bool   $dotcom_connected Is site connected to wordpress.com?.
 	 * @param string $wcs_version Installed WooCommerce Shipping & Tax version to check.
 	 * @param bool   $wcs_tos_accepted WooCommerce Shipping & Tax Terms of Service accepted?.
 	 * @param bool   $incompatible_plugins_installed Are there any incompatible plugins installed?.
 	 */
-	public function __construct( $jetpack_version, $jetpack_connected, $wcs_version, $wcs_tos_accepted, $incompatible_plugins_installed ) {
-		$this->jetpack_version                   = $jetpack_version;
-		$this->jetpack_connected                 = $jetpack_connected;
+	public function __construct( $dotcom_connected, $wcs_version, $wcs_tos_accepted, $incompatible_plugins_installed ) {
+		$this->dotcom_connected                 = $dotcom_connected;
 		$this->wcs_version                       = $wcs_version;
 		$this->wcs_tos_accepted                  = $wcs_tos_accepted;
 		$this->no_incompatible_plugins_installed = ! $incompatible_plugins_installed;
@@ -82,7 +80,7 @@ class ShippingLabelBannerDisplayRules {
 	 */
 	public function should_display_banner() {
 		return $this->banner_not_dismissed() &&
-			$this->jetpack_connected &&
+			$this->dotcom_connected &&
 			$this->no_incompatible_plugins_installed &&
 			$this->order_has_shippable_products() &&
 			$this->store_in_us_and_usd() &&

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -11,14 +11,6 @@ namespace Automattic\WooCommerce\Internal\Admin;
 class ShippingLabelBannerDisplayRules {
 
 	/**
-	 * Holds the installed Jetpack version.
-	 *
-	 * @var string
-	 */
-	private $jetpack_version;
-
-
-	/**
 	 * Whether or not the installed Jetpack is connected.
 	 *
 	 * @var bool
@@ -45,13 +37,6 @@ class ShippingLabelBannerDisplayRules {
 	 * @var bool
 	 */
 	private $wcs_tos_accepted;
-
-	/**
-	 * Minimum supported Jetpack version.
-	 *
-	 * @var string
-	 */
-	private $min_jetpack_version = '4.4';
 
 	/**
 	 * Minimum supported WooCommerce Shipping & Tax version.
@@ -97,8 +82,6 @@ class ShippingLabelBannerDisplayRules {
 	 */
 	public function should_display_banner() {
 		return $this->banner_not_dismissed() &&
-			$this->jetpack_installed_and_active() &&
-			$this->jetpack_up_to_date() &&
 			$this->jetpack_connected &&
 			$this->no_incompatible_plugins_installed &&
 			$this->order_has_shippable_products() &&
@@ -127,24 +110,6 @@ class ShippingLabelBannerDisplayRules {
 		$dismissed_24h      = time() < $expired_timestamp;
 
 		return ! $dismissed_for_good && ! $dismissed_24h;
-	}
-
-	/**
-	 * Checks if jetpack is installed and active.
-	 *
-	 * @return bool
-	 */
-	private function jetpack_installed_and_active() {
-		return ! ! $this->jetpack_version;
-	}
-
-	/**
-	 * Checks if Jetpack version is supported.
-	 *
-	 * @return bool
-	 */
-	private function jetpack_up_to_date() {
-		return version_compare( $this->jetpack_version, $this->min_jetpack_version, '>=' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -32,13 +32,6 @@ class ShippingLabelBannerDisplayRules {
 	private $wcs_version;
 
 	/**
-	 * Whether the WooCommerce Shipping & Tax ToS has been accepted.
-	 *
-	 * @var bool
-	 */
-	private $wcs_tos_accepted;
-
-	/**
 	 * Supported countries by USPS, see: https://webpmt.usps.gov/pmt010.cfm
 	 *
 	 * @var array
@@ -58,13 +51,11 @@ class ShippingLabelBannerDisplayRules {
 	 *
 	 * @param bool        $dotcom_connected Is site connected to wordpress.com?.
 	 * @param string|null $wcs_version Installed WooCommerce Shipping version to check, null if not installed.
-	 * @param bool        $wcs_tos_accepted WooCommerce Shipping & Tax Terms of Service accepted?.
 	 * @param bool        $incompatible_plugins_installed Are there any incompatible plugins installed?.
 	 */
-	public function __construct( $dotcom_connected, $wcs_version, $wcs_tos_accepted, $incompatible_plugins_installed ) {
+	public function __construct( $dotcom_connected, $wcs_version, $incompatible_plugins_installed ) {
 		$this->dotcom_connected                  = $dotcom_connected;
 		$this->wcs_version                       = $wcs_version;
-		$this->wcs_tos_accepted                  = $wcs_tos_accepted;
 		$this->no_incompatible_plugins_installed = ! $incompatible_plugins_installed;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBannerDisplayRules.php
@@ -56,9 +56,10 @@ class ShippingLabelBannerDisplayRules {
 	/**
 	 * Constructor.
 	 *
-	 * @param bool $dotcom_connected Is site connected to wordpress.com?.
-	 * @param bool $wcs_tos_accepted WooCommerce Shipping & Tax Terms of Service accepted?.
-	 * @param bool $incompatible_plugins_installed Are there any incompatible plugins installed?.
+	 * @param bool        $dotcom_connected Is site connected to wordpress.com?.
+	 * @param string|null $wcs_version Installed WooCommerce Shipping version to check, null if not installed.
+	 * @param bool        $wcs_tos_accepted WooCommerce Shipping & Tax Terms of Service accepted?.
+	 * @param bool        $incompatible_plugins_installed Are there any incompatible plugins installed?.
 	 */
 	public function __construct( $dotcom_connected, $wcs_version, $wcs_tos_accepted, $incompatible_plugins_installed ) {
 		$this->dotcom_connected                  = $dotcom_connected;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -66,7 +66,6 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	/**
 	 * Test if the banner is displayed when all conditions are satisfied:
 	 *   - Banner NOT dismissed
-	 *   - Jetpack >= 4.4 installed and active
 	 *   - Jetpack Connected
 	 *   - No incompatible extensions installed:
 	 *       - Shipstation not installed
@@ -76,13 +75,12 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 *   - Order contains physical products which need to be shipped (we should check that the order status is not set to complete)
 	 *   - Store is located in US
 	 *   - Store currency is set to USD
-	 *   - WCS plugin not installed OR WCS is installed *AND* ToS have NOT been accepted *AND* WCS version is 1.22.5 or greater
-	 *     (The 1.22.5 or greater requirement is so we can launch the shipping modal from the banner)
+	 *   - WCS plugin not installed OR WCS is installed
 	 */
 	public function test_display_banner_if_all_conditions_are_met() {
 		$this->with_order(
 			function ( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, null, false, false );
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, null, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
 			}
@@ -93,7 +91,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 * Test if the banner is hidden when Jetpack is not active.
 	 */
 	public function test_if_banner_hidden_when_jetpack_disconnected() {
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( null, null, null, null );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( null, null, null );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -103,7 +101,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_dismiss_option_enabled() {
 		update_option( 'woocommerce_shipping_dismissed_timestamp', -1 );
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -115,7 +113,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		$two_hours_from_ago = ( time() - 2 * 60 * 60 ) * 1000;
 		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_ago );
 
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -140,7 +138,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 * Test if the banner is hidden when no shippable product available.
 	 */
 	public function test_if_banner_hidden_when_no_shippable_product() {
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -166,7 +164,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		update_option( 'woocommerce_currency', 'EUR' );
 		$this->with_order(
 			function ( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -192,20 +190,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	public function test_if_banner_hidden_when_jetpack_version_is_old() {
 		$this->with_order(
 			function ( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
-
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
-			}
-		);
-	}
-
-	/**
-	 * Test if the banner is hidden when the WooCommerce Shipping & Tax Terms of Service has been already accepted.
-	 */
-	public function test_if_banner_hidden_when_wcs_tos_accepted() {
-		$this->with_order(
-			function ( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', true, false );
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -218,7 +203,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	public function test_if_banner_hidden_when_wcs_not_installed() {
 		$this->with_order(
 			function ( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.4', false, false );
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.4', false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -13,13 +13,6 @@ use Automattic\WooCommerce\Internal\Admin\ShippingLabelBannerDisplayRules;
 class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 
 	/**
-	 * Jetpack version to test the display manager.
-	 *
-	 * @var string
-	 */
-	private $valid_jetpack_version = '4.4';
-
-	/**
 	 * Stores the default WordPress options stored in the database.
 	 *
 	 * @var array
@@ -178,19 +171,6 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		$this->with_order(
 			function ( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, true );
-
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
-			}
-		);
-	}
-
-	/**
-	 * Test if the banner is hidden when Jetpack version is not at least 4.4.
-	 */
-	public function test_if_banner_hidden_when_jetpack_version_is_old() {
-		$this->with_order(
-			function ( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -81,8 +81,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_display_banner_if_all_conditions_are_met() {
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, null, false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
 			}
@@ -93,7 +93,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 * Test if the banner is hidden when Jetpack is not active.
 	 */
 	public function test_if_banner_hidden_when_jetpack_disconnected() {
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( null, null, null, null, null );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( null, null, null, null );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -103,7 +103,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_dismiss_option_enabled() {
 		update_option( 'woocommerce_shipping_dismissed_timestamp', -1 );
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -115,7 +115,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		$two_hours_from_ago = ( time() - 2 * 60 * 60 ) * 1000;
 		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_ago );
 
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -128,8 +128,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		update_option( 'woocommerce_shipping_dismissed_timestamp', $twenty_four_hours_one_sec_ago );
 
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, null, false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
 			}
@@ -140,7 +140,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 * Test if the banner is hidden when no shippable product available.
 	 */
 	public function test_if_banner_hidden_when_no_shippable_product() {
-		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
 
 		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
@@ -151,8 +151,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	public function test_if_banner_hidden_when_store_is_not_in_us() {
 		update_option( 'woocommerce_default_country', 'ES' );
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -165,8 +165,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	public function test_if_banner_hidden_when_currency_is_not_usd() {
 		update_option( 'woocommerce_currency', 'EUR' );
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -178,8 +178,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_incompatible_plugin_installed() {
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, true );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, true );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -191,8 +191,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_jetpack_version_is_old() {
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.3', true, '1.22.5', false, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -204,8 +204,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_wcs_tos_accepted() {
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', true, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.5', true, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -217,8 +217,8 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_wcs_not_installed() {
 		$this->with_order(
-			function( $that ) {
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.4', false, false );
+			function ( $that ) {
+				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( true, '1.22.4', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
@@ -230,20 +230,10 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	private function create_order() {
 		$product = WC_Helper_Product::create_simple_product();
-		$product->set_props( array( 'virtual' => true ) );
+		$order   = WC_Helper_Order::create_order( 1, $product );
 
-		$order      = new WC_Order();
-		$order_item = new WC_Order_Item_Product();
-		$order_item->set_props( array( 'product' => $product ) );
-		$order->add_item( $order_item );
-		$order->save();
-
-		global $post;
-
-		// phpcs:disable 	WordPress.WP.GlobalVariablesOverride.Prohibited
-		$post     = new \stdClass();
-		$post->ID = $order->get_id();
-
+		global $theorder;
+		$theorder = $order;
 		return $order;
 	}
 
@@ -274,5 +264,4 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 
 		$this->destroy_order( $order );
 	}
-
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
With the advent of the new WooCommerce Shipping, we need to update the promo banner shown to merchant to enable it to create shipping labels.
- It fixes the issue that prevents the promo banner from showing on HPOS order pages.
- This PR addresses this objective by taking care of the following cases.
1) The website doesn't have WooComemrce Shipping and Tax ( WCS&T ) active.
2) WCS&T is active and it's compatible with WooCommerce Shipping ( [at least version 2.7.0](https://github.com/Automattic/woocommerce-services/releases/tag/2.7.0) )
3) WCS&T is active, but is not compatible with WooCommerce Shipping.
4) Any of the above for WCS&T, and WC Shipping version lower than 1.1.0.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce-shipping/issues/188
Closes https://github.com/woocommerce/woocommerce/issues/50653

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
### For all the different cases you need to:
- Have WooCommerce either from this PR or using the attached WooCommerce active 
- Have at least one order with shippable products.
- Have connection to DOTCOM, either via Jetpack or a version of WCS&T.

### For case 1, 2 and 3:
- Install but not activate WooCommerce Shipping (the attached copy). Please verify the installed copy of WooCommerce Shipping is 1.1.0.

### For case 4:
- Install but not activate  WooCommerce Shipping (any version lower than 1.1.0).

#### Case 1:
WCS&T is not installed not active:
1. Visit an order page with shippable products.
2. Verify you see the [promotion banner](![UcaUQ1.png](https://github.com/user-attachments/assets/ab7ee8af-2ea6-4a60-a607-9973d1fb1f0d)) 
3. Click on `Create shipping label` button.
4. Observe WooCommerce Shipping is installed and activated and the label purchase modal opens.

#### Case 2:
[Version 2.7.0 (or higher](https://github.com/Automattic/woocommerce-services/releases/tag/2.7.0)) of WCS&T is  installed and active:
1. Visit an order page with shippable products.
2. Verify you see the [promotion banner](![UcaUQ1.png](https://github.com/user-attachments/assets/ab7ee8af-2ea6-4a60-a607-9973d1fb1f0d)) 
3. Click on `Install WooCommerce Shipping` button.
4. Observe WooCommerce Shipping is installed and activated BUT the label purchase modal doesn't open.
5. Verify the action `Create shipping label` of WCS&T is replaced by the one from WooCommerce Shipping, but clicking on it to see the new label purchase modal.

#### Case 3:
[Version 2.6.2( or lower](https://github.com/Automattic/woocommerce-services/releases/tag/2.6.2) ) of WCS&T is  installed and active:
1. Visit an order page with shippable products.
2. Verify you see the [promotion banner](![UcaUQ1.png](https://github.com/user-attachments/assets/ab7ee8af-2ea6-4a60-a607-9973d1fb1f0d)) 
3. Click on `Install WooCommerce Shipping` button.
4. Observe WooCommerce Shipping is installed and activated BUT the label purchase modal doesn't open.
5. Verify an error notice with this text `Please update the WooCommerce Shipping & Tax plugin to the latest version to ensure compatibility with WooCommerce Shipping.` is shown (without page refresh).
6. Check plugins page and verify both plugins ( WCS&T and WooCommerce Shipping ) are active.

#### Case 4:
Any new version of WCS&T is  installed and active, and 
1. Visit an order page with shippable products.
2. Verify you see the [promotion banner](![UcaUQ1.png](https://github.com/user-attachments/assets/ab7ee8af-2ea6-4a60-a607-9973d1fb1f0d)) 
3. Click on `Install WooCommerce Shipping` button.
5. Verify WooCommerce Shipping gets installed and activated, and the order page refreshed at the end
6. If the WCS&T version is not compatible with WooCommerce Shipping, you should see the incompatibility banner after refresh.

[woocommerce-shipping.zip](https://github.com/user-attachments/files/16820555/woocommerce-shipping.zip)

[woocommerce.zip](https://github.com/user-attachments/files/16820563/woocommerce.zip)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>