### PR TITLE
[e2e tests] Fix restricted coupons tests - wait for animation to finish

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-restricted-coupons-tests-wait-for-animation
+++ b/plugins/woocommerce/changelog/e2e-fix-restricted-coupons-tests-wait-for-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
@@ -8,15 +8,28 @@ const excludedProductName = 'Excluded test product';
 const includedCategoryName = 'Included Category';
 const excludedCategoryName = 'Excluded Category';
 
-// This applies a coupon and waits for the result to prevent flakyness.
-const applyCoupon = async ( page ) => {
+// This applies a coupon and waits for the result to prevent flakiness.
+const applyCoupon = async ( page, couponCode ) => {
 	const responsePromise = page.waitForResponse(
 		( response ) =>
 			response.url().includes( '?wc-ajax=apply_coupon' ) &&
 			response.status() === 200
 	);
+	await page.getByPlaceholder( 'Coupon code' ).fill( couponCode );
 	await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
 	await responsePromise;
+};
+
+const expandCouponForm = async ( page ) => {
+	await page
+		.getByRole( 'link', {
+			name: 'Click here to enter your code',
+		} )
+		.click();
+	// This is to wait for the expand animation to finish, it avoids flakiness.
+	await expect(
+		page.locator( 'form.woocommerce-form-coupon' )
+	).toHaveAttribute( 'style', '' );
 };
 
 test.describe(
@@ -201,12 +214,8 @@ test.describe(
 		test( 'expired coupon cannot be used', async ( { page, context } ) => {
 			await test.step( 'Load cart page and try expired coupon usage', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'expired-coupon' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'expired-coupon' );
 				await expect(
 					page.getByText( 'This coupon has expired.' )
 				).toBeVisible();
@@ -216,17 +225,9 @@ test.describe(
 
 			await test.step( 'Load checkout page and try expired coupon usage', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'expired-coupon' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'expired-coupon' );
 				await expect(
 					page.getByText( 'This coupon has expired.' )
 				).toBeVisible();
@@ -239,12 +240,8 @@ test.describe(
 		} ) => {
 			await test.step( 'Load cart page and try limited coupon usage', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'min-max-spend-individual' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'min-max-spend-individual' );
 				// failed because we need to have at least $50 in cart (single product is only $20)
 				await expect(
 					page.getByText(
@@ -257,20 +254,14 @@ test.describe(
 
 				// passed because we're between 50 and 200 dollars
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'min-max-spend-individual' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'min-max-spend-individual' );
 				await expect(
 					page.getByText( 'Coupon code applied successfully.' )
 				).toBeVisible();
 
 				// fail because the min-max coupon can only be used by itself
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'no-sale-use-limit' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'no-sale-use-limit' );
 				await expect(
 					page.getByText(
 						'Sorry, coupon "min-max-spend-individual" has already been applied and cannot be used in conjunction with other coupons.'
@@ -284,15 +275,8 @@ test.describe(
 				await addAProductToCart( page, firstProductId );
 
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'min-max-spend-individual' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'min-max-spend-individual' );
 				// failed because we need to have at least $50 in cart (single product is only $20)
 				await expect(
 					page.getByText(
@@ -305,30 +289,16 @@ test.describe(
 
 				// passed because we're between 50 and 200 dollars
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'min-max-spend-individual' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'min-max-spend-individual' );
 				await expect(
 					page.getByText( 'Coupon code applied successfully.' )
 				).toBeVisible();
 
 				// fail because the min-max coupon can only be used by itself
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'no-sale-use-limit' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'no-sale-use-limit' );
 				await expect(
 					page.getByText(
 						'Sorry, coupon "min-max-spend-individual" has already been applied and cannot be used in conjunction with other coupons.'
@@ -343,12 +313,8 @@ test.describe(
 		} ) => {
 			await test.step( 'Load cart page and try coupon usage on sale item', async () => {
 				await addAProductToCart( page, secondProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'no-sale-use-limit' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'no-sale-use-limit' );
 				// failed because this product is on sale.
 				await expect(
 					page.getByText(
@@ -361,17 +327,9 @@ test.describe(
 
 			await test.step( 'Load checkout page and try coupon usage on sale item', async () => {
 				await addAProductToCart( page, secondProductId );
-
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'no-sale-use-limit' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'no-sale-use-limit' );
 				// failed because this product is on sale
 				await expect(
 					page.getByText(
@@ -423,12 +381,8 @@ test.describe(
 
 			await test.step( 'Load cart page and try over limit coupon usage', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'no-sale-use-limit' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'no-sale-use-limit' );
 				// failed because this coupon code has been used too much
 				await expect(
 					page.getByText(
@@ -441,17 +395,9 @@ test.describe(
 
 			await test.step( 'Load checkout page and try over limit coupon usage', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'no-sale-use-limit' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'no-sale-use-limit' );
 				// failed because this coupon code has been used too much
 				await expect(
 					page.getByText(
@@ -471,12 +417,8 @@ test.describe(
 		} ) => {
 			await test.step( 'Load cart page and try included certain items coupon usage', async () => {
 				await addAProductToCart( page, secondProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// failed because this product is not included for coupon
 				await expect(
 					page.getByText(
@@ -489,17 +431,9 @@ test.describe(
 
 			await test.step( 'Load checkout page and try included certain items coupon usage', async () => {
 				await addAProductToCart( page, secondProductId );
-
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// failed because this product is not included for coupon
 				await expect(
 					page.getByText(
@@ -515,12 +449,8 @@ test.describe(
 		} ) => {
 			await test.step( 'Load cart page and try on certain products coupon usage', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// succeeded
 				await expect(
 					page.getByText( 'Coupon code applied successfully.' )
@@ -533,15 +463,8 @@ test.describe(
 				await addAProductToCart( page, firstProductId );
 
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// succeeded
 				await expect(
 					page.getByText( 'Coupon code applied successfully.' )
@@ -555,12 +478,8 @@ test.describe(
 		} ) => {
 			await test.step( 'Load cart page and try excluded items coupon usage', async () => {
 				await addAProductToCart( page, secondProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// failed because this product is excluded from coupon
 				await expect(
 					page.getByText(
@@ -573,17 +492,9 @@ test.describe(
 
 			await test.step( 'Load checkout page and try excluded items coupon usage', async () => {
 				await addAProductToCart( page, secondProductId );
-
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// failed because this product is excluded from coupon
 				await expect(
 					page.getByText(
@@ -599,12 +510,8 @@ test.describe(
 		} ) => {
 			await test.step( 'Load cart page and try coupon usage on other items', async () => {
 				await addAProductToCart( page, firstProductId );
-
 				await page.goto( '/cart/' );
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// succeeded
 				await expect(
 					page.getByText( 'Coupon code applied successfully.' )
@@ -617,15 +524,8 @@ test.describe(
 				await addAProductToCart( page, firstProductId );
 
 				await page.goto( '/checkout/' );
-				await page
-					.getByRole( 'link', {
-						name: 'Click here to enter your code',
-					} )
-					.click();
-				await page
-					.getByPlaceholder( 'Coupon code' )
-					.fill( 'product-and-category-included' );
-				await applyCoupon( page );
+				await expandCouponForm( page );
+				await applyCoupon( page, 'product-and-category-included' );
 				// succeeded
 				await expect(
 					page.getByText( 'Coupon code applied successfully.' )
@@ -637,12 +537,8 @@ test.describe(
 			page,
 		} ) => {
 			await addAProductToCart( page, firstProductId );
-
 			await page.goto( '/cart/' );
-			await page
-				.getByPlaceholder( 'Coupon code' )
-				.fill( 'email-restricted' );
-			await applyCoupon( page );
+			await applyCoupon( page, 'email-restricted' );
 			await expect(
 				page.getByText(
 					'Please enter a valid email at checkout to use coupon code "email-restricted".'
@@ -674,13 +570,8 @@ test.describe(
 				.first()
 				.fill( 'marge.simpson@example.org' );
 
-			await page
-				.getByRole( 'link', { name: 'Click here to enter your code' } )
-				.click();
-			await page
-				.getByPlaceholder( 'Coupon code' )
-				.fill( 'email-restricted' );
-			await applyCoupon( page );
+			await expandCouponForm( page );
+			await applyCoupon( page, 'email-restricted' );
 			await expect(
 				page.getByText(
 					'Please enter a valid email to use coupon code "email-restricted".'
@@ -720,13 +611,8 @@ test.describe(
 				.first()
 				.fill( 'homer@example.com' );
 
-			await page
-				.getByRole( 'link', { name: 'Click here to enter your code' } )
-				.click();
-			await page
-				.getByPlaceholder( 'Coupon code' )
-				.fill( 'email-restricted' );
-			await applyCoupon( page );
+			await expandCouponForm( page );
+			await applyCoupon( page, 'email-restricted' );
 			await expect(
 				page.getByText( 'Coupon code applied successfully.' )
 			).toBeVisible();
@@ -760,13 +646,8 @@ test.describe(
 				.first()
 				.fill( 'homer@example.com' );
 
-			await page
-				.getByRole( 'link', { name: 'Click here to enter your code' } )
-				.click();
-			await page
-				.getByPlaceholder( 'Coupon code' )
-				.fill( 'email-restricted' );
-			await applyCoupon( page );
+			await expandCouponForm( page );
+			await applyCoupon( page, 'email-restricted' );
 			await expect(
 				page.getByText( 'Coupon code applied successfully.' )
 			).toBeVisible();


### PR DESCRIPTION
### Submission Review Guidelines:

Another attempt to fix the flakiness of `cart-checkout-restricted-coupons.spec.js`. 
This was hard to fix because it's not reproducible locally, where all tests pass just fine in the first attempt.
I believe the issue was caused by the coupon form expanding animation. Clicking `Click here to enter your code` starts to expand the coupon form but that takes a few ms. Playwright is fast and start filling out the input and clicks the apply button before the animation is finished. The expected error message is displayed, but I believe it gets cleared once the animation completes.

![page@9e02356e282ba7f5efcaca5797323082-1725371273 905277](https://github.com/user-attachments/assets/16830e06-4ba9-4c14-8183-7da33f85810c)
![page@9e02356e282ba7f5efcaca5797323082-1725371273 925147](https://github.com/user-attachments/assets/4c6c4860-b6b1-4417-ad7b-57d4b1512827)
![page@9e02356e282ba7f5efcaca5797323082-1725371273 943686](https://github.com/user-attachments/assets/7602c560-d8a3-4975-b91b-25c549b158ba)


Closes https://github.com/woocommerce/woocommerce/issues/50928
Closes https://github.com/woocommerce/woocommerce/issues/50932
Closes https://github.com/woocommerce/woocommerce/issues/50933
Closes https://github.com/woocommerce/woocommerce/issues/50929
Closes https://github.com/woocommerce/woocommerce/issues/50931
Closes https://github.com/woocommerce/woocommerce/issues/50930


### How to test the changes in this Pull Request:

I ran the tests locally 60 times each (`--repeat-each=60`) and had a 100% pass rate.
I re-ran the job in CI [a few times](https://github.com/woocommerce/woocommerce/actions/runs/10689247104/job/29632464502) and they all passed on each run on the first attempt.

- CI green
- Run locally:
```
pnpm test:e2e cart-checkout-restricted-coupons.spec.js
```
