### PR TITLE
[e2e tests] Fix flakiness in page publishing action

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-page-publish-flakiness
+++ b/plugins/woocommerce/changelog/e2e-fix-page-publish-flakiness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix flakiness in page publishing action

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
@@ -77,7 +77,7 @@ exports.test = base.test.extend( {
 	testPostTitlePrefix: [ '', { option: true } ],
 
 	testPost: async ( { wpApi, testPostTitlePrefix }, use ) => {
-		const postTitle = `${ testPostTitlePrefix } Post ${ random() }`;
+		const postTitle = `${ testPostTitlePrefix } Post ${ random() }`.trim();
 		const postSlug = postTitle.replace( / /gi, '-' ).toLowerCase();
 
 		await use( { title: postTitle, slug: postSlug } );

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
@@ -48,7 +48,7 @@ exports.test = base.test.extend( {
 	testPageTitlePrefix: [ '', { option: true } ],
 
 	testPage: async ( { wpApi, testPageTitlePrefix }, use ) => {
-		const pageTitle = `${ testPageTitlePrefix } Page ${ random() }`;
+		const pageTitle = `${ testPageTitlePrefix } Page ${ random() }`.trim();
 		const pageSlug = pageTitle.replace( / /gi, '-' ).toLowerCase();
 
 		await use( { title: pageTitle, slug: pageSlug } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
@@ -23,17 +23,20 @@ test.describe(
 
 			await fillPageTitle( page, testPage.title );
 
+			await page.pause();
 			const canvas = await getCanvas( page );
 
 			await canvas
 				.getByRole( 'button', { name: 'Add default block' } )
 				.click();
 
+			await page.pause();
 			await canvas
 				.getByRole( 'document', {
 					name: 'Empty block; start writing or type forward slash to choose a block',
 				} )
 				.fill( 'Test Page' );
+			await page.pause();
 
 			await publishPage( page, testPage.title );
 		} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
@@ -18,25 +18,20 @@ test.describe(
 		// eslint-disable-next-line playwright/expect-expect
 		test( 'can create new page', async ( { page, testPage } ) => {
 			await goToPageEditor( { page } );
-
 			await closeChoosePatternModal( { page } );
-
 			await fillPageTitle( page, testPage.title );
 
-			await page.pause();
 			const canvas = await getCanvas( page );
 
 			await canvas
 				.getByRole( 'button', { name: 'Add default block' } )
 				.click();
 
-			await page.pause();
 			await canvas
 				.getByRole( 'document', {
 					name: 'Empty block; start writing or type forward slash to choose a block',
 				} )
 				.fill( 'Test Page' );
-			await page.pause();
 
 			await publishPage( page, testPage.title );
 		} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -31,7 +31,7 @@ test.describe(
 				} )
 				.fill( 'Test Post' );
 
-			await publishPage( page, testPost.title );
+			await publishPage( page, testPost.title, true );
 		} );
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -129,14 +129,14 @@ const transformIntoBlocks = async ( page ) => {
 	);
 };
 
-const publishPage = async ( page, pageTitle ) => {
+const publishPage = async ( page, pageTitle, isPost = false ) => {
 	await page
 		.getByRole( 'button', { name: 'Publish', exact: true } )
 		.dispatchEvent( 'click' );
 
-	const createPageResponse = page.waitForResponse(
-		( response ) =>
-			response.url().includes( '/pages' ) &&
+	const createPageResponse = page.waitForResponse( ( response ) => {
+		return (
+			response.url().includes( isPost ? '/posts/' : '/pages/' ) &&
 			response.ok() &&
 			response.request().method() === 'POST' &&
 			response
@@ -146,7 +146,8 @@ const publishPage = async ( page, pageTitle ) => {
 						json.title.rendered === pageTitle &&
 						json.status === 'publish'
 				)
-	);
+		);
+	} );
 
 	await page
 		.getByRole( 'region', { name: 'Editor publish' } )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes flakiness in the publishPage method. This mostly occurs when WooCommerce PayPal Payments is installed. After adding a cart block the tests proceed to publish the page and checks for the message `<Page title> is live`. But the PayPal setting panel sometimes interferes, and even though the page was successfully published the expected message is dismissed by the PayPal setting panel. 

The tricky part here was to find a solution that works for all cases, all environments and is fast enough without checking for installed plugins or panels that may or may not appear.

I opted to check for the API response to validate the page was published instead of checking the UI. I think this is fine because it's not really a WooCommerce flow anyway, and we can skip using the UI in this case.

Closes https://github.com/woocommerce/woocommerce/issues/51026
Closes https://github.com/woocommerce/woocommerce/issues/50735
Closes https://github.com/woocommerce/woocommerce/issues/50330
Closes https://github.com/woocommerce/woocommerce/issues/50326
Closes https://github.com/woocommerce/woocommerce/issues/50325

### How to test the changes in this Pull Request:

The affected specs are:

```
merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js shopper/cart-block-calculate-shipping.spec.js shopper/cart-block-coupons.spec.js shopper/cart-block.spec.js shopper/cart-checkout-block-calculate-tax.spec.js shopper/checkout-block-coupons.spec.js shopper/checkout-block.spec.js shopper/hop-products-filter-by-price.spec.js
```

- Check CI - it should be green
- Run the affected specs with multiple environments, multiple times:

Basic setup
```
pnpm test:e2e merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js shopper/cart-block-calculate-shipping.spec.js shopper/cart-block-coupons.spec.js shopper/cart-block.spec.js shopper/cart-checkout-block-calculate-tax.spec.js shopper/checkout-block-coupons.spec.js shopper/checkout-block.spec.js shopper/hop-products-filter-by-price.spec.js
```
With WooCommerce PayPal Payments
```
pnpm test:e2e:with-env woocommerce-paypal-payments merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js shopper/cart-block-calculate-shipping.spec.js shopper/cart-block-coupons.spec.js shopper/cart-block.spec.js shopper/cart-checkout-block-calculate-tax.spec.js shopper/checkout-block-coupons.spec.js shopper/checkout-block.spec.js shopper/hop-products-filter-by-price.spec.js
```
With Gutenberg
```
pnpm test:e2e:with-env gutenberg-stable merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js shopper/cart-block-calculate-shipping.spec.js shopper/cart-block-coupons.spec.js shopper/cart-block.spec.js shopper/cart-checkout-block-calculate-tax.spec.js shopper/checkout-block-coupons.spec.js shopper/checkout-block.spec.js shopper/hop-products-filter-by-price.spec.js
```