### PR TITLE
PTK: Check if theres a scheduled action before logging warning.

### DIFF
--- a/plugins/woocommerce/changelog/fix-register-ptk-patterns-warning-log
+++ b/plugins/woocommerce/changelog/fix-register-ptk-patterns-warning-log
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only log PTK error if no action has been scheduled

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -141,9 +141,12 @@ class BlockPatterns {
 
 		$patterns = $this->ptk_patterns_store->get_patterns();
 		if ( empty( $patterns ) ) {
-			wc_get_logger()->warning(
-				__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),
-			);
+			// Check if there's a scheduled 'fetch_patterns' action.
+			if ( ! as_has_scheduled_action( 'fetch_patterns' ) ) {
+				wc_get_logger()->warning(
+					__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),
+				);
+			}
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -141,7 +141,9 @@ class BlockPatterns {
 
 		$patterns = $this->ptk_patterns_store->get_patterns();
 		if ( empty( $patterns ) ) {
-			// Check if there's a scheduled 'fetch_patterns' action.
+			// By only logging when patterns are empty and no fetch is scheduled,
+			// we ensure that warnings are only generated in genuinely problematic situations,
+			// such as when the pattern fetching mechanism has failed entirely.
 			if ( ! as_has_scheduled_action( 'fetch_patterns' ) ) {
 				wc_get_logger()->warning(
 					__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The previous implementation would log a warning every time the patterns were empty, which could happen frequently due to the asynchronous nature of pattern fetching. This led to:

1. Unnecessary noise in log files
2. Potential performance impact from excessive logging
3. Confusion for users and developers trying to diagnose issues

By only logging when patterns are empty and no fetch is scheduled, we ensure that warnings are only generated in genuinely problematic situations, such as when the pattern fetching mechanism has failed entirely.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Before checking out this branch:**

1. Delete transient `ptk_patterns`
2. Load your homepage
3. Check that the log is present in your log file

**After checking out this branch:**

1. Delete transient `ptk_patterns`
2. Load your homepage
3. Check that the log is not present in your log file

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
