### PR TITLE
[e2e tests] Don't catch api errors in fixtures

### DIFF
--- a/plugins/woocommerce/changelog/e2e-dont-catch-api-errors
+++ b/plugins/woocommerce/changelog/e2e-dont-catch-api-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
@@ -35,15 +35,7 @@ const test = baseTest.extend( {
 	coupon: async ( { api }, use ) => {
 		const coupon = {};
 		await use( coupon );
-		await api
-			.delete( `coupons/${ coupon.id }`, { force: true } )
-			.then( ( response ) => {
-				console.log( 'Delete successful:', response.data );
-			} )
-			.catch( ( error ) => {
-				console.log( 'Error response data:', error.response.data );
-				throw new Error( error.response.data );
-			} );
+		await api.delete( `coupons/${ coupon.id }`, { force: true } );
 	},
 } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
@@ -74,15 +74,7 @@ const test = baseTest.extend( {
 	coupon: async ( { api }, use ) => {
 		const coupon = {};
 		await use( coupon );
-		await api
-			.delete( `coupons/${ coupon.id }`, { force: true } )
-			.then( ( response ) => {
-				console.log( 'Delete successful:', response.data );
-			} )
-			.catch( ( error ) => {
-				console.log( 'Error response data:', error.response.data );
-				throw new Error( error.response.data );
-			} );
+		await api.delete( `coupons/${ coupon.id }`, { force: true } );
 	},
 
 	product: async ( { api }, use ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/51014 introduced a catch on api errors when deleting coupons in the test teardown, to better understand the error.
The problem is that sometimes the `error.response` object is `undefined` (see [this run](https://github.com/woocommerce/woocommerce/actions/runs/10732308275/job/29763820351#step:9:688)), causing the `TypeError: Cannot read properties of undefined (reading 'data')` error in the catch block and masking the real error.
Before this change there were a few occurrences of `Error: socket hang up` which I suspect is the error this catch block is actually masking. See [this run](https://github.com/woocommerce/woocommerce/actions/runs/10404386569/job/28812779243#step:9:217).
We should better let the original error be thrown and if we get many socket hang up we should probably catch that and retry the request.

Related: https://github.com/woocommerce/woocommerce/issues/50704

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```
pnpm test:e2e create-coupon.spec.js create-restricted-coupons.spec.js
```