### PR TITLE
[e2e tests] Fix flaky product images test: can update a product gallery

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-can-update-a-product-gallery-not-in-view
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-can-update-a-product-gallery-not-in-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
@@ -280,6 +280,13 @@ test.describe(
 				const imageSelector = '#product_images_container img';
 				imagesCount = await page.locator( imageSelector ).count();
 
+				await page
+					.getByRole( 'link', {
+						name: 'Add product gallery images',
+					} )
+					.scrollIntoViewIfNeeded();
+
+				await page.pause();
 				await page.locator( imageSelector ).first().hover();
 				await page.getByRole( 'link', { name: ' Delete' } ).click();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
@@ -286,7 +286,6 @@ test.describe(
 					} )
 					.scrollIntoViewIfNeeded();
 
-				await page.pause();
 				await page.locator( imageSelector ).first().hover();
 				await page.getByRole( 'link', { name: ' Delete' } ).click();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/50824

I believe these failures are caused by un unfortunate position of the images in the screen. The image element is hovered to activate the delete button and in all failed occurrences the image was barely visible in the viewport. I believe this position messed up the hovering part.
The fix attempt is to explicitly scroll into view the link below the images. This way the image will always be fully into view.

### How to test the changes in this Pull Request:

```pnpm test:e2e -g "can update a product gallery"```