### PR TITLE
[tests] Execute test env setup on host instead of wp-env container (reverts #50445)

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -16,8 +16,8 @@
 		"test-data/images/": "./tests/e2e-pw/test-data/images/"
 	},
 	"lifecycleScripts": {
-		"afterStart": "wp-env run tests-cli bash wp-content/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh",
-		"afterClean": "wp-env run tests-cli bash wp-content/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh"
+		"afterStart": "./tests/e2e-pw/bin/test-env-setup.sh",
+		"afterClean": "./tests/e2e-pw/bin/test-env-setup.sh"
 	},
 	"env": {
 		"development": {

--- a/plugins/woocommerce/changelog/revert-50445
+++ b/plugins/woocommerce/changelog/revert-50445
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Execute test env setup on host instead of wp-env container

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
 echo -e 'Activate default theme \n'
-wp theme activate twentytwentythree
+wp-env run tests-cli wp theme activate twentytwentythree
 
 echo -e 'Update URL structure \n'
-wp rewrite structure '/%postname%/' --hard
+wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
 
 echo -e 'Activate Filter Setter utility plugin \n'
-wp plugin activate filter-setter
+wp-env run tests-cli wp plugin activate filter-setter
 
 # This plugin allows you to process queued scheduled actions immediately.
 # It's used in the analytics e2e tests so that order numbers are shown in Analytics.
 echo -e 'Activate Process Waiting Actions utility plugin \n'
-wp plugin activate process-waiting-actions
+wp-env run tests-cli wp plugin activate process-waiting-actions
 
 echo -e 'Activate Test Helper APIs utility plugin \n'
-wp plugin activate test-helper-apis
+wp-env run tests-cli wp plugin activate test-helper-apis
 
 echo -e 'Add Customer user \n'
-wp user create customer customer@woocommercecoree2etestsuite.com \
+wp-env run tests-cli wp user create customer customer@woocommercecoree2etestsuite.com \
 	--user_pass=password \
 	--role=customer \
 	--first_name='Jane' \
@@ -26,17 +26,17 @@ wp user create customer customer@woocommercecoree2etestsuite.com \
 	--user_registered='2022-01-01 12:23:45'
 
 echo -e 'Update Blog Name \n'
-wp option update blogname 'WooCommerce Core E2E Test Suite'
+wp-env run tests-cli wp option update blogname 'WooCommerce Core E2E Test Suite'
 
 echo -e 'Preparing Test Files \n'
-sudo cp /var/www/html/wp-content/plugins/woocommerce/tests/legacy/unit-tests/importer/sample.csv /var/www/sample.csv
+wp-env run tests-cli sudo cp /var/www/html/wp-content/plugins/woocommerce/tests/legacy/unit-tests/importer/sample.csv /var/www/sample.csv
 
 ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
 if [ $ENABLE_TRACKING == 1 ]; then
 	echo -e 'Enable tracking\n'
-	wp option update woocommerce_allow_tracking 'yes'
+	wp-env run tests-cli wp option update woocommerce_allow_tracking 'yes'
 fi
 
 echo -e 'Upload test images \n'
-wp media import './test-data/images/image-01.png' './test-data/images/image-02.png' './test-data/images/image-03.png'
+wp-env run tests-cli wp media import './test-data/images/image-01.png' './test-data/images/image-02.png' './test-data/images/image-03.png'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This reverts the changes introduced by https://github.com/woocommerce/woocommerce/pull/50445.
Executing the `test-env-setup.sh` script from the container fails during [release-checks](https://github.com/woocommerce/woocommerce/actions/runs/10584457804/job/29372093538#step:5:27), where we're using the built release package which doesn't contain the script.
Reverting to running the script on host.

### How to test the changes in this Pull Request:

CI should be green.
After merging it can be tested by editing the [nightly release](https://github.com/woocommerce/woocommerce/releases/tag/nightly). That should trigger a release checks run in CI that should pass the setup step affected by this change.