### PR TITLE
Fix badge number fails to match the number of unfinished tasks

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -277,7 +277,7 @@ export const getPages = () => {
 				capability: 'manage_woocommerce',
 				layout: {
 					header: false,
-					footer: true,
+					footer: false,
 					showNotices: true,
 					showStoreAlerts: false,
 					showPluginArea: false,

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -275,6 +275,13 @@ export const getPages = () => {
 					__( 'Profiler', 'woocommerce' ),
 				],
 				capability: 'manage_woocommerce',
+				layout: {
+					header: false,
+					footer: true,
+					showNotices: true,
+					showStoreAlerts: false,
+					showPluginArea: false,
+				},
 			} );
 		}
 	}

--- a/plugins/woocommerce/changelog/fix-menu-badge
+++ b/plugins/woocommerce/changelog/fix-menu-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix badge number fails to match the number of unfinished tasks


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50878


Currently, the core profiler renders the header, footer, StoreAlerts, and Plugin area, which is not needed for the setup wizard. It is fetching the task list data from the server on the core profiler page load and causing the LYS task to be marked as completed. This PR hides the header, footer, StoreAlerts, and Plugin area for the setup wizard to fix the issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site.
2. Complete or skip the core profiler (Please make sure Core profiler is working as expected).
3. Go to WooCommerce > Home
4. Observe that the badge number matches the number of unfinished tasks in the setup list on the "WooCommerce > Home" menu item.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
