### PR TITLE
Reduce slow reports tests

### DIFF
--- a/plugins/woocommerce/changelog/dev-slow-tests
+++ b/plugins/woocommerce/changelog/dev-slow-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix slow test for Reports

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
@@ -39,12 +39,12 @@ class WC_Helper_Queue {
 	 */
 	public static function run_all_pending( $group = null ) {
 		$queue_runner = new ActionScheduler_QueueRunner();
-		$jobs         = self::get_all_pending(  $group );
+		$jobs         = self::get_all_pending( $group );
 		while ( $jobs ) {
 			foreach ( $jobs as $job_id => $job ) {
 				$queue_runner->process_action( $job_id );
 			}
-			$jobs = self::get_all_pending(  $group );
+			$jobs = self::get_all_pending( $group );
 		}
 	}
 

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
@@ -39,10 +39,13 @@ class WC_Helper_Queue {
 	 */
 	public static function run_all_pending( $group = null ) {
 		$queue_runner = new ActionScheduler_QueueRunner();
-		while ( $jobs = self::get_all_pending(  $group ) ) {
+		$jobs = self::get_all_pending(  $group );
+		while ( $jobs ) {
 			foreach ( $jobs as $job_id => $job ) {
 				$queue_runner->process_action( $job_id );
 			}
+
+			$jobs = self::get_all_pending(  $group );
 		}
 	}
 

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
@@ -13,35 +13,39 @@
 class WC_Helper_Queue {
 	/**
 	 * Get all pending queued actions.
-	 *
+	 * @param string|null $group Optionally. Filter the actions by group.
 	 * @return array Pending jobs.
 	 */
-	public static function get_all_pending() {
-		$jobs = WC()->queue()->search(
-			array(
-				'per_page' => -1,
-				'status'   => 'pending',
-				'claimed'  => false,
-			)
+	public static function get_all_pending( $group = null ) {
+		$args = array(
+			'per_page' => -1,
+			'status'   => 'pending',
+			'claimed'  => false,
 		);
 
-		return $jobs;
+		if ( $group ) {
+			$args['group'] = $group;
+		}
+
+		return WC()->queue()->search( $args );
 	}
+
+
 
 	/**
 	 * Run all pending queued actions.
-	 *
+	 * @param string|null $group Optionally. Filter the actions by group.
 	 * @return void
 	 */
-	public static function run_all_pending() {
+	public static function run_all_pending( $group = null ) {
 		$queue_runner = new ActionScheduler_QueueRunner();
-
-		while ( $jobs = self::get_all_pending() ) {
+		while ( $jobs = self::get_all_pending(  $group ) ) {
 			foreach ( $jobs as $job_id => $job ) {
 				$queue_runner->process_action( $job_id );
 			}
 		}
 	}
+
 
 	/**
 	 * Cancel all pending actions.

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-queue.php
@@ -39,12 +39,11 @@ class WC_Helper_Queue {
 	 */
 	public static function run_all_pending( $group = null ) {
 		$queue_runner = new ActionScheduler_QueueRunner();
-		$jobs = self::get_all_pending(  $group );
+		$jobs         = self::get_all_pending(  $group );
 		while ( $jobs ) {
 			foreach ( $jobs as $job_id => $job ) {
 				$queue_runner->process_action( $job_id );
 			}
-
 			$jobs = self::get_all_pending(  $group );
 		}
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/products-lowinstock.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/products-lowinstock.php
@@ -51,7 +51,7 @@ class WC_Admin_Tests_API_ProductsLowInStock extends WC_REST_Unit_Test_Case {
 		$order->save();
 
 		// Sync analytics data (used for last order date).
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', '/wc-analytics/products/low-in-stock' );
 		$request->set_param( 'low_in_stock', true );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-categories.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-categories.php
@@ -66,7 +66,7 @@ class WC_Admin_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$uncategorized_term = get_term_by( 'slug', 'uncategorized', 'product_cat' );
 
@@ -114,7 +114,7 @@ class WC_Admin_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$product->set_category_ids( array( $second_category_id ) );
 		$product->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$uncategorized_term = get_term_by( 'slug', 'uncategorized', 'product_cat' );
 
@@ -170,7 +170,7 @@ class WC_Admin_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Populate all of the data.
 		$product = new WC_Product_Simple();
@@ -186,7 +186,7 @@ class WC_Admin_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$order->set_total( 400 ); // $100 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$uncategorized_term = get_term_by( 'slug', 'uncategorized', 'product_cat' );
 		$params             = array(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-coupons-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-coupons-stats.php
@@ -87,7 +87,7 @@ class WC_Admin_Tests_API_Reports_Coupons_Stats extends WC_REST_Unit_Test_Case {
 		$order_2c->set_date_created( $time );
 		$order_2c->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-coupons.php
@@ -82,7 +82,7 @@ class WC_Admin_Tests_API_Reports_Coupons extends WC_REST_Unit_Test_Case {
 		$order_2c->calculate_totals();
 		$order_2c->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$response       = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$coupon_reports = $response->get_data();
@@ -132,7 +132,7 @@ class WC_Admin_Tests_API_Reports_Coupons extends WC_REST_Unit_Test_Case {
 		$order_1c->calculate_totals();
 		$order_1c->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers-stats.php
@@ -127,7 +127,7 @@ class WC_Admin_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case 
 		$order->set_total( 9.12 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-customers.php
@@ -149,7 +149,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params( array( 'per_page' => 10 ) );
@@ -164,7 +164,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Creating a customer should show up regardless of orders.
 		$customer = WC_Helper_Customer::create_customer( 'customer', 'password', 'customer@example.com' );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
@@ -221,7 +221,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
@@ -317,7 +317,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->save();
 
 		// Ensure order customer data is synced to lookup table.
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$query_params = array(
 			'force_cache_refresh' => true,
@@ -400,7 +400,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$customer->set_billing_city( '' );
 		$customer->set_first_name( 'customer_andrei_1' );
 		$customer->save();
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request->set_query_params(
 			array(
@@ -433,7 +433,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 
 		// Test filter_empty param by state and postcode non empty.
 		$customer = WC_Helper_Customer::create_customer( 'customer_2', 'password', 'customer_2@example.com' );
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request->set_query_params(
 			array(
@@ -498,7 +498,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
@@ -527,7 +527,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
@@ -555,7 +555,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
@@ -584,7 +584,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Creating a customer should show up regardless of orders.
 		$customer = WC_Helper_Customer::create_customer( 'deleteme', 'password', 'deleteme@example.com' );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
@@ -602,7 +602,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Delete the user associated with the customer.
 		wp_delete_user( $customer->get_id() );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Verify they are gone.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
@@ -630,7 +630,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// update order info.
 		$order->set_billing_city( 'Random' );
@@ -638,11 +638,11 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_billing_postcode( '54321' );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$result = CustomersDataStore::sync_order_customer( $order->get_id() );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$this->assertNotEquals( -1, $result );
 
@@ -671,7 +671,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order2->set_total( 100 );
 		$order2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$customer_id  = CustomersDataStore::get_existing_customer_id_from_order( $order );
 		$customer2_id = CustomersDataStore::get_existing_customer_id_from_order( $order2 );
@@ -682,11 +682,11 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order->set_billing_postcode( '54321' );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$result = CustomersDataStore::sync_order_customer( $order->get_id() );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Didn't update anything.
 		$this->assertTrue( -1 === $result );
@@ -721,7 +721,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order3->set_billing_email( 'different@example.org' );
 		$order3->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$customer_id  = CustomersDataStore::get_existing_customer_id_from_order( $order );
 		$customer2_id = CustomersDataStore::get_existing_customer_id_from_order( $order2 );
@@ -734,11 +734,11 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order3->set_billing_postcode( '54321' );
 		$order3->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$result = CustomersDataStore::sync_order_customer( $order3->get_id() );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Didn't update anything.
 		$this->assertNotEquals( -1, $result );
@@ -780,7 +780,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$order3->set_total( 100 );
 		$order3->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$customer_id  = CustomersDataStore::get_existing_customer_id_from_order( $order );
 		$customer2_id = CustomersDataStore::get_existing_customer_id_from_order( $order2 );
@@ -794,7 +794,7 @@ class WC_Admin_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 
 		$order->set_date_created( time() + 60 );
 		$order->save();
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$latest_order = CustomersDataStore::get_last_order( $customer_id );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-downloads-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-downloads-stats.php
@@ -152,7 +152,7 @@ class WC_Admin_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case 
 		$order->save();
 		$order_1 = $order->get_id();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$download = new WC_Customer_Download();
 		$download->set_user_id( 1 );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-downloads.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-downloads.php
@@ -169,7 +169,7 @@ class WC_Admin_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$object->set_timestamp( gmdate( 'Y-m-d H:00:00', $time - ( 2 * DAY_IN_SECONDS ) ) );
 		$id = $object->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		return array(
 			'time'      => $time,

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-export.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-export.php
@@ -119,7 +119,7 @@ class WC_Admin_Tests_API_Reports_Export extends WC_REST_Unit_Test_Case {
 		$order->calculate_totals();
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Initiate an export of the taxes report.
 		$response   = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc-analytics/reports/taxes/export' ) );
@@ -143,7 +143,7 @@ class WC_Admin_Tests_API_Reports_Export extends WC_REST_Unit_Test_Case {
 		$this->assertStringMatchesFormat( '%s/wc-analytics/reports/taxes/export/%d/status', $status['_links']['self'][0]['href'] );
 
 		// Run the pending export jobs.
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Check that the status shows 100% and includes a download url.
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $status_route ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-import.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-import.php
@@ -119,7 +119,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $report['status'] );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request  = new WP_REST_Request( 'GET', '/wc-analytics/reports/customers' );
 		$response = $this->server->dispatch( $request );
@@ -161,7 +161,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $report['status'] );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request  = new WP_REST_Request( 'GET', '/wc-analytics/reports/customers' );
 		$response = $this->server->dispatch( $request );
@@ -247,7 +247,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		}
 
 		// Check that stats exist before deleting.
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', '/wc-analytics/reports/orders' );
 		$request->set_query_params( array( 'per_page' => 25 ) );
@@ -273,7 +273,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $report['status'] );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Check that stats have been deleted.
 		$request  = new WP_REST_Request( 'GET', '/wc-analytics/reports/orders' );
@@ -375,7 +375,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 0, $report['orders']['imported'] );
 		$this->assertEquals( 4, $report['orders']['total'] );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Test import status after processing.
 		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/status' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders-stats.php
@@ -154,7 +154,7 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$global_attribute = new WC_Product_Attribute();
 		$global_attribute->set_id( $size_attr_id );
 		$global_attribute->set_name( 'pa_size' );
-		$global_attribute->set_options( array( $large_term->term_id ) ); // Set to small.
+		$global_attribute->set_options( array( $large_term->term_id ) ); // Set to large.
 		$global_attribute->set_position( 1 );
 		$global_attribute->set_visible( true );
 		$global_attribute->set_variation( false );
@@ -187,7 +187,8 @@ class WC_Admin_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 			$order->save();
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+		WC_Helper_Queue::run_all_pending( 'woocommerce-db-updates' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params( array( 'per_page' => 15 ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
@@ -69,7 +69,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$expected_customer_id = CustomersDataStore::get_customer_id_by_user_id( 1 );
 
@@ -126,7 +126,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();
@@ -238,7 +238,8 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 			$order->save();
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+		WC_Helper_Queue::run_all_pending( 'woocommerce-db-updates' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params( array( 'per_page' => 15 ) );
@@ -369,7 +370,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 			$order->save();
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params( array( 'per_page' => 15 ) );
@@ -438,7 +439,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$order_to_be_included->set_status( 'completed' );
 		$order_to_be_included->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Test product exclusion.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
@@ -515,7 +516,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$second_order->set_status( 'on-hold' );
 		$second_order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Get the created orders from REST API.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-performance-indicators.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-performance-indicators.php
@@ -90,7 +90,7 @@ class WC_Admin_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Tes
 		$object->set_user_ip_address( '1.2.3.4' );
 		$object->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$time    = time();
 		$request = new WP_REST_Request( 'GET', $this->endpoint );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-products-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-products-stats.php
@@ -71,7 +71,7 @@ class WC_Admin_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-products.php
@@ -67,7 +67,7 @@ class WC_Admin_Tests_API_Reports_Products extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();
@@ -109,7 +109,7 @@ class WC_Admin_Tests_API_Reports_Products extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes-stats.php
@@ -99,7 +99,7 @@ class WC_Admin_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 			$wc_refund = wc_create_refund( $refund );
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-taxes.php
@@ -115,7 +115,7 @@ class WC_Admin_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();
@@ -416,6 +416,6 @@ class WC_Admin_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-variations.php
@@ -69,7 +69,7 @@ class WC_Admin_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();
@@ -102,7 +102,7 @@ class WC_Admin_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 		$order->set_total( 15 );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
@@ -146,7 +146,7 @@ class WC_Admin_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons-stats.php
@@ -57,7 +57,7 @@ class WC_Admin_Tests_Reports_Coupons_Stats extends WC_Unit_Test_Case {
 		$order_2c->calculate_totals();
 		$order_2c->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new CouponsStatsDataStore();
 		$start_time = gmdate( 'Y-m-d 00:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -133,7 +133,7 @@ class WC_Admin_Tests_Reports_Coupons_Stats extends WC_Unit_Test_Case {
 		// Delete the coupon.
 		$coupon_1->delete( true );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$start_time = gmdate( 'Y-m-d 00:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = gmdate( 'Y-m-d 23:59:59', $order->get_date_created()->getOffsetTimestamp() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-coupons.php
@@ -59,7 +59,7 @@ class WC_Admin_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 		$order_2c->calculate_totals();
 		$order_2c->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new CouponsDataStore();
 		$start_time = gmdate( 'Y-m-d 00:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -375,7 +375,7 @@ class WC_Admin_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 		// Delete the coupons.
 		$coupon_2->delete( true );
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new CouponsDataStore();
 		$start_time = gmdate( 'Y-m-d 00:00:00', $order->get_date_created()->getOffsetTimestamp() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-customers.php
@@ -29,7 +29,7 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		$product->set_regular_price( 25 );
 		$product->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
 
@@ -39,7 +39,7 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 			$order->save();
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Customer should have 3 orders.
 		$this->assertSame( 3, DataStore::get_order_count( $customer_id ) );
@@ -75,7 +75,7 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		$product2->set_regular_price( 2 );
 		$product2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Create the first order.
 		$order1 = WC_Helper_Order::create_order( $customer->get_id(), $product1 );
@@ -85,7 +85,7 @@ class WC_Admin_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order( $customer->get_id(), $product2 );
 		$order2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -63,7 +63,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			)
 		);
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -208,7 +208,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$order->save();
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -377,7 +377,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			)
 		);
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -666,7 +666,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$orders[] = $order;
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -917,7 +917,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			}
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -3865,7 +3865,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order->apply_coupon( $coupon );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Check if lookup tables are populated.
 		foreach ( $tables as $table ) {
@@ -3996,7 +3996,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_2->calculate_totals();
 		$order_2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -4544,7 +4544,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$orders[] = $order;
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersStatsDataStore();
 
@@ -5328,7 +5328,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$orders[] = $order;
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		global $wpdb;
 		$res = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}wc_order_stats" );
@@ -6094,7 +6094,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_0->set_total( 100 );
 		$order_0->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$start_time  = gmdate( 'Y-m-d H:00:00', $order_0->get_date_created()->getOffsetTimestamp() );
 		$end_time    = gmdate( 'Y-m-d H:59:59', $order_0->get_date_created()->getOffsetTimestamp() );
@@ -6114,7 +6114,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_1->set_total( 100 );
 		$order_1->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Time frame includes both orders -> customer is a new customer.
 		$start_time = gmdate( 'Y-m-d H:00:00', $order_0->get_date_created()->getOffsetTimestamp() );
@@ -6153,7 +6153,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_2->set_total( 100 );
 		$order_2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Time frame includes second and third order -> there is one returning customer.
 		$start_time  = gmdate( 'Y-m-d H:i:s', $order_0_time + 1 );
@@ -6204,7 +6204,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_0->set_total( 100 );
 		$order_0->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$start_time  = gmdate( 'Y-m-d H:00:00', $order_0->get_date_created()->getOffsetTimestamp() );
 		$end_time    = gmdate( 'Y-m-d H:59:59', $order_0->get_date_created()->getOffsetTimestamp() );
@@ -6224,7 +6224,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_1->set_total( 100 );
 		$order_1->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Time frame includes both orders -> customer is a new customer.
 		$start_time = gmdate( 'Y-m-d H:00:00', $order_0->get_date_created()->getOffsetTimestamp() );
@@ -6263,7 +6263,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order_2->set_total( 100 );
 		$order_2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// Time frame includes second and third order -> there is one returning customer.
 		$start_time  = gmdate( 'Y-m-d H:i:s', $order_0_time + 1 );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -64,7 +64,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$order->set_status( 'completed' );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -143,7 +143,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			)
 		);
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -255,7 +255,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$order2->set_status( 'completed' );
 		$order2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new OrdersDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -310,7 +310,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$order_2->set_status( 'completed' );
 		$order_2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = gmdate( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-products.php
@@ -42,7 +42,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new ProductsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -119,7 +119,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$order_2->set_date_created( $date_created_2 );
 		$order_2->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new ProductsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -220,7 +220,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new ProductsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -301,7 +301,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new ProductsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -383,7 +383,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 			break;
 		}
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new ProductsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -441,7 +441,7 @@ class WC_Admin_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$term = wp_insert_term( 'Unused Category', 'product_cat' );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-revenue-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-revenue-stats.php
@@ -43,7 +43,7 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		// /reports/revenue/stats is mapped to Orders_Data_Store.
 		$data_store = new OrdersStatsDataStore();

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-variations.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-variations.php
@@ -42,7 +42,7 @@ class WC_Admin_Tests_Reports_Variations extends WC_Unit_Test_Case {
 		$order->set_status( 'completed' );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new VariationsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -111,7 +111,7 @@ class WC_Admin_Tests_Reports_Variations extends WC_Unit_Test_Case {
 		$order->set_status( 'completed' );
 		$order->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new VariationsDataStore();
 		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
@@ -228,7 +228,7 @@ class WC_Admin_Tests_Reports_Variations extends WC_Unit_Test_Case {
 		$order_3->set_status( 'completed' );
 		$order_3->save();
 
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
 		$data_store = new VariationsDataStore();
 


### PR DESCRIPTION
### Submission Review Guidelines:

### Changes proposed in this Pull Request:

Fixes most of the slow tests reported here https://github.com/woocommerce/woocommerce/pull/50733
See more context here: pdV5qK-Fr-p2

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See test passing https://github.com/woocommerce/woocommerce/actions/runs/10810983263/job/29989444412?pr=51279 and 
2. See how slow tests are reduced from around 80 to 23. 

Before 
```
The WC_Admin_Tests_API_ProductsLowInStock::test_low_stock test took 7.651859379 seconds!
The WC_Admin_Tests_API_Reports_Categories::test_get_reports test took 7.171513003 seconds!
The WC_Admin_Tests_API_Reports_Categories::test_get_reports_categories_param test took 7.252111754 seconds!
The WC_Admin_Tests_API_Reports_Categories::test_get_reports_categories_sort test took 7.397390503 seconds!
The WC_Admin_Tests_API_Reports_Coupons_Stats::test_get_reports test took 7.481947712 seconds!
The WC_Admin_Tests_API_Reports_Coupons::test_get_reports test took 7.871677503 seconds!
The WC_Admin_Tests_API_Reports_Coupons::test_get_reports_coupons_param test took 7.299858211 seconds!
The WC_Admin_Tests_API_Reports_Customers_Stats::test_get_reports test took 8.172190212 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_user_creation test took 10.030503713 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_get_reports test took 8.114017628 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_search test took 7.903302921 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_get_reports_with_filter_empty test took 7.838757171 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_user_profile_name test took 7.860637462 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_billing_name test took 7.833468962 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_customer_shipping_name test took 7.996129795 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_user_deletion test took 7.916966753 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_sync_order_customer test took 8.029619212 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_sync_latest_order_customer test took 8.123112295 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_sync_latest_order_customer_with_multiple_customers test took 8.398171461 seconds!
The WC_Admin_Tests_API_Reports_Customers::test_get_last_order test took 8.931760879 seconds!
The WC_Admin_Tests_API_Reports_Downloads_Stats::test_get_report_with_user_filter test took 9.627980422 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_date_filter test took 10.651628046 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_product_filter test took 9.665541088 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_order_filter test took 9.893068547 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_user_filter test took 8.571670837 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_ip_address_filter test took 7.943404795 seconds!
The WC_Admin_Tests_API_Reports_Downloads::test_get_report_with_deleted_product test took 7.946299962 seconds!
The WC_Admin_Tests_API_Reports_Export::test_taxes_report_export test took 15.031257007 seconds!
The WC_Admin_Tests_API_Reports_Import::test_import_params test took 8.063384254 seconds!
The WC_Admin_Tests_API_Reports_Import::test_delete_stats test took 9.087046588 seconds!
The WC_Admin_Tests_API_Reports_Import::test_import_status test took 8.217980795 seconds!
The WC_Admin_Tests_API_Reports_Orders_Stats::test_product_attributes_filter test took 8.972321213 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_get_reports test took 8.138717879 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_get_reports_with_orphaned_refund test took 8.069469296 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_product_attributes_filter test took 9.011540129 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_custom_product_attributes_filter test took 10.849896172 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_product_variation_exclusion_filter test took 8.413865088 seconds!
The WC_Admin_Tests_API_Reports_Orders::test_order_price_formatting_with_different_base_currency test took 8.303399503 seconds!
The WC_Admin_Tests_API_Reports_Performance_Indicators::test_get_indicators test took 8.399841962 seconds!
The WC_Admin_Tests_API_Reports_Products_Stats::test_get_reports test took 8.224058129 seconds!
The WC_Admin_Tests_API_Reports_Products::test_get_reports test took 16.177644423 seconds!
The WC_Admin_Tests_API_Reports_Products::test_get_reports_products_param test took 12.135282089 seconds!
The WC_Admin_Tests_API_Reports_Taxes_Stats::test_get_reports test took 8.405378587 seconds!
The WC_Admin_Tests_API_Reports_Taxes::test_get_reports test took 8.46526442 seconds!
The WC_Admin_Tests_API_Reports_Taxes::test_get_reports_taxes_param test took 8.68503738 seconds!
The WC_Admin_Tests_API_Reports_Variations::test_get_reports test took 8.529748004 seconds!
The WC_Admin_Tests_API_Reports_Variations::test_simple_products_excluded_from_variations_reports_by_default test took 8.571996753 seconds!
The WC_Admin_Tests_API_Reports_Variations::test_get_reports_variations_param test took 8.63920942 seconds!
The WC_Admin_Tests_Reports_Regenerate_Batching::test_queue_dependent_action test took 8.490106004 seconds!
The WC_Admin_Tests_Reports_Coupons_Stats::test_populate_and_query test took 8.771648129 seconds!
The WC_Admin_Tests_Reports_Coupons_Stats::test_deleted_coupon test took 11.856961006 seconds!
The WC_Admin_Tests_Reports_Coupons::test_populate_and_query test took 8.863062837 seconds!
The WC_Admin_Tests_Reports_Coupons::test_deleted_coupons test took 8.724935212 seconds!
The WC_Admin_Tests_Reports_Customer::test_customer_order_count test took 17.058729383 seconds!
The WC_Admin_Tests_Reports_Customer::test_order_deletion_removes_customer test took 8.787423711 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query test took 8.706576712 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_statuses test took 9.297790338 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_refunds test took 8.957721212 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_multiple_coupons test took 9.091193004 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_populate_and_query_multiple_intervals test took 20.346302217 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_order_deletion test took 9.074559296 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_segmenting_by_product_and_variation test took 9.149284505 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_zero_fill_order_by_date test took 9.367587254 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_zero_fill_order_by_orders_count test took 9.400743462 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_guest_returning_customer test took 10.155412755 seconds!
The WC_Admin_Tests_Reports_Orders_Stats::test_registered_returning_customer test took 10.465344547 seconds!
The WC_Admin_Tests_Reports_Orders::test_extended_info test took 9.114539754 seconds!
The WC_Admin_Tests_Reports_Orders::test_products_in_orders test took 9.687378838 seconds!
The WC_Admin_Tests_Reports_Orders::test_product_and_variation_includes_count test took 9.351572879 seconds!
The WC_Admin_Tests_Reports_Orders::test_coupon_exclusion_includes_orders_without_coupons test took 9.274998629 seconds!
The WC_Admin_Tests_Reports_Products::test_populate_and_query test took 9.383748921 seconds!
The WC_Admin_Tests_Reports_Products::test_order_by_product_name test took 11.760081589 seconds!
The WC_Admin_Tests_Reports_Products::test_extended_info test took 9.357908128 seconds!
The WC_Admin_Tests_Reports_Products::test_variable_product_extended_info test took 9.406975005 seconds!
The WC_Admin_Tests_Reports_Products::test_populate_and_refund test took 9.572978837 seconds!
The WC_Admin_Tests_Reports_Products::test_report_export_arguments test took 9.397020545 seconds!
The WC_Admin_Tests_Reports_Revenue_Stats::test_populate_and_query test took 9.469328796 seconds!
The WC_Admin_Tests_Reports_Variations::test_populate_and_query test took 9.530857088 seconds!
The WC_Admin_Tests_Reports_Variations::test_extended_info test took 9.507518254 seconds!
The WC_Admin_Tests_Reports_Variations::test_attribute_filtering test took 9.766785004 seconds!
```

After
<img width="1455" alt="Screenshot 2024-09-11 at 15 52 41" src="https://github.com/user-attachments/assets/b565fb40-88eb-41f1-b11d-b406396e143e">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>