### PR TITLE
Select bank transfer explicitly on customer payment page e2e test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-select-payment-method
+++ b/plugins/woocommerce/changelog/e2e-select-payment-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Explicitly select the payment method on the customer payment page e2e test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
@@ -100,25 +100,33 @@ test.describe(
 		test( 'can pay for the order through the customer payment page', async ( {
 			page,
 		} ) => {
-			// key required, so can't go directly to the customer payment page
-			await page.goto(
-				`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
-			);
-			await page.locator( 'label[for=order_status] > a' ).click();
-
-			// pay for the order
-			await page.locator( 'button#place_order' ).click();
-
-			// Verify we landed on the order received page
-			await expect(
-				page.getByText( 'Your order has been received' )
-			).toBeVisible();
-			await expect(
-				page.getByText( `Order #: ${ orderId }` )
-			).toBeVisible();
-			await expect(
-				await page.getByText( `Total: $${ productPrice }` ).count()
-			).toBeGreaterThan( 0 );
+			await test.step( 'Load the customer payment page', async () => {
+				// key required, so can't go directly to the customer payment page
+				await page.goto(
+					`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+				);
+				await page.locator( 'label[for=order_status] > a' ).click();
+			} );
+			await test.step( 'Select payment method and pay for the order', async () => {
+				// explicitly select the payment method
+				await page.getByText( 'Direct bank transfer' ).click();
+				// pay for the order
+				await page
+					.getByRole( 'button', { name: 'Pay for order' } )
+					.click();
+			} );
+			await test.step( 'Verify the order received page', async () => {
+				// Verify we landed on the order received page
+				await expect(
+					page.getByText( 'Your order has been received' )
+				).toBeVisible();
+				await expect(
+					page.getByText( `Order #: ${ orderId }` )
+				).toBeVisible();
+				await expect(
+					await page.getByText( `Total: $${ productPrice }` ).count()
+				).toBeGreaterThan( 0 );
+			} );
 		} );
 	}
 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Change to the customer payment page e2e test to explicitly select the payment method when submitting the order.  If other payment gateways are installed, multiple options may be present on this page, so explicitly clicking bank transfers will reduce flakiness.

Closes [#50767 ](https://github.com/woocommerce/woocommerce/issues/50767)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm test:e2e merchant/customer-payment-page.spec.js` (should pass anyways)
2. Load up http://localhost:8086/wp-admin/ and go to WooCommerce > Settings > Payments.  Enable a couple of other payment methods.
3. `pnpm test:e2e merchant/customer-payment-page.spec.js` test should still pass.

<!-- End testing instructions -->