### PR TITLE
Remove usage of team specific names within PHP unit tests

### DIFF
--- a/plugins/woocommerce/changelog/update-mothra_name_usage
+++ b/plugins/woocommerce/changelog/update-mothra_name_usage
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Update PHP unit tests to remove specific team names for generic names.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/array-column.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/array-column.php
@@ -58,20 +58,20 @@ class WC_Admin_Tests_RemoteInboxNotifications_Transformers_ArrayColumn extends W
 	public function test_it_returns_value_by_array_column() {
 		$items = array(
 			array(
-				'name' => 'mothra',
+				'name' => 'team-a',
 			),
 			array(
-				'name' => 'gezora',
+				'name' => 'team-b',
 			),
 			array(
-				'name' => 'ghidorah',
+				'name' => 'team-c',
 			),
 		);
 
 		$arguments    = (object) array( 'key' => 'name' );
 		$array_column = new ArrayColumn();
 		$result       = $array_column->transform( $items, $arguments );
-		$expected     = array( 'mothra', 'gezora', 'ghidorah' );
+		$expected     = array( 'team-a', 'team-b', 'team-c' );
 		$this->assertEquals( $expected, $result );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/dot-notation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/dot-notation.php
@@ -51,11 +51,11 @@ class WC_Admin_Tests_RemoteInboxNotifications_Transformers_DotNotation extends W
 	 * Test it get getvalue by dot notation.
 	 */
 	public function test_it_can_get_value_by_dot_notation() {
-		$arguments = (object) array( 'path' => 'teams.mothra' );
+		$arguments = (object) array( 'path' => 'teams.a' );
 
 		$items = array(
 			'teams' => array(
-				'mothra' => 'nice!',
+				'a' => 'nice!',
 			),
 		);
 
@@ -72,7 +72,7 @@ class WC_Admin_Tests_RemoteInboxNotifications_Transformers_DotNotation extends W
 
 		$items = array(
 			'teams' => array(
-				'mothra' => 'nice!',
+				'a' => 'nice!',
 			),
 		);
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/transformer-service.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/transformer-service.php
@@ -109,24 +109,24 @@ class WC_Admin_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit
 	 * When it uses DotNotation to select 'teams'
 	 * When it uses ArrayColumn to select 'members' in 'teams'
 	 * When it uses ArrayFlatten to flatten 'members'
-	 * When it uses ArraySearch to select 'mothra-member'
-	 * Then 'mothra-member' should be returned.
+	 * When it uses ArraySearch to select 'team-a'
+	 * Then 'team-a-member' should be returned.
 	 */
 	public function test_it_returns_transformed_value() {
 		// Given.
 		$items = array(
 			'teams' => array(
 				array(
-					'name'    => 'mothra',
-					'members' => array( 'mothra-member' ),
+					'name'    => 'team-a',
+					'members' => array( 'team-a-member' ),
 				),
 				array(
-					'name'    => 'gezora',
-					'members' => array( 'gezora-member' ),
+					'name'    => 'team-b',
+					'members' => array( 'team-b-member' ),
 				),
 				array(
-					'name'    => 'ghidorah',
-					'members' => array( 'ghidorah-member' ),
+					'name'    => 'team-c',
+					'members' => array( 'team-c-member' ),
 				),
 			),
 		);
@@ -135,12 +135,12 @@ class WC_Admin_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit
 		$dot_notation  = $this->transformer_config( 'dot_notation', array( 'path' => 'teams' ) );
 		$array_column  = $this->transformer_config( 'array_column', array( 'key' => 'members' ) );
 		$array_flatten = $this->transformer_config( 'array_flatten' );
-		$array_search  = $this->transformer_config( 'array_search', array( 'value' => 'mothra-member' ) );
+		$array_search  = $this->transformer_config( 'array_search', array( 'value' => 'team-a-member' ) );
 
 		$result = TransformerService::apply( $items, array( $dot_notation, $array_column, $array_flatten, $array_search ), false, null );
 
 		// Then.
-		$this->assertEquals( 'mothra-member', $result );
+		$this->assertEquals( 'team-a-member', $result );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the use of Mothra, Ghidorah team names within the PHP unit tests and replaces them with generic names.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the PHP unit tests run correctly in the GH action
2. Run PHP unit tests locally: 
     1. `pnpm --filter=@woocommerce/plugin-woocommerce env:dev`
     2. `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=WC_Admin_Tests_RemoteInboxNotifications_TransformerService`
     3. `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=WC_Admin_Tests_RemoteInboxNotifications_Transformers_ArrayColumn`
     4. `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=WC_Admin_Tests_RemoteInboxNotifications_Transformers_DotNotation`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
