### PR TITLE
Change event to document.body for dynamically added elements

### DIFF
--- a/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
+++ b/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Not needed as it doesn't change how woocommerce is working or is used.
+

--- a/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
+++ b/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
@@ -1,4 +1,5 @@
-Significance: patch
-Type: tweak
-Comment: Not needed as it doesn't change how woocommerce is working or is used.
+Significance: minor
+Type: update
+
+Make the scripts that initialize the meta boxes on the Edit Order screen accessible to third parties
 

--- a/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
+++ b/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
@@ -1,5 +1,4 @@
-Significance: minor
-Type: update
-
-Make the scripts that initialize the meta boxes on the Edit Order screen accessible to third parties
+Significance: patch
+Type: tweak
+Comment: Not needed as it doesn't change how woocommerce is working or is used.
 

--- a/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
+++ b/plugins/woocommerce/changelog/51185-JQUERY_ON_DOCUMENT
@@ -1,4 +1,4 @@
-Significance: patch
-Type: tweak
-Comment: Not needed as it doesn't change how woocommerce is working or is used.
+Significance: minor
+Type: enhancement
 
+Make the scripts that initialize the meta boxes on the Edit Order screen accessible to third parties

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -25,14 +25,14 @@ jQuery( function ( $ ) {
 			$( '.js_field-country' ).selectWoo().on( 'change', this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
-			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
+			$( document.body ).on( 'click', '#woocommerce-order-actions input, #woocommerce-order-actions a', function() {
 				window.onbeforeunload = '';
 			});
-			$( 'a.edit_address' ).on( 'click', this.edit_address );
-			$( 'a.billing-same-as-shipping' ).on( 'click', this.copy_billing_to_shipping );
-			$( 'a.load_customer_billing' ).on( 'click', this.load_billing );
-			$( 'a.load_customer_shipping' ).on( 'click', this.load_shipping );
-			$( '#customer_user' ).on( 'change', this.change_customer_user );
+			$( document.body ).on( 'click', 'a.edit_address', this.edit_address );
+			$( document.body ).on( 'click', 'a.billing-same-as-shipping', this.copy_billing_to_shipping );
+			$( document.body ).on( 'click', 'a.load_customer_billing', this.load_billing );
+			$( document.body ).on( 'click', 'a.load_customer_shipping', this.load_shipping );
+			$( document.body ).on( 'change', '#customer_user', this.change_customer_user );
 		},
 
 		change_country: function( e, stickValue ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -25,14 +25,14 @@ jQuery( function ( $ ) {
 			$( '.js_field-country' ).selectWoo().on( 'change', this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
-			$( document.body ).on( 'click', '#woocommerce-order-actions input, #woocommerce-order-actions a', function() {
+			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
 				window.onbeforeunload = '';
 			});
-			$( document.body ).on( 'click', 'a.edit_address', this.edit_address );
-			$( document.body ).on( 'click', 'a.billing-same-as-shipping', this.copy_billing_to_shipping );
-			$( document.body ).on( 'click', 'a.load_customer_billing', this.load_billing );
-			$( document.body ).on( 'click', 'a.load_customer_shipping', this.load_shipping );
-			$( document.body ).on( 'change', '#customer_user', this.change_customer_user );
+			$( 'a.edit_address' ).on( 'click', this.edit_address );
+			$( 'a.billing-same-as-shipping' ).on( 'click', this.copy_billing_to_shipping );
+			$( 'a.load_customer_billing' ).on( 'click', this.load_billing );
+			$( 'a.load_customer_shipping' ).on( 'click', this.load_shipping );
+			$( '#customer_user' ).on( 'change', this.change_customer_user );
 		},
 
 		change_country: function( e, stickValue ) {
@@ -1599,4 +1599,13 @@ jQuery( function ( $ ) {
 	wc_meta_boxes_order_notes.init();
 	wc_meta_boxes_order_downloads.init();
 	wc_meta_boxes_order_custom_meta.init();
+
+	// this allows third party plugin to call woocommerce function
+	window.wcOrderMetaBoxes = {
+		wc_meta_boxes_order: wc_meta_boxes_order,
+		wc_meta_boxes_order_items: wc_meta_boxes_order_items,
+		wc_meta_boxes_order_notes: wc_meta_boxes_order_notes,
+		wc_meta_boxes_order_downloads: wc_meta_boxes_order_downloads,
+		wc_meta_boxes_order_custom_meta: wc_meta_boxes_order_custom_meta,
+	};
 });


### PR DESCRIPTION
Change event to document.body to allow third party plugin to add, remove, update elements. Because this approach works for dynamically added elements.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

These changes allow a third party plugin to modify the content of the order details in javascript without having to "recall" all the javascript event linked to these elements.

Even in the future if WooCommerce starts to modify the content of `#woocommerce-order-data` this will be needed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Before checking out this branch, verify the current behavior in trunk.
1. Install this snippet in your test site: https://gist.github.com/Lenny4/448cc3894b940d3877f02754a9893cdf
2. In WP Admin, navigate to the screen to add a new order. You'll see two buttons at the top of the screen added by the snippet.
3. Click the pencil icon to edit the Billing Address for the order. It should expand to a set of fields. Then click the first "Run Test" button at the top of the screen. This will regenerate the Billing Address section, so the fields are collapsed again. Now if you click the pencil icon again, nothing will happen, because the set of fields is no longer initialized.
4. Try the same with the second "Run Test" button, and you will get the same result.
5. Now check out this branch. You may need to rebuild the admin scripts with `pnpm --filter='@woocommerce/plugin-woocommerce' build`
6. Do the same procedure with the pencil icon and the two "Run Test" buttons. The first button should still result in an unresponsive pencil icon. But the second button should result in being able to re-expand the set of billing address fields.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

Make the scripts that initialize the meta boxes on the Edit Order screen accessible to third parties

</details>
