### PR TITLE
Fix unsnooze notes not working

### DIFF
--- a/plugins/woocommerce/changelog/fix-unsnooze-notes
+++ b/plugins/woocommerce/changelog/fix-unsnooze-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc_admin_unsnooze_admin_notes events are being needlessly created

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -534,7 +534,7 @@ class Note extends \WC_Data {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note date prop cannot be empty.', 'woocommerce' ) );
 		}
 
-		if ( is_string( $date ) ) {
+		if ( is_string( $date ) && ! is_numeric( $date ) ) {
 			$date = wc_string_to_timestamp( $date );
 		}
 		$this->set_date_prop( 'date_created', $date );
@@ -546,7 +546,7 @@ class Note extends \WC_Data {
 	 * @param string|integer|null $date UTC timestamp, or ISO 8601 DateTime. If the DateTime string has no timezone or offset, WordPress site timezone will be assumed. Null if there is no date.
 	 */
 	public function set_date_reminder( $date ) {
-		if ( is_string( $date ) ) {
+		if ( is_string( $date ) && ! is_numeric( $date ) ) {
 			$date = wc_string_to_timestamp( $date );
 		}
 		$this->set_date_prop( 'date_reminder', $date );

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -24,6 +24,7 @@ class Notes {
 		add_action( 'admin_init', array( __CLASS__, 'schedule_unsnooze_notes' ) );
 		add_action( 'admin_init', array( __CLASS__, 'possibly_delete_survey_notes' ) );
 		add_action( 'update_option_woocommerce_show_marketplace_suggestions', array( __CLASS__, 'possibly_delete_marketing_notes' ), 10, 2 );
+		add_action( self::UNSNOOZE_HOOK, array( __CLASS__, 'unsnooze_notes' ) );
 	}
 
 	/**
@@ -406,7 +407,6 @@ class Notes {
 		wp_set_current_user( $user_id );
 		self::record_tracks_event_without_cookies( $event_name, $params );
 		wp_set_current_user( $current_user_id );
-
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-note.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-note.php
@@ -53,4 +53,31 @@ class WC_Admin_Tests_Notes_Note extends WC_Unit_Test_Case {
 		$this->assertEquals( $date_created_from_first_save, $date_created_from_second_save );
 	}
 
+	/**
+	 * Tests setting date_reminder with various input types.
+	 *
+	 * @dataProvider date_reminder_provider
+	 * @param mixed $input Input date value.
+	 * @param int   $expected_timestamp Expected timestamp.
+	 */
+	public function test_set_date_reminder_with_various_inputs( $input, $expected_timestamp ) {
+		$note = new Note();
+		$note->set_date_reminder( $input );
+		$date_reminder = $note->get_date_reminder();
+		$this->assertEquals( $expected_timestamp, $date_reminder );
+	}
+
+	/**
+	 * Data provider for test_set_date_reminder_with_various_inputs.
+	 *
+	 * @return array
+	 */
+	public function date_reminder_provider() {
+		return array(
+			'timestamp'          => array( 1609459200, '2021-01-01T00:00:00+00:00' ),
+			'timestamp string'   => array( '1609459200', '2021-01-01T00:00:00+00:00' ),
+			'date string'        => array( '2021-01-01', '2021-01-01T00:00:00+00:00' ),
+			'WC_DateTime object' => array( new WC_DateTime( '2021-01-01' ), '2021-01-01T00:00:00+00:00' ),
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36287


Users can snooze notes, but the snooze notes do not display after the snooze period has passed. There are two issues:

1. `wc_admin_unsnooze_admin_notes` event are being created but no action is being taken to unsnooze the notes.
2. `set_date_reminder` contains a bug that pass timestamp to `wc_string_to_timestamp` which expects a English textual datetime description and not a timestamp.


This PR adds missing action to unsnooze notes and fixes the bug in `set_date_reminder`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Make sure you have a Store Alert visible

1. First see what's already in your DB.

```sql
SELECT note_id,is_read,is_deleted,status,type from wp_wc_admin_notes WHERE type = 'update'
```

2. Make one "unactioned".

```sql
UPDATE wp_wc_admin_notes SET status = 'unactioned' WHERE note_id = 15;
```

3. You may need to mark some as not deleted.

```sql 
UPDATE wp_wc_admin_notes SET is_deleted = 0 WHERE note_id = 15;
```

4. Make note snoozable.

```sql
UPDATE wp_wc_admin_notes SET is_snoozable = 1 WHERE note_id = 15;
```
5. Go to `WooComerce > Home`
6. Confirm the Store Alert is visible and snoozable.
7. Click on the snooze button and select a snooze period.
8. Confirm the note is snoozed and the date reminder is set correctly.

```sql
select date_reminder, status from wp_wc_admin_notes where note_id = 15;
```

9. Run the following query to set the date reminder to a past date so that the note can be unsnoozed.

```sql
update wp_wc_admin_notes SET date_reminder = '2024-09-09 00:00:00' WHERE note_id IN  (15);
```

10. Install and activate the [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) plugin.
11. Go to `Tools > Cron Events` and confirm that the `wc_admin_unsnooze_admin_notes` event is scheduled.
12. Run the `wc_admin_unsnooze_admin_notes` event manually.
13. Go to `WooComerce > Home`
14. Confirm the Store Alert is visible and not snoozed.


![Screenshot 2024-09-10 at 17 01 41](https://github.com/user-attachments/assets/85d1ec9e-9eb4-447e-9364-639be8546d20)
![Screenshot 2024-09-10 at 16 30 24](https://github.com/user-attachments/assets/bb5e4597-5525-49dd-aac9-46a669daf493)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
