### PR TITLE
Remove extra bottom padding in filters in the editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/active-filters/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/active-filters/style.scss
@@ -16,7 +16,6 @@
 }
 
 .wc-block-active-filters {
-	margin-bottom: $gap-large;
 	overflow: hidden;
 
 	.wc-block-active-filters__clear-all {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/active-filters/style.scss
@@ -1,7 +1,6 @@
 @import "../../../../../../packages/components/chip/style";
 
 .wp-block-woocommerce-product-filter-active {
-	margin-bottom: $gap-large;
 	overflow: hidden;
 
 	.clear-all {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/rating-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filter/inner-blocks/rating-filter/style.scss
@@ -1,4 +1,6 @@
 .wp-block-woocommerce-product-filter-rating {
+	display: grid;
+
 	.wc-block-components-product-rating {
 		margin-bottom: 0;
 		display: flex;

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/style.scss
@@ -19,8 +19,6 @@
 		border-radius: 0;
 	}
 
-	margin-bottom: $gap-large;
-
 	.wc-block-stock-filter-list {
 		margin: 0;
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/style.scss
@@ -12,6 +12,8 @@
 }
 
 .wc-block-stock-filter {
+	display: grid;
+
 	&.is-loading {
 		@include placeholder();
 		margin-top: $gap;

--- a/plugins/woocommerce/changelog/51012-47886-remove-padding-filters
+++ b/plugins/woocommerce/changelog/51012-47886-remove-padding-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove extra bottom padding in filters in the editor.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/47886

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `wp-admin/site-editor.php?`, click `Templates`, and edit the `Product Catalog` template.
2. Insert the `Product Filters (Experimental)` block.
3. For each one of the filter blocks, check there's no extra margin at the bottom.

| Before | After |
|--------|--------|
| <img width="241" alt="Screenshot 2024-08-28 at 12 28 49" src="https://github.com/user-attachments/assets/1ce94140-2c92-4af6-9bb5-f2e506c6aa84"> |<img width="230" alt="Screenshot 2024-08-28 at 12 27 44" src="https://github.com/user-attachments/assets/e1ffcbac-8d8f-472b-b135-8162d73df069">| 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove extra bottom padding in filters in the editor.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
