### PR TITLE
Add a check to make themes API query safer

### DIFF
--- a/plugins/woocommerce/changelog/fix-make-themes-api-safer
+++ b/plugins/woocommerce/changelog/fix-make-themes-api-safer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add check to ensure themes API is safe

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
@@ -110,7 +110,7 @@ class OnboardingThemes {
 			$themes     = array();
 
 			if ( ! is_wp_error( $theme_data ) ) {
-				$theme_data    = json_decode( $theme_data['body'] );
+				$theme_data = json_decode( $theme_data['body'] );
 
 				if ( $theme_data ) {
 					$woo_themes    = property_exists( $theme_data, 'products' ) ? $theme_data->products : array();

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
@@ -111,15 +111,18 @@ class OnboardingThemes {
 
 			if ( ! is_wp_error( $theme_data ) ) {
 				$theme_data    = json_decode( $theme_data['body'] );
-				$woo_themes    = property_exists( $theme_data, 'products' ) ? $theme_data->products : array();
-				$sorted_themes = self::sort_woocommerce_themes( $woo_themes );
 
-				foreach ( $sorted_themes as $theme ) {
-					$slug                                       = sanitize_title_with_dashes( $theme->slug );
-					$themes[ $slug ]                            = (array) $theme;
-					$themes[ $slug ]['is_installed']            = false;
-					$themes[ $slug ]['has_woocommerce_support'] = true;
-					$themes[ $slug ]['slug']                    = $slug;
+				if ( $theme_data ) {
+					$woo_themes    = property_exists( $theme_data, 'products' ) ? $theme_data->products : array();
+					$sorted_themes = self::sort_woocommerce_themes( $woo_themes );
+
+					foreach ( $sorted_themes as $theme ) {
+						$slug                                       = sanitize_title_with_dashes( $theme->slug );
+						$themes[ $slug ]                            = (array) $theme;
+						$themes[ $slug ]['is_installed']            = false;
+						$themes[ $slug ]['has_woocommerce_support'] = true;
+						$themes[ $slug ]['slug']                    = $slug;
+					}
 				}
 			}
 

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
@@ -78,10 +78,10 @@ class OnboardingThemes {
 		usort(
 			$themes,
 			function ( $product_1, $product_2 ) {
-				if ( ! property_exists( $product_1, 'id' ) || ! property_exists( $product_1, 'slug' ) ) {
+				if ( ! is_object( $product_1 ) || ! property_exists( $product_1, 'id' ) || ! property_exists( $product_1, 'slug' ) ) {
 					return 1;
 				}
-				if ( ! property_exists( $product_2, 'id' ) || ! property_exists( $product_2, 'slug' ) ) {
+				if ( ! is_object( $product_2 ) || ! property_exists( $product_2, 'id' ) || ! property_exists( $product_2, 'slug' ) ) {
 					return 1;
 				}
 				if ( in_array( 'Storefront', array( $product_1->slug, $product_2->slug ), true ) ) {
@@ -117,6 +117,9 @@ class OnboardingThemes {
 					$sorted_themes = self::sort_woocommerce_themes( $woo_themes );
 
 					foreach ( $sorted_themes as $theme ) {
+						if ( ! isset( $theme->slug ) ) {
+							continue;
+						}
 						$slug                                       = sanitize_title_with_dashes( $theme->slug );
 						$themes[ $slug ]                            = (array) $theme;
 						$themes[ $slug ]['is_installed']            = false;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Reported in p1725007685579129-slack-C01SFMVEYAK, homescreen crashes when https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=themes fails. 

Note that the `OnboardingThemes.php` use is mostly deprecated and is intended to be removed in https://github.com/woocommerce/woocommerce/issues/50624, this PR only fix the fatal to minimize the change for a CFE:

```
[02-Sep-2024 03:03:31 UTC] PHP Fatal error:  Uncaught TypeError: property_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php:114
Stack trace:
#0 /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php(114): property_exists(NULL, 'products')
#1 /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php(209): Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes::get_themes()
#2 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes::preload_data(Array)
#3 /srv/htdocs/__wp__/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#4 /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php(241): apply_filters('woocommerce_adm...', Array)
#5 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingSetupWizard->component_settings(Array)
#6 /srv/htdocs/__wp__/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#7 /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php(61): apply_filters('woocommerce_adm...', Array)
#8 /srv/htdocs/wp-content/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php(271): Automattic\WooCommerce\Internal\Admin\WCAdminSharedSettings->Automattic\WooCommerce\Internal\Admin\{closure}()
#9 /srv/htdocs/wp-content/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php(387): Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry->execute_lazy_data()
#10 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry->enqueue_asset_data('')
#11 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#12 /srv/htdocs/__wp__/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#13 /srv/htdocs/__wp__/wp-admin/admin-footer.php(95): do_action('admin_print_foo...')
#14 /srv/htdocs/__wp__/wp-admin/admin.php(297): require_once('/srv/htdocs/__w...')
#15 {main}
  thrown in /srv/htdocs/wp-content/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php on line 114
```

### How to test the changes in this Pull Request:

1. Install `wc-beta-tester` built from latest trunk or download my build: [woocommerce-beta-tester.zip](https://github.com/user-attachments/files/16832004/woocommerce-beta-tester.zip)
2. Go to `WooCommerce > Settings > Advanced > WooCommerce.com` and ensure `Allow usage of WooCommerce to be tracked` is checked
3. Go to `Tools > WCA Test Helper > Tools`
4. Select `500` for `Force errors on woocommerce.com requests`
5. With `wp-cli`, run `wp transient delete --all && wp cache flush`, or alternatively, delete `wc_onboarding_themes` transient manually
6. Go to `WooCommerce > Home`
7. Observe Homescreen does not crash
8. Open up browser console and run `wc.wcSettings.allSettings.admin.onboarding.themes`
9. Observe it produces default values ([screenshot](https://github.com/user-attachments/assets/9ca83b26-c1b3-4291-879c-226c56e1e191))
10. In `wp-cli` run `wp transient get wc_onboarding_themes` and ensure it exists


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>