### PR TITLE
Fix My Account block icon being too small when inserted via block hooks

### DIFF
--- a/plugins/woocommerce/changelog/fix-50667-my-account-hooked-size
+++ b/plugins/woocommerce/changelog/fix-50667-my-account-hooked-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix My Account block icon being too small when inserted via block hooks

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CustomerAccount.php
@@ -68,6 +68,7 @@ class CustomerAccount extends AbstractBlock {
 	public function modify_hooked_block_attributes( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
 		$parsed_hooked_block['attrs']['displayStyle'] = 'icon_only';
 		$parsed_hooked_block['attrs']['iconStyle']    = 'line';
+		$parsed_hooked_block['attrs']['iconClass']    = 'wc-block-customer-account__account-icon';
 
 		/*
 		* The Mini Cart block (which is hooked into the header) has a margin of 0.5em on the left side.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/50667.

Some time ago, we made the default My Account block icon bigger, it was implemented by adding an extra class in a way that it would only affect new instances of the block (see https://github.com/woocommerce/woocommerce-blocks/pull/8594 for more details). However, we weren't adding that specific class when inserting the My Account block via block hooks. That caused the icon to look too small next to the Mini-Cart block. The issue became more apparent since 9.2, when we switched the filled icon style to the line icon style.

### How to test the changes in this Pull Request:

1. Create a new site from scratch and install WooCommerce.
2. Check the default header and verify the My Account block icon is big enough so it doesn't look out of place next to the Mini-Cart block (see screenshots below):

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/7b0b0c7e-0144-4ab8-89a3-81255ae5672d) | ![imatge](https://github.com/user-attachments/assets/6cadff93-769c-4bfe-80dc-a013b52244a0)
