### PR TITLE
Use `get_filtered_ids` consistently in `taxes` and `…/stats` datastores

### DIFF
--- a/plugins/woocommerce/changelog/fix-49635-tax-totals-filter
+++ b/plugins/woocommerce/changelog/fix-49635-tax-totals-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use `get_filtered_ids` consistently in `reports/taxes` and `reports/taxes/stats` datastores

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/DataStore.php
@@ -124,6 +124,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Updates the database query with parameters used for Taxes report: categories and order status.
 	 *
+	 * @see Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore::update_sql_query_params()
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
 	protected function add_sql_query_params( $query_args ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -93,8 +93,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
 			$allowed_taxes = self::get_filtered_ids( $query_args, 'taxes' );
-			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
-			$taxes_where_clause .= $wpdb->prepare( " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})" );
+			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- `$allowed_taxes` was prepared by get_filtered_ids above. */
+			$taxes_where_clause .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
 			/* phpcs:enable */
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -79,28 +79,29 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Updates the database query with parameters used for Taxes Stats report
 	 *
+	 * @see Automattic\WooCommerce\Admin\API\Reports\Taxes\DataStore::add_sql_query_params()
 	 * @param array $query_args       Query arguments supplied by the user.
 	 */
 	protected function update_sql_query_params( $query_args ) {
 		global $wpdb;
 
-		$taxes_where_clause     = '';
 		$order_tax_lookup_table = self::get_db_table_name();
 
+		$this->add_time_period_sql_params( $query_args, $order_tax_lookup_table );
+		$taxes_where_clause  = '';
+		$order_status_filter = $this->get_status_subquery( $query_args );
+
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
-			$query_args['taxes'] = (array) $query_args['taxes'];
-			$tax_id_placeholders = implode( ',', array_fill( 0, count( $query_args['taxes'] ), '%d' ) );
+			$allowed_taxes = self::get_filtered_ids( $query_args, 'taxes' );
 			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
-			$taxes_where_clause .= $wpdb->prepare( " AND {$order_tax_lookup_table}.tax_rate_id IN ({$tax_id_placeholders})", $query_args['taxes'] );
+			$taxes_where_clause .= $wpdb->prepare( " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})" );
 			/* phpcs:enable */
 		}
 
-		$order_status_filter = $this->get_status_subquery( $query_args );
 		if ( $order_status_filter ) {
 			$taxes_where_clause .= " AND ( {$order_status_filter} )";
 		}
 
-		$this->add_time_period_sql_params( $query_args, $order_tax_lookup_table );
 		$this->total_query->add_sql_clause( 'where', $taxes_where_clause );
 
 		$this->add_intervals_sql_params( $query_args, $order_tax_lookup_table );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`<TaxesReportTable>` uses both endpoints to render the results. However, only one of them was using the `woocommerce_analytics_taxes` filter to filter results. This could lead to 


Use `get_filtered_ids` consistently in `taxes` and `…/stats` datastores
Potentially addresses https://github.com/woocommerce/woocommerce/issues/49635

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create some taxes and orders
2. Add a snippet that filters `woocommerce_analytics_taxes`, for example to return only the first one.
```php
add_filter(
	'woocommerce_analytics_taxes',
	function ( $ids ) {
		// unset( $ids[0] );
        return [ $ids[0] ];
	}
);
```
4. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Ftaxes&period=last_month&compare=previous_year` and pick a time frame with those orders.
5. Use the UI table filter "Search by item name" to filter more than one tax. (custom snippet should filter it down to 1)
6. Check if the number of items and other totals in the table summary are correct.

<!-- End testing instructions -->
#### Before
![image](https://github.com/user-attachments/assets/d593266a-f226-47c6-a9fc-94d37dfe2cd7)

#### After 
![image](https://github.com/user-attachments/assets/1be66339-7449-4385-8e2f-94fe7628075a)



### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
