### PR TITLE
Revert "Store API: Do not resume orders with `pending` status (#50531)"

### DIFF
--- a/plugins/woocommerce/changelog/51067-revert-50531
+++ b/plugins/woocommerce/changelog/51067-revert-50531
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This reverts an existing PR.
+

--- a/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/DraftOrderTrait.php
@@ -60,9 +60,8 @@ trait DraftOrderTrait {
 			return true;
 		}
 
-		// Failed orders and those needing payment can be retried if the cart hasn't changed.
-		// Pending orders are excluded from this check since they may be awaiting an update from the payment processor.
-		if ( $order_object->needs_payment() && ! $order_object->has_status( 'pending' ) && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
+		// Pending and failed orders can be retried if the cart hasn't changed.
+		if ( $order_object->needs_payment() && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
This PR reverts https://github.com/woocommerce/woocommerce/pull/50531 because it was breaking WooPay.

WooPay sets an order to pending before actually submitting it using Store API, this broke the whole flow.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Open 2 browsers and in one be logged in as admin, and in the other visit the store as a guest.
2. Place an order as the guest by adding 1 item to the cart. Pay using COD or BACs. Leave thanks page open. Note down the order ID.
3. As the admin, edit the new order and change the order status from processing or on-hold (depending on gateway) to `pending`. Save the order.
4. Back as the customer, click through to the product from the thanks page and add it to the cart again. Go through the checkout process again with the same details and same payment method. Ensure the items in the cart are identical to the last order.
5. After placing the order, check that the order ID does match the original order ID and that no new draft order was created.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

This reverts an existing PR.
</details>
