### PR TITLE
Dynamically set plugin_name when redirecting to Jetpack Auth from core profiler

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -300,15 +300,28 @@ const exitToWooHome = fromPromise( async () => {
 	window.location.href = getNewPath( {}, '/', {} );
 } );
 
+const getPluginNameParam = (
+	pluginSelected: CoreProfilerStateMachineContext[ 'pluginsSelected' ]
+) => {
+	if ( pluginSelected.includes( 'woocommerce-payments' ) ) {
+		return 'woocommerce-payments';
+	}
+	return 'jetpack-ai';
+};
+
 const redirectToJetpackAuthPage = ( {
 	event,
+	context,
 }: {
 	context: CoreProfilerStateMachineContext;
 	event: { output: { url: string } };
 } ) => {
 	const url = new URL( event.output.url );
 	url.searchParams.set( 'installed_ext_success', '1' );
-	url.searchParams.set( 'plugin_name', 'jetpack-ai' );
+	url.searchParams.set(
+		'plugin_name',
+		getPluginNameParam( context.pluginsSelected )
+	);
 	window.location.href = url.toString();
 };
 

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -301,9 +301,9 @@ const exitToWooHome = fromPromise( async () => {
 } );
 
 const getPluginNameParam = (
-	pluginSelected: CoreProfilerStateMachineContext[ 'pluginsSelected' ]
+	pluginsSelected: CoreProfilerStateMachineContext[ 'pluginsSelected' ]
 ) => {
-	if ( pluginSelected.includes( 'woocommerce-payments' ) ) {
+	if ( pluginsSelected.includes( 'woocommerce-payments' ) ) {
 		return 'woocommerce-payments';
 	}
 	return 'jetpack-ai';

--- a/plugins/woocommerce/changelog/update-dynamically-set-plugin-name
+++ b/plugins/woocommerce/changelog/update-dynamically-set-plugin-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Dynamically set plugin_name when redirecting to Jetpack Auth from core profiler


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51248

This PR updates the core profiler's extensions page to set the `plugin_name` param to `woocommerce-payments` when the user selects `WooPayments` and redirects to Jetpack Auth.

`plugin_name` is used to [determine](https://github.com/Automattic/wp-calypso/blob/066f9c222970f41c45abf31f2717ba560f66dd69/client/lib/login/index.js#L239-L248) the title.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Select a WC-Pay eligible country such as the US
3. Go to the extensions page
4. Select WooPayments and Jetpack (if Jetpack is not installed yet)
5. Confirm you're redirected to the Jetpack connection page with url parameters `plugin_name=woocommerce-payments`
6. Go back to the site without connecting Jetpack
7. Go to the extensions page
8. Select other extensions and continue with the setup
9. Confirm you're redirected to the Jetpack connection page with url parameters `plugin_name=jetpack-ai`



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
