### PR TITLE
Add search results count to the in-app marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -69,9 +69,6 @@ export default function Content(): JSX.Element {
 					if ( category === 'business-services' ) {
 						setHasBusinessServices( productList.length > 0 );
 					}
-					setSearchResultsCount( {
-						[ category ]: productList.length, // updating the appropriate category
-					} );
 				} );
 				return () => {
 					abortControllers.forEach( ( controller ) => {

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -44,7 +44,7 @@ export default function Content(): JSX.Element {
 
 		categories.forEach( ( category: keyof SearchResultsCountType, index ) => {
 			const params = new URLSearchParams();
-			if ( 'extensions' !== 'category' ) {
+			if ( 'extensions' !== category ) {
 				params.append( 'category', category );
 			}
 

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -32,44 +32,55 @@ import SubscriptionsExpiredExpiringNotice from '~/marketplace/components/my-subs
 export default function Content(): JSX.Element {
 	const marketplaceContextValue = useContext( MarketplaceContext );
 	const [ products, setProducts ] = useState< Product[] >( [] );
-	const { setIsLoading, selectedTab, setHasBusinessServices, searchResultsCount, setSearchResultsCount } =
-		marketplaceContextValue;
+	const {
+		setIsLoading,
+		selectedTab,
+		setHasBusinessServices,
+		setSearchResultsCount,
+	} = marketplaceContextValue;
 	const query = useQuery();
 
 	// On initial load of the in-app marketplace, fetch extensions, themes and business services
 	// and check if there are any business services available on WCCOM
 	useEffect( () => {
-		const categories: Array<keyof SearchResultsCountType> = [ 'extensions', 'themes', 'business-services' ];
+		const categories: Array< keyof SearchResultsCountType > = [
+			'extensions',
+			'themes',
+			'business-services',
+		];
 		const abortControllers = categories.map( () => new AbortController() );
 
-		categories.forEach( ( category: keyof SearchResultsCountType, index ) => {
-			const params = new URLSearchParams();
-			if ( 'extensions' !== category ) {
-				params.append( 'category', category );
-			}
+		categories.forEach(
+			( category: keyof SearchResultsCountType, index ) => {
+				const params = new URLSearchParams();
+				if ( category !== 'extensions' ) {
+					params.append( 'category', category );
+				}
 
-			const wccomSettings = getAdminSetting( 'wccomHelper', false );
-			if ( wccomSettings.storeCountry ) {
-				params.append( 'country', wccomSettings.storeCountry );
-			}
+				const wccomSettings = getAdminSetting( 'wccomHelper', false );
+				if ( wccomSettings.storeCountry ) {
+					params.append( 'country', wccomSettings.storeCountry );
+				}
 
-			fetchSearchResults( params, abortControllers[ index ].signal ).then(
-				( productList ) => {
+				fetchSearchResults(
+					params,
+					abortControllers[ index ].signal
+				).then( ( productList ) => {
 					if ( category === 'business-services' ) {
 						setHasBusinessServices( productList.length > 0 );
 					}
 					setSearchResultsCount( ( prevResults ) => ( {
 						...prevResults,
-						[category]: productList.length, // updating the appropriate category
+						[ category ]: productList.length, // updating the appropriate category
 					} ) );
-				}
-			);
-			return () => {
-				abortControllers.forEach( ( controller ) => {
-					controller.abort();
 				} );
-			};
-		} );
+				return () => {
+					abortControllers.forEach( ( controller ) => {
+						controller.abort();
+					} );
+				};
+			}
+		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
@@ -118,9 +129,15 @@ export default function Content(): JSX.Element {
 				if ( query.term ) {
 					setSearchResultsCount( ( prevState ) => ( {
 						...prevState,
-						extensions: productList.filter( ( p ) => p.type === 'extension' ).length,
-						themes: productList.filter( ( p ) => p.type === 'theme' ).length,
-						'business-services': productList.filter( ( p ) => p.type === 'business-service' ).length,
+						extensions: productList.filter(
+							( p ) => p.type === 'extension'
+						).length,
+						themes: productList.filter(
+							( p ) => p.type === 'theme'
+						).length,
+						'business-services': productList.filter(
+							( p ) => p.type === 'business-service'
+						).length,
 					} ) );
 				}
 			} )
@@ -157,7 +174,9 @@ export default function Content(): JSX.Element {
 			case 'extensions':
 				return (
 					<Products
-						products={ products.filter( p => 'extension' === p.type ) }
+						products={ products.filter(
+							( p ) => p.type === 'extension'
+						) }
 						categorySelector={ true }
 						type={ ProductType.extension }
 					/>
@@ -165,7 +184,9 @@ export default function Content(): JSX.Element {
 			case 'themes':
 				return (
 					<Products
-						products={ products.filter( p => 'theme' === p.type ) }
+						products={ products.filter(
+							( p ) => p.type === 'theme'
+						) }
 						categorySelector={ true }
 						type={ ProductType.theme }
 					/>
@@ -173,7 +194,9 @@ export default function Content(): JSX.Element {
 			case 'business-services':
 				return (
 					<Products
-						products={ products.filter( p => 'business-service' === p.type ) }
+						products={ products.filter(
+							( p ) => p.type === 'business-service'
+						) }
 						categorySelector={ true }
 						type={ ProductType.businessService }
 					/>

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -69,10 +69,9 @@ export default function Content(): JSX.Element {
 					if ( category === 'business-services' ) {
 						setHasBusinessServices( productList.length > 0 );
 					}
-					setSearchResultsCount( ( prevResults ) => ( {
-						...prevResults,
+					setSearchResultsCount( {
 						[ category ]: productList.length, // updating the appropriate category
-					} ) );
+					} );
 				} );
 				return () => {
 					abortControllers.forEach( ( controller ) => {
@@ -127,8 +126,7 @@ export default function Content(): JSX.Element {
 				setProducts( productList );
 
 				if ( query.term ) {
-					setSearchResultsCount( ( prevState ) => ( {
-						...prevState,
+					setSearchResultsCount( {
 						extensions: productList.filter(
 							( p ) => p.type === 'extension'
 						).length,
@@ -138,7 +136,7 @@ export default function Content(): JSX.Element {
 						'business-services': productList.filter(
 							( p ) => p.type === 'business-service'
 						).length,
-					} ) );
+					} );
 				}
 			} )
 			.catch( () => {

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -39,12 +39,12 @@ export default function Content(): JSX.Element {
 	// On initial load of the in-app marketplace, fetch extensions, themes and business services
 	// and check if there are any business services available on WCCOM
 	useEffect( () => {
-		const categories: Array<keyof SearchResultsCountType> = ['extensions', 'themes', 'business-services'];
+		const categories: Array<keyof SearchResultsCountType> = [ 'extensions', 'themes', 'business-services' ];
 		const abortControllers = categories.map( () => new AbortController() );
 
 		categories.forEach( ( category: keyof SearchResultsCountType, index ) => {
 			const params = new URLSearchParams();
-			if ( category !== 'extensions' ) {
+			if ( 'extensions' !== 'category' ) {
 				params.append( 'category', category );
 			}
 
@@ -86,7 +86,6 @@ export default function Content(): JSX.Element {
 
 		setIsLoading( true );
 		setProducts( [] );
-
 
 		const params = new URLSearchParams();
 

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -47,15 +47,15 @@
 	}
 
 	&__update-count-extensions {
-		background-color: #000000;
+		background-color: #000;
 	}
 
 	&__update-count-themes {
-		background-color: #000000;
+		background-color: #000;
 	}
 
 	&__update-count-business-services {
-		background-color: #000000;
+		background-color: #000;
 	}
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -45,6 +45,18 @@
 		text-align: center;
 		z-index: 26;
 	}
+
+	&__update-count-extensions {
+		background-color: #000000;
+	}
+
+	&__update-count-themes {
+		background-color: #000000;
+	}
+
+	&__update-count-business-services {
+		background-color: #000000;
+	}
 }
 
 @media (width <= $breakpoint-medium) {

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -46,15 +46,7 @@
 		z-index: 26;
 	}
 
-	&__update-count-extensions {
-		background-color: #000;
-	}
-
-	&__update-count-themes {
-		background-color: #000;
-	}
-
-	&__update-count-business-services {
+	&__update-count {
 		background-color: #000;
 	}
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -35,45 +35,6 @@ interface Tabs {
 const wccomSettings = getAdminSetting( 'wccomHelper', {} );
 const wooUpdateCount = wccomSettings?.wooUpdateCount ?? 0;
 
-const tabs: Tabs = {
-	search: {
-		name: 'search',
-		title: __( 'Search results', 'woocommerce' ),
-		showUpdateCount: false,
-		updateCount: 0,
-	},
-	discover: {
-		name: 'discover',
-		title: __( 'Discover', 'woocommerce' ),
-		showUpdateCount: false,
-		updateCount: 0,
-	},
-	extensions: {
-		name: 'extensions',
-		title: __( 'Extensions', 'woocommerce' ),
-		showUpdateCount: false,
-		updateCount: 0,
-	},
-	themes: {
-		name: 'themes',
-		title: __( 'Themes', 'woocommerce' ),
-		showUpdateCount: false,
-		updateCount: 0,
-	},
-	'business-services': {
-		name: 'business-services',
-		title: __( 'Business services', 'woocommerce' ),
-		showUpdateCount: false,
-		updateCount: 0,
-	},
-	'my-subscriptions': {
-		name: 'my-subscriptions',
-		title: __( 'My subscriptions', 'woocommerce' ),
-		showUpdateCount: true,
-		updateCount: wooUpdateCount,
-	},
-};
-
 const setUrlTabParam = ( tabKey: string ) => {
 	navigateTo( {
 		url: getNewPath(
@@ -84,7 +45,7 @@ const setUrlTabParam = ( tabKey: string ) => {
 	} );
 };
 
-const getVisibleTabs = ( selectedTab: string, hasBusinessServices = false ) => {
+const getVisibleTabs = ( selectedTab: string, hasBusinessServices = false, tabs: Tabs ) => {
 	if ( selectedTab === '' ) {
 		return tabs;
 	}
@@ -101,7 +62,8 @@ const getVisibleTabs = ( selectedTab: string, hasBusinessServices = false ) => {
 
 const renderTabs = (
 	marketplaceContextValue: MarketplaceContextType,
-	visibleTabs: Tabs
+	visibleTabs: Tabs,
+	tabs: Tabs
 ) => {
 	const { selectedTab, setSelectedTab } = marketplaceContextValue;
 
@@ -141,12 +103,11 @@ const renderTabs = (
 					key={ tabKey }
 				>
 					{ tabs[ tabKey ]?.title }
-					{ tabs[ tabKey ]?.showUpdateCount &&
-						tabs[ tabKey ]?.updateCount > 0 && (
-							<span className="woocommerce-marketplace__update-count">
-								<span> { tabs[ tabKey ]?.updateCount } </span>
-							</span>
-						) }
+					{ tabs[ tabKey ]?.showUpdateCount && (
+						<span className={`woocommerce-marketplace__update-count woocommerce-marketplace__update-count-${ tabKey }`}>
+							<span> { tabs[ tabKey ]?.updateCount } </span>
+						</span>
+					) }
 				</Button>
 			)
 		);
@@ -159,7 +120,48 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 	const marketplaceContextValue = useContext( MarketplaceContext );
 	const { selectedTab, setSelectedTab, hasBusinessServices } =
 		marketplaceContextValue;
-	const [ visibleTabs, setVisibleTabs ] = useState( getVisibleTabs( '' ) );
+	const { searchResultsCount } = marketplaceContextValue;
+
+	const tabs: Tabs = {
+		search: {
+			name: 'search',
+			title: __( 'Search results', 'woocommerce' ),
+			showUpdateCount: false,
+			updateCount: 0,
+		},
+		discover: {
+			name: 'discover',
+			title: __( 'Discover', 'woocommerce' ),
+			showUpdateCount: false,
+			updateCount: 0,
+		},
+		extensions: {
+			name: 'extensions',
+			title: __( 'Extensions', 'woocommerce' ),
+			showUpdateCount: true,
+			updateCount: searchResultsCount.extensions,
+		},
+		themes: {
+			name: 'themes',
+			title: __( 'Themes', 'woocommerce' ),
+			showUpdateCount: true,
+			updateCount: searchResultsCount.themes,
+		},
+		'business-services': {
+			name: 'business-services',
+			title: __( 'Business services', 'woocommerce' ),
+			showUpdateCount: true,
+			updateCount: searchResultsCount['business-services'],
+		},
+		'my-subscriptions': {
+			name: 'my-subscriptions',
+			title: __( 'My subscriptions', 'woocommerce' ),
+			showUpdateCount: true,
+			updateCount: wooUpdateCount,
+		},
+	};
+
+	const [ visibleTabs, setVisibleTabs ] = useState( getVisibleTabs( '', false, tabs ) );
 
 	const query: Record< string, string > = useQuery();
 
@@ -172,8 +174,9 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 	}, [ query, setSelectedTab ] );
 
 	useEffect( () => {
-		setVisibleTabs( getVisibleTabs( selectedTab, hasBusinessServices ) );
+		setVisibleTabs( getVisibleTabs( selectedTab, hasBusinessServices, tabs ) );
 	}, [ selectedTab, hasBusinessServices ] );
+
 	return (
 		<nav
 			className={ clsx(
@@ -181,7 +184,7 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 				additionalClassNames || []
 			) }
 		>
-			{ renderTabs( marketplaceContextValue, visibleTabs ) }
+			{ renderTabs( marketplaceContextValue, visibleTabs, tabs ) }
 		</nav>
 	);
 };

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -128,6 +128,8 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 		marketplaceContextValue;
 	const { searchResultsCount } = marketplaceContextValue;
 
+	const query: Record< string, string > = useQuery();
+
 	const tabs: Tabs = {
 		search: {
 			name: 'search',
@@ -144,19 +146,19 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 		extensions: {
 			name: 'extensions',
 			title: __( 'Extensions', 'woocommerce' ),
-			showUpdateCount: true,
+			showUpdateCount: !! query.term,
 			updateCount: searchResultsCount.extensions,
 		},
 		themes: {
 			name: 'themes',
 			title: __( 'Themes', 'woocommerce' ),
-			showUpdateCount: true,
+			showUpdateCount: !! query.term,
 			updateCount: searchResultsCount.themes,
 		},
 		'business-services': {
 			name: 'business-services',
 			title: __( 'Business services', 'woocommerce' ),
-			showUpdateCount: true,
+			showUpdateCount: !! query.term,
 			updateCount: searchResultsCount[ 'business-services' ],
 		},
 		'my-subscriptions': {
@@ -170,8 +172,6 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 	const [ visibleTabs, setVisibleTabs ] = useState(
 		getVisibleTabs( '', false, tabs )
 	);
-
-	const query: Record< string, string > = useQuery();
 
 	useEffect( () => {
 		if ( query?.tab && tabs[ query.tab ] ) {

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -45,7 +45,11 @@ const setUrlTabParam = ( tabKey: string ) => {
 	} );
 };
 
-const getVisibleTabs = ( selectedTab: string, hasBusinessServices = false, tabs: Tabs ) => {
+const getVisibleTabs = (
+	selectedTab: string,
+	hasBusinessServices = false,
+	tabs: Tabs
+) => {
 	if ( selectedTab === '' ) {
 		return tabs;
 	}
@@ -104,7 +108,9 @@ const renderTabs = (
 				>
 					{ tabs[ tabKey ]?.title }
 					{ tabs[ tabKey ]?.showUpdateCount && (
-						<span className={`woocommerce-marketplace__update-count woocommerce-marketplace__update-count-${ tabKey }`}>
+						<span
+							className={ `woocommerce-marketplace__update-count woocommerce-marketplace__update-count-${ tabKey }` }
+						>
 							<span> { tabs[ tabKey ]?.updateCount } </span>
 						</span>
 					) }
@@ -151,7 +157,7 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 			name: 'business-services',
 			title: __( 'Business services', 'woocommerce' ),
 			showUpdateCount: true,
-			updateCount: searchResultsCount['business-services'],
+			updateCount: searchResultsCount[ 'business-services' ],
 		},
 		'my-subscriptions': {
 			name: 'my-subscriptions',
@@ -161,7 +167,9 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 		},
 	};
 
-	const [ visibleTabs, setVisibleTabs ] = useState( getVisibleTabs( '', false, tabs ) );
+	const [ visibleTabs, setVisibleTabs ] = useState(
+		getVisibleTabs( '', false, tabs )
+	);
 
 	const query: Record< string, string > = useQuery();
 
@@ -174,7 +182,9 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 	}, [ query, setSelectedTab ] );
 
 	useEffect( () => {
-		setVisibleTabs( getVisibleTabs( selectedTab, hasBusinessServices, tabs ) );
+		setVisibleTabs(
+			getVisibleTabs( selectedTab, hasBusinessServices, tabs )
+		);
 	}, [ selectedTab, hasBusinessServices ] );
 
 	return (

--- a/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, createContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { MarketplaceContextType } from './types';
+import { SearchResultsCountType, MarketplaceContextType } from './types';
 import { getAdminSetting } from '../../utils/admin-settings';
 
 export const MarketplaceContext = createContext< MarketplaceContextType >( {
@@ -18,6 +18,12 @@ export const MarketplaceContext = createContext< MarketplaceContextType >( {
 	addInstalledProduct: () => {},
 	hasBusinessServices: false,
 	setHasBusinessServices: () => {},
+	searchResultsCount: {
+		extensions: 0,
+		themes: 0,
+		'business-services': 0,
+	},
+	setSearchResultsCount: () => {},
 } );
 
 export function MarketplaceContextProvider( props: {
@@ -29,6 +35,11 @@ export function MarketplaceContextProvider( props: {
 		[]
 	);
 	const [ hasBusinessServices, setHasBusinessServices ] = useState( false );
+	const [ searchResultsCount, setSearchResultsCount ] = useState< SearchResultsCountType >( {
+		extensions: 0,
+		themes: 0,
+		'business-services': 0,
+	} );
 
 	/**
 	 * Knowing installed products will help us to determine which products
@@ -59,6 +70,8 @@ export function MarketplaceContextProvider( props: {
 		addInstalledProduct,
 		hasBusinessServices,
 		setHasBusinessServices,
+		searchResultsCount,
+		setSearchResultsCount,
 	};
 
 	return (

--- a/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { useState, useEffect, createContext } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	createContext,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,12 +40,22 @@ export function MarketplaceContextProvider( props: {
 		[]
 	);
 	const [ hasBusinessServices, setHasBusinessServices ] = useState( false );
-	const [ searchResultsCount, setSearchResultsCount ] =
+	const [ searchResultsCount, setSearchResultsCountState ] =
 		useState< SearchResultsCountType >( {
 			extensions: 0,
 			themes: 0,
 			'business-services': 0,
 		} );
+
+	const setSearchResultsCount = useCallback(
+		( updatedCounts: Partial< SearchResultsCountType > ) => {
+			setSearchResultsCountState( ( prev ) => ( {
+				...prev,
+				...updatedCounts,
+			} ) );
+		},
+		[]
+	);
 
 	/**
 	 * Knowing installed products will help us to determine which products

--- a/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/marketplace-context.tsx
@@ -35,11 +35,12 @@ export function MarketplaceContextProvider( props: {
 		[]
 	);
 	const [ hasBusinessServices, setHasBusinessServices ] = useState( false );
-	const [ searchResultsCount, setSearchResultsCount ] = useState< SearchResultsCountType >( {
-		extensions: 0,
-		themes: 0,
-		'business-services': 0,
-	} );
+	const [ searchResultsCount, setSearchResultsCount ] =
+		useState< SearchResultsCountType >( {
+			extensions: 0,
+			themes: 0,
+			'business-services': 0,
+		} );
 
 	/**
 	 * Knowing installed products will help us to determine which products

--- a/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
@@ -8,6 +8,12 @@ import { Options } from '@wordpress/notices';
  */
 import { Subscription } from '../components/my-subscriptions/types';
 
+export interface SearchResultsCountType {
+	extensions: number;
+	themes: number;
+	'business-services': number;
+}
+
 export type MarketplaceContextType = {
 	isLoading: boolean;
 	setIsLoading: ( isLoading: boolean ) => void;
@@ -17,6 +23,10 @@ export type MarketplaceContextType = {
 	addInstalledProduct: ( slug: string ) => void;
 	hasBusinessServices: boolean;
 	setHasBusinessServices: ( hasBusinessServices: boolean ) => void;
+	searchResultsCount: SearchResultsCountType;
+	setSearchResultsCount: (
+		cb: ( prevState: SearchResultsCountType ) => SearchResultsCountType
+	) => void;
 };
 
 export type SubscriptionsContextType = {

--- a/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
@@ -25,7 +25,7 @@ export type MarketplaceContextType = {
 	setHasBusinessServices: ( hasBusinessServices: boolean ) => void;
 	searchResultsCount: SearchResultsCountType;
 	setSearchResultsCount: (
-		cb: ( prevState: SearchResultsCountType ) => SearchResultsCountType
+		setState: ( prevState: SearchResultsCountType ) => SearchResultsCountType
 	) => void;
 };
 

--- a/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
@@ -25,7 +25,7 @@ export type MarketplaceContextType = {
 	setHasBusinessServices: ( hasBusinessServices: boolean ) => void;
 	searchResultsCount: SearchResultsCountType;
 	setSearchResultsCount: (
-		setState: ( prevState: SearchResultsCountType ) => SearchResultsCountType
+		updatedCounts: Partial< SearchResultsCountType >
 	) => void;
 };
 

--- a/plugins/woocommerce/changelog/tweak-21597-in-app-search-results-count
+++ b/plugins/woocommerce/changelog/tweak-21597-in-app-search-results-count
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add search result counts to the in-app marketplace header tabs (Extensions area)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/21597.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to http://localhost:8080/wp-admin/admin.php?page=wc-admin&path=%2Fextensions
2. Depending on your locale, you should see numbers in the ribbons for Extensions/Themes/Business services when you do a search.
    - My locale is `MK` and the requests to https://woocommerce.com...search?country=MK generates the numbers 100, 94 and 6 respectively
3. Search for "WooPayments" -> ribbons updated to 3, 0, 0 respectively
4. Search for "Glowess" -> ribbons updated to 0, 1, 0 respectively
5. Search for "LegalVision" -> ribbons updated to 0, 0, 1 respectively

Known issue: switching to another tab after search dismisses the term (should be addressed in https://github.com/Automattic/woocommerce.com/issues/21576)

Known issue: reload after search messes the numbers (should be addressed in https://github.com/Automattic/woocommerce.com/issues/21576)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
