### PR TITLE
Fix fatal when adding the Product Gallery (Beta) block into a pattern

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
 import ErrorPlaceholder, {
 	ErrorObject,
 } from '@woocommerce/editor-components/error-placeholder';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,7 +25,6 @@ import {
 } from './utils';
 import { ProductGalleryBlockSettings } from './block-settings/index';
 import type { ProductGalleryAttributes } from './types';
-import { __ } from '@wordpress/i18n';
 
 const TEMPLATE: InnerBlockTemplate[] = [
 	[
@@ -136,7 +136,8 @@ export const Edit = ( {
 
 	useEffect( () => {
 		const mode = getMode( currentTemplateId, templateType );
-		const newProductGalleryClientId = attributes.productGalleryClientId || clientId;
+		const newProductGalleryClientId =
+			attributes.productGalleryClientId || clientId;
 
 		setAttributes( {
 			...attributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
@@ -10,6 +10,9 @@ import {
 import { BlockEditProps, InnerBlockTemplate } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import ErrorPlaceholder, {
+	ErrorObject,
+} from '@woocommerce/editor-components/error-placeholder';
 
 /**
  * Internal dependencies
@@ -21,6 +24,7 @@ import {
 } from './utils';
 import { ProductGalleryBlockSettings } from './block-settings/index';
 import type { ProductGalleryAttributes } from './types';
+import { __ } from '@wordpress/i18n';
 
 const TEMPLATE: InnerBlockTemplate[] = [
 	[
@@ -132,14 +136,15 @@ export const Edit = ( {
 
 	useEffect( () => {
 		const mode = getMode( currentTemplateId, templateType );
+		const newProductGalleryClientId = attributes.productGalleryClientId || clientId;
 
 		setAttributes( {
 			...attributes,
 			mode,
-			productGalleryClientId: clientId,
+			productGalleryClientId: newProductGalleryClientId,
 		} );
 		// Move the Thumbnails block to the correct above or below the Large Image based on the thumbnailsPosition attribute.
-		moveInnerBlocksToPosition( attributes, clientId );
+		moveInnerBlocksToPosition( attributes, newProductGalleryClientId );
 	}, [
 		setAttributes,
 		attributes,
@@ -147,6 +152,18 @@ export const Edit = ( {
 		currentTemplateId,
 		templateType,
 	] );
+
+	if ( attributes.productGalleryClientId !== clientId ) {
+		const error = {
+			message: __(
+				'productGalleryClientId and clientId codes mismatch.',
+				'woocommerce'
+			),
+			type: 'general',
+		} as ErrorObject;
+
+		return <ErrorPlaceholder error={ error } isLoading={ false } />;
+	}
 
 	return (
 		<div { ...blockProps }>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
@@ -136,10 +136,10 @@ export const moveInnerBlocksToPosition = (
 ): void => {
 	const { getBlock, getBlockRootClientId, getBlockIndex } =
 		select( 'core/block-editor' );
-	const { moveBlockToPosition } = dispatch( 'core/block-editor' );
 	const productGalleryBlock = getBlock( clientId );
 
-	if ( productGalleryBlock ) {
+	if ( productGalleryBlock?.name === "woocommerce/product-gallery" ) {
+		const { moveBlockToPosition } = dispatch( 'core/block-editor' );
 		const previousLayout = productGalleryBlock.innerBlocks.length
 			? productGalleryBlock.innerBlocks[ 0 ].attributes.layout
 			: null;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
@@ -138,7 +138,7 @@ export const moveInnerBlocksToPosition = (
 		select( 'core/block-editor' );
 	const productGalleryBlock = getBlock( clientId );
 
-	if ( productGalleryBlock?.name === "woocommerce/product-gallery" ) {
+	if ( productGalleryBlock?.name === 'woocommerce/product-gallery' ) {
 		const { moveBlockToPosition } = dispatch( 'core/block-editor' );
 		const previousLayout = productGalleryBlock.innerBlocks.length
 			? productGalleryBlock.innerBlocks[ 0 ].attributes.layout

--- a/plugins/woocommerce/changelog/fix-51154-product-gallery-fatal
+++ b/plugins/woocommerce/changelog/fix-51154-product-gallery-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix error when adding the Product Gallery (Beta) block into a pattern

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -110,11 +110,14 @@ class ProductGallery extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$post_id                = $block->context['postId'] ?? '';
+		$post_id = $block->context['postId'] ?? '';
+		$product = wc_get_product( $post_id );
+		if ( ! $product instanceof \WC_Product ) {
+			return '';
+		}
+
 		$product_gallery_images = ProductGalleryUtils::get_product_gallery_images( $post_id, 'thumbnail', array() );
 		$classname_single_image = '';
-		// This is a temporary solution. We have to refactor this code when the block will have to be addable on every page/post https://github.com/woocommerce/woocommerce-blocks/issues/10882.
-		global $product;
 
 		if ( count( $product_gallery_images ) < 2 ) {
 			// The gallery consists of a single image.
@@ -124,8 +127,6 @@ class ProductGallery extends AbstractBlock {
 		$number_of_thumbnails           = $block->attributes['thumbnailsNumberOfThumbnails'] ?? 0;
 		$classname                      = $attributes['className'] ?? '';
 		$dialog                         = isset( $attributes['mode'] ) && 'full' !== $attributes['mode'] ? $this->render_dialog() : '';
-		$post_id                        = $block->context['postId'] ?? '';
-		$product                        = wc_get_product( $post_id );
 		$product_gallery_first_image    = ProductGalleryUtils::get_product_gallery_image_ids( $product, 1 );
 		$product_gallery_first_image_id = reset( $product_gallery_first_image );
 		$product_id                     = strval( $product->get_id() );

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -26,7 +26,7 @@ class ProductGalleryUtils {
 		$product_gallery_images = array();
 		$product                = wc_get_product( $post_id );
 
-		if ( $product ) {
+		if ( $product instanceof \WC_Product ) {
 			$all_product_gallery_image_ids = self::get_product_gallery_image_ids( $product );
 
 			if ( 'full' === $size || 'full' !== $size && count( $all_product_gallery_image_ids ) > 1 ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

* Fixes a fatal when adding the Product Gallery (Beta) block into a pattern (see https://github.com/woocommerce/woocommerce/issues/51154).
* Shows a user-friendly error in the editor when the `clientId` and `productGalleryClientId` are not the same, fixing https://github.com/woocommerce/woocommerce/issues/51175.

Closes #51154.
Closes #51175.

### How to test the changes in this Pull Request:


1. Go to Appearance > Editor > Patterns > Add New Pattern. Give a name to it an click on _Add_.
2. Open the inserter and search for _gallery_.
3. Add the Product Gallery (Beta) block to the pattern:

![imatge](https://github.com/user-attachments/assets/2ac637c1-b1ad-4e3e-879f-7f0d3c46e168)

4. Save the pattern and verify there was no error when saving.
5. Go to Appearance > Editor > Templates and edit the Single Product template.
6. Add the pattern you just created.
7. Verify a nice error box appears instead of the editor completely hanging.

![image](https://github.com/user-attachments/assets/b0811229-aaea-497c-a83a-b893dc1017fb)