### PR TITLE
Deprecate unsupported Inbox note banner layout

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -727,7 +727,7 @@
           "menu_title": "Implement merchant onboarding",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/handling-merchant-onboarding.md",
-          "hash": "c73e3c5015e6cda3be9ebd2d5fbda590ac9fa599e5fb02163c971c01060970ad",
+          "hash": "85fc7d70f47fdb195ad2c690d3b95565169221f9e4d7afa98e88f3824ad0e267",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/handling-merchant-onboarding.md",
           "id": "89fe15dc232379f546852822230c334d3d940b93"
         },
@@ -1804,5 +1804,5 @@
       "categories": []
     }
   ],
-  "hash": "1f651a59399c34644d2f91a0366bbd01da2c7dc677a1c53329b184badd3b8d13"
+  "hash": "77c102c35a45b0681e7b70def9d639d764e4e5068121c2ef4dd23477c0f8784c"
 }

--- a/docs/extension-development/handling-merchant-onboarding.md
+++ b/docs/extension-development/handling-merchant-onboarding.md
@@ -448,7 +448,7 @@ class ExampleNote {
         $note-&gt;set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
  
         // Set the type of layout the note uses. Supported layout types are:
-        // 'banner', 'plain', 'thumbnail'
+        // 'plain', 'thumbnail'
         $note-&gt;set_layout( 'plain' );
  
         // Set the image for the note. This property renders as the src

--- a/plugins/woocommerce-admin/docs/examples/extensions/simple-inbox-note/class-simpleinboxnote.php
+++ b/plugins/woocommerce-admin/docs/examples/extensions/simple-inbox-note/class-simpleinboxnote.php
@@ -83,7 +83,7 @@ class SimpleInboxNote {
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 
 		// Set the type of layout the note uses. Supported layout types are:
-		// 'banner', 'plain', 'thumbnail'.
+		// 'plain', 'thumbnail'.
 		$note->set_layout( 'plain' );
 
 		// Set the image for the note. This property renders as the src

--- a/plugins/woocommerce-beta-tester/api/admin-notes/add-note.php
+++ b/plugins/woocommerce-beta-tester/api/admin-notes/add-note.php
@@ -73,7 +73,6 @@ function get_mock_note_data() {
 	return array(
 		'content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud.',
 		'info'    => array(
-			'banner'    => $plugin_url . 'images/admin-notes/banner.jpg',
 			'thumbnail' => $plugin_url . 'images/admin-notes/thumbnail.jpg',
 			'plain'     => '',
 		),

--- a/plugins/woocommerce-beta-tester/changelog/update-deprecate-banner-layout
+++ b/plugins/woocommerce-beta-tester/changelog/update-deprecate-banner-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Deprecate unsupported Inbox note banner layout

--- a/plugins/woocommerce/changelog/update-deprecate-banner-layout
+++ b/plugins/woocommerce/changelog/update-deprecate-banner-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Deprecate unsupported Inbox note banner layout

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -579,6 +579,11 @@ class Note extends \WC_Data {
 			$layout = 'plain';
 		}
 		$valid_layouts = array( 'banner', 'plain', 'thumbnail' );
+
+		if ( 'banner' === $layout ) {
+			wc_deprecated_argument( 'Note::set_layout', '9.4.0', 'The "banner" layout is deprecated. Please use "thumbnail" instead to display a image.' );
+		}
+
 		if ( in_array( $layout, $valid_layouts, true ) ) {
 			$this->set_prop( 'layout', $layout );
 		} else {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -72,6 +72,9 @@ class SpecRunner {
 		if ( isset( $spec->source ) ) {
 			$note->set_source( $spec->source );
 		}
+		if ( isset( $spec->layout ) ) {
+			$note->set_layout( $spec->layout );
+		}
 
 		// Recreate actions.
 		$note->set_actions( self::get_actions( $spec ) );

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-admin-notes.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-admin-notes.php
@@ -60,7 +60,7 @@ class WC_Helper_Admin_Notes {
 		$note_2->set_source( 'PHPUNIT_TEST' );
 		$note_2->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 		$note_2->set_is_snoozable( true );
-		$note_2->set_layout( 'banner' );
+		$note_2->set_layout( 'thumbnail' );
 		$note_2->set_image( 'https://an-image.jpg' );
 		// This note has no actions.
 		$note_2->save();
@@ -100,7 +100,6 @@ class WC_Helper_Admin_Notes {
 			'?s=PHPUNIT_TEST_NOTE_4_ACTION_2_URL'
 		);
 		$note_4->save();
-
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/issues/33067

This PR deprecates the `banner` layout for Inbox notes. This layout was not supported in the front-end.

https://github.com/woocommerce/woocommerce/blob/02ef6c534e6cefbc935731df5a0eb0b55867d8a5/packages/js/experimental/src/inbox-note/inbox-note.tsx#L161

But our backend accepts this layout and also documentation mentions it. This PR deprecates the layout and updates the documentation so that developers are aware of the change and we can remove the layout in the future.

Additionally, this PR made a small change to allow setting the layout when importing notes via specs. We seems missed this functionality in the past.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Go to `WooCommerce > Home`
3. Confirm that the `The Note::set_layout argument is deprecated since version 9.4.0. The "banner" layout is deprecated. Please use "thumbnail" instead to display a image.` is not displayed in `debug.log`
4. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` > `Remote Inbox Notifications`
5. Click on `Import from URL` and use the following URL: https://gist.githubusercontent.com/chihsuan/8fbe10bd506461069e104db9734dd34c/raw/2b127b29fe0d6279834f403604b30f1b2cee0f5f/Banner%2520Layout%2520Note
6. Confirm that the note is imported successfully
7. Confirm that the deprecation notice is displayed in `debug.log` 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


---

