### PR TITLE
`Product SKU` improvements

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/attributes.ts
@@ -24,6 +24,14 @@ export const blockAttributes: BlockAttributes = {
 		type: 'boolean',
 		default: false,
 	},
+	prefix: {
+		type: 'string',
+		default: 'SKU:',
+	},
+	suffix: {
+		type: 'string',
+		default: '',
+	},
 };
 
 export default blockAttributes;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -10,6 +10,8 @@ import {
 import { withProductDataContext } from '@woocommerce/shared-hocs';
 import type { HTMLAttributes } from 'react';
 import { useStyleProps } from '@woocommerce/base-hooks';
+import { RichText } from '@wordpress/block-editor';
+import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -17,18 +19,24 @@ import { useStyleProps } from '@woocommerce/base-hooks';
 import './style.scss';
 import type { Attributes } from './types';
 
-type Props = Attributes & HTMLAttributes< HTMLDivElement >;
+type Props = BlockEditProps< Attributes > & HTMLAttributes< HTMLDivElement >;
 
 const Preview = ( {
+	setAttributes,
 	parentClassName,
 	sku,
 	className,
 	style,
+	prefix,
+	suffix,
 }: {
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
 	parentClassName: string;
 	sku: string;
 	className?: string | undefined;
 	style?: React.CSSProperties | undefined;
+	prefix?: string;
+	suffix?: string;
 } ) => (
 	<div
 		className={ clsx( className, {
@@ -36,7 +44,21 @@ const Preview = ( {
 		} ) }
 		style={ style }
 	>
-		{ __( 'SKU:', 'woocommerce' ) } <strong>{ sku }</strong>
+		<RichText
+			value={ prefix }
+			placeholder="Prefix"
+			onChange={ ( value ) =>
+				setAttributes( { prefix: value } )
+			}
+		/>
+		<strong>{ sku }</strong>
+		<RichText
+			value={ suffix }
+			placeholder="Suffix"
+			onChange={ ( value ) =>
+				setAttributes( { suffix: value } )
+			}
+		/>
 	</div>
 );
 
@@ -50,9 +72,12 @@ const Block = ( props: Props ): JSX.Element | null => {
 	if ( props.isDescendentOfSingleProductTemplate ) {
 		return (
 			<Preview
+				setAttributes={ props.setAttributes }
 				parentClassName={ parentClassName }
 				className={ className }
 				sku={ 'Product SKU' }
+				prefix={ props.prefix }
+				suffix={ props.suffix }
 			/>
 		);
 	}
@@ -63,9 +88,12 @@ const Block = ( props: Props ): JSX.Element | null => {
 
 	return (
 		<Preview
+			setAttributes={ props.setAttributes }
 			className={ className }
 			parentClassName={ parentClassName }
 			sku={ sku }
+			prefix={ props.prefix }
+			suffix={ props.suffix }
 			{ ...( props.isDescendantOfAllProducts && {
 				className: clsx(
 					className,

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -44,14 +44,16 @@ const Preview = ( {
 		style={ style }
 	>
 		<RichText
-			value={ prefix }
+			tagName="span"
 			placeholder="Prefix"
+			value={ prefix }
 			onChange={ ( value ) => setAttributes( { prefix: value } ) }
 		/>
 		<strong>{ sku }</strong>
 		<RichText
-			value={ suffix }
+			tagName="span"
 			placeholder="Suffix"
+			value={ suffix }
 			onChange={ ( value ) => setAttributes( { suffix: value } ) }
 		/>
 	</div>

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import {
 	useInnerBlockLayoutContext,
@@ -47,17 +46,13 @@ const Preview = ( {
 		<RichText
 			value={ prefix }
 			placeholder="Prefix"
-			onChange={ ( value ) =>
-				setAttributes( { prefix: value } )
-			}
+			onChange={ ( value ) => setAttributes( { prefix: value } ) }
 		/>
 		<strong>{ sku }</strong>
 		<RichText
 			value={ suffix }
 			placeholder="Suffix"
-			onChange={ ( value ) =>
-				setAttributes( { suffix: value } )
-			}
+			onChange={ ( value ) => setAttributes( { suffix: value } ) }
 		/>
 	</div>
 );

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -68,7 +68,7 @@ const Edit = ( {
 					attributes.isDescendantOfAllProducts ? undefined : style
 				}
 			>
-				<Block { ...blockAttrs } />
+				<Block { ...blockAttrs } setAttributes={setAttributes} />
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -68,7 +68,7 @@ const Edit = ( {
 					attributes.isDescendantOfAllProducts ? undefined : style
 				}
 			>
-				<Block { ...blockAttrs } setAttributes={setAttributes} />
+				<Block { ...blockAttrs } setAttributes={ setAttributes } />
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -10,6 +10,7 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import './editor.scss';
 import Block from './block';
 import type { Attributes } from './types';
 import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/editor.scss
@@ -1,0 +1,4 @@
+.wc-block-components-product-sku strong {
+	margin-left: $gap-smallest;
+	margin-right: $gap-smallest;
+}

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/index.tsx
@@ -29,6 +29,9 @@ const blockConfig: BlockConfiguration = {
 		'woocommerce/product-meta',
 	],
 	edit,
+	save() {
+		return null;
+	},
 	supports,
 };
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
@@ -1,6 +1,9 @@
 .wc-block-components-product-sku {
 	display: block;
-	text-transform: uppercase;
 	@include font-size(small);
 	overflow-wrap: break-word;
+
+	strong {
+		text-transform: uppercase;
+	}
 }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
@@ -5,5 +5,7 @@
 
 	strong {
 		text-transform: uppercase;
+		margin-left: $gap-smallest;
+		margin-right: $gap-smallest;
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/style.scss
@@ -5,7 +5,5 @@
 
 	strong {
 		text-transform: uppercase;
-		margin-left: $gap-smallest;
-		margin-right: $gap-smallest;
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/sku/types.ts
@@ -5,4 +5,6 @@ export interface Attributes {
 	isDescendentOfSingleProductBlock: boolean;
 	showProductSelector: boolean;
 	isDescendantOfAllProducts: boolean;
+	prefix: string;
+	suffix: string;
 }

--- a/plugins/woocommerce/changelog/51033-47922-product-sku-improvements
+++ b/plugins/woocommerce/changelog/51033-47922-product-sku-improvements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Product SKU block: add editable prefixes and suffixes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -69,17 +69,27 @@ class ProductSKU extends AbstractBlock {
 
 		$styles_and_classes = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
+		$prefix = isset( $attributes['prefix'] ) ? wp_kses_post( ( $attributes['prefix'] ) ) : __( 'SKU: ', 'woocommerce' );
+		if ( ! empty( $prefix ) ) {
+			$prefix = sprintf( '<span class="prefix">%s</span>', $prefix );
+		}
+
+		$suffix = isset( $attributes['suffix'] ) ? wp_kses_post( ( $attributes['suffix'] ) ) : '';
+		if ( ! empty( $suffix ) ) {
+			$suffix = sprintf( '<span class="suffix">%s</span>', $suffix );
+		}
+
 		return sprintf(
 			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta %1$s" style="%2$s">
-				<span>%3$s</span>
+				%3$s
 				<strong class="sku">%4$s</strong>
-				<span>%5$s</span>
+				%5$s
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
-			isset( $attributes['prefix'] ) ? wp_kses_post( ( $attributes['prefix'] ) ) : __( 'SKU: ', 'woocommerce' ),
+			$prefix,
 			$product_sku,
-			isset( $attributes['suffix'] ) ? wp_kses_post( ( $attributes['suffix'] ) ) : ''
+			$suffix
 		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -71,12 +71,15 @@ class ProductSKU extends AbstractBlock {
 
 		return sprintf(
 			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta %1$s" style="%2$s">
-				SKU:
-				<strong class="sku">%3$s</strong>
+				<span>%3$s</span>
+				<strong class="sku">%4$s</strong>
+				<span>%5$s</span>
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
-			$product_sku
+			esc_attr( $attributes['prefix'] ),
+			$product_sku,
+			esc_attr( $attributes['suffix'] ),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -77,9 +77,9 @@ class ProductSKU extends AbstractBlock {
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
-			isset( $attributes['prefix'] ) ? esc_attr( $attributes['prefix'] ) : __( 'SKU: ', 'woocommerce' ),
+			isset( $attributes['prefix'] ) ? wp_kses_post( ( $attributes['prefix'] ) ) : __( 'SKU: ', 'woocommerce' ),
 			$product_sku,
-			isset( $attributes['suffix'] ) ? esc_attr( $attributes['suffix'] ) : ''
+			isset( $attributes['suffix'] ) ? wp_kses_post( ( $attributes['suffix'] ) ) : ''
 		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -77,9 +77,9 @@ class ProductSKU extends AbstractBlock {
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
-			esc_attr( $attributes['prefix'] ),
+			isset( $attributes['prefix'] ) ? esc_attr( $attributes['prefix'] ) : __( 'SKU: ', 'woocommerce' ),
 			$product_sku,
-			esc_attr( $attributes['suffix'] ),
+			isset( $attributes['suffix'] ) ? esc_attr( $attributes['suffix'] ) : ''
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a prefix and a suffix to the `Product SKU` block. Both of them are editable by users. The default prefix is `SKU:`, the default suffix is an empty string.

Closes https://github.com/woocommerce/woocommerce/issues/47922

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Single Product block**
1. Create a new page or post.
2. Insert the `Single Product` block.
3. Check there's an SKU block and you can edit the prefix and suffix (the default suffix should be `SKU:`).
<img width="321" alt="Screenshot 2024-08-29 at 14 23 16" src="https://github.com/user-attachments/assets/8721a226-80a6-4501-b9af-b187a41308c0">

4. Change also some other settings in the sidebar (colors, sizes, etc.) and check all are applied in the editor.
5. Save and go to the front end.
6. Check the same styles are applied there.

**Single Product template**
1. Go to the Site Editor, open the `Single Product` template, and repeat the steps above for the `Product SKU` block.

**Check old blocks are not affected**
1. Go to `trunk`.
2. Create a new page or post.
3. Insert the `Single Product` block, and save and open the frontend page on another tab.
4. Switch to this PR branch.
5. Refresh the editor and the frontend tabs and check everything looks the same.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product SKU block: add editable prefixes and suffixes.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
