### PR TITLE
Coming Soon Block: Do not load the block inside the customizer 

### DIFF
--- a/plugins/woocommerce/changelog/fix-coming-soon-customizer
+++ b/plugins/woocommerce/changelog/fix-coming-soon-customizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Do not load the Coming Soon block in the customize.php, widgets.php, theme.php and not gutenberg edit site page

--- a/plugins/woocommerce/changelog/fix-coming-soon-customizer
+++ b/plugins/woocommerce/changelog/fix-coming-soon-customizer
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: performance
 
 Do not load the Coming Soon block in the customize.php, widgets.php, theme.php and not gutenberg edit site page

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -426,6 +426,7 @@ final class BlockTypesController {
 					'AllProducts',
 					'Cart',
 					'Checkout',
+					'ComingSoon',
 					'ProductGallery',
 				)
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Do remove `ComingSoon` class from the `$block_types` array when it's inside the customizer.php, widgets.php, theme.php and not in a gutenberg edit page. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Changes made: Added the `ComingSoon` class to the condition which removes some classes from the `$block_types` array when we are in the customizer.php, widgets.php, theme.php and not in a gutenberg edit page.

Reason: Since Woo 9.2.0+ the customizer is very slow to load. This is happening only with themes that contains a high number of customizer controls registered (Botiga and OceanWP themes are a case). This is not happening with version prior to 9.2.0. The issue is related with the `assets/client/blocks/coming-soon.css` file which is being loaded inside the customizer but this is actually not needed. The CSS `has:()` pseudo-class present in that file is 'lookahead' to elements such as `a`, `ul`, `li` which are html tags rendered by customizer controls. This is causing a big performance issue in terms of rendering and overloading the browser. Even though there are `body:has(.woocommerce-coming-soon-entire-site)` and `body:has(.woocommerce-coming-soon-banner)` selectors being declared, it seems the `a`, `ul`, `li` are still being evaluated.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the Botiga v2.2.6 or OceanWP theme. This happen only with themes that contains a high number of customizer controls registered and being loaded in the first load of the page.
2. Install WooCommerce 9.2.0+
3. Go to the customizer. It will take long time to load

If you test the same scenario with WooCommerce prior to 9.2.0 version this isn't happening (the coming soon block wasn't included yet).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [X] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
