### PR TITLE
[e2e tests] Fix linked products flaky test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-create-linked-product-tests
+++ b/plugins/woocommerce/changelog/e2e-fix-create-linked-product-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -2,7 +2,7 @@ const { test } = require( '../../../../fixtures/block-editor-fixtures' );
 const { expect } = require( '@playwright/test' );
 
 const { clickOnTab } = require( '../../../../utils/simple-products' );
-const { api, helpers } = require( '../../../../utils' );
+const { helpers } = require( '../../../../utils' );
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
@@ -10,8 +10,11 @@ const NEW_EDITOR_ADD_PRODUCT_URL =
 const isTrackingSupposedToBeEnabled = !! process.env.ENABLE_TRACKING;
 
 const uniqueId = helpers.random();
+let categoryId = 0;
+const categoryName = `cat_${ uniqueId }`;
+const productName = `Product ${ uniqueId }`;
 const productData = {
-	name: `Linked product name ${ uniqueId }`,
+	name: `Linked ${ productName }`,
 	summary: 'This is a product summary',
 };
 
@@ -21,25 +24,48 @@ let productId = 0;
 
 test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 	test.describe( 'Linked product', () => {
-		test.beforeAll( async () => {
+		test.beforeAll( async ( { api } ) => {
+			await api
+				.post( 'products/categories', {
+					name: categoryName,
+				} )
+				.then( ( response ) => {
+					categoryId = response.data.id;
+				} );
+
 			for ( let i = 1; i <= 5; i++ ) {
+				// const id = await api.create.product( product );
 				const product = {
 					name: `Product ${ uniqueId } ${ i }`,
-					productPrice: `${ i }00`,
+					regular_price: `${ i }0000`,
+					sale_price: `${ i }000`,
 					type: 'simple',
+					categories: [ { id: categoryId } ],
 				};
-				linkedProductsData.push( product );
-				const id = await api.create.product( product );
-				productIds.push( id );
+				await api.post( 'products', product ).then( ( response ) => {
+					productIds.push( response.data.id );
+					linkedProductsData.push( product );
+				} );
 			}
 		} );
 
-		test.afterAll( async () => {
+		test.afterAll( async ( { api } ) => {
 			for ( const aProductId of productIds ) {
-				await api.deletePost.product( aProductId );
+				// await api.deletePost.product( aProductId );
+				await api.delete( `products/${ aProductId }`, {
+					force: true,
+				} );
 			}
-			await api.deletePost.product( productId );
+			// await api.deletePost.product( productId );
+			await api.delete( `products/${ productId }`, {
+				force: true,
+			} );
+
+			await api.delete( `products/categories/${ categoryId }`, {
+				force: true,
+			} );
 		} );
+
 		test.skip(
 			isTrackingSupposedToBeEnabled,
 			'The block product editor is not being tested'
@@ -60,7 +86,24 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				.last()
 				.fill( productData.summary );
 
+			// Include in category
+			await clickOnTab( 'Organization', page );
+			await page.getByLabel( 'Categories' ).click();
+			await page.getByLabel( categoryName ).check();
+			await page.getByLabel( `Remove Uncategorized` ).click();
+			await expect(
+				page.getByLabel( `Remove ${ categoryName }` )
+			).toBeVisible();
+
+			const waitForProductsSearchResponse = page.waitForResponse(
+				( response ) =>
+					response
+						.url()
+						.includes( '/wp-json/wc/v3/products?search' ) &&
+					response.status() === 200
+			);
 			await clickOnTab( 'Linked products', page );
+			await waitForProductsSearchResponse;
 
 			await expect(
 				page.getByRole( 'heading', {
@@ -74,7 +117,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				)
 				.first()
 				.getByRole( 'combobox' )
-				.fill( linkedProductsData[ 0 ].name );
+				.pressSequentially( productName );
 
 			await page.getByText( linkedProductsData[ 0 ].name ).click();
 
@@ -91,7 +134,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			await chooseProductsResponsePromise;
 
 			await expect(
-				page.getByRole( 'row', { name: `Product ${ uniqueId }` } )
+				page.getByRole( 'row', { name: productName } )
 			).toHaveCount( 4 );
 
 			const upsellsRows = page.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -9,24 +9,22 @@ const NEW_EDITOR_ADD_PRODUCT_URL =
 
 const isTrackingSupposedToBeEnabled = !! process.env.ENABLE_TRACKING;
 
+const uniqueId = helpers.random();
 const productData = {
-	name: `Linked product Name ${ new Date().getTime().toString() }`,
+	name: `Linked product name ${ uniqueId }`,
 	summary: 'This is a product summary',
 };
 
 const linkedProductsData = [],
 	productIds = [];
 let productId = 0;
-const uniqueId = helpers.random();
 
 test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 	test.describe( 'Linked product', () => {
 		test.beforeAll( async () => {
 			for ( let i = 1; i <= 5; i++ ) {
 				const product = {
-					name: `Product ${ uniqueId } ${ i } ${ new Date()
-						.getTime()
-						.toString() }`,
+					name: `Product ${ uniqueId } ${ i }`,
 					productPrice: `${ i }00`,
 					type: 'simple',
 				};

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -88,7 +88,13 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 			// Include in category
 			await clickOnTab( 'Organization', page );
+			const waitForCategoriesResponse = page.waitForResponse(
+				( response ) =>
+					response.url().includes( '/wp-json/wp/v2/product_cat' ) &&
+					response.status() === 200
+			);
 			await page.getByLabel( 'Categories' ).click();
+			await waitForCategoriesResponse;
 			await page.getByLabel( categoryName ).check();
 			await page.getByLabel( `Remove Uncategorized` ).click();
 			await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -2,7 +2,7 @@ const { test } = require( '../../../../fixtures/block-editor-fixtures' );
 const { expect } = require( '@playwright/test' );
 
 const { clickOnTab } = require( '../../../../utils/simple-products' );
-const { api } = require( '../../../../utils' );
+const { api, helpers } = require( '../../../../utils' );
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
@@ -17,13 +17,14 @@ const productData = {
 const linkedProductsData = [],
 	productIds = [];
 let productId = 0;
+const uniqueId = helpers.random();
 
 test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 	test.describe( 'Linked product', () => {
 		test.beforeAll( async () => {
 			for ( let i = 1; i <= 5; i++ ) {
 				const product = {
-					name: `Product name ${ i } ${ new Date()
+					name: `Product ${uniqueId} ${ i } ${ new Date()
 						.getTime()
 						.toString() }`,
 					productPrice: `${ i }00`,
@@ -91,8 +92,9 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			await page.getByText( 'Choose products for me' ).first().click();
 			await chooseProductsResponsePromise;
 
+			await page.pause();
 			await expect(
-				page.getByRole( 'row', { name: 'Product name' } )
+				page.getByRole( 'row', { name: `Product ${uniqueId}` } )
 			).toHaveCount( 4 );
 
 			const upsellsRows = page.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -34,7 +34,6 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				} );
 
 			for ( let i = 1; i <= 5; i++ ) {
-				// const id = await api.create.product( product );
 				const product = {
 					name: `Product ${ uniqueId } ${ i }`,
 					regular_price: `${ i }0000`,
@@ -51,12 +50,10 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 		test.afterAll( async ( { api } ) => {
 			for ( const aProductId of productIds ) {
-				// await api.deletePost.product( aProductId );
 				await api.delete( `products/${ aProductId }`, {
 					force: true,
 				} );
 			}
-			// await api.deletePost.product( productId );
 			await api.delete( `products/${ productId }`, {
 				force: true,
 			} );
@@ -123,7 +120,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				)
 				.first()
 				.getByRole( 'combobox' )
-				.pressSequentially( productName );
+				.fill( productName );
 
 			await page.getByText( linkedProductsData[ 0 ].name ).click();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -90,7 +90,6 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 			await page.getByText( 'Choose products for me' ).first().click();
 			await chooseProductsResponsePromise;
 
-			await page.pause();
 			await expect(
 				page.getByRole( 'row', { name: `Product ${ uniqueId }` } )
 			).toHaveCount( 4 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -24,7 +24,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 		test.beforeAll( async () => {
 			for ( let i = 1; i <= 5; i++ ) {
 				const product = {
-					name: `Product ${uniqueId} ${ i } ${ new Date()
+					name: `Product ${ uniqueId } ${ i } ${ new Date()
 						.getTime()
 						.toString() }`,
 					productPrice: `${ i }00`,
@@ -94,7 +94,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 			await page.pause();
 			await expect(
-				page.getByRole( 'row', { name: `Product ${uniqueId}` } )
+				page.getByRole( 'row', { name: `Product ${ uniqueId }` } )
 			).toHaveCount( 4 );
 
 			const upsellsRows = page.locator(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes flaky `linked-product-tab-product-block-editor.spec.js:49:3 › General tab › Linked product › can create a product with linked products`

The test was failing because it expected a specific set of products to be included in the suggested upsells list. This worked fine if those were the only products in the site, but other tests are creating products that can be included in the suggested list.

The fix is to narrow down the list of possible suggestions by including the linked products in the same unique category. 

Other small fixes are included, like waiting for specific requests before checking the UI.

### How to test the changes in this Pull Request:

CI green
Locally run
```
pnpm test:e2e linked-product-tab-product-block-editor.spec.js
```