### PR TITLE
Hide site visibility badge when "Launch Your Store" feature is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-site-visibility-badge
+++ b/plugins/woocommerce/changelog/fix-site-visibility-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Put site visibility badge behind the launch your store feature flag

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ComingSoon;
 
+use Automattic\WooCommerce\Admin\Features\Features;
+
 /**
  * Adds hooks to add a badge to the WordPress admin bar showing site visibility.
  */
@@ -27,6 +29,11 @@ class ComingSoonAdminBarBadge {
 	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
+		// Early exit if LYS feature is disabled.
+		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+			return;
+		}
+
 		$labels = array(
 			'coming-soon'       => __( 'Coming soon', 'woocommerce' ),
 			'store-coming-soon' => __( 'Store coming soon', 'woocommerce' ),
@@ -60,6 +67,11 @@ class ComingSoonAdminBarBadge {
 	 * @internal
 	 */
 	public function output_css() {
+		// Early exit if LYS feature is disabled.
+		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+			return;
+		}
+
 		if ( is_admin_bar_showing() ) {
 			echo '<style>
 				#wpadminbar .quicklinks #wp-admin-bar-woocommerce-site-visibility-badge {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The site visibility badge is displayed even when the "Launch Your Store" feature is disabled. This PR puts the badge behind the feature flag.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch.
2. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` > Features
3. Confirm that site visibility badge is displayed when "Launch Your Store" feature is enabled.
4. Turn off the "Launch Your Store" feature.
5. Confirm that site visibility badge is not displayed.
6. Right-click on page and view Page source to confirm that `#wpadminbar .quicklinks #wp-admin-bar-woocommerce-site-visibility-badge` CSS is not present.

<img width="1147" alt="Screenshot 2024-09-05 at 11 56 09" src="https://github.com/user-attachments/assets/364e7e9b-5973-4420-a469-3e5879e065a2">

<img width="1146" alt="Screenshot 2024-09-05 at 11 56 54" src="https://github.com/user-attachments/assets/2d58c234-4bc9-4ac2-b1f7-7d0e0c327083">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
