### PR TITLE
Product Collection - Add Editor UI for missing product reference

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/ProductPicker.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/ProductPicker.tsx
@@ -21,7 +21,11 @@ import {
 import type { ProductCollectionEditComponentProps } from '../types';
 import { getCollectionByName } from '../collections';
 
-const ProductPicker = ( props: ProductCollectionEditComponentProps ) => {
+const ProductPicker = (
+	props: ProductCollectionEditComponentProps & {
+		isDeletedProductReference: boolean;
+	}
+) => {
 	const blockProps = useBlockProps();
 	const { attributes, isDeletedProductReference } = props;
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/ProductPicker.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/ProductPicker.tsx
@@ -23,12 +23,29 @@ import { getCollectionByName } from '../collections';
 
 const ProductPicker = ( props: ProductCollectionEditComponentProps ) => {
 	const blockProps = useBlockProps();
-	const attributes = props.attributes;
+	const { attributes, isDeletedProductReference } = props;
 
 	const collection = getCollectionByName( attributes.collection );
 	if ( ! collection ) {
-		return;
+		return null;
 	}
+
+	const infoText = isDeletedProductReference
+		? __(
+				'Previously selected product is no longer available.',
+				'woocommerce'
+		  )
+		: createInterpolateElement(
+				sprintf(
+					/* translators: %s: collection title */
+					__(
+						'<strong>%s</strong> requires a product to be selected in order to display associated items.',
+						'woocommerce'
+					),
+					collection.title
+				),
+				{ strong: <strong /> }
+		  );
 
 	return (
 		<div { ...blockProps }>
@@ -38,21 +55,7 @@ const ProductPicker = ( props: ProductCollectionEditComponentProps ) => {
 						icon={ info }
 						className="wc-blocks-product-collection__info-icon"
 					/>
-					<Text>
-						{ createInterpolateElement(
-							sprintf(
-								/* translators: %s: collection title */
-								__(
-									'<strong>%s</strong> requires a product to be selected in order to display associated items.',
-									'woocommerce'
-								),
-								collection.title
-							),
-							{
-								strong: <strong />,
-							}
-						) }
-					</Text>
+					<Text>{ infoText }</Text>
 				</HStack>
 				<ProductControl
 					selected={

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/editor.scss
@@ -174,6 +174,10 @@ $max-button-width: calc(100% / #{$max-button-columns});
 	.wc-blocks-product-collection__info-icon {
 		fill: var(--wp--preset--color--luminous-vivid-orange, #e26f56);
 	}
+
+	.woocommerce-search-list__search {
+		margin: 0;
+	}
 }
 
 // Linked Product Control

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -72,11 +72,6 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 					/>
 				);
 			case ProductCollectionUIStatesInEditor.VALID:
-				return (
-					<ProductCollectionContent
-						{ ...productCollectionContentProps }
-					/>
-				);
 			case ProductCollectionUIStatesInEditor.VALID_WITH_PREVIEW:
 				return (
 					<ProductCollectionContent

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -68,7 +68,10 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 				return (
 					<ProductPicker
 						{ ...props }
-						isDeletedProductReference={ true }
+						isDeletedProductReference={
+							productCollectionUIStateInEditor ===
+							ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE
+						}
 					/>
 				);
 			case ProductCollectionUIStatesInEditor.VALID:

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -32,12 +32,24 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 		[ clientId ]
 	);
 
-	const productCollectionUIStateInEditor = useProductCollectionUIState( {
-		location,
-		attributes,
-		hasInnerBlocks,
-		...( props.usesReference && { usesReference: props.usesReference } ),
-	} );
+	const { productCollectionUIStateInEditor, isLoading } =
+		useProductCollectionUIState( {
+			location,
+			attributes,
+			hasInnerBlocks,
+			...( props.usesReference && {
+				usesReference: props.usesReference,
+			} ),
+		} );
+
+	// Show spinner while calculating Editor UI state.
+	if ( isLoading ) {
+		return (
+			<Flex justify="center" align="center">
+				<Spinner />
+			</Flex>
+		);
+	}
 
 	/**
 	 * Component to render based on the UI state.
@@ -62,15 +74,6 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 		default:
 			// By default showing collection chooser.
 			Component = ProductCollectionPlaceholder;
-	}
-
-	// Show spinner while fetching UI state.
-	if ( productCollectionUIStateInEditor === null ) {
-		return (
-			<Flex justify="center" align="center">
-				<Spinner />
-			</Flex>
-		);
 	}
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -64,14 +64,17 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 			case ProductCollectionUIStatesInEditor.COLLECTION_PICKER:
 				return <ProductCollectionPlaceholder { ...props } />;
 			case ProductCollectionUIStatesInEditor.PRODUCT_REFERENCE_PICKER:
+				return (
+					<ProductPicker
+						{ ...props }
+						isDeletedProductReference={ false }
+					/>
+				);
 			case ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE:
 				return (
 					<ProductPicker
 						{ ...props }
-						isDeletedProductReference={
-							productCollectionUIStateInEditor ===
-							ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE
-						}
+						isDeletedProductReference={ true }
 					/>
 				);
 			case ProductCollectionUIStatesInEditor.VALID:

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -37,9 +37,7 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 			location,
 			attributes,
 			hasInnerBlocks,
-			...( props.usesReference && {
-				usesReference: props.usesReference,
-			} ),
+			usesReference: props.usesReference,
 		} );
 
 	// Show spinner while calculating Editor UI state.

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/index.tsx
@@ -11,6 +11,7 @@ import { Spinner, Flex } from '@wordpress/components';
  * Internal dependencies
  */
 import {
+	ProductCollectionContentProps,
 	ProductCollectionEditComponentProps,
 	ProductCollectionUIStatesInEditor,
 } from '../types';
@@ -49,46 +50,47 @@ const Edit = ( props: ProductCollectionEditComponentProps ) => {
 		);
 	}
 
-	/**
-	 * Component to render based on the UI state.
-	 */
-	let Component,
-		isUsingReferencePreviewMode = false;
-	switch ( productCollectionUIStateInEditor ) {
-		case ProductCollectionUIStatesInEditor.COLLECTION_PICKER:
-			Component = ProductCollectionPlaceholder;
-			break;
-		case ProductCollectionUIStatesInEditor.PRODUCT_REFERENCE_PICKER:
-		case ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE:
-			Component = ProductPicker;
-			break;
-		case ProductCollectionUIStatesInEditor.VALID:
-			Component = ProductCollectionContent;
-			break;
-		case ProductCollectionUIStatesInEditor.VALID_WITH_PREVIEW:
-			Component = ProductCollectionContent;
-			isUsingReferencePreviewMode = true;
-			break;
-		default:
-			// By default showing collection chooser.
-			Component = ProductCollectionPlaceholder;
-	}
+	const productCollectionContentProps: ProductCollectionContentProps = {
+		...props,
+		openCollectionSelectionModal: () => setIsSelectionModalOpen( true ),
+		location,
+		isUsingReferencePreviewMode:
+			productCollectionUIStateInEditor ===
+			ProductCollectionUIStatesInEditor.VALID_WITH_PREVIEW,
+	};
+
+	const renderComponent = () => {
+		switch ( productCollectionUIStateInEditor ) {
+			case ProductCollectionUIStatesInEditor.COLLECTION_PICKER:
+				return <ProductCollectionPlaceholder { ...props } />;
+			case ProductCollectionUIStatesInEditor.PRODUCT_REFERENCE_PICKER:
+			case ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE:
+				return (
+					<ProductPicker
+						{ ...props }
+						isDeletedProductReference={ true }
+					/>
+				);
+			case ProductCollectionUIStatesInEditor.VALID:
+				return (
+					<ProductCollectionContent
+						{ ...productCollectionContentProps }
+					/>
+				);
+			case ProductCollectionUIStatesInEditor.VALID_WITH_PREVIEW:
+				return (
+					<ProductCollectionContent
+						{ ...productCollectionContentProps }
+					/>
+				);
+			default:
+				return <ProductCollectionPlaceholder { ...props } />;
+		}
+	};
 
 	return (
 		<>
-			<Component
-				{ ...props }
-				openCollectionSelectionModal={ () =>
-					setIsSelectionModalOpen( true )
-				}
-				isUsingReferencePreviewMode={ isUsingReferencePreviewMode }
-				location={ location }
-				usesReference={ props.usesReference }
-				isDeletedProductReference={
-					productCollectionUIStateInEditor ===
-					ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE
-				}
-			/>
+			{ renderComponent() }
 			{ isSelectionModalOpen && (
 				<CollectionSelectionModal
 					clientId={ clientId }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-advanced-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-advanced-controls/index.tsx
@@ -7,10 +7,10 @@ import { InspectorAdvancedControls } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import ForcePageReloadControl from './force-page-reload-control';
-import type { ProductCollectionEditComponentProps } from '../../types';
+import type { ProductCollectionContentProps } from '../../types';
 
 export default function ProductCollectionAdvancedInspectorControls(
-	props: Omit< ProductCollectionEditComponentProps, 'preview' >
+	props: ProductCollectionContentProps
 ) {
 	const { clientId, attributes, setAttributes } = props;
 	const { forcePageReload } = attributes;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -27,7 +27,7 @@ import {
 import metadata from '../../block.json';
 import { useTracksLocation } from '../../tracks-utils';
 import {
-	ProductCollectionEditComponentProps,
+	ProductCollectionContentProps,
 	ProductCollectionAttributes,
 	CoreFilterNames,
 	FilterName,
@@ -58,7 +58,7 @@ const prepareShouldShowFilter =
 	};
 
 const ProductCollectionInspectorControls = (
-	props: ProductCollectionEditComponentProps
+	props: ProductCollectionContentProps
 ) => {
 	const { attributes, context, setAttributes } = props;
 	const { query, hideControls, displayLayout } = attributes;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -18,7 +18,7 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 import type {
 	ProductCollectionAttributes,
 	ProductCollectionQuery,
-	ProductCollectionEditComponentProps,
+	ProductCollectionContentProps,
 } from '../types';
 import { DEFAULT_ATTRIBUTES, INNER_BLOCKS_TEMPLATE } from '../constants';
 import {
@@ -68,7 +68,7 @@ const useQueryId = (
 const ProductCollectionContent = ( {
 	preview: { setPreviewState, initialPreviewState } = {},
 	...props
-}: ProductCollectionEditComponentProps ) => {
+}: ProductCollectionContentProps ) => {
 	const isInitialAttributesSet = useRef( false );
 	const {
 		clientId,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/toolbar-controls/index.tsx
@@ -11,10 +11,10 @@ import { setQueryAttribute } from '../../utils';
 import DisplaySettingsToolbar from './display-settings-toolbar';
 import DisplayLayoutToolbar from './display-layout-toolbar';
 import CollectionChooserToolbar from './collection-chooser-toolbar';
-import type { ProductCollectionEditComponentProps } from '../../types';
+import type { ProductCollectionContentProps } from '../../types';
 
 export default function ToolbarControls(
-	props: Omit< ProductCollectionEditComponentProps, 'preview' >
+	props: ProductCollectionContentProps
 ) {
 	const { attributes, openCollectionSelectionModal, setAttributes } = props;
 	const { query, displayLayout } = attributes;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
@@ -110,7 +110,6 @@ export interface ProductCollectionQuery {
 
 export type ProductCollectionEditComponentProps =
 	BlockEditProps< ProductCollectionAttributes > & {
-		openCollectionSelectionModal: () => void;
 		preview?: {
 			initialPreviewState?: PreviewState;
 			setPreviewState?: SetPreviewState;
@@ -119,9 +118,13 @@ export type ProductCollectionEditComponentProps =
 		context: {
 			templateSlug: string;
 		};
-		isUsingReferencePreviewMode: boolean;
+	};
+
+export type ProductCollectionContentProps =
+	ProductCollectionEditComponentProps & {
 		location: WooCommerceBlockLocation;
-		isDeletedProductReference?: boolean;
+		isUsingReferencePreviewMode: boolean;
+		openCollectionSelectionModal: () => void;
 	};
 
 export type TProductCollectionOrder = 'asc' | 'desc';

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
@@ -14,9 +14,9 @@ export enum ProductCollectionUIStatesInEditor {
 	PRODUCT_REFERENCE_PICKER = 'product_context_picker',
 	VALID_WITH_PREVIEW = 'uses_reference_preview_mode',
 	VALID = 'valid',
+	DELETED_PRODUCT_REFERENCE = 'deleted_product_reference',
 	// Future states
 	// INVALID = 'invalid',
-	// DELETED_PRODUCT_REFERENCE = 'deleted_product_reference',
 }
 
 export interface ProductCollectionAttributes {
@@ -121,6 +121,7 @@ export type ProductCollectionEditComponentProps =
 		};
 		isUsingReferencePreviewMode: boolean;
 		location: WooCommerceBlockLocation;
+		isDeletedProductReference?: boolean;
 	};
 
 export type TProductCollectionOrder = 'asc' | 'desc';

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -206,7 +206,7 @@ export const useProductCollectionUIState = ( {
 	hasInnerBlocks,
 }: {
 	location: WooCommerceBlockLocation;
-	usesReference?: string[];
+	usesReference?: string[] | undefined;
 	attributes: ProductCollectionAttributes;
 	hasInnerBlocks: boolean;
 } ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -259,7 +259,9 @@ export const useProductCollectionUIState = ( {
 			! isInRequiredLocation &&
 			isProductContextSelected
 		) {
-			const isProductDeleted = productId && product === undefined;
+			const isProductDeleted =
+				productId &&
+				( product === undefined || product?.status === 'trash' );
 			if ( isProductDeleted ) {
 				return ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE;
 			}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -233,8 +233,6 @@ export const useProductCollectionUIState = ( {
 		[ productId ]
 	);
 
-	console.log( 'hasResolved', hasResolved );
-
 	const productCollectionUIStateInEditor = useMemo( () => {
 		const isInRequiredLocation = usesReference?.includes( location.type );
 		const isCollectionSelected = !! attributes.collection;
@@ -254,7 +252,7 @@ export const useProductCollectionUIState = ( {
 			return ProductCollectionUIStatesInEditor.PRODUCT_REFERENCE_PICKER;
 		}
 
-		// Case 2: Check if product reference is deleted
+		// Case 2: Deleted product reference
 		if (
 			isCollectionSelected &&
 			isProductContextRequired &&

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -207,7 +207,8 @@ class ProductCollectionPage {
 	}
 
 	async chooseProductInEditorProductPickerIfAvailable(
-		pageReference: Page | FrameLocator
+		pageReference: Page | FrameLocator,
+		productName = 'Album'
 	) {
 		const editorProductPicker = pageReference.locator(
 			SELECTORS.productPicker
@@ -217,7 +218,7 @@ class ProductCollectionPage {
 			await editorProductPicker
 				.locator( 'label' )
 				.filter( {
-					hasText: 'Album',
+					hasText: productName,
 				} )
 				.click();
 		}

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -356,18 +356,15 @@ test.describe( 'Product Collection registration', () => {
 			await expect( previewButtonLocator ).toBeHidden();
 		} );
 	} );
-} );
 
-test.describe( 'Deleted product reference in Product Collection block', () => {
-	let testProductId: number | null = null;
-
-	test.beforeEach( async ( { requestUtils } ) => {
-		// Activate plugin
-		await requestUtils.activatePlugin(
-			'register-product-collection-tester'
-		);
-
+	test( 'Product picker should be shown when selected product is deleted', async ( {
+		pageObject,
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
 		// Add a new test product to the database
+		let testProductId: number | null = null;
 		const newProduct = await requestUtils.rest( {
 			method: 'POST',
 			path: 'wc/v3/products',
@@ -377,14 +374,7 @@ test.describe( 'Deleted product reference in Product Collection block', () => {
 			},
 		} );
 		testProductId = newProduct.id;
-	} );
 
-	test( 'Product picker should be shown when product reference is deleted', async ( {
-		pageObject,
-		admin,
-		editor,
-		requestUtils,
-	} ) => {
 		await admin.createNewPost();
 		await pageObject.insertProductCollection();
 		await pageObject.chooseCollectionInPost(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -367,29 +367,16 @@ test.describe( 'Deleted product reference in Product Collection block', () => {
 			'register-product-collection-tester'
 		);
 
-		// Check if "A Test Product" exists
-		const products = await requestUtils.rest( {
-			method: 'GET',
+		// Add a new test product to the database
+		const newProduct = await requestUtils.rest( {
+			method: 'POST',
 			path: 'wc/v3/products',
-			params: {
-				search: 'A Test Product',
+			data: {
+				name: 'A Test Product',
+				price: 10,
 			},
 		} );
-
-		// Add "Test Product" only if it doesn't exist
-		if ( products.length === 0 ) {
-			const newProduct = await requestUtils.rest( {
-				method: 'POST',
-				path: 'wc/v3/products',
-				data: {
-					name: 'A Test Product',
-					price: 10,
-				},
-			} );
-			testProductId = newProduct.id;
-		} else {
-			testProductId = products[ 0 ].id;
-		}
+		testProductId = newProduct.id;
 	} );
 
 	test( 'Product picker should be shown when product reference is deleted', async ( {
@@ -420,12 +407,10 @@ test.describe( 'Deleted product reference in Product Collection block', () => {
 		await editor.saveDraft();
 
 		// Delete the product
-		if ( testProductId ) {
-			await requestUtils.rest( {
-				method: 'DELETE',
-				path: `wc/v3/products/${ testProductId }`,
-			} );
-		}
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path: `wc/v3/products/${ testProductId }`,
+		} );
 
 		// Product picker should be shown in Editor
 		await admin.page.reload();
@@ -435,31 +420,27 @@ test.describe( 'Deleted product reference in Product Collection block', () => {
 		await expect( deletedProductPicker ).toBeVisible();
 
 		// Change status from "trash" to "publish"
-		if ( testProductId ) {
-			await requestUtils.rest( {
-				method: 'PUT',
-				path: `wc/v3/products/${ testProductId }`,
-				data: {
-					status: 'publish',
-				},
-			} );
-		}
+		await requestUtils.rest( {
+			method: 'PUT',
+			path: `wc/v3/products/${ testProductId }`,
+			data: {
+				status: 'publish',
+			},
+		} );
 
 		// Product Picker shouldn't be shown as product is available now
 		await admin.page.reload();
 		await expect( editorProductPicker ).toBeHidden();
 
 		// Delete the product from database, instead of trashing it
-		if ( testProductId ) {
-			await requestUtils.rest( {
-				method: 'DELETE',
-				path: `wc/v3/products/${ testProductId }`,
-				params: {
-					// Bypass trash and permanently delete the product
-					force: true,
-				},
-			} );
-		}
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path: `wc/v3/products/${ testProductId }`,
+			params: {
+				// Bypass trash and permanently delete the product
+				force: true,
+			},
+		} );
 
 		// Product picker should be shown in Editor
 		await expect( deletedProductPicker ).toBeVisible();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -362,6 +362,7 @@ test.describe( 'Product Collection registration', () => {
 		admin,
 		editor,
 		requestUtils,
+		page,
 	} ) => {
 		// Add a new test product to the database
 		let testProductId: number | null = null;
@@ -419,7 +420,7 @@ test.describe( 'Product Collection registration', () => {
 		} );
 
 		// Product Picker shouldn't be shown as product is available now
-		await admin.page.reload();
+		await page.reload();
 		await expect( editorProductPicker ).toBeHidden();
 
 		// Delete the product from database, instead of trashing it

--- a/plugins/woocommerce/changelog/51114-add-44878-product-collection-handling-missing-product-context
+++ b/plugins/woocommerce/changelog/51114-add-44878-product-collection-handling-missing-product-context
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Collection: Added Editor UI for missing product reference


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #44878 

This PR addresses the issue of handling missing product reference. For example, if merchant selects a product in the Product Collection block, but then deletes that product, we need to inform the merchant that the selected product is no longer available and provide a way to select a new product.
![image](https://github.com/user-attachments/assets/0210192f-d5bf-4d96-af34-3aae9c75d505)

Key changes:
1. Converted `getProductCollectionUIStateInEditor` to a hook `useProductCollectionUIState` to handle API calls for checking deleted product references.
2. Added a spinner to indicate loading state while checking for deleted product references.
3. Introduced a new UI state `DELETED_PRODUCT_REFERENCE` to handle the missing product state.
4. Updated the existing `ProductPicker` component to handle the new UI state, providing a seamless experience for selecting a new product when the previous reference is missing.

These changes ensure that users can smoothly recover from situations where a selected product has been deleted, maintaining the integrity of the Product Collection block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Pre-requisite:** Install this plugin - 
[register-product-collection-tester.zip](https://github.com/user-attachments/files/16362323/register-product-collection-tester.zip)

#### Case 1: Adding "My Custom Collection - Product Context" to a place where product context doesn't exist

1. Create a new post and add `Product Collection` block.
2. Choose "My Custom Collection - Product Context" block.
3. Choose any product from Editor product picker.
4. Now delete the selected product from: Admin > Products > All Products.
	- _Tip:_ If you know how to manually edit block attributes using Code Editor then you can switch to Code Editor, update the `productReference` attribute with any random product ID. This way, you are manually providing product ID that doesn't exist. You must save the post after updating `productReference` attribute.
5. Once you have deleted the product, refresh the page. 
	- Verify that, you can see following UI with message "Previously selected product is no longer available.". This is the missing product state.
![image](https://github.com/user-attachments/assets/0210192f-d5bf-4d96-af34-3aae9c75d505)
	
6. Now select any other product from the product picker.
	- Verify that, product collection renders with products.
	- Newly selected product is available in "Linked Product" control in inspector controls. (See screenshot below)
![image](https://github.com/user-attachments/assets/f928177f-0a1e-4a0c-a622-36ca9485999b)

7. Publish the post and verify that Frontend is working as expected.

#### Case 2: Adding "My Custom Collection - Product Context" on Single Product template

1. Go to Single Product template and add Product Collection block.
2. Choose "My Custom Collection - Product Context" block.
3. Verify that product picker is not shown in Inspector control.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Collection: Added Editor UI for missing product reference

</details>

This new UI state will allow merchants to select a new product.

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
