### PR TITLE
[remote-specs-validation] Fix `base_location_state` and `base_location_country` value type

### DIFF
--- a/packages/php/remote-specs-validation/bundles/obw-free-extensions.json
+++ b/packages/php/remote-specs-validation/bundles/obw-free-extensions.json
@@ -195,7 +195,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },
@@ -217,7 +220,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },

--- a/packages/php/remote-specs-validation/bundles/payment-gateway-suggestions.json
+++ b/packages/php/remote-specs-validation/bundles/payment-gateway-suggestions.json
@@ -179,7 +179,10 @@
                           "$ref": "#/definitions/operations"
                         },
                         "value": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "array"
+                          ]
                         }
                       }
                     },
@@ -201,7 +204,10 @@
                           "$ref": "#/definitions/operations"
                         },
                         "value": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "array"
+                          ]
                         }
                       }
                     },
@@ -864,7 +870,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },
@@ -886,7 +895,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },

--- a/packages/php/remote-specs-validation/bundles/remote-inbox-notification.json
+++ b/packages/php/remote-specs-validation/bundles/remote-inbox-notification.json
@@ -283,7 +283,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },
@@ -305,7 +308,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },

--- a/packages/php/remote-specs-validation/bundles/shipping-partner-suggestions.json
+++ b/packages/php/remote-specs-validation/bundles/shipping-partner-suggestions.json
@@ -173,7 +173,10 @@
                           "$ref": "#/definitions/operations"
                         },
                         "value": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "array"
+                          ]
                         }
                       }
                     },
@@ -195,7 +198,10 @@
                           "$ref": "#/definitions/operations"
                         },
                         "value": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "array"
+                          ]
                         }
                       }
                     },
@@ -847,7 +853,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },
@@ -869,7 +878,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },

--- a/packages/php/remote-specs-validation/bundles/wc-pay-promotions.json
+++ b/packages/php/remote-specs-validation/bundles/wc-pay-promotions.json
@@ -176,7 +176,10 @@
                           "$ref": "#/definitions/operations"
                         },
                         "value": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "array"
+                          ]
                         }
                       }
                     },
@@ -198,7 +201,10 @@
                           "$ref": "#/definitions/operations"
                         },
                         "value": {
-                          "type": "string"
+                          "type": [
+                            "string",
+                            "array"
+                          ]
                         }
                       }
                     },
@@ -844,7 +850,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },
@@ -866,7 +875,10 @@
               "$ref": "#/definitions/operations"
             },
             "value": {
-              "type": "string"
+              "type": [
+                "string",
+                "array"
+              ]
             }
           }
         },

--- a/packages/php/remote-specs-validation/changelog/fix-remote-spec-schema
+++ b/packages/php/remote-specs-validation/changelog/fix-remote-spec-schema
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix base_location_state and base_location_country value type

--- a/packages/php/remote-specs-validation/schemas/shared/rules/base_location_country.json
+++ b/packages/php/remote-specs-validation/schemas/shared/rules/base_location_country.json
@@ -10,7 +10,10 @@
 			"$ref": "#/definitions/operations"
 		},
 		"value": {
-			"type": "string"
+			"type": [
+				"string",
+				"array"
+			]
 		}
 	}
 }

--- a/packages/php/remote-specs-validation/schemas/shared/rules/base_location_state.json
+++ b/packages/php/remote-specs-validation/schemas/shared/rules/base_location_state.json
@@ -10,7 +10,10 @@
 			"$ref": "#/definitions/operations"
 		},
 		"value": {
-			"type": "string"
+			"type": [
+				"string",
+				"array"
+			]
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `base_location_state` and `base_location_country` type support `in` and `!in` operators so they should be updated to support an array of values. It's causing integration tests to fail in https://github.com/Automattic/woocommerce.com/pull/21642.

This PR updates the value type of `base_location_state` and `base_location_country` to allow the array of values to fix the issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open `packages/php/remote-specs-validation/bundles/shipping-partner-suggestions.json` and copy the content.
2. Open [https://www.jsonschemavalidator.net/ ](https://www.jsonschemavalidator.net/)and paste the schema on the left panel.

```json
[{
    "id": "easyship-woocommerce-shipping-rates",
    "name": "Easyship",
    "slug": "easyship-woocommerce-shipping-rates",
    "description": "",
    "learn_more_link": "https://woocommerce.com/products/easyship-shipping-rates/",
    "is_visible": [
        {
            "type": "base_location_country",
            "operation": "in",
            "value": [
                "SG",
                "HK",
                "AU",
                "NZ"
            ]
        }
    ],
    "available_layouts": []
}]
```

4. Paste the content above on the right panel.
5. Validation should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>