### PR TITLE
Delayed account creation: Admin settings

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
@@ -10,6 +10,7 @@ import {
 	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -71,13 +72,18 @@ type EditProps = {
 export const Edit = ( {
 	attributes,
 	setAttributes,
-}: EditProps ): JSX.Element => {
+}: EditProps ): JSX.Element | null => {
 	const className = clsx( 'wc-block-order-confirmation-create-account', {
 		'has-dark-controls': attributes.hasDarkControls,
 	} );
 	const blockProps = useBlockProps( {
 		className,
 	} );
+	const isEnabled = getSetting( 'delayedAccountCreationEnabled', true );
+
+	if ( ! isEnabled ) {
+		return null;
+	}
 
 	return (
 		<div { ...blockProps }>

--- a/plugins/woocommerce/changelog/51236-add-delayed-account-creation-settings
+++ b/plugins/woocommerce/changelog/51236-add-delayed-account-creation-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Updates account creation options.
+

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5190,17 +5190,19 @@ img.help_tip {
 			float: none;
 		}
 
-		.disabled {
-			opacity: 0.9;
+		label:has(input:disabled) {
 			cursor: not-allowed;
-			> input {
+			> input:disabled {
+				opacity: 0.7;
 				cursor: not-allowed;
+				pointer-events: none;
 			}
-			&[aria-label] {
+			&[disabled-tooltip] {
 				position: relative;
 			}
-			&[aria-label]::before {
-				content: attr(aria-label);
+			&[disabled-tooltip]::before {
+				pointer-events: none;
+				content: attr(disabled-tooltip);
 				position: absolute;
 				top: -6px;
 				left: 6px;
@@ -5216,7 +5218,8 @@ img.help_tip {
 				pointer-events: none;
 				opacity:0;
 			}
-			&[aria-label]:hover::before {
+			&[disabled-tooltip]:hover::before,
+			&[disabled-tooltip]:focus::before {
 				opacity:1
 			}
 		}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5190,8 +5190,35 @@ img.help_tip {
 			float: none;
 		}
 
-		td.disabled {
-			opacity: 0.5;
+		.disabled {
+			opacity: 0.9;
+			cursor: not-allowed;
+			> input {
+				cursor: not-allowed;
+			}
+			&[aria-label] {
+				position: relative;
+			}
+			&[aria-label]::before {
+				content: attr(aria-label);
+				position: absolute;
+				top: -6px;
+				left: 6px;
+				transform: translateX(-50%) translateY(-100%);
+				background: black;
+				text-align: center;
+				color: #fff;
+				padding: 6px;
+				font-size: 12px;
+				min-width: 80px;
+				max-width: 200px;
+				border-radius: 5px;
+				pointer-events: none;
+				opacity:0;
+			}
+			&[aria-label]:hover::before {
+				opacity:1
+			}
 		}
 
 		fieldset {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -12,6 +12,7 @@ if ( class_exists( 'WC_Settings_Accounts', false ) ) {
 }
 
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * WC_Settings_Accounts.
@@ -262,6 +263,15 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'id'   => 'personal_data_retention',
 			),
 		);
+
+		if ( ! Features::is_enabled( 'experimental-blocks' ) ) {
+			$account_settings = array_filter(
+				$account_settings,
+				function ( $setting ) {
+					return 'woocommerce_enable_delayed_account_creation' !== $setting['id'];
+				},
+			);
+		}
 
 		// Change settings when using the block based checkout.
 		if ( CartCheckoutUtils::is_checkout_block_default() ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -78,23 +78,26 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'default'       => 'no',
 				'type'          => 'checkbox',
 				'checkboxgroup' => 'start',
-				'legend'        => __( 'Allow customers to create an account:', 'woocommerce' ),
+				'legend'        => __( 'Allow customers to create an account', 'woocommerce' ),
 				'autoload'      => false,
 			),
 			array(
-				'title'         => __( 'Account creation', 'woocommerce' ),
-				'desc'          => __( 'After checkout (recommended)', 'woocommerce' ),
-				'desc_tip'      => sprintf(
+				'title'             => __( 'Account creation', 'woocommerce' ),
+				'desc'              => __( 'After checkout (recommended)', 'woocommerce' ),
+				'desc_tip'          => sprintf(
 					/* Translators: %1$s and %2$s are opening and closing <a> tags respectively. */
 					__( 'Customers can create an account after their order is placed. Customize messaging %1$shere%2$s.', 'woocommerce' ),
 					'<a href="' . esc_url( admin_url( 'site-editor.php?postId=woocommerce%2Fwoocommerce%2F%2Forder-confirmation&postType=wp_template&canvas=edit' ) ) . '">',
 					'</a>'
 				),
-				'id'            => 'woocommerce_enable_delayed_account_creation',
-				'default'       => 'yes',
-				'type'          => 'checkbox',
-				'checkboxgroup' => '',
-				'autoload'      => false,
+				'id'                => 'woocommerce_enable_delayed_account_creation',
+				'default'           => 'yes',
+				'type'              => 'checkbox',
+				'checkboxgroup'     => '',
+				'autoload'          => false,
+				'custom_attributes' => array(
+					'disabled-tooltip' => __( 'Enable guest checkout to use this feature.', 'woocommerce' ),
+				),
 			),
 			array(
 				'title'         => __( 'Account creation', 'woocommerce' ),
@@ -106,24 +109,30 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'      => false,
 			),
 			array(
-				'title'         => __( 'Account creation options', 'woocommerce' ),
-				'desc'          => __( 'Use email address as account login (recommended)', 'woocommerce' ),
-				'desc_tip'      => __( 'If unchecked, customers will need to set a username during account creation.', 'woocommerce' ),
-				'id'            => 'woocommerce_registration_generate_username',
-				'default'       => 'yes',
-				'type'          => 'checkbox',
-				'checkboxgroup' => 'start',
-				'autoload'      => false,
+				'title'             => __( 'Account creation options', 'woocommerce' ),
+				'desc'              => __( 'Send password setup link (recommended)', 'woocommerce' ),
+				'desc_tip'          => __( 'New users receive an email to set up their password.', 'woocommerce' ),
+				'id'                => 'woocommerce_registration_generate_password',
+				'default'           => 'yes',
+				'type'              => 'checkbox',
+				'checkboxgroup'     => 'start',
+				'autoload'          => false,
+				'custom_attributes' => array(
+					'disabled-tooltip' => __( 'Enable an account creation method to use this feature.', 'woocommerce' ),
+				),
 			),
 			array(
-				'title'         => __( 'Account creation options', 'woocommerce' ),
-				'desc'          => __( 'Send password setup link (recommended)', 'woocommerce' ),
-				'desc_tip'      => __( 'New customers receive an email to set up their password.', 'woocommerce' ),
-				'id'            => 'woocommerce_registration_generate_password',
-				'default'       => 'yes',
-				'type'          => 'checkbox',
-				'checkboxgroup' => 'end',
-				'autoload'      => false,
+				'title'             => __( 'Account creation options', 'woocommerce' ),
+				'desc'              => __( 'Use email address as account login (recommended)', 'woocommerce' ),
+				'desc_tip'          => __( 'If unchecked, customers will need to set a username during account creation.', 'woocommerce' ),
+				'id'                => 'woocommerce_registration_generate_username',
+				'default'           => 'yes',
+				'type'              => 'checkbox',
+				'checkboxgroup'     => 'end',
+				'autoload'          => false,
+				'custom_attributes' => array(
+					'disabled-tooltip' => __( 'Enable an account creation method to use this feature.', 'woocommerce' ),
+				),
 			),
 			array(
 				'title'         => __( 'Account erasure requests', 'woocommerce' ),
@@ -272,11 +281,22 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				$account_settings
 			);
 		} else {
-			$account_settings = array_filter(
-				$account_settings,
+			$account_settings = array_map(
 				function ( $setting ) {
-					return 'woocommerce_enable_delayed_account_creation' !== $setting['id'];
+					if ( 'woocommerce_enable_delayed_account_creation' === $setting['id'] ) {
+						$setting['desc_tip'] = sprintf(
+							/* Translators: %1$s and %2$s are opening and closing <a> tags respectively. */
+							__( 'This feature is only available with the Cart & Checkout blocks. %1$sLearn more%2$s.', 'woocommerce' ),
+							'<a href="https://woocommerce.com/document/woocommerce-store-editing/customizing-cart-and-checkout">',
+							'</a>'
+						);
+						$setting['disabled']                              = true;
+						$setting['value']                                 = 0;
+						$setting['custom_attributes']['disabled-tooltip'] = __( 'Your store is using shortcode checkout. Use the Checkout blocks to activate this option.', 'woocommerce' );
+					}
+					return $setting;
 				},
+				$account_settings
 			);
 		}
 
@@ -300,6 +320,14 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 		?>
 		<script type="text/javascript">
 			document.addEventListener('DOMContentLoaded', function() {
+				// Move tooltips to label element. This is not possible through the settings field API so this is a workaround
+				// until said API is refactored.
+				document.querySelectorAll('input[disabled-tooltip]').forEach(function(element) {
+					const label = element.closest('label');
+					label.setAttribute('disabled-tooltip', element.getAttribute('disabled-tooltip'));
+				});
+
+				// This handles settings that are enabled/disabled based on other settings.
 				const checkboxes = [
 					document.getElementById("woocommerce_enable_signup_and_login_from_checkout"),
 					document.getElementById("woocommerce_enable_myaccount_registration"),
@@ -310,47 +338,26 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					document.getElementById("woocommerce_registration_generate_username"),
 					document.getElementById("woocommerce_registration_generate_password")
 				];
-
-				function setTooltip(element, text) {
-					if ( text ) {
-						element.setAttribute('aria-label', text);
-					} else {
-						element.removeAttribute('aria-label', text);
-					}
-				}
-
-				function updateAccountCreationInputs() {
+				checkboxes.forEach(cb => cb && cb.addEventListener('change', function() {
 					const isChecked = checkboxes.some(cb => cb && cb.checked);
 					inputs.forEach(input => {
 						if ( ! input ) {
 							return;
 						}
-						const label = input.closest('label');
-
 						input.disabled = !isChecked;
-						label.classList.toggle("disabled", !isChecked);
-						setTooltip(label, !isChecked ? '<?php echo esc_attr__( 'Enable an account creation method to use this feature.', 'woocommerce' ); ?>' : '');
 					});
-				}
+				}));
+				checkboxes[0].dispatchEvent(new Event('change')); // Initial state
 
-				checkboxes.forEach(cb => cb && cb.addEventListener('change', updateAccountCreationInputs));
-				updateAccountCreationInputs(); // Initial state
+				// Guest checkout should toggle off some options.
+				const guestCheckout = document.getElementById("woocommerce_enable_guest_checkout");
 
-				const guestCheckoutInput = document.getElementById("woocommerce_enable_guest_checkout");
-				const delayedAccountCreationInput = document.getElementById("woocommerce_enable_delayed_account_creation");
-
-				function updateDelayedAccountCreationInput() {
-					const isChecked = guestCheckoutInput.checked;
-					const label = delayedAccountCreationInput.closest('label');
-
-					delayedAccountCreationInput.disabled = !isChecked;
-					label.classList.toggle("disabled", !isChecked);
-					setTooltip(label, !isChecked ? '<?php echo esc_attr__( 'Enable guest checkout to use this feature.', 'woocommerce' ); ?>' : '');
-				}
-
-				if ( guestCheckoutInput && delayedAccountCreationInput ) {
-					guestCheckoutInput.addEventListener('change', updateDelayedAccountCreationInput);
-					updateDelayedCheckoutInput();
+				if ( guestCheckout ) {
+					guestCheckout.addEventListener('change', function() {
+						const isChecked = this.checked;
+						document.getElementById("woocommerce_enable_delayed_account_creation").disabled = !isChecked;
+					});
+					guestCheckout.dispatchEvent(new Event('change')); // Initial state
 				}
 			});
 		</script>

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -365,7 +365,11 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				if ( guestCheckout ) {
 					guestCheckout.addEventListener('change', function() {
 						const isChecked = this.checked;
-						document.getElementById("woocommerce_enable_delayed_account_creation").disabled = !isChecked;
+						const input = document.getElementById("woocommerce_enable_delayed_account_creation");
+						if ( ! input ) {
+							return;
+						}
+						input.disabled = !isChecked;
 					});
 					guestCheckout.dispatchEvent(new Event('change')); // Initial state
 				}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
 
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * CreateAccount class.
@@ -31,6 +32,15 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 			'dependencies' => [],
 		];
 		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Returns if delayed account creation is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_feature_enabled() {
+		return Features::is_enabled( 'experimental-blocks' ) && get_option( 'woocommerce_enable_delayed_account_creation', 'yes' ) === 'yes';
 	}
 
 	/**
@@ -111,7 +121,7 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( ! $permission ) {
+		if ( ! $permission || ! $this->is_feature_enabled() ) {
 			return '';
 		}
 
@@ -189,6 +199,7 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 
+		$this->asset_data_registry->add( 'delayedAccountCreationEnabled', $this->is_feature_enabled() );
 		$this->asset_data_registry->add( 'registrationGeneratePassword', filter_var( get_option( 'woocommerce_registration_generate_password' ), FILTER_VALIDATE_BOOLEAN ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
@@ -22,7 +22,7 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_account_settings',
-			function( $settings ) use ( &$actual_settings_via_filter ) {
+			function ( $settings ) use ( &$actual_settings_via_filter ) {
 				$actual_settings_via_filter = $settings;
 				return $settings;
 			},
@@ -67,6 +67,7 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_trash_failed_orders'              => 'relative_date_selector',
 			'woocommerce_trash_cancelled_orders'           => 'relative_date_selector',
 			'woocommerce_anonymize_completed_orders'       => 'relative_date_selector',
+			'woocommerce_enable_delayed_account_creation'  => 'checkbox',
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );
@@ -113,12 +114,12 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 	public function test_linked_text_for_erasure_request_settings( $current_user_can_manage_privacy_options, $blog_version, $expected_order_erasure_text, $expected_downloads_erasure_text ) {
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'current_user_can' => function( $capability, ...$args ) use ( $current_user_can_manage_privacy_options ) {
+				'current_user_can' => function ( $capability, ...$args ) use ( $current_user_can_manage_privacy_options ) {
 					return 'manage_privacy_options' === $capability ?
 						$current_user_can_manage_privacy_options :
 						current_user_can( $capability, ...$args );
 				},
-				'get_bloginfo'     => function( $show = '', $filter = 'raw' ) use ( $blog_version ) {
+				'get_bloginfo'     => function ( $show = '', $filter = 'raw' ) use ( $blog_version ) {
 					return 'version' === $show ?
 						$blog_version :
 						get_bloginfo( $show, $filter );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements the changes to settings under WooCommerce > Settings > Accounts and Privacy for the new delayed account creation block. This includes:

- Option to enable/disable "account creation **after** checkout"
- ^ option is disabled if guest checkout is turned off
- updates from design (styling and tooltips)

When delayed account creation is disabled the block will render `null`. In a follow up when this is added to the actual templates we'll force the block so it cannot be removed.

Closes #50637

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**This block is behind an experimental flag. If you are testing on a production version of WooCommerce this block should not be available (yet).** 

These instructions are for testing the development build:

1. Ensure your store is setup to use the block cart and checkout
2. Head on over to WooCommerce > Settings > Accounts and Privacy 
3. Toggle off "enable guest checkout"
4. Confirm that the "After checkout (recommended)" option is is greyed out
5. Mouse over the "After checkout (recommended)" option and confirm a tooltip is shown with further information
6. Toggle on "enable guest checkout" and settings are not greyed out any more
7. Toggle off all "Account creation" settings
8. Confirm the "Account creation options" settings get greyed out and have tooltips

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
Updates account creation options.

</details>
