### PR TITLE
Enhance WooCommerce version checking for remote logging reliability

### DIFF
--- a/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
+++ b/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
@@ -74,6 +74,7 @@ function toggle_remote_logging( $request ) {
 		update_option( 'woocommerce_feature_remote_logging_enabled', 'yes' );
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 		update_option( 'woocommerce_remote_variant_assignment', 1 );
+		set_site_transient( RemoteLogger::WC_NEW_VERSION_TRANSIENT, WC()->version );
 	} else {
 		update_option( 'woocommerce_feature_remote_logging_enabled', 'no' );
 	}

--- a/plugins/woocommerce-beta-tester/changelog/update-move-woo-version-check
+++ b/plugins/woocommerce-beta-tester/changelog/update-move-woo-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update remote logger tool to toggle remote logging feature properly

--- a/plugins/woocommerce/changelog/update-move-woo-version-check
+++ b/plugins/woocommerce/changelog/update-move-woo-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Enhance WooCommerce version checking for remote logging reliability

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -20,11 +20,10 @@ use WC_Log_Levels;
  * @package WooCommerce\Classes
  */
 class RemoteLogger extends \WC_Log_Handler {
-	const LOG_ENDPOINT                = 'https://public-api.wordpress.com/rest/v1.1/logstash';
-	const RATE_LIMIT_ID               = 'woocommerce_remote_logging';
-	const RATE_LIMIT_DELAY            = 60; // 1 minute.
-	const WC_LATEST_VERSION_TRANSIENT = 'latest_woocommerce_version';
-	const FETCH_LATEST_VERSION_RETRY  = 'fetch_latest_woocommerce_version_retry';
+	const LOG_ENDPOINT             = 'https://public-api.wordpress.com/rest/v1.1/logstash';
+	const RATE_LIMIT_ID            = 'woocommerce_remote_logging';
+	const RATE_LIMIT_DELAY         = 60; // 1 minute.
+	const WC_NEW_VERSION_TRANSIENT = 'woocommerce_new_version';
 
 	/**
 	 * Handle a log entry.
@@ -150,7 +149,7 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 
-		if ( ! $this->is_latest_woocommerce_version() ) {
+		if ( ! $this->should_current_version_be_logged() ) {
 			return false;
 		}
 
@@ -221,7 +220,7 @@ class RemoteLogger extends \WC_Log_Handler {
 				self::LOG_ENDPOINT,
 				array(
 					'body'     => wp_json_encode( $body ),
-					'timeout'  => 2,
+					'timeout'  => 3,
 					'headers'  => array(
 						'Content-Type' => 'application/json',
 					),
@@ -256,14 +255,22 @@ class RemoteLogger extends \WC_Log_Handler {
 	 *
 	 * @return bool
 	 */
-	private function is_latest_woocommerce_version() {
-		$latest_wc_version = $this->fetch_latest_woocommerce_version();
+	private function should_current_version_be_logged() {
+		$new_version = get_site_transient( self::WC_NEW_VERSION_TRANSIENT );
 
-		if ( is_null( $latest_wc_version ) ) {
-			return false;
+		if ( false === $new_version ) {
+			$new_version = $this->fetch_new_woocommerce_version();
+			// Cache the new version for a week since we want to keep logging in with the same version for a while even if the new version is available.
+			set_site_transient( self::WC_NEW_VERSION_TRANSIENT, $new_version, WEEK_IN_SECONDS );
 		}
 
-		return version_compare( WC()->version, $latest_wc_version, '>=' );
+		if ( ! is_string( $new_version ) || '' === $new_version ) {
+			// If the new version is not available, we consider the current version to be the latest.
+			return true;
+		}
+
+		// If the current version is the latest, we don't want to log errors.
+		return version_compare( WC()->version, $new_version, '>=' );
 	}
 
 	/**
@@ -316,45 +323,34 @@ class RemoteLogger extends \WC_Log_Handler {
 	}
 
 	/**
-	 * Fetch the latest WooCommerce version using the WordPress API and cache it.
+	 * Fetch the new version of WooCommerce from the WordPress API.
 	 *
-	 * @return string|null
+	 * @return string|null New version if an update is available, null otherwise.
 	 */
-	private function fetch_latest_woocommerce_version() {
-		$cached_version = get_transient( self::WC_LATEST_VERSION_TRANSIENT );
-		if ( $cached_version ) {
-			return $cached_version;
+	private function fetch_new_woocommerce_version() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		if ( ! function_exists( 'get_plugin_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
 		}
 
-		$retry_count = get_transient( self::FETCH_LATEST_VERSION_RETRY );
-		if ( false === $retry_count || ! is_numeric( $retry_count ) ) {
-			$retry_count = 0;
-		}
+		$plugin_updates = get_plugin_updates();
 
-		if ( $retry_count >= 3 ) {
+		// Check if WooCommerce plugin update information is available.
+		if ( ! is_array( $plugin_updates ) || ! isset( $plugin_updates[ WC_PLUGIN_BASENAME ] ) ) {
 			return null;
 		}
 
-		if ( ! function_exists( 'plugins_api' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-		}
-		// Fetch the latest version from the WordPress API.
-		$plugin_info = plugins_api( 'plugin_information', array( 'slug' => 'woocommerce' ) );
+		$wc_plugin_update = $plugin_updates[ WC_PLUGIN_BASENAME ];
 
-		if ( is_wp_error( $plugin_info ) ) {
-			++$retry_count;
-			set_transient( self::FETCH_LATEST_VERSION_RETRY, $retry_count, HOUR_IN_SECONDS );
+		// Ensure the update object exists and has the required information.
+		if ( ! $wc_plugin_update || ! isset( $wc_plugin_update->update->new_version ) ) {
 			return null;
 		}
 
-		if ( ! empty( $plugin_info->version ) ) {
-			$latest_version = $plugin_info->version;
-			set_transient( self::WC_LATEST_VERSION_TRANSIENT, $latest_version, WEEK_IN_SECONDS );
-			delete_transient( self::FETCH_LATEST_VERSION_RETRY );
-			return $latest_version;
-		}
-
-		return null;
+		$new_version = $wc_plugin_update->update->new_version;
+		return is_string( $new_version ) ? $new_version : null;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50982.

> currently we do this check -> is_latest_woocommerce_version. This involves a remote call to wordpress.org and is cached in transient. Unfortunately, in some problematic sites, transients are not reliable and can be evicted as soon as they are set, effectively providing no caching. this means we would end up doing a remote request on every warning, error etc.

We initially decided to move that check to the end to avoid unnecessary remote calls. However, this is insufficient because we call `is_remote_logging_allowed` on the admin page load for JS error logging. This means that we can't move the check after rate limiting.

This PR instead uses `get_plugin_updates` function to fetch the new version of WooCommerce. This function is used by the plugin updates page and is cached in the `update_plugins` transient.

We still use a transient to cache the version because we want to keep logging in with the same version for a while even if the new version is available and it's helpful for beta tester to fake the version.


I encountered a timeout on the logging API on a slow site, so I also
increase the timeout from 2 to 3 seconds to avoid timeouts on slow sites. 


The request is non-blocking so it shouldn't affect the performance of the site.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch
2. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` > Remote Logging
3. Enable remote logging and refresh the page
4. Confirm that remote logging is still enabled
5. Go to /wp-admin/plugin-editor.php
6. Select woocommerce plugin and edit `woocommerce.php`

```diff
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An ecommerce toolkit that helps you sell anything. Beautifully.
- * Version: 9.4.0-dev
+ * Version: 9.1.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
```

7. Edit `includes/class-woocommerce.php`

```diff
         *
         * @var string
         */
-       public $version = '9.4.0';
+       public $version = '9.1.0';
```

8. Go to `/wp-admin/plugins.php` and confirm WooCommerce is outdated
9. Go to beta tester Remote Logging page and confirm remote logging is disabled
10. Run `wp transient get woocommerce_new_version --network` and confirm the version is latest woocommerce version (https://wordpress.org/plugins/woocommerce/)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Enhance WooCommerce version checking for remote logging reliability

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
