### PR TITLE
[Experimental] Product filters > Attributes loading state in editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -13,7 +13,7 @@ import {
 } from '@woocommerce/types';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Disabled, Notice, withSpokenMessages } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -111,6 +111,20 @@ const Edit = ( props: EditProps ) => {
 		</div>
 	);
 
+	const loadingState = useMemo( () => {
+		return [ ...Array( 5 ) ].map( ( x, i ) => (
+			<li
+				key={ i }
+				style={ {
+					/* stylelint-disable */
+					width: Math.floor( Math.random() * ( 100 - 25 ) ) + '%',
+				} }
+			>
+				&nbsp;
+			</li>
+		) );
+	}, [] );
+
 	if ( isPreview ) {
 		return (
 			<Wrapper>
@@ -153,22 +167,7 @@ const Edit = ( props: EditProps ) => {
 		return (
 			<Wrapper>
 				<ul className="is-loading wp-block-woocommerce-product-filter-attribute__loading">
-					{ [ ...Array( 5 ) ].map( ( x, i ) => {
-						return (
-							<li
-								key={ i }
-								style={ {
-									/* stylelint-disable */
-									width:
-										Math.floor(
-											Math.random() * ( 100 - 25 )
-										) + '%',
-								} }
-							>
-								&nbsp;
-							</li>
-						);
-					} ) }
+					{ loadingState }
 				</ul>
 			</Wrapper>
 		);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -27,6 +27,7 @@ import { attributeOptionsPreview } from './constants';
 import './style.scss';
 import { EditProps, isAttributeCounts } from './types';
 import { getAttributeFromId } from './utils';
+import './editor.scss';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
@@ -49,22 +50,26 @@ const Edit = ( props: EditProps ) => {
 		AttributeTerm[]
 	>( [] );
 
-	const { results: attributeTerms } = useCollection< AttributeTerm >( {
-		namespace: '/wc/store/v1',
-		resourceName: 'products/attributes/terms',
-		resourceValues: [ attributeObject?.id || 0 ],
-		shouldSelect: !! attributeObject?.id,
-		query: { orderby: 'menu_order', hide_empty: hideEmpty },
-	} );
+	const { results: attributeTerms, isLoading: isTermsLoading } =
+		useCollection< AttributeTerm >( {
+			namespace: '/wc/store/v1',
+			resourceName: 'products/attributes/terms',
+			resourceValues: [ attributeObject?.id || 0 ],
+			shouldSelect: !! attributeObject?.id,
+			query: { orderby: 'menu_order', hide_empty: hideEmpty },
+		} );
 
-	const { results: filteredCounts } = useCollectionData( {
-		queryAttribute: {
-			taxonomy: attributeObject?.taxonomy || '',
-			queryType,
-		},
-		queryState: {},
-		isEditor: true,
-	} );
+	const { results: filteredCounts, isLoading: isCountsLoading } =
+		useCollectionData( {
+			queryAttribute: {
+				taxonomy: attributeObject?.taxonomy || '',
+				queryType,
+			},
+			queryState: {},
+			isEditor: true,
+		} );
+
+	const isLoading = isTermsLoading || isCountsLoading;
 
 	useEffect( () => {
 		const termIdHasProducts =
@@ -144,7 +149,31 @@ const Edit = ( props: EditProps ) => {
 			</Wrapper>
 		);
 
-	if ( attributeOptions.length === 0 )
+	if ( isLoading )
+		return (
+			<Wrapper>
+				<ul className="is-loading wp-block-woocommerce-product-filter-attribute__loading">
+					{ [ ...Array( 5 ) ].map( ( x, i ) => {
+						return (
+							<li
+								key={ i }
+								style={ {
+									/* stylelint-disable */
+									width:
+										Math.floor(
+											Math.random() * ( 100 - 25 )
+										) + '%',
+								} }
+							>
+								&nbsp;
+							</li>
+						);
+					} ) }
+				</ul>
+			</Wrapper>
+		);
+
+	if ( attributeTerms.length === 0 )
 		return (
 			<Wrapper>
 				<Notice status="warning" isDismissible={ false }>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/editor.scss
@@ -1,0 +1,8 @@
+.wp-block-woocommerce-product-filter-attribute__loading {
+	padding: 0;
+
+	li {
+		@include placeholder();
+		margin: 5px 0;
+	}
+}

--- a/plugins/woocommerce/changelog/51151-product-filters-attributes-loading-state
+++ b/plugins/woocommerce/changelog/51151-product-filters-attributes-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Product filters: add loading state for attributes filter
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50150

This PR adds a loading state when attributes' terms are loading. This is so that during loading (when network is slow), the user can visually see a loading representation of the state. I have modeled this the same as the rating block to be consistent.

![Google Chrome - Product Filters (Experimental) ‹ Template part ‹ woo-blocks-dev ‹ Editor — WordPress 2024-09-04 at 7 22 35 AM](https://github.com/user-attachments/assets/9012590d-3227-4e7e-9723-b4681b05b836)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Test by developers only**

**Prereq:**

Ensure you have the WC Beta Tester Plugin installed and go to Tools > WCA Test Helper > Features. Toggle on the experimental-blocks option.

1. Go to the editor and navigate to Patterns->General template parts->Product Filters (Experimental).
2. Using the browser's console, throttle your network to a slower setting.
3. Refresh the page and you should see the initial loading state of the attributes before the terms are populated.
4. Click on the filter options, change the attribute to another term and ensure you also see the pulsing loading state.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Product filters: add loading state for attributes filter
</details>
