### PR TITLE
Fix REST API incorrectly returns 500 when deleting tax rate if woocommerce_tax_rate_deleted does $wpdb queries that affect rows (#51191)

### DIFF
--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -1117,16 +1117,28 @@ class WC_Tax {
 	 *
 	 * @since 2.3.0
 	 * @param  int $tax_rate_id Tax rate to delete.
+	 * @return bool
 	 */
 	public static function _delete_tax_rate( $tax_rate_id ) {
 		global $wpdb;
 
+		$deleted = false;
+
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d;", $tax_rate_id ) );
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %d;", $tax_rate_id ) );
 
-		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
+		if ( $wpdb->rows_affected > 0 ) {
 
-		do_action( 'woocommerce_tax_rate_deleted', $tax_rate_id );
+			$deleted = true;
+
+			WC_Cache_Helper::invalidate_cache_group( 'taxes' );
+
+			do_action( 'woocommerce_tax_rate_deleted', $tax_rate_id );
+
+		}
+
+		return $deleted;
+
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
@@ -504,9 +504,9 @@ class WC_REST_Taxes_V1_Controller extends WC_REST_Controller {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $tax, $request );
 
-		WC_Tax::_delete_tax_rate( $id );
+		$deleted = WC_Tax::_delete_tax_rate( $id );
 
-		if ( 0 === $wpdb->rows_affected ) {
+		if ( !$deleted ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'The resource cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
@@ -506,7 +506,7 @@ class WC_REST_Taxes_V1_Controller extends WC_REST_Controller {
 
 		$deleted = WC_Tax::_delete_tax_rate( $id );
 
-		if ( !$deleted ) {
+		if ( ! $deleted ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'The resource cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes an issue that when deleting a tax rate via the API, it can return 500 rather than 200 after deleting the tax rate, this is because it determines if a tax rate has been deleted via `$wpdb->rows_affected` based on `WC_Tax::_delete_tax_rate( $id )`, however that function may have other functions hooked via the `woocommerce_tax_rate_deleted` action hook which do $wpdb queries affecting the affected rows count, and therefore the current method of using `$wpdb->rows_affected` to determine 200 or 500 isn't reliable.

Closes #51191.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add the following to functions.php, this is a simple example of some $wpdb query happening off of the `woocommerce_tax_rate_deleted` action hook which affects rows

```
function test_tax_rate_delete() {

	global $wpdb;

	$wpdb->query( "INSERT INTO `{$wpdb->prefix}options`(`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('','test','test','on')" );

}
add_action( 'woocommerce_tax_rate_deleted', 'test_tax_rate_delete' );
```

2. Ensure taxes are enabled and create a tax rate in the WooCommerce tax settings
3. Ensure the WooCommerce API is enabled
4. Via the API do GET https://example.com/wp-json/wc/v3/taxes/ to find the ID of the tax rate added
5. Via the API do DELETE https://example.com/wp-json/wc/v3/taxes/x?force=true where x is the tax rate ID
6. See that the response is now 200
7. You can check the 500 response by reverting the files in this commit while keeping the functions.php in place and repeating the tax rate setup/API steps

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Deleting tax rate via API may return an incorrect 500 response if functions hooked via woocommerce_tax_rate_deleted affect row counts</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
