### PR TITLE
Add phone to searchable FTS fields for order addresses.

### DIFF
--- a/plugins/woocommerce/changelog/enhance-fts-index
+++ b/plugins/woocommerce/changelog/enhance-fts-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add phone number to FTS index to improve order searchability.

--- a/plugins/woocommerce/changelog/enhance-fts-index-2
+++ b/plugins/woocommerce/changelog/enhance-fts-index-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Remove relevancy ranking from FTS queries to improve performance.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -266,6 +266,9 @@ class WC_Install {
 			'wc_update_930_add_woocommerce_coming_soon_option',
 			'wc_update_930_migrate_user_meta_for_launch_your_store_tour',
 		),
+		'9.4.0' => array(
+			'wc_update_940_add_phone_to_order_address_fts_index',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -8,6 +8,9 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -216,6 +219,11 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'Note:', 'woocommerce' ),
 					__( 'This tool will update your WooCommerce database to the latest version. Please ensure you make sufficient backups before proceeding.', 'woocommerce' )
 				),
+			),
+			'recreate_order_address_fts_index'     => array(
+				'name'   => __( 'Recreate order address FTS index', 'woocommerce' ),
+				'button' => __( 'Recreate index', 'woocommerce' ),
+				'desc'   => __( 'This tool will recreate the full text search index for order addresses. If the index does not exist, it will try to create it.', 'woocommerce' ),
 			),
 		);
 		if ( method_exists( 'WC_Install', 'verify_base_tables' ) ) {
@@ -596,6 +604,13 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					$message .= implode( ', ', $missing_tables );
 					$ran      = false;
 				}
+				break;
+
+			case 'recreate_order_address_fts_index':
+				$hpos_controller = wc_get_container()->get( CustomOrdersTableController::class );
+				$results         = $hpos_controller->recreate_order_address_fts_index();
+				$ran             = $results['status'];
+				$message         = $results['message'];
 				break;
 
 			default:

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -221,7 +221,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				),
 			),
 			'recreate_order_address_fts_index'     => array(
-				'name'   => __( 'Recreate order address FTS index', 'woocommerce' ),
+				'name'   => __( 'Re-create Order Address FTS index', 'woocommerce' ),
 				'button' => __( 'Recreate index', 'woocommerce' ),
 				'desc'   => __( 'This tool will recreate the full text search index for order addresses. If the index does not exist, it will try to create it.', 'woocommerce' ),
 			),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -322,7 +322,7 @@ class CustomOrdersTableController {
 	 *
 	 * @return void
 	 */
-	public function process_updated_option_fts_index( $option, $old_value, $value ) {
+	private function process_updated_option_fts_index( $option, $old_value, $value ) {
 		if ( self::HPOS_FTS_INDEX_OPTION !== $option ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -345,9 +345,9 @@ class CustomOrdersTableController {
 
 		// Check again to see if index was actually created.
 		if ( $this->db_util->fts_index_on_order_address_table_exists() ) {
-			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'yes', true );
+			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'yes', false );
 		} else {
-			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'no', true );
+			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'no', false );
 			if ( class_exists( 'WC_Admin_Settings ' ) ) {
 				WC_Admin_Settings::add_error( __( 'Failed to create FTS index on address table', 'woocommerce' ) );
 			}
@@ -359,9 +359,9 @@ class CustomOrdersTableController {
 
 		// Check again to see if index was actually created.
 		if ( $this->db_util->fts_index_on_order_item_table_exists() ) {
-			update_option( self::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION, 'yes', true );
+			update_option( self::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION, 'yes', false );
 		} else {
-			update_option( self::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION, 'no', true );
+			update_option( self::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION, 'no', false );
 			if ( class_exists( 'WC_Admin_Settings ' ) ) {
 				WC_Admin_Settings::add_error( __( 'Failed to create FTS index on order item table', 'woocommerce' ) );
 			}
@@ -383,7 +383,7 @@ class CustomOrdersTableController {
 				'message' => __( 'Failed to modify existing FTS index. Please go to WooCommerce > Status > Tools and run the "Re-create Order Address FTS index" tool.', 'woocommerce' ),
 			);
 		} else {
-			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'no', true );
+			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'no', false );
 		}
 
 		$this->db_util->create_fts_index_order_address_table();
@@ -393,7 +393,7 @@ class CustomOrdersTableController {
 				'message' => __( 'Failed to create FTS index on order address table. Please go to WooCommerce > Status > Tools and run the "Re-create Order Address FTS index" tool.', 'woocommerce' ),
 			);
 		} else {
-			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'yes' );
+			update_option( self::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION, 'yes', false );
 			return array(
 				'status'  => true,
 				'message' => __( 'FTS index recreated.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Exception;
 
 /**
@@ -238,6 +239,7 @@ class OrdersTableSearchQuery {
 	 */
 	private function get_where_for_products() {
 		global $wpdb;
+		$db_util      = wc_get_container()->get( DatabaseUtil::class );
 		$items_table  = $this->query->get_table_name( 'items' );
 		$orders_table = $this->query->get_table_name( 'orders' );
 		$fts_enabled  = get_option( CustomOrdersTableController::HPOS_FTS_INDEX_OPTION ) === 'yes' && get_option( CustomOrdersTableController::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION ) === 'yes';
@@ -251,7 +253,7 @@ $orders_table.id in (
 	MATCH ( search_query_items.order_item_name ) AGAINST ( %s IN BOOLEAN MODE )
 )
 ",
-				'*' . $wpdb->esc_like( $this->search_term ) . '*'
+				$wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) ),
 			);
 			// phpcs:enable
 		}
@@ -279,6 +281,8 @@ $orders_table.id in (
 		$order_table   = $this->query->get_table_name( 'orders' );
 		$address_table = $this->query->get_table_name( 'addresses' );
 
+		$db_util = wc_get_container()->get( DatabaseUtil::class );
+
 		$fts_enabled = get_option( CustomOrdersTableController::HPOS_FTS_INDEX_OPTION ) === 'yes' && get_option( CustomOrdersTableController::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION ) === 'yes';
 
 		if ( $fts_enabled ) {
@@ -287,10 +291,10 @@ $orders_table.id in (
 				"
 $order_table.id IN (
 	SELECT order_id FROM $address_table WHERE
-	MATCH( $address_table.first_name, $address_table.last_name, $address_table.company, $address_table.address_1, $address_table.address_2, $address_table.city, $address_table.state, $address_table.postcode, $address_table.country, $address_table.email ) AGAINST ( %s IN BOOLEAN MODE )
+	MATCH( $address_table.first_name, $address_table.last_name, $address_table.company, $address_table.address_1, $address_table.address_2, $address_table.city, $address_table.state, $address_table.postcode, $address_table.country, $address_table.email, $address_table.phone ) AGAINST ( %s IN BOOLEAN MODE )
 )
 ",
-				'*' . $wpdb->esc_like( $this->search_term ) . '*'
+				$wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) )
 			);
 			// phpcs:enable
 		}

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -357,7 +357,43 @@ $on_duplicate_clause
 		global $wpdb;
 		$address_table = $wpdb->prefix . 'wc_order_addresses';
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $address_table is hardcoded.
-		$wpdb->query( "CREATE FULLTEXT INDEX order_addresses_fts ON $address_table (first_name, last_name, company, address_1, address_2, city, state, postcode, country, email)" );
+		$wpdb->query( "CREATE FULLTEXT INDEX order_addresses_fts ON $address_table (first_name, last_name, company, address_1, address_2, city, state, postcode, country, email, phone)" );
+	}
+
+	/**
+	 * Sanitize FTS Search params to remove relevancy operators for performance, and add partial matches. Useful when the sorting is already happening based on some other conditions, so relevancy calculation is not needed.
+	 *
+	 * @since 9.4.0
+	 *
+	 * @param string $param Search term.
+	 *
+	 * @return string Sanitized search term.
+	 */
+	public function sanitise_boolean_fts_search_term( string $param ): string {
+		// Replace fts stopwords with spaces.
+		$param = preg_replace( '/[^\p{L}\p{N}_]+/u', ' ', $param );
+		// Split the search phrase into words so that we can add operators when needed.
+		$words           = explode( ' ', $param );
+		$sanitized_words = array();
+		foreach ( $words as $word ) {
+			// If quotes are provided, then we need to search as is.
+			if ( str_starts_with( $word, '"' ) && str_ends_with( $word, '"' ) ) {
+				$sanitized_words[] = $word;
+				continue;
+			}
+
+			// Strip away relevancy operators to keep the search performant.
+			$word = preg_replace( '/[><\(\)~*\"@]+/', '', $word );
+			if ( strlen( $word ) === 0 ) {
+				continue;
+			}
+
+			// Add `*` as suffix to every term so that partial matches happens.
+			$word = str_ends_with( $word, '*' ) ? $word : $word . '*';
+
+			$sanitized_words[] = $word;
+		}
+		return implode( ' ', $sanitized_words );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -361,6 +361,20 @@ $on_duplicate_clause
 	}
 
 	/**
+	 * Helper method to drop the fulltext index on order address table.
+	 *
+	 * @since 9.4.0
+	 *
+	 * @return void
+	 */
+	public function drop_fts_index_order_address_table(): void {
+		global $wpdb;
+		$address_table = $wpdb->prefix . 'wc_order_addresses';
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $address_table is hardcoded.
+		$wpdb->query( "ALTER TABLE $address_table DROP INDEX order_addresses_fts;" );
+	}
+
+	/**
 	 * Sanitize FTS Search params to remove relevancy operators for performance, and add partial matches. Useful when the sorting is already happening based on some other conditions, so relevancy calculation is not needed.
 	 *
 	 * @since 9.4.0

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -386,28 +386,17 @@ $on_duplicate_clause
 	public function sanitise_boolean_fts_search_term( string $param ): string {
 		// Remove any operator to prevent incorrect query and fatals, such as search starting with `++`. We can allow this in the future if we have proper validation for FTS search operators.
 		// Space is allowed to provide multiple words.
-		if ( preg_replace( '/[^\p{L}\p{N}_]+/u', ' ', $param ) !== $param ) {
-			return '"' . trim( $param, '"' ) . '"';
+		$sanitized_param = preg_replace( '/[^\p{L}\p{N}_]+/u', ' ', $param );
+		if ( $sanitized_param !== $param ) {
+			$param = str_replace( '"', '', $param );
+			return '"' . $param . '"';
 		}
 		// Split the search phrase into words so that we can add operators when needed.
 		$words           = explode( ' ', $param );
 		$sanitized_words = array();
 		foreach ( $words as $word ) {
-			// If quotes are provided, then we need to search as is.
-			if ( str_starts_with( $word, '"' ) && str_ends_with( $word, '"' ) ) {
-				$sanitized_words[] = $word;
-				continue;
-			}
-
-			// Strip away relevancy operators to keep the search performant.
-			$word = preg_replace( '/[><\(\)~*\"@]+/', '', $word );
-			if ( strlen( $word ) === 0 ) {
-				continue;
-			}
-
 			// Add `*` as suffix to every term so that partial matches happens.
-			$word = str_ends_with( $word, '*' ) ? $word : $word . '*';
-
+			$word              = $word . '*';
 			$sanitized_words[] = $word;
 		}
 		return implode( ' ', $sanitized_words );

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -384,8 +384,11 @@ $on_duplicate_clause
 	 * @return string Sanitized search term.
 	 */
 	public function sanitise_boolean_fts_search_term( string $param ): string {
-		// Replace fts stopwords with spaces.
-		$param = preg_replace( '/[^\p{L}\p{N}_]+/u', ' ', $param );
+		// Remove any operator to prevent incorrect query and fatals, such as search starting with `++`. We can allow this in the future if we have proper validation for FTS search operators.
+		// Space is allowed to provide multiple words.
+		if ( preg_replace( '/[^\p{L}\p{N}_]+/u', ' ', $param ) !== $param ) {
+			return '"' . trim( $param, '"' ) . '"';
+		}
 		// Split the search phrase into words so that we can add operators when needed.
 		$words           = explode( ' ', $param );
 		$sanitized_words = array();

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
@@ -131,4 +131,28 @@ class DatabaseUtilTest extends WC_Unit_Test_Case {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Hardcoded query.
 		$this->assertEquals( 'Updated Content', $wpdb->get_var( $content_query ) );
 	}
+
+	/**
+	 * @testDox Test that sanitise_boolean_fts_search_term() works as expected.
+	 */
+	public function test_sanitise_boolean_fts_search_term(): void {
+		$terms_sanitized_mapping = array(
+			// Normal terms are suffixed with wildcard.
+			'abc'             => 'abc*',
+			'abc def'         => 'abc* def*',
+			// Terms containing operators are quoted.
+			'+abc -def'       => '"+abc -def"',
+			'++abc-def'       => '"++abc-def"',
+			'abc (>def <fgh)' => '"abc (>def <fgh)"',
+			'"abc" def'       => '"abc def"',
+			'abc*'            => '"abc*"',
+			// Some edge cases.
+			''                => '*',
+			'"'               => '""',
+		);
+
+		foreach ( $terms_sanitized_mapping as $term => $expected ) {
+			$this->assertEquals( $expected, $this->sut->sanitise_boolean_fts_search_term( $term ) );
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the following changes:
1. Add the phone number to the FTS index on the order address table.
2. Add migration routines for the above, so that we can recreate the index for shops that already have this enabled.

Additionally, it also removes support for relevancy operators to make search performant.

Also, see discussion: https://github.com/woocommerce/woocommerce/discussions/48138

Fixes #51213

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since there's a migration routine involved, testing is a little bit complex.

1. With HPOS authoritative, create an order and add a phone number to this order. We will search with this phone number as part of the testing.
2. Go to WooCommerce > Settings > Advanced > Features and enable the "HPOS Full-text search indexes" experimental feature if it's not already enabled.
3. Switch to this branch, and run the following command: `wp option update woocommerce_db_version 9.3.0` and `wp option delete woocommerce_version`.
4. Open any admin page. You will get a prompt to update the WooCommerce DB, but **do not update the DB yet.**
5. Go to WooCommerce > Orders and search using the phone number used in step 1. You should not be able to search the order.
6. Run the DB update and wait for it to finish. Search again using the phone number, this time you should be able to see the order.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
