### PR TITLE
[Legacy Settings] Enable Save button on pages with tables

### DIFF
--- a/plugins/woocommerce/changelog/51102-fix-settings-js-save-activation
+++ b/plugins/woocommerce/changelog/51102-fix-settings-js-save-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Settings Save button when WP List Tables are present

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -97,7 +97,7 @@
 			$( 'input, textarea, select, checkbox' ).on( 'change input', function (
 				event
 			) {
-				// Toggling WP List Table checkboxes should not trigger navigation warnings.
+				// Toggling WP List Table checkboxes should not trigger navigation warnings. Theses checkboxes only select/unselect rows, they don't change the form.
 				if (
 					$check_column.length &&
 					$check_column.has( event.target ).length

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -100,7 +100,7 @@
 				// Toggling WP List Table checkboxes should not trigger navigation warnings.
 				if (
 					$check_column.length &&
-					$check_column.has( event.target )
+					$check_column.has( event.target ).length
 				) {
 					return;
 				}

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -97,7 +97,8 @@
 			$( 'input, textarea, select, checkbox' ).on( 'change input', function (
 				event
 			) {
-				// Toggling WP List Table checkboxes should not trigger navigation warnings. Theses checkboxes only select/unselect rows, they don't change the form.
+				// Toggling WP List Table checkboxes should not trigger navigation warnings.
+				// Theses checkboxes only select/unselect rows, they don't change the form.
 				if (
 					$check_column.length &&
 					$check_column.has( event.target ).length


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

See https://github.com/woocommerce/team-ghidorah/issues/355#issuecomment-2321050702

On table row inputs we don't need to enable save when those are checked, no editing has happened. The check was faulty as `$( ... ).has()` [always returns an object](https://api.jquery.com/has/), even when empty. So this check will always be true. This PR adds a `.length` to ensure the target is properly computed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a JN site enable [Stripe Tax](https://wordpress.org/plugins/stripe-tax-for-woocommerce/#description).
2. Settings > General and turn on tax calculations.
3. Settings > Stripe Tax and connect Stripe.
4. Change any element in the form and make sure the "Save" button is activated.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Settings Save button when WP List Tables are present

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
