### PR TITLE
Hide reviews in the frontend when they are disabled at store or product level

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-template/single-product-template.product-rating.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-template/single-product-template.product-rating.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { Editor, test as base, expect } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+
+const blockData = {
+	name: 'Single Product',
+	slug: 'woocommerce/single-product',
+	product: 'Hoodie',
+	productSlug: 'hoodie',
+};
+
+class BlockUtils {
+	editor: Editor;
+	admin;
+
+	constructor( { editor, admin }: { editor: Editor; admin } ) {
+		this.editor = editor;
+		this.admin = admin;
+	}
+
+	async configureSingleProductBlockForProduct( product: string ) {
+		const singleProductBlock = await this.editor.getBlockByName(
+			'woocommerce/single-product'
+		);
+
+		await singleProductBlock
+			.locator( `input[type="radio"][value="${ product }"]` )
+			.nth( 0 )
+			.click();
+
+		await singleProductBlock.getByText( 'Done' ).click();
+	}
+
+	async insertBlockAndVisit( block: string, product: string ) {
+		await this.admin.createNewPost();
+		await this.editor.insertBlock( { name: block } );
+		await this.configureSingleProductBlockForProduct( product );
+		await this.editor.publishAndVisitPost();
+	}
+}
+
+const test = base.extend< { blockUtils: BlockUtils } >( {
+	blockUtils: async ( { editor, admin }, use ) => {
+		await use( new BlockUtils( { editor, admin } ) );
+	},
+} );
+
+test.describe( `${ blockData.slug } Block`, () => {
+	test( 'Product Rating block is not visible if ratings are disabled for product', async ( {
+		admin,
+		page,
+	} ) => {
+		await test.step( `Disable reviews for ${ blockData.productSlug }`, async () => {
+			await page.goto( `/products/${ blockData.productSlug }` );
+			await page.click( 'text=Edit product' );
+			await page.getByRole( 'link', { name: 'Inventory' } ).click();
+			await page.getByRole( 'link', { name: 'Advanced' } ).click();
+			await page.waitForSelector( 'text=Enable reviews' );
+			await admin.page
+				.getByRole( 'checkbox', {
+					name: 'Enable reviews',
+				} )
+				.uncheck();
+			await page.getByRole( 'button', { name: 'Update' } ).click();
+		} );
+
+		await page.goto( '/product/hoodie/' );
+
+		await expect(
+			page.locator( '.wc-block-components-product-rating' )
+		).not.toBeVisible();
+	} );
+
+	test( 'Product Rating block is not visible if ratings are disabled globally in the store', async ( {
+		admin,
+		page,
+	} ) => {
+		await test.step( `Disable reviews in the store`, async () => {
+			await page.goto(
+				'/wp-admin/admin.php?page=wc-settings&tab=products'
+			);
+			await admin.page
+				.getByRole( 'checkbox', {
+					name: 'Enable product reviews',
+				} )
+				.uncheck();
+			await page.getByRole( 'button', { name: 'Save changes' } ).click();
+		} );
+
+		await page.goto( '/product/hoodie/' );
+
+		await expect(
+			page.locator( '.wc-block-components-product-rating' )
+		).not.toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product/product-rating-single-product.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product/product-rating-single-product.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { Editor, test as base, expect } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+
+const blockData = {
+	name: 'Single Product',
+	slug: 'woocommerce/single-product',
+	product: 'Hoodie',
+	productSlug: 'hoodie',
+};
+
+class BlockUtils {
+	editor: Editor;
+	admin;
+
+	constructor( { editor, admin }: { editor: Editor; admin } ) {
+		this.editor = editor;
+		this.admin = admin;
+	}
+
+	async configureSingleProductBlockForProduct( product: string ) {
+		const singleProductBlock = await this.editor.getBlockByName(
+			'woocommerce/single-product'
+		);
+
+		await singleProductBlock
+			.locator( `input[type="radio"][value="${ product }"]` )
+			.nth( 0 )
+			.click();
+
+		await singleProductBlock.getByText( 'Done' ).click();
+	}
+
+	async insertBlockAndVisit( block: string, product: string ) {
+		await this.admin.createNewPost();
+		await this.editor.insertBlock( { name: block } );
+		await this.configureSingleProductBlockForProduct( product );
+		await this.editor.publishAndVisitPost();
+	}
+}
+
+const test = base.extend< { blockUtils: BlockUtils } >( {
+	blockUtils: async ( { editor, admin }, use ) => {
+		await use( new BlockUtils( { editor, admin } ) );
+	},
+} );
+
+test.describe( `${ blockData.slug } Block`, () => {
+	test( 'Product Rating block is not visible if ratings are disabled for product', async ( {
+		admin,
+		page,
+		blockUtils,
+	} ) => {
+		await test.step( `Disable reviews for ${ blockData.productSlug }`, async () => {
+			await page.goto( `/products/${ blockData.productSlug }` );
+			await page.click( 'text=Edit product' );
+			await page.getByRole( 'link', { name: 'Inventory' } ).click();
+			await page.getByRole( 'link', { name: 'Advanced' } ).click();
+			await page.waitForSelector( 'text=Enable reviews' );
+			await admin.page
+				.getByRole( 'checkbox', {
+					name: 'Enable reviews',
+				} )
+				.uncheck();
+			await page.getByRole( 'button', { name: 'Update' } ).click();
+		} );
+
+		await test.step( `Insert the block in a post an visit it`, async () => {
+			await blockUtils.insertBlockAndVisit(
+				blockData.slug,
+				blockData.productSlug
+			);
+		} );
+
+		await expect(
+			page.locator( '.wc-block-components-product-rating' )
+		).not.toBeVisible();
+	} );
+
+	test( 'Product Rating block is not visible if ratings are disabled globally in the store', async ( {
+		admin,
+		page,
+		blockUtils,
+	} ) => {
+		await test.step( `Disable reviews in the store`, async () => {
+			await page.goto(
+				'/wp-admin/admin.php?page=wc-settings&tab=products'
+			);
+			await admin.page
+				.getByRole( 'checkbox', {
+					name: 'Enable product reviews',
+				} )
+				.uncheck();
+			await page.getByRole( 'button', { name: 'Save changes' } ).click();
+		} );
+
+		await test.step( 'Insert the block in a post an visit it', async () => {
+			await blockUtils.insertBlockAndVisit(
+				blockData.slug,
+				blockData.productSlug
+			);
+		} );
+
+		await expect(
+			page.locator( '.wc-block-components-product-rating' )
+		).not.toBeVisible();
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product/product-rating-single-product.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product/product-rating-single-product.spec.ts
@@ -70,7 +70,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 			await page.getByRole( 'button', { name: 'Update' } ).click();
 		} );
 
-		await test.step( `Insert the block in a post an visit it`, async () => {
+		await test.step( `Insert the block in a post and visit it`, async () => {
 			await blockUtils.insertBlockAndVisit(
 				blockData.slug,
 				blockData.productSlug
@@ -99,7 +99,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 			await page.getByRole( 'button', { name: 'Save changes' } ).click();
 		} );
 
-		await test.step( 'Insert the block in a post an visit it', async () => {
+		await test.step( 'Insert the block in a post and visit it', async () => {
 			await blockUtils.insertBlockAndVisit(
 				blockData.slug,
 				blockData.productSlug

--- a/plugins/woocommerce/changelog/50979-42947-disable-product-rating
+++ b/plugins/woocommerce/changelog/50979-42947-disable-product-rating
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Product Rating: Not show reviews in the front end when disabled at store or product level.
+Product Rating: hide reviews in the front end when disabled at store or product level.

--- a/plugins/woocommerce/changelog/50979-42947-disable-product-rating
+++ b/plugins/woocommerce/changelog/50979-42947-disable-product-rating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Product Rating: Not show reviews in the front end when disabled at store or product level.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductRating.php
@@ -114,7 +114,9 @@ class ProductRating extends AbstractBlock {
 		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : '';
 		$product = wc_get_product( $post_id );
 
-		if ( $product && $product->get_review_count() > 0 ) {
+		if ( $product && $product->get_review_count() > 0
+			&& $product->get_reviews_allowed()
+			&& wc_reviews_enabled() ) {
 			$product_reviews_count                    = $product->get_review_count();
 			$product_rating                           = $product->get_average_rating();
 			$parsed_attributes                        = $this->parse_attributes( $attributes );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/42947

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Single product block, disable ratings for product**
1. Create a new product and add at least one review.
2. Create a new page or post.
3. Insert the `Single Product` block and select the product from step 1.
4. Save and open the page. 
5. Edit the product, go to the `Advanced` tab, uncheck the `Enable reviews`, and save.
6. Open the page created on step 2 and check you don't see the `Product rating` block in the front end.
<img width="568" alt="Screenshot 2024-08-27 at 11 10 47" src="https://github.com/user-attachments/assets/6839dc9c-16f3-4223-89da-7891d47479ed">

**Single product block, disable ratings for store**
1. Create a new product and add at least one review.
2. Create a new page or post.
3. Insert the `Single Product` block and select the product from step 1.
4. Save and open the page. 
5. Go to `wp-admin/admin.php?page=wc-settings&tab=products`, uncheck `Enable product reviews`, and save.
6. Open the page created on step 2 and check you don't see the `Product rating` block in the front end.

**Single product template, disable ratings for product**
1. Create a new product and add at least one review.
2. Edit the product, go to the `Advanced` tab, uncheck the `Enable reviews`, and save.
3. Open the product page and check you don't see the `Product rating` block in the front end.

**Single product template, disable ratings for store**
1. Create a new product and add at least one review.
2. Go to `wp-admin/admin.php?page=wc-settings&tab=products`, uncheck `Enable product reviews`, and save.
3. Open the product page and check you don't see the `Product rating` block in the front end.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Rating: hide reviews in the front end when disabled at store or product level.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
