### PR TITLE
[e2e tests] Tag some e2e tests to help with test audit

### DIFF
--- a/plugins/woocommerce/changelog/e2e-tag-e2e-tests
+++ b/plugins/woocommerce/changelog/e2e-tag-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
@@ -96,7 +96,7 @@ const test = baseTest.extend( {
 	},
 } );
 
-test.describe( 'Restricted coupon management', { tag: '@services' }, () => {
+test.describe( 'Restricted coupon management', { tag: [ '@services' ] }, () => {
 	for ( const couponType of Object.keys( couponData ) ) {
 		test( `can create new ${ couponType } coupon`, async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -130,157 +130,173 @@ test.describe(
 			} );
 		} );
 
-		test( 'allows customer to calculate Free Shipping in cart block if in Netherlands', async ( {
-			page,
-			context,
-			cartBlockPage,
-		} ) => {
-			await context.clearCookies();
+		test(
+			'allows customer to calculate Free Shipping in cart block if in Netherlands',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page, context, cartBlockPage } ) => {
+				await context.clearCookies();
 
-			await addAProductToCart( page, product1Id );
-			await page.goto( cartBlockPage.slug );
+				await addAProductToCart( page, product1Id );
+				await page.goto( cartBlockPage.slug );
 
-			// Set shipping country to Netherlands
-			await page.getByLabel( 'Add an address for shipping' ).click();
-			await page
-				.getByRole( 'combobox' )
-				.first()
-				.selectOption( 'Netherlands' );
-			await page.getByLabel( 'Postal code' ).fill( '1011AA' );
-			await page.getByLabel( 'City' ).fill( 'Amsterdam' );
-			await page.getByRole( 'button', { name: 'Update' } ).click();
+				// Set shipping country to Netherlands
+				await page.getByLabel( 'Add an address for shipping' ).click();
+				await page
+					.getByRole( 'combobox' )
+					.first()
+					.selectOption( 'Netherlands' );
+				await page.getByLabel( 'Postal code' ).fill( '1011AA' );
+				await page.getByLabel( 'City' ).fill( 'Amsterdam' );
+				await page.getByRole( 'button', { name: 'Update' } ).click();
 
-			// Verify shipping costs
-			await expect(
-				page.getByRole( 'group' ).getByText( 'Free shipping' )
-			).toBeVisible();
-			await expect(
-				page.getByRole( 'strong' ).getByText( 'Free', { exact: true } )
-			).toBeVisible();
-			await expect( page.getByText( '$' ).nth( 2 ) ).toContainText(
-				firstProductPrice
-			);
-		} );
+				// Verify shipping costs
+				await expect(
+					page.getByRole( 'group' ).getByText( 'Free shipping' )
+				).toBeVisible();
+				await expect(
+					page
+						.getByRole( 'strong' )
+						.getByText( 'Free', { exact: true } )
+				).toBeVisible();
+				await expect( page.getByText( '$' ).nth( 2 ) ).toContainText(
+					firstProductPrice
+				);
+			}
+		);
 
-		test( 'allows customer to calculate Flat rate and Local pickup in cart block if in Portugal', async ( {
-			page,
-			context,
-			cartBlockPage,
-		} ) => {
-			await context.clearCookies();
+		test(
+			'allows customer to calculate Flat rate and Local pickup in cart block if in Portugal',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page, context, cartBlockPage } ) => {
+				await context.clearCookies();
 
-			await addAProductToCart( page, product1Id );
-			await page.goto( cartBlockPage.slug );
+				await addAProductToCart( page, product1Id );
+				await page.goto( cartBlockPage.slug );
 
-			// Set shipping country to Portugal
-			await page.getByLabel( 'Add an address for shipping' ).click();
-			await page
-				.getByRole( 'combobox' )
-				.first()
-				.selectOption( 'Portugal' );
-			await page.getByLabel( 'Postal code' ).fill( '1000-001' );
-			await page.getByLabel( 'City' ).fill( 'Lisbon' );
-			await page.getByRole( 'button', { name: 'Update' } ).click();
+				// Set shipping country to Portugal
+				await page.getByLabel( 'Add an address for shipping' ).click();
+				await page
+					.getByRole( 'combobox' )
+					.first()
+					.selectOption( 'Portugal' );
+				await page.getByLabel( 'Postal code' ).fill( '1000-001' );
+				await page.getByLabel( 'City' ).fill( 'Lisbon' );
+				await page.getByRole( 'button', { name: 'Update' } ).click();
 
-			// Verify shipping costs
-			await expect(
-				page.getByRole( 'group' ).getByText( 'Flat rate' )
-			).toBeVisible();
-			await expect( page.getByText( 'Shipping$5.00Flat' ) ).toBeVisible();
-			await expect(
-				page.getByText( `$${ firstProductWithFlatRate }` )
-			).toBeVisible();
+				// Verify shipping costs
+				await expect(
+					page.getByRole( 'group' ).getByText( 'Flat rate' )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Shipping$5.00Flat' )
+				).toBeVisible();
+				await expect(
+					page.getByText( `$${ firstProductWithFlatRate }` )
+				).toBeVisible();
 
-			// Set shipping to local pickup instead of flat rate
-			await page.getByRole( 'group' ).getByText( 'Local pickup' ).click();
+				// Set shipping to local pickup instead of flat rate
+				await page
+					.getByRole( 'group' )
+					.getByText( 'Local pickup' )
+					.click();
 
-			// Verify updated shipping costs
-			await expect( page.getByText( 'ShippingFreeLocal' ) ).toBeVisible();
-			await expect( page.getByText( '$' ).nth( 2 ) ).toContainText(
-				firstProductPrice
-			);
-		} );
+				// Verify updated shipping costs
+				await expect(
+					page.getByText( 'ShippingFreeLocal' )
+				).toBeVisible();
+				await expect( page.getByText( '$' ).nth( 2 ) ).toContainText(
+					firstProductPrice
+				);
+			}
+		);
 
-		test( 'should show correct total cart block price after updating quantity', async ( {
-			page,
-			context,
-			cartBlockPage,
-		} ) => {
-			await context.clearCookies();
+		test(
+			'should show correct total cart block price after updating quantity',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page, context, cartBlockPage } ) => {
+				await context.clearCookies();
 
-			await addAProductToCart( page, product1Id );
-			await page.goto( cartBlockPage.slug );
+				await addAProductToCart( page, product1Id );
+				await page.goto( cartBlockPage.slug );
 
-			// Set shipping country to Portugal
-			await page.getByLabel( 'Add an address for shipping' ).click();
-			await page
-				.getByRole( 'combobox' )
-				.first()
-				.selectOption( 'Portugal' );
-			await page.getByLabel( 'Postal code' ).fill( '1000-001' );
-			await page.getByLabel( 'City' ).fill( 'Lisbon' );
-			await page.getByRole( 'button', { name: 'Update' } ).click();
+				// Set shipping country to Portugal
+				await page.getByLabel( 'Add an address for shipping' ).click();
+				await page
+					.getByRole( 'combobox' )
+					.first()
+					.selectOption( 'Portugal' );
+				await page.getByLabel( 'Postal code' ).fill( '1000-001' );
+				await page.getByLabel( 'City' ).fill( 'Lisbon' );
+				await page.getByRole( 'button', { name: 'Update' } ).click();
 
-			// Increase product quantity and verify the updated price
-			await page.getByLabel( 'Increase quantity of First' ).click();
-			await expect(
-				page.getByText(
-					`$${
-						parseInt( firstProductPrice, 10 ) +
-						parseInt( firstProductPrice, 10 ) +
-						5
-					}`.toString()
-				)
-			).toBeVisible();
-		} );
+				// Increase product quantity and verify the updated price
+				await page.getByLabel( 'Increase quantity of First' ).click();
+				await expect(
+					page.getByText(
+						`$${
+							parseInt( firstProductPrice, 10 ) +
+							parseInt( firstProductPrice, 10 ) +
+							5
+						}`.toString()
+					)
+				).toBeVisible();
+			}
+		);
 
-		test( 'should show correct total cart block price with 2 different products and flat rate/local pickup', async ( {
-			page,
-			context,
-			cartBlockPage,
-		} ) => {
-			await context.clearCookies();
+		test(
+			'should show correct total cart block price with 2 different products and flat rate/local pickup',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page, context, cartBlockPage } ) => {
+				await context.clearCookies();
 
-			await addAProductToCart( page, product1Id );
-			await addAProductToCart( page, product2Id );
-			await page.goto( cartBlockPage.slug );
+				await addAProductToCart( page, product1Id );
+				await addAProductToCart( page, product2Id );
+				await page.goto( cartBlockPage.slug );
 
-			// Set shipping country to Portugal
-			await page.getByLabel( 'Add an address for shipping' ).click();
-			await page
-				.getByRole( 'combobox' )
-				.first()
-				.selectOption( 'Portugal' );
-			await page.getByLabel( 'Postal code' ).fill( '1000-001' );
-			await page.getByLabel( 'City' ).fill( 'Lisbon' );
-			await page.getByRole( 'button', { name: 'Update' } ).click();
+				// Set shipping country to Portugal
+				await page.getByLabel( 'Add an address for shipping' ).click();
+				await page
+					.getByRole( 'combobox' )
+					.first()
+					.selectOption( 'Portugal' );
+				await page.getByLabel( 'Postal code' ).fill( '1000-001' );
+				await page.getByLabel( 'City' ).fill( 'Lisbon' );
+				await page.getByRole( 'button', { name: 'Update' } ).click();
 
-			// Verify shipping costs
-			await expect(
-				page.getByRole( 'group' ).getByText( 'Flat rate' )
-			).toBeVisible();
-			await expect( page.getByText( 'Shipping$5.00Flat' ) ).toBeVisible();
-			await expect(
-				page.getByText(
-					`$${
-						parseInt( firstProductPrice, 10 ) +
-						parseInt( secondProductPrice, 10 ) +
-						5
-					}`.toString()
-				)
-			).toBeVisible();
+				// Verify shipping costs
+				await expect(
+					page.getByRole( 'group' ).getByText( 'Flat rate' )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Shipping$5.00Flat' )
+				).toBeVisible();
+				await expect(
+					page.getByText(
+						`$${
+							parseInt( firstProductPrice, 10 ) +
+							parseInt( secondProductPrice, 10 ) +
+							5
+						}`.toString()
+					)
+				).toBeVisible();
 
-			// Set shipping to local pickup instead of flat rate
-			await page.getByRole( 'group' ).getByText( 'Local pickup' ).click();
+				// Set shipping to local pickup instead of flat rate
+				await page
+					.getByRole( 'group' )
+					.getByText( 'Local pickup' )
+					.click();
 
-			// Verify updated shipping costs
-			await expect( page.getByText( 'ShippingFreeLocal' ) ).toBeVisible();
-			await expect(
-				page
-					.locator( 'div' )
-					.filter( { hasText: /^\$30\.00$/ } )
-					.locator( 'span' )
-			).toBeVisible();
-		} );
+				// Verify updated shipping costs
+				await expect(
+					page.getByText( 'ShippingFreeLocal' )
+				).toBeVisible();
+				await expect(
+					page
+						.locator( 'div' )
+						.filter( { hasText: /^\$30\.00$/ } )
+						.locator( 'span' )
+				).toBeVisible();
+			}
+		);
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
@@ -127,17 +127,111 @@ test.describe(
 			} );
 		} );
 
-		test( 'allows cart block to apply coupon of any type', async ( {
-			page,
-		} ) => {
-			const totals = [ '$50.00', '$27.50', '$45.00' ];
+		test(
+			'allows cart block to apply coupon of any type',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				const totals = [ '$50.00', '$27.50', '$45.00' ];
 
-			// apply all coupon types
-			for ( let i = 0; i < coupons.length; i++ ) {
+				// apply all coupon types
+				for ( let i = 0; i < coupons.length; i++ ) {
+					await page
+						.getByRole( 'button', { name: 'Add a coupon' } )
+						.click();
+					await page
+						.getByLabel( 'Enter code' )
+						.fill( coupons[ i ].code );
+					await page.getByText( 'Apply', { exact: true } ).click();
+					await expect(
+						page
+							.locator(
+								'.wc-block-components-notice-banner__content'
+							)
+							.getByText(
+								`Coupon code "${ coupons[ i ].code }" has been applied to your cart.`
+							)
+					).toBeVisible();
+					await expect(
+						page.locator(
+							'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+						)
+					).toHaveText( totals[ i ] );
+					await page
+						.getByLabel( `Remove coupon "${ coupons[ i ].code }"` )
+						.click();
+					await expect(
+						page
+							.locator(
+								'.wc-block-components-notice-banner__content'
+							)
+							.getByText(
+								`Coupon code "${ coupons[ i ].code }" has been removed from your cart.`
+							)
+					).toBeVisible();
+				}
+			}
+		);
+
+		test(
+			'allows cart block to apply multiple coupons',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				const totals = [ '$50.00', '$22.50', '$12.50' ];
+				const totalsReverse = [ '$17.50', '$45.00', '$55.00' ];
+				const discounts = [ '-$5.00', '-$32.50', '-$42.50' ];
+
+				// add all coupons and verify prices
+				for ( let i = 0; i < coupons.length; i++ ) {
+					await page
+						.getByRole( 'button', { name: 'Add a coupon' } )
+						.click();
+					await page
+						.getByLabel( 'Enter code' )
+						.fill( coupons[ i ].code );
+					await page.getByText( 'Apply', { exact: true } ).click();
+					await expect(
+						page
+							.locator(
+								'.wc-block-components-notice-banner__content'
+							)
+							.getByText(
+								`Coupon code "${ coupons[ i ].code }" has been applied to your cart.`
+							)
+					).toBeVisible();
+					await expect(
+						page.locator(
+							'.wc-block-components-totals-discount > .wc-block-components-totals-item__value'
+						)
+					).toHaveText( discounts[ i ] );
+					await expect(
+						page.locator(
+							'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+						)
+					).toHaveText( totals[ i ] );
+				}
+
+				for ( let i = 0; i < coupons.length; i++ ) {
+					await page
+						.getByLabel( `Remove coupon "${ coupons[ i ].code }"` )
+						.click();
+					await expect(
+						page.locator(
+							'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+						)
+					).toHaveText( totalsReverse[ i ] );
+				}
+			}
+		);
+
+		test(
+			'prevents cart block applying same coupon twice',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				// try to add two same coupons and verify the error message
 				await page
 					.getByRole( 'button', { name: 'Add a coupon' } )
 					.click();
-				await page.getByLabel( 'Enter code' ).fill( coupons[ i ].code );
+				await page.getByLabel( 'Enter code' ).fill( coupons[ 0 ].code );
 				await page.getByText( 'Apply', { exact: true } ).click();
 				await expect(
 					page
@@ -145,114 +239,40 @@ test.describe(
 							'.wc-block-components-notice-banner__content'
 						)
 						.getByText(
-							`Coupon code "${ coupons[ i ].code }" has been applied to your cart.`
+							`Coupon code "${ coupons[ 0 ].code }" has been applied to your cart.`
 						)
 				).toBeVisible();
-				await expect(
-					page.locator(
-						'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-					)
-				).toHaveText( totals[ i ] );
-				await page
-					.getByLabel( `Remove coupon "${ coupons[ i ].code }"` )
-					.click();
-				await expect(
-					page
-						.locator(
-							'.wc-block-components-notice-banner__content'
-						)
-						.getByText(
-							`Coupon code "${ coupons[ i ].code }" has been removed from your cart.`
-						)
-				).toBeVisible();
-			}
-		} );
-
-		test( 'allows cart block to apply multiple coupons', async ( {
-			page,
-		} ) => {
-			const totals = [ '$50.00', '$22.50', '$12.50' ];
-			const totalsReverse = [ '$17.50', '$45.00', '$55.00' ];
-			const discounts = [ '-$5.00', '-$32.50', '-$42.50' ];
-
-			// add all coupons and verify prices
-			for ( let i = 0; i < coupons.length; i++ ) {
 				await page
 					.getByRole( 'button', { name: 'Add a coupon' } )
 					.click();
-				await page.getByLabel( 'Enter code' ).fill( coupons[ i ].code );
+				await page.getByLabel( 'Enter code' ).fill( coupons[ 0 ].code );
 				await page.getByText( 'Apply', { exact: true } ).click();
 				await expect(
 					page
-						.locator(
-							'.wc-block-components-notice-banner__content'
-						)
+						.getByRole( 'alert' )
 						.getByText(
-							`Coupon code "${ coupons[ i ].code }" has been applied to your cart.`
+							`Coupon code "${ coupons[ 0 ].code }" has already been applied.`
 						)
 				).toBeVisible();
-				await expect(
-					page.locator(
-						'.wc-block-components-totals-discount > .wc-block-components-totals-item__value'
-					)
-				).toHaveText( discounts[ i ] );
-				await expect(
-					page.locator(
-						'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-					)
-				).toHaveText( totals[ i ] );
 			}
+		);
 
-			for ( let i = 0; i < coupons.length; i++ ) {
+		test(
+			'prevents cart block applying coupon with usage limit',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				// add coupon with usage limit
 				await page
-					.getByLabel( `Remove coupon "${ coupons[ i ].code }"` )
+					.getByRole( 'button', { name: 'Add a coupon' } )
 					.click();
+				await page.getByLabel( 'Enter code' ).fill( couponLimitedCode );
+				await page.getByText( 'Apply', { exact: true } ).click();
 				await expect(
-					page.locator(
-						'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-					)
-				).toHaveText( totalsReverse[ i ] );
+					page
+						.getByRole( 'alert' )
+						.getByText( 'Coupon usage limit has been reached.' )
+				).toBeVisible();
 			}
-		} );
-
-		test( 'prevents cart block applying same coupon twice', async ( {
-			page,
-		} ) => {
-			// try to add two same coupons and verify the error message
-			await page.getByRole( 'button', { name: 'Add a coupon' } ).click();
-			await page.getByLabel( 'Enter code' ).fill( coupons[ 0 ].code );
-			await page.getByText( 'Apply', { exact: true } ).click();
-			await expect(
-				page
-					.locator( '.wc-block-components-notice-banner__content' )
-					.getByText(
-						`Coupon code "${ coupons[ 0 ].code }" has been applied to your cart.`
-					)
-			).toBeVisible();
-			await page.getByRole( 'button', { name: 'Add a coupon' } ).click();
-			await page.getByLabel( 'Enter code' ).fill( coupons[ 0 ].code );
-			await page.getByText( 'Apply', { exact: true } ).click();
-			await expect(
-				page
-					.getByRole( 'alert' )
-					.getByText(
-						`Coupon code "${ coupons[ 0 ].code }" has already been applied.`
-					)
-			).toBeVisible();
-		} );
-
-		test( 'prevents cart block applying coupon with usage limit', async ( {
-			page,
-		} ) => {
-			// add coupon with usage limit
-			await page.getByRole( 'button', { name: 'Add a coupon' } ).click();
-			await page.getByLabel( 'Enter code' ).fill( couponLimitedCode );
-			await page.getByText( 'Apply', { exact: true } ).click();
-			await expect(
-				page
-					.getByRole( 'alert' )
-					.getByText( 'Coupon usage limit has been reached.' )
-			).toBeVisible();
-		} );
+		);
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
@@ -73,116 +73,132 @@ test.describe( 'Cart Block page', { tag: [ '@payments', '@services' ] }, () => {
 		} );
 	} );
 
-	test( 'can see empty cart, add and remove simple & cross sell product, increase to max quantity', async ( {
-		page,
-		testPage,
-	} ) => {
-		await goToPageEditor( { page } );
-		await fillPageTitle( page, testPage.title );
-		await insertBlockByShortcut( page, 'Cart' );
-		await publishPage( page, testPage.title );
+	test(
+		'can see empty cart, add and remove simple & cross sell product, increase to max quantity',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page, testPage } ) => {
+			await goToPageEditor( { page } );
+			await fillPageTitle( page, testPage.title );
+			await insertBlockByShortcut( page, 'Cart' );
+			await publishPage( page, testPage.title );
 
-		// go to the page to test empty cart block
-		await page.goto( testPage.slug );
-		await expect(
-			page.getByRole( 'heading', { name: testPage.title } )
-		).toBeVisible();
-		await expect(
-			await page.getByText( 'Your cart is currently empty!' ).count()
-		).toBeGreaterThan( 0 );
-		await expect(
-			page.getByRole( 'link', { name: 'Browse store' } )
-		).toBeVisible();
-		await page.getByRole( 'link', { name: 'Browse store' } ).click();
-		await expect(
-			page.getByRole( 'heading', { name: 'Shop' } )
-		).toBeVisible();
+			// go to the page to test empty cart block
+			await page.goto( testPage.slug );
+			await expect(
+				page.getByRole( 'heading', { name: testPage.title } )
+			).toBeVisible();
+			await expect(
+				await page.getByText( 'Your cart is currently empty!' ).count()
+			).toBeGreaterThan( 0 );
+			await expect(
+				page.getByRole( 'link', { name: 'Browse store' } )
+			).toBeVisible();
+			await page.getByRole( 'link', { name: 'Browse store' } ).click();
+			await expect(
+				page.getByRole( 'heading', { name: 'Shop' } )
+			).toBeVisible();
 
-		await addAProductToCart( page, product1Id );
-		await page.goto( testPage.slug );
-		await expect(
-			page.getByRole( 'heading', { name: testPage.title } )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'link', { name: simpleProductName, exact: true } )
-		).toBeVisible();
-		await expect( page.getByText( simpleProductDesc ) ).toBeVisible();
-		await expect(
-			page.getByText( `Save $${ singleProductSalePrice }` )
-		).toBeVisible();
+			await addAProductToCart( page, product1Id );
+			await page.goto( testPage.slug );
+			await expect(
+				page.getByRole( 'heading', { name: testPage.title } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', {
+					name: simpleProductName,
+					exact: true,
+				} )
+			).toBeVisible();
+			await expect( page.getByText( simpleProductDesc ) ).toBeVisible();
+			await expect(
+				page.getByText( `Save $${ singleProductSalePrice }` )
+			).toBeVisible();
 
-		// increase product quantity to its maximum
-		await expect( page.getByText( '2 left in stock' ) ).toBeVisible();
-		await page
-			.getByRole( 'button' )
-			.filter( { hasText: '＋', exact: true } )
-			.click();
-		await expect(
-			page.locator(
-				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-			)
-		).toContainText( `$${ doubleProductsPrice.toString() }` );
-		await expect(
-			page.getByRole( 'button' ).filter( { hasText: '＋', exact: true } )
-		).toBeDisabled();
+			// increase product quantity to its maximum
+			await expect( page.getByText( '2 left in stock' ) ).toBeVisible();
+			await page
+				.getByRole( 'button' )
+				.filter( { hasText: '＋', exact: true } )
+				.click();
+			await expect(
+				page.locator(
+					'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+				)
+			).toContainText( `$${ doubleProductsPrice.toString() }` );
+			await expect(
+				page
+					.getByRole( 'button' )
+					.filter( { hasText: '＋', exact: true } )
+			).toBeDisabled();
 
-		// add cross-sell products to cart
-		await expect(
-			page.getByRole( 'heading', { name: 'You may be interested in…' } )
-		).toBeVisible();
-		await page
-			.getByLabel( `Add to cart: “${ simpleProductName } Cross-Sell 1”` )
-			.click();
-		await expect(
-			page
-				.locator( '.wc-block-cart-items' )
-				.getByText( `${ simpleProductName } Cross-Sell 1` )
-		).toBeVisible();
-		await page
-			.getByLabel( `Add to cart: “${ simpleProductName } Cross-Sell 2”` )
-			.click();
-		await expect(
-			page
-				.locator( '.wc-block-cart-items' )
-				.getByText( `${ simpleProductName } Cross-Sell 2` )
-		).toBeVisible();
+			// add cross-sell products to cart
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'You may be interested in…',
+				} )
+			).toBeVisible();
+			await page
+				.getByLabel(
+					`Add to cart: “${ simpleProductName } Cross-Sell 1”`
+				)
+				.click();
+			await expect(
+				page
+					.locator( '.wc-block-cart-items' )
+					.getByText( `${ simpleProductName } Cross-Sell 1` )
+			).toBeVisible();
+			await page
+				.getByLabel(
+					`Add to cart: “${ simpleProductName } Cross-Sell 2”`
+				)
+				.click();
+			await expect(
+				page
+					.locator( '.wc-block-cart-items' )
+					.getByText( `${ simpleProductName } Cross-Sell 2` )
+			).toBeVisible();
 
-		await page.goto( testPage.slug );
-		await expect(
-			page.getByRole( 'heading', { name: testPage.title } )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'heading', { name: 'You may be interested in…' } )
-		).toBeHidden();
-		await expect(
-			page.locator(
-				'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-			)
-		).toContainText(
-			`$${ singleProductWithCrossSellProducts.toString() }`
-		);
+			await page.goto( testPage.slug );
+			await expect(
+				page.getByRole( 'heading', { name: testPage.title } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'You may be interested in…',
+				} )
+			).toBeHidden();
+			await expect(
+				page.locator(
+					'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+				)
+			).toContainText(
+				`$${ singleProductWithCrossSellProducts.toString() }`
+			);
 
-		// remove cross-sell products from cart
-		await page.locator( ':nth-match(:text("Remove item"), 3)' ).click();
-		await page.locator( ':nth-match(:text("Remove item"), 2)' ).click();
-		await expect(
-			page.getByRole( 'heading', { name: 'You may be interested in…' } )
-		).toBeVisible();
+			// remove cross-sell products from cart
+			await page.locator( ':nth-match(:text("Remove item"), 3)' ).click();
+			await page.locator( ':nth-match(:text("Remove item"), 2)' ).click();
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'You may be interested in…',
+				} )
+			).toBeVisible();
 
-		// check if the link to proceed to the checkout exists
-		await expect(
-			page.getByRole( 'link', {
-				name: 'Proceed to Checkout',
-			} )
-		).toBeVisible();
+			// check if the link to proceed to the checkout exists
+			await expect(
+				page.getByRole( 'link', {
+					name: 'Proceed to Checkout',
+				} )
+			).toBeVisible();
 
-		// remove product from cart
-		await page.locator( ':text("Remove item")' ).click();
-		await expect(
-			page.getByText( 'Your cart is currently empty!' )
-		).toBeVisible();
-		await expect(
-			page.getByRole( 'link', { name: 'Browse store' } )
-		).toBeVisible();
-	} );
+			// remove product from cart
+			await page.locator( ':text("Remove item")' ).click();
+			await expect(
+				page.getByText( 'Your cart is currently empty!' )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', { name: 'Browse store' } )
+			).toBeVisible();
+		}
+	);
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
@@ -125,108 +125,120 @@ test.describe(
 			} );
 		} );
 
-		test( 'allows customer to calculate Free Shipping if in Germany', async ( {
-			page,
-		} ) => {
-			await page.goto( '/cart/' );
-			// Set shipping country to Germany
-			await page.locator( 'a.shipping-calculator-button' ).click();
-			await page
-				.locator( '#calc_shipping_country' )
-				.selectOption( shippingCountryDE );
-			await page.locator( 'button[name="calc_shipping"]' ).click();
+		test(
+			'allows customer to calculate Free Shipping if in Germany',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				await page.goto( '/cart/' );
+				// Set shipping country to Germany
+				await page.locator( 'a.shipping-calculator-button' ).click();
+				await page
+					.locator( '#calc_shipping_country' )
+					.selectOption( shippingCountryDE );
+				await page.locator( 'button[name="calc_shipping"]' ).click();
 
-			// Verify shipping costs
-			await expect(
-				page.locator( '.shipping ul#shipping_method > li' )
-			).toContainText( 'Free shipping' );
-			await expect(
-				page.locator( '.order-total .amount' )
-			).toContainText( firstProductPrice );
-		} );
+				// Verify shipping costs
+				await expect(
+					page.locator( '.shipping ul#shipping_method > li' )
+				).toContainText( 'Free shipping' );
+				await expect(
+					page.locator( '.order-total .amount' )
+				).toContainText( firstProductPrice );
+			}
+		);
 
-		test( 'allows customer to calculate Flat rate and Local pickup if in France', async ( {
-			page,
-		} ) => {
-			await page.goto( '/cart/' );
-			// Set shipping country to France
-			await page.locator( 'a.shipping-calculator-button' ).click();
-			await page
-				.locator( '#calc_shipping_country' )
-				.selectOption( shippingCountryFR );
-			await page.locator( 'button[name="calc_shipping"]' ).click();
+		test(
+			'allows customer to calculate Flat rate and Local pickup if in France',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				await page.goto( '/cart/' );
+				// Set shipping country to France
+				await page.locator( 'a.shipping-calculator-button' ).click();
+				await page
+					.locator( '#calc_shipping_country' )
+					.selectOption( shippingCountryFR );
+				await page.locator( 'button[name="calc_shipping"]' ).click();
 
-			// Verify shipping costs
-			await expect( page.locator( '.shipping .amount' ) ).toContainText(
-				'$5.00'
-			);
-			await expect(
-				page.locator( '.order-total .amount' )
-			).toContainText( `$${ firstProductWithFlatRate }` );
+				// Verify shipping costs
+				await expect(
+					page.locator( '.shipping .amount' )
+				).toContainText( '$5.00' );
+				await expect(
+					page.locator( '.order-total .amount' )
+				).toContainText( `$${ firstProductWithFlatRate }` );
 
-			// Set shipping to local pickup instead of flat rate
-			await page.locator( 'text=Local pickup' ).click();
+				// Set shipping to local pickup instead of flat rate
+				await page.locator( 'text=Local pickup' ).click();
 
-			// Verify updated shipping costs
-			await expect(
-				page.locator( '.order-total .amount' ).first()
-			).toContainText( `$${ firstProductPrice }` );
-		} );
+				// Verify updated shipping costs
+				await expect(
+					page.locator( '.order-total .amount' ).first()
+				).toContainText( `$${ firstProductPrice }` );
+			}
+		);
 
-		test( 'should show correct total cart price after updating quantity', async ( {
-			page,
-		} ) => {
-			await page.goto( '/cart/' );
-			await page.locator( 'input.qty' ).fill( '4' );
-			await page.locator( 'text=Update cart' ).click();
+		test(
+			'should show correct total cart price after updating quantity',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				await page.goto( '/cart/' );
+				await page.locator( 'input.qty' ).fill( '4' );
+				await page.locator( 'text=Update cart' ).click();
 
-			// Set shipping country to France
-			await page.locator( 'a.shipping-calculator-button' ).click();
-			await page
-				.locator( '#calc_shipping_country' )
-				.selectOption( shippingCountryFR );
-			await page.locator( 'button[name="calc_shipping"]' ).click();
+				// Set shipping country to France
+				await page.locator( 'a.shipping-calculator-button' ).click();
+				await page
+					.locator( '#calc_shipping_country' )
+					.selectOption( shippingCountryFR );
+				await page.locator( 'button[name="calc_shipping"]' ).click();
 
-			await expect(
-				page.locator( '.order-total .amount' )
-			).toContainText( `$${ fourProductsWithFlatRate }` );
-		} );
+				await expect(
+					page.locator( '.order-total .amount' )
+				).toContainText( `$${ fourProductsWithFlatRate }` );
+			}
+		);
 
-		test( 'should show correct total cart price with 2 products and flat rate', async ( {
-			page,
-		} ) => {
-			await addAProductToCart( page, secondProductId );
+		test(
+			'should show correct total cart price with 2 products and flat rate',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				await addAProductToCart( page, secondProductId );
 
-			await page.goto( '/cart/' );
-			await page.locator( 'a.shipping-calculator-button' ).click();
-			await page
-				.locator( '#calc_shipping_country' )
-				.selectOption( shippingCountryFR );
-			await page.locator( 'button[name="calc_shipping"]' ).click();
+				await page.goto( '/cart/' );
+				await page.locator( 'a.shipping-calculator-button' ).click();
+				await page
+					.locator( '#calc_shipping_country' )
+					.selectOption( shippingCountryFR );
+				await page.locator( 'button[name="calc_shipping"]' ).click();
 
-			await expect( page.locator( '.shipping .amount' ) ).toContainText(
-				'$5.00'
-			);
-			await expect(
-				page.locator( '.order-total .amount' )
-			).toContainText( `$${ twoProductsWithFlatRate }` );
-		} );
+				await expect(
+					page.locator( '.shipping .amount' )
+				).toContainText( '$5.00' );
+				await expect(
+					page.locator( '.order-total .amount' )
+				).toContainText( `$${ twoProductsWithFlatRate }` );
+			}
+		);
 
-		test( 'should show correct total cart price with 2 products without flat rate', async ( {
-			page,
-		} ) => {
-			await addAProductToCart( page, secondProductId );
+		test(
+			'should show correct total cart price with 2 products without flat rate',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page } ) => {
+				await addAProductToCart( page, secondProductId );
 
-			// Set shipping country to Spain
-			await page.goto( '/cart/' );
-			await page.locator( 'a.shipping-calculator-button' ).click();
-			await page.locator( '#calc_shipping_country' ).selectOption( 'ES' );
-			await page.locator( 'button[name="calc_shipping"]' ).click();
+				// Set shipping country to Spain
+				await page.goto( '/cart/' );
+				await page.locator( 'a.shipping-calculator-button' ).click();
+				await page
+					.locator( '#calc_shipping_country' )
+					.selectOption( 'ES' );
+				await page.locator( 'button[name="calc_shipping"]' ).click();
 
-			// Verify shipping costs
-			await expect(
-				page.locator( '.order-total .amount' )
-			).toContainText( `$${ twoProductsTotal }` );
-		} );
+				// Verify shipping costs
+				await expect(
+					page.locator( '.order-total .amount' )
+				).toContainText( `$${ twoProductsTotal }` );
+			}
+		);
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
@@ -38,7 +38,7 @@ let productId,
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Display',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', '@services', '@hpos', '@could-be-unit-test' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 		test.beforeAll( async ( { baseURL } ) => {
@@ -240,7 +240,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Rounding',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', '@services', '@could-be-unit-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -484,7 +484,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Levels',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', '@services', '@could-be-unit-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -809,7 +809,7 @@ test.describe(
 
 test.describe(
 	'Shipping Cart & Checkout Block Tax',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', '@services', '@could-be-unit-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -24,7 +24,7 @@ let productId,
 
 test.describe.serial(
 	'Tax rates in the cart and checkout',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', '@services', '@hpos', '@could-be-unit-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
@@ -306,60 +306,65 @@ test.describe(
 			} );
 		} );
 
-		test( 'restores total when coupons are removed', async ( {
-			page,
-			context,
-		} ) => {
-			await test.step( 'Load cart page and try restoring total when removed coupons', async () => {
-				await addAProductToCart( page, firstProductId );
+		test(
+			'restores total when coupons are removed',
+			{ tag: [ '@could-be-unit-test' ] },
+			async ( { page, context } ) => {
+				await test.step( 'Load cart page and try restoring total when removed coupons', async () => {
+					await addAProductToCart( page, firstProductId );
 
-				await page.goto( '/cart/' );
-				await page.locator( '#coupon_code' ).fill( coupons[ 0 ].code );
-				await page
-					.getByRole( 'button', { name: 'Apply coupon' } )
-					.click();
+					await page.goto( '/cart/' );
+					await page
+						.locator( '#coupon_code' )
+						.fill( coupons[ 0 ].code );
+					await page
+						.getByRole( 'button', { name: 'Apply coupon' } )
+						.click();
 
-				// confirm numbers
-				await expect(
-					page.locator( '.cart-discount .amount' )
-				).toContainText( discounts[ 0 ] );
-				await expect(
-					page.locator( '.order-total .amount' )
-				).toContainText( totals[ 0 ] );
+					// confirm numbers
+					await expect(
+						page.locator( '.cart-discount .amount' )
+					).toContainText( discounts[ 0 ] );
+					await expect(
+						page.locator( '.order-total .amount' )
+					).toContainText( totals[ 0 ] );
 
-				await page.locator( 'a.woocommerce-remove-coupon' ).click();
+					await page.locator( 'a.woocommerce-remove-coupon' ).click();
 
-				await expect(
-					page.locator( '.order-total .amount' )
-				).toContainText( '$20.00' );
-			} );
+					await expect(
+						page.locator( '.order-total .amount' )
+					).toContainText( '$20.00' );
+				} );
 
-			await context.clearCookies();
+				await context.clearCookies();
 
-			await test.step( 'Load checkout page and try restoring total when removed coupons', async () => {
-				await addAProductToCart( page, firstProductId );
+				await test.step( 'Load checkout page and try restoring total when removed coupons', async () => {
+					await addAProductToCart( page, firstProductId );
 
-				await page.goto( '/checkout/' );
-				await page
-					.locator( 'text=Click here to enter your code' )
-					.click();
-				await page.locator( '#coupon_code' ).fill( coupons[ 0 ].code );
-				await page.locator( 'text=Apply coupon' ).click();
+					await page.goto( '/checkout/' );
+					await page
+						.locator( 'text=Click here to enter your code' )
+						.click();
+					await page
+						.locator( '#coupon_code' )
+						.fill( coupons[ 0 ].code );
+					await page.locator( 'text=Apply coupon' ).click();
 
-				// confirm numbers
-				await expect(
-					page.locator( '.cart-discount .amount' )
-				).toContainText( discounts[ 0 ] );
-				await expect(
-					page.locator( '.order-total .amount' )
-				).toContainText( totals[ 0 ] );
+					// confirm numbers
+					await expect(
+						page.locator( '.cart-discount .amount' )
+					).toContainText( discounts[ 0 ] );
+					await expect(
+						page.locator( '.order-total .amount' )
+					).toContainText( totals[ 0 ] );
 
-				await page.locator( 'a.woocommerce-remove-coupon' ).click();
+					await page.locator( 'a.woocommerce-remove-coupon' ).click();
 
-				await expect(
-					page.locator( '.order-total .amount' )
-				).toContainText( '$20.00' );
-			} );
-		} );
+					await expect(
+						page.locator( '.order-total .amount' )
+					).toContainText( '$20.00' );
+				} );
+			}
+		);
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
@@ -17,7 +17,7 @@ const awaitCartPageResponse = ( page ) =>
 
 test.describe(
 	'Cart & Checkout Restricted Coupons',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', '@services', '@hpos', '@could-be-unit-test' ] },
 	() => {
 		let firstProductId,
 			secondProductId,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
@@ -3,7 +3,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Cart > Redirect to cart from shop',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', '@services', '@not-e2e' ] },
 	() => {
 		let productId;
 		const productName = 'A redirect product test';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -81,100 +81,116 @@ test.describe( 'Cart page', { tag: [ '@payments', '@services' ] }, () => {
 		await responsePromise;
 	}
 
-	test( 'should display no item in the cart', async ( { page } ) => {
-		await page.goto( '/cart/' );
-		await expect(
-			page.getByText( 'Your cart is currently empty.' )
-		).toBeVisible();
-	} );
-
-	test( 'should add the product to the cart from the shop page', async ( {
-		page,
-	} ) => {
-		await goToShopPageAndAddProductToCart( page, productName );
-
-		await page.goto( '/cart/' );
-		await expect( page.locator( 'td.product-name' ) ).toContainText(
-			productName
-		);
-	} );
-
-	test( 'should increase item quantity when "Add to cart" of the same product is clicked', async ( {
-		page,
-	} ) => {
-		let qty = 2;
-		while ( qty-- ) {
-			await goToShopPageAndAddProductToCart( page, productName );
+	test(
+		'should display no item in the cart',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			await page.goto( '/cart/' );
+			await expect(
+				page.getByText( 'Your cart is currently empty.' )
+			).toBeVisible();
 		}
+	);
 
-		await page.goto( '/cart/' );
-		await expect( page.locator( 'input.qty' ) ).toHaveValue( '2' );
-	} );
+	test(
+		'should add the product to the cart from the shop page',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			await goToShopPageAndAddProductToCart( page, productName );
 
-	test( 'should update quantity when updated via quantity input', async ( {
-		page,
-	} ) => {
-		await goToShopPageAndAddProductToCart( page, productName );
+			await page.goto( '/cart/' );
+			await expect( page.locator( 'td.product-name' ) ).toContainText(
+				productName
+			);
+		}
+	);
 
-		await page.goto( '/cart/' );
-		await page.locator( 'input.qty' ).fill( '2' );
-		await page.locator( 'text=Update cart' ).click();
+	test(
+		'should increase item quantity when "Add to cart" of the same product is clicked',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			let qty = 2;
+			while ( qty-- ) {
+				await goToShopPageAndAddProductToCart( page, productName );
+			}
 
-		await expect( page.locator( '.order-total .amount' ) ).toContainText(
-			`$${ twoProductPrice }`
-		);
-	} );
+			await page.goto( '/cart/' );
+			await expect( page.locator( 'input.qty' ) ).toHaveValue( '2' );
+		}
+	);
 
-	test( 'should remove the item from the cart when remove is clicked', async ( {
-		page,
-	} ) => {
-		await goToShopPageAndAddProductToCart( page, productName );
-		await page.goto( '/cart/' );
+	test(
+		'should update quantity when updated via quantity input',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			await goToShopPageAndAddProductToCart( page, productName );
 
-		// make sure that the product is in the cart
-		await expect( page.locator( '.order-total .amount' ) ).toContainText(
-			`$${ productPrice }`
-		);
+			await page.goto( '/cart/' );
+			await page.locator( 'input.qty' ).fill( '2' );
+			await page.locator( 'text=Update cart' ).click();
 
-		await page.locator( 'a.remove' ).click();
+			await expect(
+				page.locator( '.order-total .amount' )
+			).toContainText( `$${ twoProductPrice }` );
+		}
+	);
 
-		await expect(
-			page.getByText( `“${ productName }” removed` )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Your cart is currently empty' )
-		).toBeVisible();
-	} );
+	test(
+		'should remove the item from the cart when remove is clicked',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			await goToShopPageAndAddProductToCart( page, productName );
+			await page.goto( '/cart/' );
 
-	test( 'should update subtotal in cart totals when adding product to the cart', async ( {
-		page,
-	} ) => {
-		await goToShopPageAndAddProductToCart( page, productName );
+			// make sure that the product is in the cart
+			await expect(
+				page.locator( '.order-total .amount' )
+			).toContainText( `$${ productPrice }` );
 
-		await page.goto( '/cart/' );
-		await expect( page.locator( '.cart-subtotal .amount' ) ).toContainText(
-			`$${ productPrice }`
-		);
+			await page.locator( 'a.remove' ).click();
 
-		await page.locator( 'input.qty' ).fill( '2' );
-		await page.locator( 'text=Update cart' ).click();
+			await expect(
+				page.getByText( `“${ productName }” removed` )
+			).toBeVisible();
+			await expect(
+				page.getByText( 'Your cart is currently empty' )
+			).toBeVisible();
+		}
+	);
 
-		await expect( page.locator( '.order-total .amount' ) ).toContainText(
-			`$${ twoProductPrice }`
-		);
-	} );
+	test(
+		'should update subtotal in cart totals when adding product to the cart',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			await goToShopPageAndAddProductToCart( page, productName );
 
-	test( 'should go to the checkout page when "Proceed to Checkout" is clicked', async ( {
-		page,
-	} ) => {
-		await goToShopPageAndAddProductToCart( page, productName );
+			await page.goto( '/cart/' );
+			await expect(
+				page.locator( '.cart-subtotal .amount' )
+			).toContainText( `$${ productPrice }` );
 
-		await page.goto( '/cart/' );
+			await page.locator( 'input.qty' ).fill( '2' );
+			await page.locator( 'text=Update cart' ).click();
 
-		await page.locator( '.checkout-button' ).click();
+			await expect(
+				page.locator( '.order-total .amount' )
+			).toContainText( `$${ twoProductPrice }` );
+		}
+	);
 
-		await expect( page.locator( '#order_review' ) ).toBeVisible();
-	} );
+	test(
+		'should go to the checkout page when "Proceed to Checkout" is clicked',
+		{ tag: [ '@could-be-unit-test' ] },
+		async ( { page } ) => {
+			await goToShopPageAndAddProductToCart( page, productName );
+
+			await page.goto( '/cart/' );
+
+			await page.locator( '.checkout-button' ).click();
+
+			await expect( page.locator( '#order_review' ) ).toBeVisible();
+		}
+	);
 
 	test( 'can manage cross-sell products and maximum item quantity', async ( {
 		page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
@@ -72,51 +72,43 @@ async function runComingSoonTests( themeContext = '' ) {
 	} );
 }
 
-test.describe(
-	'Launch Your Store front end - logged out',
-	{ tag: [ '@payments', '@services' ] },
-	() => {
-		test.afterAll( async ( { baseURL } ) => {
-			try {
-				await setOption(
-					request,
-					baseURL,
-					'woocommerce_coming_soon',
-					'no'
-				);
-			} catch ( error ) {
-				console.log( error );
-			}
-		} );
-
-		test.describe( 'Block Theme (Twenty Twenty Four)', () => {
-			test.beforeAll( async () => {
-				await activateTheme( 'twentytwentyfour' );
-			} );
-
-			test.afterAll( async () => {
-				// Reset theme to the default.
-				await activateTheme( DEFAULT_THEME );
-			} );
-
-			runComingSoonTests( test.step, test.use );
-		} );
-
-		test.describe( 'Classic Theme (Storefront)', () => {
-			test.beforeAll( async () => {
-				await activateTheme( 'storefront' );
-			} );
-
-			test.afterAll( async () => {
-				// Reset theme to the default.
-				await activateTheme( DEFAULT_THEME );
-			} );
-
-			runComingSoonTests(
-				test.step,
-				test.use,
-				'Classic Theme (Storefront)'
+test.describe( 'Launch Your Store front end - logged out', () => {
+	test.afterAll( async ( { baseURL } ) => {
+		try {
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_coming_soon',
+				'no'
 			);
+		} catch ( error ) {
+			console.log( error );
+		}
+	} );
+
+	test.describe( 'Block Theme (Twenty Twenty Four)', () => {
+		test.beforeAll( async () => {
+			await activateTheme( 'twentytwentyfour' );
 		} );
-	}
-);
+
+		test.afterAll( async () => {
+			// Reset theme to the default.
+			await activateTheme( DEFAULT_THEME );
+		} );
+
+		runComingSoonTests( test.step, test.use );
+	} );
+
+	test.describe( 'Classic Theme (Storefront)', () => {
+		test.beforeAll( async () => {
+			await activateTheme( 'storefront' );
+		} );
+
+		test.afterAll( async () => {
+			// Reset theme to the default.
+			await activateTheme( DEFAULT_THEME );
+		} );
+
+		runComingSoonTests( test.step, test.use, 'Classic Theme (Storefront)' );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require( '@playwright/test' );
 // test case for bug https://github.com/woocommerce/woocommerce/pull/46429
 test.describe(
 	'Check the title of the shop page after the page has been deleted',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', '@services', '@could-be-unit-test' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 		test.beforeEach( async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
@@ -6,7 +6,7 @@ const test = baseTest.extend( {
 
 test(
 	'logged-in customer can comment on a post',
-	{ tag: [ '@gutenberg', '@payments', '@services' ] },
+	{ tag: [ '@non-critical' ] },
 	async ( { page } ) => {
 		await page.goto( 'hello-world/' );
 		await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR only adds tags to some e2e tests. No functionality should be changed.
The tags will be used the filter the tests easier on a test audit.
I used the following tags: `@could-be-unit-test`, `@non-critical`, `@not-e2e`

### How to test the changes in this Pull Request:

CI green.
Check the added tags. Do they make sense to you? 