### PR TITLE
CYS: Fix bottom margin of last patterns

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/pattern-screen/style.scss
@@ -75,7 +75,7 @@
 		}
 	}
 
-	div.block-editor-block-patterns-list > div:nth-last-child(2) {
+	div.block-editor-block-patterns-list > div:nth-last-child(1 of .block-editor-block-patterns-list__list-item) {
 		margin-bottom: 0;
 	}
 }

--- a/plugins/woocommerce/changelog/fix-cys-patterns-margin
+++ b/plugins/woocommerce/changelog/fix-cys-patterns-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bottom margin of last patterns


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates a CSS selector that was causing the second last and last patterns in the CYS screen not to have spacing between them.

### How to test the changes in this Pull Request:

0. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
1. In the admin, go to WooCommerce > Customize Your Store > Create your own theme.
2. Open the _Design your homepage_ task and navigate the patterns.
3. Verify there is some margin between the last and second last patterns:

Before | After
--- | ---
![Captura de pantalla de 2024-08-27 14-58-44](https://github.com/user-attachments/assets/5ac8eb3e-04cd-4cd8-81b8-8f44f5bc394c) | ![Captura de pantalla de 2024-08-27 14-58-32](https://github.com/user-attachments/assets/4d18d0dc-8f2c-4e95-8f0a-0c79c79548b9)
