### PR TITLE
Add inspector controls to Product Search block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/constants.ts
@@ -1,0 +1,10 @@
+export const SEARCH_BLOCK_NAME = 'core/search';
+export const SEARCH_VARIATION_NAME = 'woocommerce/product-search';
+
+export enum ButtonOptions {
+	OUTSIDE = 'button-outside',
+	INSIDE = 'button-inside',
+	NO_BUTTON = 'no-button',
+	BUTTON_ONLY = 'button-only',
+	INPUT_AND_BUTTON = 'input-and-button',
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/constants.ts
@@ -1,7 +1,7 @@
 export const SEARCH_BLOCK_NAME = 'core/search';
 export const SEARCH_VARIATION_NAME = 'woocommerce/product-search';
 
-export enum ButtonOptions {
+export enum PositionOptions {
 	OUTSIDE = 'button-outside',
 	INSIDE = 'button-inside',
 	NO_BUTTON = 'no-button',

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/index.tsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { addFilter } from '@wordpress/hooks';
 import { store as blockEditorStore, Warning } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -9,6 +10,7 @@ import { Icon, search } from '@wordpress/icons';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 import { Button } from '@wordpress/components';
+import type { Block as BlockType } from '@wordpress/blocks';
 import {
 	// @ts-ignore waiting for @types/wordpress__blocks update
 	registerBlockVariation,
@@ -21,8 +23,10 @@ import {
  */
 import './style.scss';
 import './editor.scss';
+import { withProductSearchControls } from './inspector-controls';
 import Block from './block';
 import Edit from './edit';
+import { SEARCH_BLOCK_NAME, SEARCH_VARIATION_NAME } from './constants';
 
 const isBlockVariationAvailable = getSettingWithCoercion(
 	'isBlockVariationAvailable',
@@ -71,6 +75,7 @@ const PRODUCT_SEARCH_ATTRIBUTES = {
 	query: {
 		post_type: 'product',
 	},
+	namespace: SEARCH_VARIATION_NAME,
 };
 
 const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
@@ -115,7 +120,7 @@ const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
 	);
 };
 
-registerBlockType( 'woocommerce/product-search', {
+registerBlockType( SEARCH_VARIATION_NAME, {
 	title: __( 'Product Search', 'woocommerce' ),
 	apiVersion: 3,
 	icon: {
@@ -146,7 +151,7 @@ registerBlockType( 'woocommerce/product-search', {
 				isMatch: ( { idBase, instance } ) =>
 					idBase === 'woocommerce_product_search' && !! instance?.raw,
 				transform: ( { instance } ) =>
-					createBlock( 'woocommerce/product-search', {
+					createBlock( SEARCH_VARIATION_NAME, {
 						label:
 							instance.raw.title ||
 							PRODUCT_SEARCH_ATTRIBUTES.label,
@@ -172,9 +177,31 @@ registerBlockType( 'woocommerce/product-search', {
 	},
 } );
 
+function registerProductSearchNamespace( props: BlockType, blockName: string ) {
+	if ( blockName === 'core/search' ) {
+		// Gracefully handle if settings.attributes is undefined.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore -- We need this because `attributes` is marked as `readonly`
+		props.attributes = {
+			...props.attributes,
+			namespace: {
+				type: 'string',
+			},
+		};
+	}
+
+	return props;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/custom-class-name/attribute',
+	registerProductSearchNamespace
+);
+
 if ( isBlockVariationAvailable ) {
 	registerBlockVariation( 'core/search', {
-		name: 'woocommerce/product-search',
+		name: SEARCH_VARIATION_NAME,
 		title: __( 'Product Search', 'woocommerce' ),
 		icon: {
 			src: (
@@ -199,4 +226,9 @@ if ( isBlockVariationAvailable ) {
 		),
 		attributes: PRODUCT_SEARCH_ATTRIBUTES,
 	} );
+	addFilter(
+		'editor.BlockEdit',
+		SEARCH_BLOCK_NAME,
+		withProductSearchControls
+	);
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/index.tsx
@@ -195,7 +195,7 @@ function registerProductSearchNamespace( props: BlockType, blockName: string ) {
 
 addFilter(
 	'blocks.registerBlockType',
-	'core/custom-class-name/attribute',
+	SEARCH_VARIATION_NAME,
 	registerProductSearchNamespace
 );
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -28,10 +28,10 @@ import {
 	isInputAndButtonOption,
 	isWooSearchBlockVariation,
 } from './utils';
-import { ButtonPositionProps, ProductSearchBlock } from './types';
+import { ButtonPositionProps, ProductSearchBlockProps } from './types';
 import { PositionOptions } from './constants';
 
-const ProductSearchControls = ( props: ProductSearchBlock ) => {
+const ProductSearchControls = ( props: ProductSearchBlockProps ) => {
 	const { attributes, setAttributes } = props;
 	const { buttonPosition, buttonUseIcon, showLabel } = attributes;
 	const [ initialPosition, setInitialPosition ] =
@@ -144,7 +144,7 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 
 export const withProductSearchControls =
 	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>
-	( props: ProductSearchBlock ) => {
+	( props: ProductSearchBlockProps ) => {
 		return isWooSearchBlockVariation( props ) ? (
 			<>
 				<ProductSearchControls { ...props } />

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -29,7 +29,7 @@ import {
 	isWooSearchBlockVariation,
 } from './utils';
 import { ButtonPositionProps, ProductSearchBlock } from './types';
-import { ButtonOptions } from './constants';
+import { PositionOptions } from './constants';
 
 const ProductSearchControls = ( props: ProductSearchBlock ) => {
 	const { attributes, setAttributes } = props;
@@ -54,22 +54,22 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 					options={ [
 						{
 							label: __( 'Input and button', 'woocommerce' ),
-							value: ButtonOptions.INPUT_AND_BUTTON,
+							value: PositionOptions.INPUT_AND_BUTTON,
 						},
 						{
 							label: __( 'Input only', 'woocommerce' ),
-							value: ButtonOptions.NO_BUTTON,
+							value: PositionOptions.NO_BUTTON,
 						},
 						{
 							label: __( 'Button only', 'woocommerce' ),
-							value: ButtonOptions.BUTTON_ONLY,
+							value: PositionOptions.BUTTON_ONLY,
 						},
 					] }
 					onChange={ (
 						selected: Partial< ButtonPositionProps > &
 							'input-and-button'
 					) => {
-						if ( selected !== ButtonOptions.INPUT_AND_BUTTON ) {
+						if ( selected !== PositionOptions.INPUT_AND_BUTTON ) {
 							setAttributes( {
 								buttonPosition: selected,
 							} );
@@ -82,9 +82,9 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 						}
 					} }
 				/>
-				{ buttonPosition !== ButtonOptions.NO_BUTTON && (
+				{ buttonPosition !== PositionOptions.NO_BUTTON && (
 					<>
-						{ buttonPosition !== ButtonOptions.BUTTON_ONLY && (
+						{ buttonPosition !== PositionOptions.BUTTON_ONLY && (
 							<ToggleGroupControl
 								label={ __( 'BUTTON POSITION', 'woocommerce' ) }
 								isBlock
@@ -98,11 +98,11 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 								) }
 							>
 								<ToggleGroupControlOption
-									value={ ButtonOptions.INSIDE }
+									value={ PositionOptions.INSIDE }
 									label={ __( 'Inside', 'woocommerce' ) }
 								/>
 								<ToggleGroupControlOption
-									value={ ButtonOptions.OUTSIDE }
+									value={ PositionOptions.OUTSIDE }
 									label={ __( 'Outside', 'woocommerce' ) }
 								/>
 							</ToggleGroupControl>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -67,7 +67,7 @@ const ProductSearchControls = ( props: ProductSearchBlockProps ) => {
 					] }
 					onChange={ (
 						selected: Partial< ButtonPositionProps > &
-							'input-and-button'
+							PositionOptions.INPUT_AND_BUTTON
 					) => {
 						if ( selected !== PositionOptions.INPUT_AND_BUTTON ) {
 							setAttributes( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -50,101 +50,95 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 	}
 
 	return (
-		<>
-			<InspectorControls group="styles">
-				<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
-					<RadioControl
-						selected={ getSelectedRadioControlOption() }
-						options={ [
-							{
-								label: __( 'Input and button', 'woocommerce' ),
-								value: ButtonOptions.INPUT_AND_BUTTON,
-							},
-							{
-								label: __( 'Input only', 'woocommerce' ),
-								value: ButtonOptions.NO_BUTTON,
-							},
-							{
-								label: __( 'Button only', 'woocommerce' ),
-								value: ButtonOptions.BUTTON_ONLY,
-							},
-						] }
-						onChange={ (
-							selected: Partial< ButtonPositionProps > &
-								'input-and-button'
-						) => {
-							if ( selected !== ButtonOptions.INPUT_AND_BUTTON ) {
-								setAttributes( {
-									buttonPosition: selected,
-								} );
-							} else {
-								setAttributes( {
-									buttonPosition:
-										selected ===
-										ButtonOptions.INPUT_AND_BUTTON
-											? initialPosition
-											: selected,
-								} );
-							}
-						} }
-					/>
-					{ buttonPosition !== ButtonOptions.NO_BUTTON && (
-						<>
-							<ToggleGroupControl
-								label={ __( 'BUTTON POSITION', 'woocommerce' ) }
-								isBlock
-								onChange={ ( value: ButtonPositionProps ) => {
-									setAttributes( {
-										buttonPosition: value,
-									} );
-								} }
-								value={ ButtonOptions.INSIDE }
-							>
-								<ToggleGroupControlOption
-									value={ ButtonOptions.INSIDE }
-									label={ __( 'Inside', 'woocommerce' ) }
-								/>
-								<ToggleGroupControlOption
-									value={ ButtonOptions.OUTSIDE }
-									label={ __( 'Outside', 'woocommerce' ) }
-								/>
-							</ToggleGroupControl>
-							<ToggleGroupControl
-								label={ __(
-									'BUTTON APPEARANCE',
-									'woocommerce'
-								) }
-								isBlock
-								onChange={ ( value: boolean ) => {
-									setAttributes( {
-										buttonUseIcon: value,
-									} );
-								} }
-								value={ buttonUseIcon }
-							>
-								<ToggleGroupControlOption
-									value={ false }
-									label={ __( 'Text', 'woocommerce' ) }
-								/>
-								<ToggleGroupControlOption
-									value={ true }
-									label={ __( 'Icon', 'woocommerce' ) }
-								/>
-							</ToggleGroupControl>
-						</>
-					) }
-					<ToggleControl
-						label={ __( 'Show input label', 'woocommerce' ) }
-						checked={ showLabel }
-						onChange={ ( showInputLabel: boolean ) =>
+		<InspectorControls group="styles">
+			<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
+				<RadioControl
+					selected={ getSelectedRadioControlOption() }
+					options={ [
+						{
+							label: __( 'Input and button', 'woocommerce' ),
+							value: ButtonOptions.INPUT_AND_BUTTON,
+						},
+						{
+							label: __( 'Input only', 'woocommerce' ),
+							value: ButtonOptions.NO_BUTTON,
+						},
+						{
+							label: __( 'Button only', 'woocommerce' ),
+							value: ButtonOptions.BUTTON_ONLY,
+						},
+					] }
+					onChange={ (
+						selected: Partial< ButtonPositionProps > &
+							'input-and-button'
+					) => {
+						if ( selected !== ButtonOptions.INPUT_AND_BUTTON ) {
 							setAttributes( {
-								showLabel: showInputLabel,
-							} )
+								buttonPosition: selected,
+							} );
+						} else {
+							setAttributes( {
+								buttonPosition:
+									selected === ButtonOptions.INPUT_AND_BUTTON
+										? initialPosition
+										: selected,
+							} );
 						}
-					/>
-				</PanelBody>
-			</InspectorControls>
-		</>
+					} }
+				/>
+				{ buttonPosition !== ButtonOptions.NO_BUTTON && (
+					<>
+						<ToggleGroupControl
+							label={ __( 'BUTTON POSITION', 'woocommerce' ) }
+							isBlock
+							onChange={ ( value: ButtonPositionProps ) => {
+								setAttributes( {
+									buttonPosition: value,
+								} );
+							} }
+							value={ ButtonOptions.INSIDE }
+						>
+							<ToggleGroupControlOption
+								value={ ButtonOptions.INSIDE }
+								label={ __( 'Inside', 'woocommerce' ) }
+							/>
+							<ToggleGroupControlOption
+								value={ ButtonOptions.OUTSIDE }
+								label={ __( 'Outside', 'woocommerce' ) }
+							/>
+						</ToggleGroupControl>
+						<ToggleGroupControl
+							label={ __( 'BUTTON APPEARANCE', 'woocommerce' ) }
+							isBlock
+							onChange={ ( value: boolean ) => {
+								setAttributes( {
+									buttonUseIcon: value,
+								} );
+							} }
+							value={ buttonUseIcon }
+						>
+							<ToggleGroupControlOption
+								value={ false }
+								label={ __( 'Text', 'woocommerce' ) }
+							/>
+							<ToggleGroupControlOption
+								value={ true }
+								label={ __( 'Icon', 'woocommerce' ) }
+							/>
+						</ToggleGroupControl>
+					</>
+				) }
+				<ToggleControl
+					label={ __( 'Show input label', 'woocommerce' ) }
+					checked={ showLabel }
+					onChange={ ( showInputLabel: boolean ) =>
+						setAttributes( {
+							showLabel: showInputLabel,
+						} )
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -22,7 +22,12 @@ import {
 /**
  * Internal dependencies
  */
-import { isWooSearchBlockVariation } from './utils';
+import {
+	getInputAndButtonOption,
+	getSelectedRadioControlOption,
+	isInputAndButtonOption,
+	isWooSearchBlockVariation,
+} from './utils';
 import { ButtonPositionProps, ProductSearchBlock } from './types';
 import { ButtonOptions } from './constants';
 
@@ -32,28 +37,20 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 	const [ initialPosition, setInitialPosition ] =
 		useState< ButtonPositionProps >( buttonPosition );
 
-	const isInputAndButtonOption =
-		buttonPosition === 'button-outside' ||
-		buttonPosition === 'button-inside';
-
 	useEffect( () => {
-		if ( isInputAndButtonOption && initialPosition !== buttonPosition ) {
+		if (
+			isInputAndButtonOption( buttonPosition ) &&
+			initialPosition !== buttonPosition
+		) {
 			setInitialPosition( buttonPosition );
 		}
 	}, [ buttonPosition ] );
-
-	function getSelectedRadioControlOption() {
-		if ( isInputAndButtonOption ) {
-			return ButtonOptions.INPUT_AND_BUTTON;
-		}
-		return buttonPosition;
-	}
 
 	return (
 		<InspectorControls group="styles">
 			<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
 				<RadioControl
-					selected={ getSelectedRadioControlOption() }
+					selected={ getSelectedRadioControlOption( buttonPosition ) }
 					options={ [
 						{
 							label: __( 'Input and button', 'woocommerce' ),
@@ -77,36 +74,39 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 								buttonPosition: selected,
 							} );
 						} else {
+							const newButtonPosition =
+								getInputAndButtonOption( initialPosition );
 							setAttributes( {
-								buttonPosition:
-									selected === ButtonOptions.INPUT_AND_BUTTON
-										? initialPosition
-										: selected,
+								buttonPosition: newButtonPosition,
 							} );
 						}
 					} }
 				/>
 				{ buttonPosition !== ButtonOptions.NO_BUTTON && (
 					<>
-						<ToggleGroupControl
-							label={ __( 'BUTTON POSITION', 'woocommerce' ) }
-							isBlock
-							onChange={ ( value: ButtonPositionProps ) => {
-								setAttributes( {
-									buttonPosition: value,
-								} );
-							} }
-							value={ ButtonOptions.INSIDE }
-						>
-							<ToggleGroupControlOption
-								value={ ButtonOptions.INSIDE }
-								label={ __( 'Inside', 'woocommerce' ) }
-							/>
-							<ToggleGroupControlOption
-								value={ ButtonOptions.OUTSIDE }
-								label={ __( 'Outside', 'woocommerce' ) }
-							/>
-						</ToggleGroupControl>
+						{ buttonPosition !== ButtonOptions.BUTTON_ONLY && (
+							<ToggleGroupControl
+								label={ __( 'BUTTON POSITION', 'woocommerce' ) }
+								isBlock
+								onChange={ ( value: ButtonPositionProps ) => {
+									setAttributes( {
+										buttonPosition: value,
+									} );
+								} }
+								value={ getInputAndButtonOption(
+									buttonPosition
+								) }
+							>
+								<ToggleGroupControlOption
+									value={ ButtonOptions.INSIDE }
+									label={ __( 'Inside', 'woocommerce' ) }
+								/>
+								<ToggleGroupControlOption
+									value={ ButtonOptions.OUTSIDE }
+									label={ __( 'Outside', 'woocommerce' ) }
+								/>
+							</ToggleGroupControl>
+						) }
 						<ToggleGroupControl
 							label={ __( 'BUTTON APPEARANCE', 'woocommerce' ) }
 							isBlock

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -51,7 +51,7 @@ const ProductSearchControls = ( props: ProductSearchBlock ) => {
 
 	return (
 		<>
-			<InspectorControls>
+			<InspectorControls group="styles">
 				<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
 					<RadioControl
 						selected={ getSelectedRadioControlOption() }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/inspector-controls.tsx
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import { type ElementType, useEffect, useState } from '@wordpress/element';
+import { EditorBlock } from '@woocommerce/types';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RadioControl,
+	ToggleControl,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore - Ignoring because `__experimentalToggleGroupControl` is not yet in the type definitions.
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore - Ignoring because `__experimentalToggleGroupControlOption` is not yet in the type definitions.
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { isWooSearchBlockVariation } from './utils';
+import { ButtonPositionProps, ProductSearchBlock } from './types';
+import { ButtonOptions } from './constants';
+
+const ProductSearchControls = ( props: ProductSearchBlock ) => {
+	const { attributes, setAttributes } = props;
+	const { buttonPosition, buttonUseIcon, showLabel } = attributes;
+	const [ initialPosition, setInitialPosition ] =
+		useState< ButtonPositionProps >( buttonPosition );
+
+	const isInputAndButtonOption =
+		buttonPosition === 'button-outside' ||
+		buttonPosition === 'button-inside';
+
+	useEffect( () => {
+		if ( isInputAndButtonOption && initialPosition !== buttonPosition ) {
+			setInitialPosition( buttonPosition );
+		}
+	}, [ buttonPosition ] );
+
+	function getSelectedRadioControlOption() {
+		if ( isInputAndButtonOption ) {
+			return ButtonOptions.INPUT_AND_BUTTON;
+		}
+		return buttonPosition;
+	}
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Styles', 'woocommerce' ) }>
+					<RadioControl
+						selected={ getSelectedRadioControlOption() }
+						options={ [
+							{
+								label: __( 'Input and button', 'woocommerce' ),
+								value: ButtonOptions.INPUT_AND_BUTTON,
+							},
+							{
+								label: __( 'Input only', 'woocommerce' ),
+								value: ButtonOptions.NO_BUTTON,
+							},
+							{
+								label: __( 'Button only', 'woocommerce' ),
+								value: ButtonOptions.BUTTON_ONLY,
+							},
+						] }
+						onChange={ (
+							selected: Partial< ButtonPositionProps > &
+								'input-and-button'
+						) => {
+							if ( selected !== ButtonOptions.INPUT_AND_BUTTON ) {
+								setAttributes( {
+									buttonPosition: selected,
+								} );
+							} else {
+								setAttributes( {
+									buttonPosition:
+										selected ===
+										ButtonOptions.INPUT_AND_BUTTON
+											? initialPosition
+											: selected,
+								} );
+							}
+						} }
+					/>
+					{ buttonPosition !== ButtonOptions.NO_BUTTON && (
+						<>
+							<ToggleGroupControl
+								label={ __( 'BUTTON POSITION', 'woocommerce' ) }
+								isBlock
+								onChange={ ( value: ButtonPositionProps ) => {
+									setAttributes( {
+										buttonPosition: value,
+									} );
+								} }
+								value={ ButtonOptions.INSIDE }
+							>
+								<ToggleGroupControlOption
+									value={ ButtonOptions.INSIDE }
+									label={ __( 'Inside', 'woocommerce' ) }
+								/>
+								<ToggleGroupControlOption
+									value={ ButtonOptions.OUTSIDE }
+									label={ __( 'Outside', 'woocommerce' ) }
+								/>
+							</ToggleGroupControl>
+							<ToggleGroupControl
+								label={ __(
+									'BUTTON APPEARANCE',
+									'woocommerce'
+								) }
+								isBlock
+								onChange={ ( value: boolean ) => {
+									setAttributes( {
+										buttonUseIcon: value,
+									} );
+								} }
+								value={ buttonUseIcon }
+							>
+								<ToggleGroupControlOption
+									value={ false }
+									label={ __( 'Text', 'woocommerce' ) }
+								/>
+								<ToggleGroupControlOption
+									value={ true }
+									label={ __( 'Icon', 'woocommerce' ) }
+								/>
+							</ToggleGroupControl>
+						</>
+					) }
+					<ToggleControl
+						label={ __( 'Show input label', 'woocommerce' ) }
+						checked={ showLabel }
+						onChange={ ( showInputLabel: boolean ) =>
+							setAttributes( {
+								showLabel: showInputLabel,
+							} )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
+};
+
+export const withProductSearchControls =
+	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>
+	( props: ProductSearchBlock ) => {
+		return isWooSearchBlockVariation( props ) ? (
+			<>
+				<ProductSearchControls { ...props } />
+				<BlockEdit { ...props } />
+			</>
+		) : (
+			<BlockEdit { ...props } />
+		);
+	};

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/types.ts
@@ -20,4 +20,4 @@ export interface SearchBlockAttributes {
 	showLabel: boolean;
 }
 
-export type ProductSearchBlock = EditorBlock< SearchBlockAttributes >;
+export type ProductSearchBlockProps = EditorBlock< SearchBlockAttributes >;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/types.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import type { EditorBlock } from '@woocommerce/types';
+
+export type ButtonPositionProps =
+	| 'button-outside'
+	| 'button-inside'
+	| 'no-button'
+	| 'button-only';
+
+export interface SearchBlockAttributes {
+	buttonPosition: ButtonPositionProps;
+	buttonText?: string;
+	buttonUseIcon: boolean;
+	isSearchFieldHidden: boolean;
+	label?: string;
+	namespace?: string;
+	placeholder?: string;
+	showLabel: boolean;
+}
+
+export type ProductSearchBlock = EditorBlock< SearchBlockAttributes >;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
@@ -1,8 +1,12 @@
 /**
  * Internal dependencies
  */
-import { SEARCH_BLOCK_NAME, SEARCH_VARIATION_NAME } from './constants';
-import { ProductSearchBlock } from './types';
+import {
+	ButtonOptions,
+	SEARCH_BLOCK_NAME,
+	SEARCH_VARIATION_NAME,
+} from './constants';
+import { ButtonPositionProps, ProductSearchBlock } from './types';
 
 /**
  * Identifies if a block is a Search block variation from our conventions
@@ -10,10 +14,62 @@ import { ProductSearchBlock } from './types';
  * We are extending Gutenberg's core Search block with our variations, and
  * also adding extra namespaced attributes. If those namespaced attributes
  * are present, we can be fairly sure it is our own registered variation.
+ *
+ * @param {ProductSearchBlock} block - A WooCommerce block.
  */
 export function isWooSearchBlockVariation( block: ProductSearchBlock ) {
 	return (
 		block.name === SEARCH_BLOCK_NAME &&
 		block.attributes?.namespace === SEARCH_VARIATION_NAME
 	);
+}
+
+/**
+ * Checks if the given button position is a valid option for input and button placement.
+ *
+ * The function verifies if the provided `buttonPosition` matches one of the predefined
+ * values for placing a button either inside or outside an input field.
+ *
+ * @param {string} buttonPosition - The position of the button to check.
+ */
+export function isInputAndButtonOption( buttonPosition: string ): boolean {
+	return (
+		buttonPosition === 'button-outside' ||
+		buttonPosition === 'button-inside'
+	);
+}
+
+/**
+ * Returns the option for the selected button position
+ *
+ * Based on the provided `buttonPosition`, the function returns a predefined option
+ * if the position is valid for input and button placement. If the position is not
+ * one of the predefined options, it returns the original `buttonPosition`.
+ *
+ * @param {string} buttonPosition - The position of the button to evaluate.
+ */
+export function getSelectedRadioControlOption(
+	buttonPosition: string
+): string {
+	if ( isInputAndButtonOption( buttonPosition ) ) {
+		return ButtonOptions.INPUT_AND_BUTTON;
+	}
+	return buttonPosition;
+}
+
+/**
+ * Returns the appropriate option for input and button placement based on the given value
+ *
+ * This function checks if the provided `value` is a valid option for placing a button either
+ * inside or outside an input field. If the `value` is valid, it is returned as is. If the `value`
+ * is not valid, the function returns a default option.
+ *
+ * @param {ButtonPositionProps} value - The position of the button to evaluate.
+ */
+export function getInputAndButtonOption( value: ButtonPositionProps ) {
+	if ( isInputAndButtonOption( value ) ) {
+		return value;
+	}
+	// The default value is 'inside' for input and button.
+	return ButtonOptions.OUTSIDE;
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import {
-	ButtonOptions,
+	PositionOptions,
 	SEARCH_BLOCK_NAME,
 	SEARCH_VARIATION_NAME,
 } from './constants';
@@ -52,7 +52,7 @@ export function getSelectedRadioControlOption(
 	buttonPosition: string
 ): string {
 	if ( isInputAndButtonOption( buttonPosition ) ) {
-		return ButtonOptions.INPUT_AND_BUTTON;
+		return PositionOptions.INPUT_AND_BUTTON;
 	}
 	return buttonPosition;
 }
@@ -71,5 +71,5 @@ export function getInputAndButtonOption( value: ButtonPositionProps ) {
 		return value;
 	}
 	// The default value is 'inside' for input and button.
-	return ButtonOptions.OUTSIDE;
+	return PositionOptions.OUTSIDE;
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { SEARCH_BLOCK_NAME, SEARCH_VARIATION_NAME } from './constants';
+import { ProductSearchBlock } from './types';
+
+/**
+ * Identifies if a block is a Search block variation from our conventions
+ *
+ * We are extending Gutenberg's core Search block with our variations, and
+ * also adding extra namespaced attributes. If those namespaced attributes
+ * are present, we can be fairly sure it is our own registered variation.
+ */
+export function isWooSearchBlockVariation( block: ProductSearchBlock ) {
+	return (
+		block.name === SEARCH_BLOCK_NAME &&
+		block.attributes?.namespace === SEARCH_VARIATION_NAME
+	);
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-search/utils.ts
@@ -6,7 +6,7 @@ import {
 	SEARCH_BLOCK_NAME,
 	SEARCH_VARIATION_NAME,
 } from './constants';
-import { ButtonPositionProps, ProductSearchBlock } from './types';
+import { ButtonPositionProps, ProductSearchBlockProps } from './types';
 
 /**
  * Identifies if a block is a Search block variation from our conventions
@@ -15,9 +15,9 @@ import { ButtonPositionProps, ProductSearchBlock } from './types';
  * also adding extra namespaced attributes. If those namespaced attributes
  * are present, we can be fairly sure it is our own registered variation.
  *
- * @param {ProductSearchBlock} block - A WooCommerce block.
+ * @param {ProductSearchBlockProps} block - A WooCommerce block.
  */
-export function isWooSearchBlockVariation( block: ProductSearchBlock ) {
+export function isWooSearchBlockVariation( block: ProductSearchBlockProps ) {
 	return (
 		block.name === SEARCH_BLOCK_NAME &&
 		block.attributes?.namespace === SEARCH_VARIATION_NAME

--- a/plugins/woocommerce/changelog/add-47890_inspector_control_to_product_search
+++ b/plugins/woocommerce/changelog/add-47890_inspector_control_to_product_search
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add inspector controls to Product Search block #51247


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR enhances the Product Search block by adding inspector controls. The new controls reflect the options available in the toolbar and provide a consistent editing experience.

![Screenshot 2024-09-11 at 4 30 43 PM](https://github.com/user-attachments/assets/ed97c1ad-e3ce-494e-9991-abb0c5dca9b3)

Closes #47890.


### Update
It's not currently possible to remove the toolbar controls here, and that should be addressed upstream. We believe that moving the controls from the toolbar to the inspector is a good approach that can also be applied to the core block, so we'll create an issue to handle that there. More context can be found here (p1724915930676149/1724782631.062739-slack-C02FL3X7KR6)

In this PR, we’ve added the new controls to the `Product Search` inspector, and the remaining tasks will be handled in a follow-up PR in GB.

**Acceptance Criteria**

The controls shown in the toolbar for the Product Search block will be shown in the inspector.

- Button position

![Screenshot 2024-09-11 at 4 53 29 PM](https://github.com/user-attachments/assets/70628185-f961-4830-b620-a66458faafae)

  - [ ] When `Button outside` or `Button inside` is selected in the toolbar, the `Input and button` radio option should be selected in the inspector controls..
  - [ ] When `No button` is selected in the toolbar, the `Input only` radio option should be selected in the inspector controls..
  - [ ] When `Button only` option is selected in the toolbar, we will see the `Button only` radio option should be selected in the inspector controls.

- Toggle search label

![Screenshot 2024-09-11 at 4 53 43 PM](https://github.com/user-attachments/assets/05671a1f-842a-4f73-8f05-bca21ba2d1e9)

  - [ ] The toggle for the search label should be visible in the inspector controls.

- Use button with icon

![Screenshot 2024-09-11 at 4 59 55 PM](https://github.com/user-attachments/assets/dbe2f603-b7b0-411c-bf3f-8a11e55e3cb0)

  - [ ] The toggle for the button icon will be visible in the inspector as well.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and navigate to Pages > Add New Page
2. Add a `Product Search` block and focus it.
3. Select a button position in the toolbar. Select the `Button inside` option.
4. Verify that the change in the toolbar is also applied in the `Styles` section under the `Styes` tab.
5. Select the `Input only` radio button option in the inspector controls.
6. Confirm that the button appearance and position toggles are hidden as expected.
7. Ensure that the option position in the toolbar also now have that option selected.
8. Select the `Button only` option in the inspector controls.
9. Verify that the button appearance toggle becomes visible.
10. Switch back to `Input and button` and check that the previously selected option (between `Button outside` and `Button inside` options) is still applied. 

https://github.com/user-attachments/assets/c9bd643c-c4c8-42be-a8f9-39e288124918

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
