### PR TITLE
Only run "woocommerce_admin_shared_settings" filter on admin requests

### DIFF
--- a/plugins/woocommerce/changelog/perf-only-load-settings-in-admin
+++ b/plugins/woocommerce/changelog/perf-only-load-settings-in-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Only run woocommerce_admin_shared_settings filter on admin requests

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php
@@ -54,14 +54,18 @@ class WCAdminSharedSettings {
 	 * @return void
 	 */
 	public function on_woocommerce_blocks_loaded() {
+		// Ensure we only add admin settings on the admin.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		if ( class_exists( '\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry' ) ) {
 			\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )->add(
 				$this->settings_prefix,
-				function() {
+				function () {
 					return apply_filters( 'woocommerce_admin_shared_settings', array() );
 				}
 			);
 		}
 	}
 }
-


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/50773

This PR partially addresses the issue reported in https://github.com/woocommerce/woocommerce/issues/50714#issuecomment-2313703493. We're running `woocommerce_admin_shared_settings` filter on frontend as well, which is not needed. The filter is used to add settings to the shared settings array, which is then used to enqueue the `window.wcSettings.admin` settings object. This object is only used in the admin, so we should only run the filter on the admin.

We've already check if it's the admin page in many places where the filter is used, but we missed some places such as task list.

![Screenshot 2024-09-05 at 13 28 47](https://github.com/user-attachments/assets/a91bc74e-49c1-4d24-a71f-7a9675e7e29b)


This PR adds a check to ensure that the filter is only run on the admin so we will not mistakenly add settings to the shared settings array on the frontend.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch
2. Open browser console
3. Go to any WooCommerce admin page
4. Run `window.wcSettings.admin` in the console and confirm that the settings object is present
5. Smoke test the admin pages to ensure that nothing is broken
6. Go to the frontend
7. Run `window.wcSettings.admin` in the console and confirm that the settings object is undefined

![Screenshot 2024-09-05 at 13 37 00](https://github.com/user-attachments/assets/4a8fdba9-27e6-4d20-bb35-a704f3044dc6)


![Screenshot 2024-09-05 at 13 31 36](https://github.com/user-attachments/assets/ba74b51a-9bd5-4caa-8f01-a1297ba17752)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
