### PR TITLE
Fix storybook build

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -88,7 +88,8 @@
 				"webpack*"
 			],
 			"packages": [
-				"@woocommerce/block-library"
+				"@woocommerce/block-library",
+				"@woocommerce/storybook"
 			],
 			"isIgnored": true
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 9.0.11
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       lint-staged:
         specifier: ^12.5.0
         version: 12.5.0(enquirer@2.4.1)
@@ -177,10 +177,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-mock-extended:
         specifier: ^1.0.18
         version: 1.0.18(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))(typescript@5.3.3)
@@ -235,10 +235,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       postcss-loader:
         specifier: ^4.3.0
         version: 4.3.0(postcss@8.4.32)(webpack@5.89.0(webpack-cli@3.3.12))
@@ -365,10 +365,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       mini-css-extract-plugin:
         specifier: ^2.7.6
         version: 2.7.6(webpack@5.89.0(webpack-cli@3.3.12))
@@ -450,7 +450,7 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       ts-jest:
         specifier: ~29.1.1
         version: 29.1.1(@babel/core@7.24.7)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))(typescript@5.3.3)
@@ -471,7 +471,7 @@ importers:
         version: 10.0.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-allure:
         specifier: ^0.1.3
         version: 0.1.3
@@ -566,10 +566,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -900,10 +900,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -982,10 +982,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1040,10 +1040,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1149,10 +1149,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -1300,10 +1300,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       react-test-renderer:
         specifier: 17.0.2
         version: 17.0.2(react@17.0.2)
@@ -1379,10 +1379,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1413,10 +1413,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1534,7 +1534,7 @@ importers:
         version: 3.3.7
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-circus:
         specifier: 27.5.1
         version: 27.5.1
@@ -1717,10 +1717,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1841,10 +1841,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -1926,10 +1926,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1972,10 +1972,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -2069,10 +2069,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       ts-jest:
         specifier: ~29.1.1
         version: 29.1.1(@babel/core@7.23.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))(typescript@5.3.3)
@@ -2151,10 +2151,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       resize-observer-polyfill:
         specifier: 1.5.1
         version: 1.5.1
@@ -2215,10 +2215,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -2300,10 +2300,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -2364,10 +2364,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       redux:
         specifier: ^4.2.1
         version: 4.2.1
@@ -2416,10 +2416,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -2516,10 +2516,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       postcss:
         specifier: ^8.4.32
         version: 8.4.32
@@ -2778,10 +2778,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       mini-css-extract-plugin:
         specifier: ^2.7.6
         version: 2.7.6(webpack@5.89.0(webpack-cli@3.3.12))
@@ -2869,10 +2869,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -2918,10 +2918,10 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-cli:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -3220,7 +3220,7 @@ importers:
         version: 1.0.0-alpha.2
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       mocha:
         specifier: 7.2.0
         version: 7.2.0
@@ -3722,7 +3722,7 @@ importers:
         version: 11.1.1
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-environment-jsdom:
         specifier: ~27.5.1
         version: 27.5.1
@@ -4663,7 +4663,7 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       ts-jest:
         specifier: ~29.1.1
         version: 29.1.1(@babel/core@7.24.7)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))(typescript@5.3.3)
@@ -4845,7 +4845,7 @@ importers:
         version: 8.55.0
       jest:
         specifier: ~27.5.1
-        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+        version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       replace:
         specifier: ^1.2.2
         version: 1.2.2
@@ -5007,67 +5007,64 @@ importers:
         version: 7.23.5
       '@storybook/addon-a11y':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-actions':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-console':
         specifier: ^1.2.3
-        version: 1.2.3(@storybook/addon-actions@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
+        version: 1.2.3(@storybook/addon-actions@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-controls':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+        version: 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/addon-docs':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(@babel/core@7.24.7)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.89.0)
+        version: 6.5.17-alpha.0(@babel/core@7.24.7)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.89.0)
       '@storybook/addon-knobs':
         specifier: ^6.4.0
-        version: 6.4.0(@storybook/addons@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/api@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/components@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/core-events@6.5.17-alpha.0)(@storybook/theming@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.4.0(@storybook/addons@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/api@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@6.5.17-alpha.0)(@storybook/theming@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-links':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-storysource':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-viewport':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addons':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/api':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/builder-webpack5':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+        version: 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/components':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events':
         specifier: 6.5.17-alpha.0
         version: 6.5.17-alpha.0
       '@storybook/manager-webpack5':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+        version: 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/react':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(@babel/core@7.24.7)(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@types/webpack@4.41.38)(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(require-from-string@2.0.2)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@4.15.1(webpack@5.89.0))(webpack-hot-middleware@2.25.4)
+        version: 6.5.17-alpha.0(@babel/core@7.24.7)(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@types/webpack@4.41.38)(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(require-from-string@2.0.2)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@4.15.1(webpack@5.89.0))(webpack-hot-middleware@2.25.4)
       '@storybook/theming':
         specifier: 6.5.17-alpha.0
-        version: 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@woocommerce/eslint-plugin':
         specifier: workspace:*
         version: link:../../packages/js/eslint-plugin
       react:
-        specifier: ^17.0.2
-        version: 17.0.2
+        specifier: 18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^17.0.2
-        version: 17.0.2(react@17.0.2)
-      react18:
-        specifier: npm:react@^18.3.0
-        version: react@18.3.1
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -21727,7 +21724,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      react: 18.2.0
+      react: ^17.0.2
 
   react-number-format@4.9.3:
     resolution: {integrity: sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==}
@@ -21932,7 +21929,7 @@ packages:
   react-with-direction@1.4.0:
     resolution: {integrity: sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==}
     peerDependencies:
-      react: ^0.14 || ^15 || ^16
+      react: ^17.0.2
       react-dom: ^0.14 || ^15 || ^16
 
   react-with-styles-interface-css@4.0.3:
@@ -29851,6 +29848,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emotion/core@10.3.1(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.0
+      '@emotion/cache': 10.0.29
+      '@emotion/css': 10.0.27
+      '@emotion/serialize': 0.11.16
+      '@emotion/sheet': 0.9.4
+      '@emotion/utils': 0.11.3
+      react: 18.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/css@10.0.27':
     dependencies:
       '@emotion/serialize': 0.11.16
@@ -30465,7 +30474,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))':
+  '@jest/core@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1(node-notifier@8.0.2)
@@ -30479,7 +30488,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest-config: 27.5.1(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
@@ -31198,6 +31207,10 @@ snapshots:
   '@mdx-js/react@1.6.22(react@17.0.2)':
     dependencies:
       react: 17.0.2
+
+  '@mdx-js/react@1.6.22(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@mdx-js/react@2.3.0(react@18.3.1)':
     dependencies:
@@ -33692,16 +33705,16 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  '@storybook/addon-a11y@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-a11y@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/channels': 6.5.17-alpha.0
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 6.5.17-alpha.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axe-core: 4.8.2
       core-js: 3.34.0
       global: 4.4.0
@@ -33711,8 +33724,8 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/addon-a11y@7.5.2(@types/react-dom@18.0.10)(@types/react@17.0.71)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -33760,6 +33773,31 @@ snapshots:
     optionalDependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+
+  '@storybook/addon-actions@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      core-js: 3.34.0
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      polished: 4.2.2
+      prop-types: 15.8.1
+      react-inspector: 5.1.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+      uuid-browser: 3.1.0
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/addon-actions@7.5.2(@types/react-dom@18.0.10)(@types/react@17.0.71)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -33819,30 +33857,10 @@ snapshots:
       '@storybook/addon-actions': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       global: 4.4.0
 
-  '@storybook/addon-controls@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
+  '@storybook/addon-console@1.2.3(@storybook/addon-actions@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/node-logger': 6.5.17-alpha.0
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      core-js: 3.34.0
-      lodash: 4.17.21
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - typescript
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
+      '@storybook/addon-actions': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      global: 4.4.0
 
   '@storybook/addon-controls@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))':
     dependencies:
@@ -33861,6 +33879,31 @@ snapshots:
     optionalDependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+
+  '@storybook/addon-controls@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/node-logger': 6.5.17-alpha.0
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      core-js: 3.34.0
+      lodash: 4.17.21
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -33935,26 +33978,26 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-docs@6.5.17-alpha.0(@babel/core@7.24.7)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.89.0)':
+  '@storybook/addon-docs@6.5.17-alpha.0(@babel/core@7.24.7)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.89.0)':
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.7)
       '@babel/preset-env': 7.23.5(@babel/core@7.24.7)
       '@jest/transform': 26.6.2
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@mdx-js/react': 1.6.22(react@18.3.1)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/core-events': 6.5.17-alpha.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/docs-tools': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/docs-tools': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/mdx1-csf': 0.0.1(@babel/core@7.24.7)
       '@storybook/node-logger': 6.5.17-alpha.0
       '@storybook/postinstall': 6.5.17-alpha.0
-      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/source-loader': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/source-loader': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@5.89.0)
       core-js: 3.34.0
       fast-deep-equal: 3.1.3
@@ -33966,8 +34009,8 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - eslint
@@ -34090,6 +34133,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@storybook/addon-knobs@6.4.0(@storybook/addons@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/api@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@6.5.17-alpha.0)(@storybook/theming@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      copy-to-clipboard: 3.3.3
+      core-js: 3.34.0
+      escape-html: 1.0.3
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      qs: 6.11.2
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-lifecycles-compat: 3.0.4
+      react-select: 3.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@storybook/addon-knobs@7.0.2(@storybook/addons@7.5.2(react-dom@18.3.1(react@17.0.2))(react@17.0.2))(@storybook/api@7.6.4(react-dom@18.3.1(react@17.0.2))(react@17.0.2))(@storybook/components@7.6.4(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@18.3.1(react@17.0.2))(react@17.0.2))(@storybook/core-events@7.6.4)(@storybook/theming@7.6.4(react-dom@18.3.1(react@17.0.2))(react@17.0.2))(@types/react@17.0.71)(react-dom@18.3.1(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@storybook/addons': 7.5.2(react-dom@18.3.1(react@17.0.2))(react@17.0.2)
@@ -34132,6 +34199,24 @@ snapshots:
     optionalDependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+
+  '@storybook/addon-links@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/qs': 6.9.10
+      core-js: 3.34.0
+      global: 4.4.0
+      prop-types: 15.8.1
+      qs: 6.11.2
+      regenerator-runtime: 0.13.11
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/addon-links@7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -34183,24 +34268,24 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-storysource@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-storysource@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/router': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/source-loader': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/source-loader': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       core-js: 3.34.0
       estraverse: 5.3.0
       loader-utils: 2.0.4
       prop-types: 15.8.1
-      react-syntax-highlighter: 15.5.0(react@17.0.2)
+      react-syntax-highlighter: 15.5.0(react@18.3.1)
       regenerator-runtime: 0.13.11
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/addon-storysource@7.5.2(@types/react-dom@18.0.10)(@types/react@17.0.71)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -34241,22 +34326,22 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-viewport@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-viewport@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 6.5.17-alpha.0
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       core-js: 3.34.0
       global: 4.4.0
       memoizerific: 1.11.3
       prop-types: 15.8.1
       regenerator-runtime: 0.13.11
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/addon-viewport@7.5.2(@types/react-dom@18.0.10)(@types/react@17.0.71)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -34292,6 +34377,22 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
 
+  '@storybook/addons@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/channels': 6.5.17-alpha.0
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/webpack-env': 1.18.4
+      core-js: 3.34.0
+      global: 4.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+
   '@storybook/addons@7.5.2(react-dom@18.3.1(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@storybook/manager-api': 7.5.2(react-dom@18.3.1(react@17.0.2))(react@17.0.2)
@@ -34324,6 +34425,28 @@ snapshots:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+      regenerator-runtime: 0.13.11
+      store2: 2.14.2
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+
+  '@storybook/api@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/channels': 6.5.17-alpha.0
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/semver': 7.3.2
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      core-js: 3.34.0
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
       store2: 2.14.2
       telejson: 6.0.8
@@ -34426,67 +34549,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack4@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/channel-postmessage': 6.5.17-alpha.0
-      '@storybook/channels': 6.5.17-alpha.0
-      '@storybook/client-api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/core-events': 6.5.17-alpha.0
-      '@storybook/node-logger': 6.5.17-alpha.0
-      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/router': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@types/node': 16.18.68
-      '@types/webpack': 4.41.38
-      autoprefixer: 9.8.6
-      babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.34.0
-      css-loader: 3.6.0(webpack@4.47.0)
-      file-loader: 6.2.0(webpack@4.47.0)
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@8.55.0)(typescript@5.3.3)(webpack@4.47.0)
-      glob: 7.2.3
-      glob-promise: 3.4.0(glob@7.2.3)
-      global: 4.4.0
-      html-webpack-plugin: 4.5.2(webpack@4.47.0)
-      pnp-webpack-plugin: 1.6.4(typescript@5.3.3)
-      postcss: 7.0.39
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0(postcss@7.0.39)(webpack@4.47.0)
-      raw-loader: 4.0.2(webpack@4.47.0)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      stable: 0.1.8
-      style-loader: 1.3.0(webpack@4.47.0)
-      terser-webpack-plugin: 4.2.3(webpack@4.47.0)
-      ts-dedent: 2.2.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@4.47.0))(webpack@4.47.0)
-      util-deprecate: 1.0.2
-      webpack: 4.47.0
-      webpack-dev-middleware: 3.7.3(webpack@4.47.0)
-      webpack-filter-warnings-plugin: 1.2.1(webpack@4.47.0)
-      webpack-hot-middleware: 2.25.4
-      webpack-virtual-modules: 0.2.2
-    optionalDependencies:
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - bluebird
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-
   '@storybook/builder-webpack4@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))':
     dependencies:
       '@babel/core': 7.24.7
@@ -34548,24 +34610,85 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
+  '@storybook/builder-webpack4@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
     dependencies:
-      '@babel/core': 7.23.5
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@babel/core': 7.24.7
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/channel-postmessage': 6.5.17-alpha.0
       '@storybook/channels': 6.5.17-alpha.0
-      '@storybook/client-api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/client-api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/components': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/core-events': 6.5.17-alpha.0
       '@storybook/node-logger': 6.5.17-alpha.0
-      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/router': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/ui': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/node': 16.18.68
+      '@types/webpack': 4.41.38
+      autoprefixer: 9.8.6
+      babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      core-js: 3.34.0
+      css-loader: 3.6.0(webpack@4.47.0)
+      file-loader: 6.2.0(webpack@4.47.0)
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@8.55.0)(typescript@5.3.3)(webpack@4.47.0)
+      glob: 7.2.3
+      glob-promise: 3.4.0(glob@7.2.3)
+      global: 4.4.0
+      html-webpack-plugin: 4.5.2(webpack@4.47.0)
+      pnp-webpack-plugin: 1.6.4(typescript@5.3.3)
+      postcss: 7.0.39
+      postcss-flexbugs-fixes: 4.2.1
+      postcss-loader: 4.3.0(postcss@7.0.39)(webpack@4.47.0)
+      raw-loader: 4.0.2(webpack@4.47.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      stable: 0.1.8
+      style-loader: 1.3.0(webpack@4.47.0)
+      terser-webpack-plugin: 4.2.3(webpack@4.47.0)
+      ts-dedent: 2.2.0
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@4.47.0)
+      util-deprecate: 1.0.2
+      webpack: 4.47.0
+      webpack-dev-middleware: 3.7.3(webpack@4.47.0)
+      webpack-filter-warnings-plugin: 1.2.1(webpack@4.47.0)
+      webpack-hot-middleware: 2.25.4
+      webpack-virtual-modules: 0.2.2
+    optionalDependencies:
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - bluebird
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+
+  '@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
+    dependencies:
+      '@babel/core': 7.23.5
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/channel-postmessage': 6.5.17-alpha.0
+      '@storybook/channels': 6.5.17-alpha.0
+      '@storybook/client-api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/node-logger': 6.5.17-alpha.0
+      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/semver': 7.3.2
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node': 16.18.68
       babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.91.0)
       babel-plugin-named-exports-order: 0.0.2
@@ -34579,8 +34702,8 @@ snapshots:
       html-webpack-plugin: 5.5.4(webpack@5.91.0)
       path-browserify: 1.0.1
       process: 0.11.10
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       stable: 0.1.8
       style-loader: 2.0.0(webpack@5.91.0)
       terser-webpack-plugin: 5.3.6(webpack@5.91.0)
@@ -34767,6 +34890,31 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
+  '@storybook/client-api@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/channel-postmessage': 6.5.17-alpha.0
+      '@storybook/channels': 6.5.17-alpha.0
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/qs': 6.9.10
+      '@types/webpack-env': 1.18.4
+      core-js: 3.34.0
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      store2: 2.14.2
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+
   '@storybook/client-api@7.5.2':
     dependencies:
       '@storybook/client-logger': 7.5.2
@@ -34814,6 +34962,19 @@ snapshots:
       qs: 6.11.2
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+      regenerator-runtime: 0.13.11
+      util-deprecate: 1.0.2
+
+  '@storybook/components@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      core-js: 3.34.0
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
       util-deprecate: 1.0.2
 
@@ -34899,34 +35060,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.3.3
 
-  '@storybook/core-client@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@4.47.0)':
-    dependencies:
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/channel-postmessage': 6.5.17-alpha.0
-      '@storybook/channel-websocket': 6.5.17-alpha.0
-      '@storybook/client-api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/core-events': 6.5.17-alpha.0
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.34.0
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.11.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.11
-      ts-dedent: 2.2.0
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-      webpack: 4.47.0
-    optionalDependencies:
-      typescript: 5.3.3
-
   '@storybook/core-client@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.91.0(webpack-cli@3.3.12(webpack@5.89.0)))':
     dependencies:
       '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -34955,26 +35088,54 @@ snapshots:
     optionalDependencies:
       typescript: 5.3.3
 
-  '@storybook/core-client@6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.91.0)':
+  '@storybook/core-client@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@4.47.0)':
     dependencies:
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/channel-postmessage': 6.5.17-alpha.0
       '@storybook/channel-websocket': 6.5.17-alpha.0
-      '@storybook/client-api': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/client-api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 6.5.17-alpha.0
       '@storybook/core-events': 6.5.17-alpha.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/ui': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.34.0
       global: 4.4.0
       lodash: 4.17.21
       qs: 6.11.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      ts-dedent: 2.2.0
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+      webpack: 4.47.0
+    optionalDependencies:
+      typescript: 5.3.3
+
+  '@storybook/core-client@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.91.0)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/channel-postmessage': 6.5.17-alpha.0
+      '@storybook/channel-websocket': 6.5.17-alpha.0
+      '@storybook/client-api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/preview-web': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/ui': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.34.0
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.11.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
       unfetch: 4.2.0
@@ -34992,69 +35153,6 @@ snapshots:
     dependencies:
       '@storybook/client-logger': 7.6.4
       '@storybook/preview-api': 7.6.4
-
-  '@storybook/core-common@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.7)
-      '@babel/plugin-proposal-decorators': 7.23.5(@babel/core@7.24.7)
-      '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.24.7)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.7)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.7)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.7)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.7)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.24.7)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.24.7)
-      '@babel/plugin-transform-classes': 7.23.5(@babel/core@7.24.7)
-      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-for-of': 7.23.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.24.7)
-      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.24.7)
-      '@babel/preset-env': 7.23.5(@babel/core@7.24.7)
-      '@babel/preset-react': 7.23.3(@babel/core@7.24.7)
-      '@babel/preset-typescript': 7.23.3(@babel/core@7.24.7)
-      '@babel/register': 7.12.1(@babel/core@7.24.7)
-      '@storybook/node-logger': 6.5.17-alpha.0
-      '@storybook/semver': 7.3.2
-      '@types/node': 16.18.68
-      '@types/pretty-hrtime': 1.0.3
-      babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
-      babel-plugin-macros: 3.1.0
-      babel-plugin-polyfill-corejs3: 0.1.7(@babel/core@7.24.7)
-      chalk: 4.1.2
-      core-js: 3.34.0
-      express: 4.18.2
-      file-system-cache: 1.1.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.55.0)(typescript@5.3.3)(webpack@4.47.0)
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      handlebars: 4.7.8
-      interpret: 2.2.0
-      json5: 2.2.3
-      lazy-universal-dotenv: 3.0.1
-      picomatch: 2.3.1
-      pkg-dir: 5.0.0
-      pretty-hrtime: 1.0.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      resolve-from: 5.0.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-      webpack: 4.47.0
-    optionalDependencies:
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
   '@storybook/core-common@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))':
     dependencies:
@@ -35110,6 +35208,69 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
       webpack: 4.47.0(webpack-cli@3.3.12(webpack@5.89.0))
+    optionalDependencies:
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+
+  '@storybook/core-common@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-decorators': 7.23.5(@babel/core@7.24.7)
+      '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.24.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.7)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.24.7)
+      '@babel/plugin-transform-classes': 7.23.5(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-for-of': 7.23.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.24.7)
+      '@babel/preset-env': 7.23.5(@babel/core@7.24.7)
+      '@babel/preset-react': 7.23.3(@babel/core@7.24.7)
+      '@babel/preset-typescript': 7.23.3(@babel/core@7.24.7)
+      '@babel/register': 7.12.1(@babel/core@7.24.7)
+      '@storybook/node-logger': 6.5.17-alpha.0
+      '@storybook/semver': 7.3.2
+      '@types/node': 16.18.68
+      '@types/pretty-hrtime': 1.0.3
+      babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
+      babel-plugin-macros: 3.1.0
+      babel-plugin-polyfill-corejs3: 0.1.7(@babel/core@7.24.7)
+      chalk: 4.1.2
+      core-js: 3.34.0
+      express: 4.18.2
+      file-system-cache: 1.1.0
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.55.0)(typescript@5.3.3)(webpack@4.47.0)
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      handlebars: 4.7.8
+      interpret: 2.2.0
+      json5: 2.2.3
+      lazy-universal-dotenv: 3.0.1
+      picomatch: 2.3.1
+      pkg-dir: 5.0.0
+      pretty-hrtime: 1.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      resolve-from: 5.0.0
+      slash: 3.0.0
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+      webpack: 4.47.0
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -35189,20 +35350,20 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/core-server@6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
+  '@storybook/core-server@6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/core-client': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@4.47.0)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/builder-webpack4': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/core-client': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@4.47.0)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/core-events': 6.5.17-alpha.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.17-alpha.0
-      '@storybook/manager-webpack4': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/manager-webpack4': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/node-logger': 6.5.17-alpha.0
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/telemetry': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/telemetry': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@types/node': 16.18.68
       '@types/node-fetch': 2.6.9
       '@types/pretty-hrtime': 1.0.3
@@ -35226,8 +35387,8 @@ snapshots:
       open: 8.4.2
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
       serve-favicon: 2.5.0
       slash: 3.0.0
@@ -35239,8 +35400,8 @@ snapshots:
       ws: 8.18.0
       x-default-browser: 0.4.0
     optionalDependencies:
-      '@storybook/builder-webpack5': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/manager-webpack5': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/manager-webpack5': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -35377,16 +35538,16 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/core@6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.91.0)':
+  '@storybook/core@6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.91.0)':
     dependencies:
-      '@storybook/core-client': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.91.0)
-      '@storybook/core-server': 6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      '@storybook/core-client': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.91.0)
+      '@storybook/core-server': 6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       webpack: 5.91.0
     optionalDependencies:
-      '@storybook/builder-webpack5': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/manager-webpack5': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/manager-webpack5': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -35510,6 +35671,20 @@ snapshots:
       - react-dom
       - supports-color
 
+  '@storybook/docs-tools@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      core-js: 3.34.0
+      doctrine: 3.0.0
+      lodash: 4.17.21
+      regenerator-runtime: 0.13.11
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - supports-color
+
   '@storybook/docs-tools@7.5.2(encoding@0.1.13)':
     dependencies:
       '@storybook/core-common': 7.5.2(encoding@0.1.13)
@@ -35619,56 +35794,6 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/manager-webpack4@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.24.7)
-      '@babel/preset-react': 7.23.3(@babel/core@7.24.7)
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-client': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@4.47.0)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/node-logger': 6.5.17-alpha.0
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@types/node': 16.18.68
-      '@types/webpack': 4.41.38
-      babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      chalk: 4.1.2
-      core-js: 3.34.0
-      css-loader: 3.6.0(webpack@4.47.0)
-      express: 4.18.2
-      file-loader: 6.2.0(webpack@4.47.0)
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.2(webpack@4.47.0)
-      node-fetch: 2.7.0(encoding@0.1.13)
-      pnp-webpack-plugin: 1.6.4(typescript@5.3.3)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-      resolve-from: 5.0.0
-      style-loader: 1.3.0(webpack@4.47.0)
-      telejson: 6.0.8
-      terser-webpack-plugin: 4.2.3(webpack@4.47.0)
-      ts-dedent: 2.2.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@4.47.0))(webpack@4.47.0)
-      util-deprecate: 1.0.2
-      webpack: 4.47.0
-      webpack-dev-middleware: 3.7.3(webpack@4.47.0)
-      webpack-virtual-modules: 0.2.2
-    optionalDependencies:
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - bluebird
-      - encoding
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-
   '@storybook/manager-webpack4@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))':
     dependencies:
       '@babel/core': 7.24.7
@@ -35719,17 +35844,67 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
+  '@storybook/manager-webpack4@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.24.7)
+      '@babel/preset-react': 7.23.3(@babel/core@7.24.7)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-client': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@4.47.0)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/node-logger': 6.5.17-alpha.0
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/ui': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/node': 16.18.68
+      '@types/webpack': 4.41.38
+      babel-loader: 8.3.0(@babel/core@7.24.7)(webpack@4.47.0)
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      chalk: 4.1.2
+      core-js: 3.34.0
+      css-loader: 3.6.0(webpack@4.47.0)
+      express: 4.18.2
+      file-loader: 6.2.0(webpack@4.47.0)
+      find-up: 5.0.0
+      fs-extra: 9.1.0
+      html-webpack-plugin: 4.5.2(webpack@4.47.0)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      pnp-webpack-plugin: 1.6.4(typescript@5.3.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      read-pkg-up: 7.0.1
+      regenerator-runtime: 0.13.11
+      resolve-from: 5.0.0
+      style-loader: 1.3.0(webpack@4.47.0)
+      telejson: 6.0.8
+      terser-webpack-plugin: 4.2.3(webpack@4.47.0)
+      ts-dedent: 2.2.0
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@4.47.0)
+      util-deprecate: 1.0.2
+      webpack: 4.47.0
+      webpack-dev-middleware: 3.7.3(webpack@4.47.0)
+      webpack-virtual-modules: 0.2.2
+    optionalDependencies:
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - bluebird
+      - encoding
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+
+  '@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.23.5)
       '@babel/preset-react': 7.23.3(@babel/core@7.23.5)
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-client': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.91.0)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-client': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.91.0)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/node-logger': 6.5.17-alpha.0
-      '@storybook/theming': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/ui': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node': 16.18.68
       babel-loader: 8.3.0(@babel/core@7.23.5)(webpack@5.91.0)
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -35742,8 +35917,8 @@ snapshots:
       html-webpack-plugin: 5.5.4(webpack@5.91.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       process: 0.11.10
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
@@ -35919,6 +36094,27 @@ snapshots:
       unfetch: 4.2.0
       util-deprecate: 1.0.2
 
+  '@storybook/preview-web@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/channel-postmessage': 6.5.17-alpha.0
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ansi-to-html: 0.6.15
+      core-js: 3.34.0
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.11.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+
   '@storybook/preview@7.6.4': {}
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.2)(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4))':
@@ -36063,21 +36259,21 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react@6.5.17-alpha.0(@babel/core@7.24.7)(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@types/webpack@4.41.38)(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(require-from-string@2.0.2)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@4.15.1(webpack@5.89.0))(webpack-hot-middleware@2.25.4)':
+  '@storybook/react@6.5.17-alpha.0(@babel/core@7.24.7)(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@types/webpack@4.41.38)(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(require-from-string@2.0.2)(type-fest@2.19.0)(typescript@5.3.3)(webpack-dev-server@4.15.1(webpack@5.89.0))(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.23.3(@babel/core@7.24.7)
       '@babel/preset-react': 7.23.3(@babel/core@7.24.7)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@2.19.0)(webpack-dev-server@4.15.1(webpack@5.89.0))(webpack-hot-middleware@2.25.4)(webpack@5.91.0)
-      '@storybook/addons': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/core': 6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack@5.91.0)
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/core': 6.5.17-alpha.0(@storybook/builder-webpack5@6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(@storybook/manager-webpack5@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3))(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)(webpack@5.91.0)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/docs-tools': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/docs-tools': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/node-logger': 6.5.17-alpha.0
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.630821.0(typescript@5.3.3)(webpack@5.91.0)
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.17-alpha.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/estree': 0.0.51
       '@types/node': 16.18.68
       '@types/webpack-env': 1.18.4
@@ -36093,9 +36289,9 @@ snapshots:
       html-tags: 3.3.1
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-element-to-jsx-string: 14.3.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-element-to-jsx-string: 14.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-refresh: 0.11.0
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
@@ -36105,8 +36301,8 @@ snapshots:
       webpack: 5.91.0
     optionalDependencies:
       '@babel/core': 7.24.7
-      '@storybook/builder-webpack5': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
-      '@storybook/manager-webpack5': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+      '@storybook/manager-webpack5': 6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -36201,6 +36397,16 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
 
+  '@storybook/router@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/client-logger': 6.5.17-alpha.0
+      core-js: 3.34.0
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+
   '@storybook/router@7.5.2(react-dom@18.3.1(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@storybook/client-logger': 7.5.2
@@ -36243,6 +36449,21 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
 
+  '@storybook/source-loader@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      core-js: 3.34.0
+      estraverse: 5.3.0
+      global: 4.4.0
+      loader-utils: 2.0.4
+      lodash: 4.17.21
+      prettier: 2.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+
   '@storybook/source-loader@7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@storybook/csf': 0.1.2
@@ -36273,10 +36494,30 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/telemetry@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)':
+  '@storybook/store@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      core-js: 3.34.0
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      slash: 3.0.0
+      stable: 0.1.8
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+
+  '@storybook/telemetry@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))':
     dependencies:
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))
       chalk: 4.1.2
       core-js: 3.34.0
       detect-package-manager: 2.0.1
@@ -36298,10 +36539,10 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/telemetry@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))':
+  '@storybook/telemetry@6.5.17-alpha.0(encoding@0.1.13)(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
     dependencies:
       '@storybook/client-logger': 6.5.17-alpha.0
-      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.3.3)(webpack-cli@3.3.12(webpack@5.89.0))
+      '@storybook/core-common': 6.5.17-alpha.0(eslint@8.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       chalk: 4.1.2
       core-js: 3.34.0
       detect-package-manager: 2.0.1
@@ -36344,6 +36585,15 @@ snapshots:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+      regenerator-runtime: 0.13.11
+
+  '@storybook/theming@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/client-logger': 6.5.17-alpha.0
+      core-js: 3.34.0
+      memoizerific: 1.11.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
 
   '@storybook/theming@7.5.2(react-dom@18.3.1(react@17.0.2))(react@17.0.2)':
@@ -36412,6 +36662,25 @@ snapshots:
       qs: 6.11.2
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+      regenerator-runtime: 0.13.11
+      resolve-from: 5.0.0
+
+  '@storybook/ui@6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addons': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/api': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/channels': 6.5.17-alpha.0
+      '@storybook/client-logger': 6.5.17-alpha.0
+      '@storybook/components': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-events': 6.5.17-alpha.0
+      '@storybook/router': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/semver': 7.3.2
+      '@storybook/theming': 6.5.17-alpha.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      core-js: 3.34.0
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
 
@@ -40881,7 +41150,7 @@ snapshots:
       '@babel/runtime': 7.23.5
       '@wordpress/keycodes': 2.19.3
       '@wordpress/url': 2.22.2(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       lodash: 4.17.21
       node-fetch: 2.7.0(encoding@0.1.13)
       puppeteer: 2.1.1
@@ -41677,7 +41946,7 @@ snapshots:
   '@wordpress/jest-console@4.1.1(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))':
     dependencies:
       '@babel/runtime': 7.25.0
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-matcher-utils: 26.6.2
       lodash: 4.17.21
 
@@ -41690,7 +41959,7 @@ snapshots:
   '@wordpress/jest-console@5.4.0(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))':
     dependencies:
       '@babel/runtime': 7.23.5
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-matcher-utils: 27.5.1
 
   '@wordpress/jest-console@5.4.0(jest@29.7.0(@types/node@16.18.68)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.2)))':
@@ -41736,7 +42005,7 @@ snapshots:
       babel-jest: 26.6.3(@babel/core@7.12.9)
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2(enzyme@3.11.0)
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
     transitivePeerDependencies:
       - '@babel/core'
       - react
@@ -41779,7 +42048,7 @@ snapshots:
       babel-jest: 27.5.1(@babel/core@7.23.5)
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2(enzyme@3.11.0)
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
@@ -47758,7 +48027,7 @@ snapshots:
       eslint: 8.55.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.55.0)(typescript@5.3.3))(eslint@8.55.0)(typescript@5.3.3)
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -51420,16 +51689,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)):
+  jest-cli@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3)):
     dependencies:
-      '@jest/core': 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      '@jest/core': 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 27.5.1(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest-config: 27.5.1(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -51598,7 +51867,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-config@27.5.1(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)):
+  jest-config@27.5.1(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3)):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 27.5.1
@@ -52322,7 +52591,7 @@ snapshots:
 
   jest-mock-extended@1.0.18(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)))(typescript@5.3.3):
     dependencies:
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       ts-essentials: 7.0.3(typescript@5.3.3)
       typescript: 5.3.3
 
@@ -53143,11 +53412,11 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3)):
+  jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3)):
     dependencies:
-      '@jest/core': 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      '@jest/core': 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       import-local: 3.1.0
-      jest-cli: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest-cli: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -57702,6 +57971,14 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-is: 17.0.2
 
+  react-element-to-jsx-string@14.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@base2/pretty-print-object': 1.0.1
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 17.0.2
+
   react-element-to-jsx-string@15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@base2/pretty-print-object': 1.0.1
@@ -57727,12 +58004,24 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
 
+  react-input-autosize@3.0.0(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.3.1
+
   react-inspector@5.1.1(react@17.0.2):
     dependencies:
       '@babel/runtime': 7.24.7
       is-dom: 1.1.0
       prop-types: 15.8.1
       react: 17.0.2
+
+  react-inspector@5.1.1(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.24.7
+      is-dom: 1.1.0
+      prop-types: 15.8.1
+      react: 18.3.1
 
   react-inspector@6.0.2(react@18.3.1):
     dependencies:
@@ -58123,6 +58412,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-select@3.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@emotion/cache': 10.0.29
+      '@emotion/core': 10.3.1(react@18.3.1)
+      '@emotion/css': 10.0.27
+      memoize-one: 5.2.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-input-autosize: 3.0.0(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
   react-select@5.8.0(@types/react@17.0.71)(react-dom@18.3.1(react@17.0.2))(react@17.0.2):
     dependencies:
       '@babel/runtime': 7.25.0
@@ -58188,15 +58492,6 @@ snapshots:
       tslib: 2.6.3
     optionalDependencies:
       '@types/react': 17.0.71
-
-  react-syntax-highlighter@15.5.0(react@17.0.2):
-    dependencies:
-      '@babel/runtime': 7.25.0
-      highlight.js: 10.7.3
-      lowlight: 1.20.0
-      prismjs: 1.29.0
-      react: 17.0.2
-      refractor: 3.6.0
 
   react-syntax-highlighter@15.5.0(react@18.3.1):
     dependencies:
@@ -61002,7 +61297,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -61019,7 +61314,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -61036,7 +61331,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@16.18.68)(typescript@5.3.3))
+      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@16.18.68)(typescript@5.3.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -61573,15 +61868,6 @@ snapshots:
     optionalDependencies:
       file-loader: 6.2.0(webpack@4.47.0(webpack-cli@3.3.12(webpack@5.89.0)))
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@4.47.0))(webpack@4.47.0):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 4.47.0
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@4.47.0)
-
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.89.0(uglify-js@3.17.4)(webpack-cli@4.10.0)))(webpack@5.89.0(uglify-js@3.17.4)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.4
@@ -61590,6 +61876,15 @@ snapshots:
       webpack: 5.89.0(uglify-js@3.17.4)(webpack-cli@4.10.0)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.89.0(uglify-js@3.17.4)(webpack-cli@4.10.0))
+
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@4.47.0):
+    dependencies:
+      loader-utils: 2.0.4
+      mime-types: 2.1.35
+      schema-utils: 3.3.0
+      webpack: 4.47.0
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@4.47.0)
 
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)))(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:

--- a/tools/storybook/package.json
+++ b/tools/storybook/package.json
@@ -46,9 +46,8 @@
 		"@storybook/react": "6.5.17-alpha.0",
 		"@storybook/theming": "6.5.17-alpha.0",
 		"@woocommerce/eslint-plugin": "workspace:*",
-		"react": "^17.0.2",
-		"react18": "npm:react@^18.3.0",
-		"react-dom": "^17.0.2",
+		"react": "18.3.1",
+		"react-dom": "18.3.1",
 		"typescript": "^5.3.3",
 		"webpack": "^5.89.0",
 		"wireit": "0.14.3"

--- a/tools/storybook/webpack.config.js
+++ b/tools/storybook/webpack.config.js
@@ -45,7 +45,14 @@ module.exports = ( storybookConfig ) => {
 
 	// We need to use react 18 for the storybook since some dependencies are not compatible with react 17
 	// Once we upgrade react to 18 in repo, we can remove this alias
-	storybookConfig.resolve.alias.react = require.resolve( 'react18' );
+	storybookConfig.resolve.alias.react = path.resolve(
+		__dirname,
+		'./node_modules/react'
+	);
+	storybookConfig.resolve.alias[ 'react-dom' ] = path.resolve(
+		__dirname,
+		'./node_modules/react-dom'
+	);
 
 	storybookConfig.resolve.modules = [
 		path.join( __dirname, '../../plugins/woocommerce-admin/client' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The storybook build is currently broken due (most likely) to the alias to React 18 not including React DOM as well.

This adds that alias and also excludes storybook from version pinning in syncpack which is very unnecessary.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. See CI pass
2. See storybook build and work (`pnpm i` at root, `pnpm storybook` at `tools/storybook`)
3. Check the components render ok.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Fix the `@woocommerce/components` Storybook.


</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
