### PR TITLE
Deprecate single product block save

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/deprecated.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/deprecated.tsx
@@ -3,7 +3,13 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
 const v1 = {
+	attributes: metadata.attributes,
 	save: () => {
 		const blockProps = useBlockProps.save();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/deprecated.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/deprecated.tsx
@@ -10,6 +10,7 @@ import metadata from './block.json';
 
 const v1 = {
 	attributes: metadata.attributes,
+	supports: metadata.supports,
 	save: () => {
 		const blockProps = useBlockProps.save();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/deprecated.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/deprecated.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+const v1 = {
+	save: () => {
+		const blockProps = useBlockProps.save();
+
+		return (
+			<div { ...blockProps }>
+				{ /* @ts-expect-error: `InnerBlocks.Content` is a component that is typed in WordPress core*/ }
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+};
+
+const deprecated = [ v1 ];
+
+export default deprecated;

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/index.tsx
@@ -10,10 +10,12 @@ import { BLOCK_ICON } from './constants';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import deprecated from './deprecated';
 
 // @ts-expect-error: `registerBlockType` is a function that is typed in WordPress core.
 registerBlockType( metadata, {
 	icon: BLOCK_ICON,
 	edit,
 	save,
+	deprecated,
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/save.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/save.tsx
@@ -4,6 +4,7 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const Save = () => {
+	// We add the `woocommerce` class to the wrapper to apply WooCommerce styles to the block.
 	const blockProps = useBlockProps.save( {
 		className: 'woocommerce',
 	} );

--- a/plugins/woocommerce/changelog/fix-deprectated_single_product_block_save
+++ b/plugins/woocommerce/changelog/fix-deprectated_single_product_block_save
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Deprecate single product block save #51153

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -1699,7 +1699,10 @@ p.demo_store,
  * Buttons
  */
 .woocommerce:where(body:not(.woocommerce-block-theme-has-button-styles)),
-:where(body:not(.woocommerce-block-theme-has-button-styles)) .woocommerce {
+:where(body:not(.woocommerce-block-theme-has-button-styles)):where(
+		:not(.edit-post-visual-editor *)
+	)
+	.woocommerce {
 	a.button,
 	button.button,
 	input.button,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an error introduced in PR #51023. We changed the static block `Single Product` without using the deprecation API. As a result, an error was displayed. There is a GH discussion [here](https://github.com/woocommerce/woocommerce/discussions/51098), to continue analyzing a solution for the WooCommerce pages styles problem.

![image](https://github.com/user-attachments/assets/5e49c2c7-131a-404e-b012-f8e331099fe2)

This PR also includes a minor fix to prevent applying some WooCommerce styles to the editor button inside the `Single Product` block.

**Before** (note that the `Add to cart` button is violet, but it shouldn't have that color)

![Screenshot 2024-09-04 at 11 23 14 AM](https://github.com/user-attachments/assets/1e822aa3-3d0a-45ad-9d92-0961120195bb)

**After** (after this PR the button looks correct)

![Screenshot 2024-09-04 at 11 21 25 AM](https://github.com/user-attachments/assets/1f6c781c-d613-49a1-aff4-33a8f80672a1)

 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Add New and create a variable product with a few variations.
2. Checkout a commit older than [3def186](https://github.com/woocommerce/woocommerce/commit/3def18623e9b2a8df170000f6f3dbfb07b8caab7), for instance: `dec89a13111f5c8cf2bc6864677b63453bc0ef35`.
Run the following command in your terminal:
```
git checkout dec89a13111f5c8cf2bc6864677b63453bc0ef35
```
3. Build the project and go to Pages > Add New Page
4. Add a `Single Product` block and select the variable product you just created (do not select a variation, because we want to see the select used to change from one variation to another).

![Screenshot 2024-09-04 at 11 40 38 AM](https://github.com/user-attachments/assets/f8a6ef9e-30f7-47cd-ae67-969cdccc8dbc)

5. Save the page.
6. Checkout `trunk` and rebuild the project.
7. You will see an error because the block is not passing the validation since the block changed [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/assets/js/blocks/single-product/save.tsx#L7-L9).

![Screenshot 2024-09-04 at 11 44 28 AM](https://github.com/user-attachments/assets/55650ec6-a3d7-46b9-8411-db1f9ce7373c)

8. Now add another `Single Product` block to the page. Select the same variable product you created in step 1.
9. Update your page and view it.
10. You will notice the first product has the selector's styles broken and the second one appears fine. That happens because the second one has the class `woocommerce` that fixes the selector styles.

![Screenshot 2024-09-04 at 11 51 59 AM](https://github.com/user-attachments/assets/8fd1274d-527e-4688-8a28-7c0ede4b70ef)

11. Now checkout this branch and build the project.
```
git checkout fix/deprectated_single_product_block_save
```
12. Go back to the post editor and refresh it.
13. You won't see the error mentioned in step 7 anymore.

This PR fixes the validation error and a styling bug. To reproduce the bug you will have to: 

14. Checkout the old commit again and build your project using the following command:
```
git checkout dec89a13111f5c8cf2bc6864677b63453bc0ef35
```
15. Refresh the page editor you were editing.
16. The `Add to cart` button is now violet (the button styles should be different).

![Screenshot 2024-09-04 at 11 23 14 AM](https://github.com/user-attachments/assets/1e822aa3-3d0a-45ad-9d92-0961120195bb)

17. After checking out this branch and rebuilding the project, the styling bug shouldn't be there anymore.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
