### PR TITLE
PluginUtil: Add method to get active valid plugins (2nd attempt)

### DIFF
--- a/plugins/woocommerce/changelog/fix-48132-ssr-active-plugins
+++ b/plugins/woocommerce/changelog/fix-48132-ssr-active-plugins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Ensure that active plugins shown in the System Status API endpoint actually exist

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchro
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper as WCConnectionHelper;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
-use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\{ OrderUtil, PluginUtil };
 use Automattic\WooCommerce\Internal\Utilities\PluginInstaller;
 
 defined( 'ABSPATH' ) || exit;
@@ -1283,7 +1283,8 @@ class WC_Install {
 				return;
 			}
 
-			if ( in_array( $legacy_api_plugin, wp_get_active_and_valid_plugins(), true ) ) {
+			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_all_active_valid_plugins();
+			if ( in_array( $legacy_api_plugin, $active_valid_plugins, true ) ) {
 				return;
 			}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -373,7 +373,41 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
-						'type' => 'string',
+						'type'       => 'object',
+						'properties' => array(
+							'plugin'            => array(
+								'description' => __( 'Plugin basename. The path to the main plugin file relative to the plugins directory.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'name'              => array(
+								'description' => __( 'Name of the plugin.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'version'           => array(
+								'description' => __( 'Current plugin version.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'version_latest'    => array(
+								'description' => __( 'Latest available plugin version.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'url'               => array(
+								'description' => __( 'Plugin URL.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'author_name'       => array(
+								'description' => __( 'Plugin author name.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'author_url'        => array(
+								'description' => __( 'Plugin author URL.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'network_activated' => array(
+								'description' => __( 'Whether the plugin can only be activated network-wide.', 'woocommerce' ),
+								'type'        => 'boolean',
+							),
+						),
 					),
 				),
 				'inactive_plugins'   => array(
@@ -382,7 +416,41 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
-						'type' => 'string',
+						'type'       => 'object',
+						'properties' => array(
+							'plugin'            => array(
+								'description' => __( 'Plugin basename. The path to the main plugin file relative to the plugins directory.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'name'              => array(
+								'description' => __( 'Name of the plugin.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'version'           => array(
+								'description' => __( 'Current plugin version.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'version_latest'    => array(
+								'description' => __( 'Latest available plugin version.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'url'               => array(
+								'description' => __( 'Plugin URL.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'author_name'       => array(
+								'description' => __( 'Plugin author name.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'author_url'        => array(
+								'description' => __( 'Plugin author URL.', 'woocommerce' ),
+								'type'        => 'string',
+							),
+							'network_activated' => array(
+								'description' => __( 'Whether the plugin can only be activated network-wide.', 'woocommerce' ),
+								'type'        => 'boolean',
+							),
+						),
 					),
 				),
 				'dropins_mu_plugins' => array(
@@ -1048,7 +1116,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			$active_plugins_data  = array();
 
 			foreach ( $active_valid_plugins as $plugin ) {
-				$data                  = get_plugin_data( $plugin );
+				$data                  = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
 				$active_plugins_data[] = $this->format_plugin_data( $plugin, $data );
 			}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
-use Automattic\WooCommerce\Utilities\{ LoggingUtil, OrderUtil };
+use Automattic\WooCommerce\Utilities\{ LoggingUtil, OrderUtil, PluginUtil };
 
 /**
  * System status controller class.
@@ -1044,16 +1044,11 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				return array();
 			}
 
-			$active_plugins = (array) get_option( 'active_plugins', array() );
-			if ( is_multisite() ) {
-				$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
-				$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
-			}
+			$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_all_active_valid_plugins();
+			$active_plugins_data  = array();
 
-			$active_plugins_data = array();
-
-			foreach ( $active_plugins as $plugin ) {
-				$data                  = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+			foreach ( $active_valid_plugins as $plugin ) {
+				$data                  = get_plugin_data( $plugin );
 				$active_plugins_data[] = $this->format_plugin_data( $plugin, $data );
 			}
 

--- a/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
+++ b/plugins/woocommerce/src/Internal/Utilities/PluginInstaller.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Internal\Utilities;
 
 use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
-use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Utilities\{ PluginUtil, StringUtil };
 
 /**
  * This class allows installing a plugin programmatically.
@@ -206,7 +206,14 @@ class PluginInstaller implements RegisterHooksInterface {
 	 * @return bool True if WooCommerce is installed and active in the current blog, false otherwise.
 	 */
 	private static function woocommerce_is_active_in_current_site(): bool {
-		return ! empty( array_filter( wp_get_active_and_valid_plugins(), fn( $plugin ) => substr_compare( $plugin, '/woocommerce.php', -strlen( '/woocommerce.php' ) ) === 0 ) );
+		$active_valid_plugins = wc_get_container()->get( PluginUtil::class )->get_all_active_valid_plugins();
+
+		return ! empty(
+			array_filter(
+				$active_valid_plugins,
+				fn( $plugin ) => substr_compare( $plugin, '/woocommerce.php', -strlen( '/woocommerce.php' ) ) === 0
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -78,7 +78,7 @@ class PluginUtil {
 	 * Note that the doc block for `wp_get_active_and_valid_plugins` says it returns "Array of paths to plugin files
 	 * relative to the plugins directory", but it actually returns absolute paths.
 	 *
-	 * @return string[] Array of absolute paths to plugin files.
+	 * @return string[] Array of plugin basenames (paths relative to the plugin directory).
 	 */
 	public function get_all_active_valid_plugins() {
 		$local = wp_get_active_and_valid_plugins();
@@ -91,8 +91,11 @@ class PluginUtil {
 		}
 
 		$all = array_merge( $local, $network );
+		$all = array_unique( $all );
+		$all = array_map( 'plugin_basename', $all );
+		sort( $all );
 
-		return array_unique( $all );
+		return $all;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
@@ -154,9 +154,8 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_system_status_info_active_plugins() {
-		$this->skip_on_php_8_1();
-
 		wp_set_current_user( self::$administrator_user );
+		delete_transient( 'wc_system_status_active_plugins' );
 
 		$actual_plugins = array( 'hello.php' );
 		update_option( 'active_plugins', $actual_plugins );
@@ -165,9 +164,20 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 
 		$data    = $response->get_data();
 		$plugins = (array) $data['active_plugins'];
-
 		$this->assertEquals( 1, count( $plugins ) );
-		$this->assertEquals( 'Hello Dolly', $plugins[0]['name'] );
+
+		$plugin = reset( $plugins );
+		$this->assertArrayHasKey( 'plugin', $plugin );
+		$this->assertEquals( 'hello.php', $plugin['plugin'] );
+		$this->assertArrayHasKey( 'name', $plugin );
+		$this->assertEquals( 'Hello Dolly', $plugin['name'] );
+		$this->assertArrayHasKey( 'version', $plugin );
+		$this->assertArrayHasKey( 'version_latest', $plugin );
+		$this->assertArrayHasKey( 'url', $plugin );
+		$this->assertArrayHasKey( 'author_name', $plugin );
+		$this->assertArrayHasKey( 'author_url', $plugin );
+		$this->assertArrayHasKey( 'network_activated', $plugin );
+		$this->assertEquals( false, $plugin['network_activated'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
@@ -183,6 +183,8 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_system_status_info_active_plugins() {
 		wp_set_current_user( self::$administrator_user );
+		delete_transient( 'wc_system_status_active_plugins' );
+
 		$actual_plugins = array( 'hello.php' );
 		update_option( 'active_plugins', $actual_plugins );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/system_status' ) );
@@ -190,9 +192,20 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$data    = $response->get_data();
 		$plugins = (array) $data['active_plugins'];
-
 		$this->assertEquals( 1, count( $plugins ) );
-		$this->assertEquals( 'Hello Dolly', $plugins[0]['name'] );
+
+		$plugin = reset( $plugins );
+		$this->assertArrayHasKey( 'plugin', $plugin );
+		$this->assertEquals( 'hello.php', $plugin['plugin'] );
+		$this->assertArrayHasKey( 'name', $plugin );
+		$this->assertEquals( 'Hello Dolly', $plugin['name'] );
+		$this->assertArrayHasKey( 'version', $plugin );
+		$this->assertArrayHasKey( 'version_latest', $plugin );
+		$this->assertArrayHasKey( 'url', $plugin );
+		$this->assertArrayHasKey( 'author_name', $plugin );
+		$this->assertArrayHasKey( 'author_url', $plugin );
+		$this->assertArrayHasKey( 'network_activated', $plugin );
+		$this->assertEquals( false, $plugin['network_activated'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -64,12 +64,12 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 
 		if ( is_multisite() ) {
 			$this->assertCount( 2, $active_valid_plugins );
-			$this->assertContains( WP_PLUGIN_DIR . '/test3/test3.php', $active_valid_plugins );
+			$this->assertContains( 'test3/test3.php', $active_valid_plugins );
 		} else {
 			$this->assertCount( 1, $active_valid_plugins );
 		}
 
-		$this->assertContains( WP_PLUGIN_DIR . '/test1/test1.php', $active_valid_plugins );
+		$this->assertContains( 'test1/test1.php', $active_valid_plugins );
 
 		if ( false === $orig_local_plugins ) {
 			delete_option( 'active_plugins' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a re-do of #48709, which had to be [reverted](https://github.com/woocommerce/woocommerce/pull/50881) when it was released because it unknowingly changed the format of the data in the `active_plugins[].plugin` property, which caused some issues for the mobile apps (and potentially anyone else using the `system_status` API endpoint). In addition to restoring the changes from that first PR and fixing the formatting issue, this adds missing data to the API endpoint schema for the `active_plugins` and `inactive_plugins` properties, and updates unit tests for the API endpoint to better ensure the correct format of some fields.

**Original PR description**

When getting a list of active plugins directly from the options table, you can run into an error if you try to then access one of the plugin files if it doesn't actually exist. WP Core has a method that verifies that the files exist before returning the list. But it's marked as a "private" method, which means it could change and break backcompat. That seems very unlikely, though, so we're using the method (it was already in use actually), but putting in some safeguards so we can detect if a backcompat issue arises.

Fixes https://github.com/woocommerce/woocommerce/issues/48132

### How to test the changes in this Pull Request:

Replicate the issue on trunk:

1. Ensure that `WP_DEBUG` and `WP_DEBUG_LOG` constants are set to true.
1. Have at least two plugins active on your test site.
1. Make a request to `wc/v3/system_status?_fields=active_plugins`. Note which plugins are shown. Copy the data provided so you can compare it to the response data with the changes from this PR.
1. Now in the filesystem, remove or rename one of the active plugins (this must be done outside of a WordPress context so that the cached values don't get updated automatically).
1. Clear the transient that stores the current active plugins list for the System Status tool: `wp transient delete wc_system_status_active_plugins`
1. Now make another request to `wc/v3/system_status?_fields=active_plugins`. Check your WP debug log file, you should see an error message like the following: `PHP Warning:  file_get_contents(/var/www/html/wp-content/plugins/wc-smooth-generator/wc-smooth-generator.php): Failed to open stream: No such file or directory in /var/www/html/wp-includes/functions.php on line 6852`

On this PR branch:

1. Follow the same steps as above. This time, when making the second request to `wc/v3/system_status?_fields=active_plugins`, you should only see the active plugins that haven't been renamed/deleted, and there shouldn't be any new PHP warnings in the log file. Compare the response data to what you received on the trunk branch. The way the data is formatted should not have changed. In particular, the `plugin` property of each plugin should still be a relative file path rather than an absolute path.
2. Try the same thing on a multisite network, with network activated plugins.
