### PR TITLE
CYS: Mark several classes as internal

### DIFF
--- a/plugins/woocommerce/changelog/fix-cys-internal-classes
+++ b/plugins/woocommerce/changelog/fix-cys-internal-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Mark several Customize Your Store PHP classes as internal

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -7,6 +7,8 @@ use WP_Post;
 
 /**
  * Customize Your Store Task
+ *
+ * @internal
  */
 class CustomizeStore extends Task {
 	/**

--- a/plugins/woocommerce/src/Blocks/AI/Configuration.php
+++ b/plugins/woocommerce/src/Blocks/AI/Configuration.php
@@ -8,6 +8,8 @@ use Automattic\Jetpack\Connection\Utils;
 
 /**
  * Class Configuration
+ *
+ * @internal
  */
 class Configuration {
 

--- a/plugins/woocommerce/src/Blocks/AI/Connection.php
+++ b/plugins/woocommerce/src/Blocks/AI/Connection.php
@@ -10,6 +10,8 @@ use WpOrg\Requests\Requests;
 
 /**
  * Class Connection
+ *
+ * @internal
  */
 class Connection {
 	const TEXT_COMPLETION_API_URL = 'https://public-api.wordpress.com/wpcom/v2/text-completion';

--- a/plugins/woocommerce/src/Blocks/AIContent/ContentProcessor.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/ContentProcessor.php
@@ -10,6 +10,8 @@ use WP_Error;
  * ContentProcessor class.
  *
  * Process images for content
+ *
+ * @internal
  */
 class ContentProcessor {
 

--- a/plugins/woocommerce/src/Blocks/AIContent/PatternsDictionary.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/PatternsDictionary.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Blocks\AIContent;
 
 /**
  * Patterns Dictionary class.
+ *
+ * @internal
  */
 class PatternsDictionary {
 	/**

--- a/plugins/woocommerce/src/Blocks/AIContent/PatternsHelper.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/PatternsHelper.php
@@ -6,6 +6,8 @@ use WP_Error;
 
 /**
  * Patterns Helper class.
+ *
+ * @internal
  */
 class PatternsHelper {
 	/**

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdatePatterns.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdatePatterns.php
@@ -7,6 +7,8 @@ use WP_Error;
 
 /**
  * Pattern Images class.
+ *
+ * @internal
  */
 class UpdatePatterns {
 

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -6,6 +6,8 @@ use Automattic\WooCommerce\Blocks\AI\Connection;
 use WP_Error;
 /**
  * Pattern Images class.
+ *
+ * @internal
  */
 class UpdateProducts {
 

--- a/plugins/woocommerce/src/Blocks/Patterns/AIPatterns.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/AIPatterns.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\Blocks\Images\Pexels;
 
 /**
  * AIPatterns class.
+ *
+ * @internal
  */
 class AIPatterns {
 	const PATTERNS_AI_DATA_POST_TYPE = 'patterns_ai_data';

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKClient.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKClient.php
@@ -5,6 +5,8 @@ use WP_Error;
 
 /**
  * PatternsToolkit class.
+ *
+ * @internal
  */
 class PTKClient {
 	/**

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -7,6 +7,8 @@ use WP_Upgrader;
 
 /**
  * PTKPatterns class.
+ *
+ * @internal
  */
 class PTKPatternsStore {
 	const TRANSIENT_NAME = 'ptk_patterns';

--- a/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
@@ -5,6 +5,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * PatternRegistry class.
+ *
+ * @internal
  */
 class PatternRegistry {
 	const SLUG_REGEX            = '/^[A-z0-9\/_-]+$/';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR marks several CYS PHP classes as internal. I guess that was probably already assumed, but I think it's better to be explicit. This will allow us to make changes or remove those classes in the future.

### How to test the changes in this Pull Request:

This PR only makes changes to comments, so no need to test it, simply make sure automated testing keeps passing.