### PR TITLE
Add framework to reduce number of classes and hooks WooCommerce loads on every request.

### DIFF
--- a/plugins/woocommerce/changelog/autoloader-perf
+++ b/plugins/woocommerce/changelog/autoloader-perf
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Load less files on every request.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-compat.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-compat.php
@@ -20,7 +20,6 @@ class WC_Helper_Compat {
 	 * Loads the class, runs on init.
 	 */
 	public static function load() {
-		add_action( 'woocommerce_helper_loaded', array( __CLASS__, 'helper_loaded' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-orders-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-orders-api.php
@@ -21,7 +21,6 @@ class WC_Helper_Orders_API {
 	 * @return void
 	 */
 	public static function load() {
-		add_filter( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
@@ -23,7 +23,6 @@ class WC_Helper_Subscriptions_API {
 	 * @return void
 	 */
 	public static function load() {
-		add_filter( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -24,11 +24,6 @@ class WC_Helper_Updater {
 	 * Loads the class, runs on init.
 	 */
 	public static function load() {
-		add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins' ), 21, 1 );
-		add_action( 'pre_set_site_transient_update_themes', array( __CLASS__, 'transient_update_themes' ), 21, 1 );
-		add_action( 'upgrader_process_complete', array( __CLASS__, 'upgrader_process_complete' ) );
-		add_action( 'upgrader_pre_download', array( __CLASS__, 'block_expired_updates' ), 10, 2 );
-		add_action( 'admin_init', array( __CLASS__, 'add_hook_for_modifying_update_notices' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -54,16 +54,7 @@ class WC_Helper {
 	 * Include supporting helper classes.
 	 */
 	protected static function includes() {
-		include_once __DIR__ . '/class-wc-helper-options.php';
-		include_once __DIR__ . '/class-wc-helper-api.php';
-		include_once __DIR__ . '/class-wc-woo-update-manager-plugin.php';
-		include_once __DIR__ . '/class-wc-helper-updater.php';
-		include_once __DIR__ . '/class-wc-plugin-api-updater.php';
-		include_once __DIR__ . '/class-wc-helper-compat.php';
 		include_once __DIR__ . '/class-wc-helper-admin.php';
-		include_once __DIR__ . '/class-wc-helper-subscriptions-api.php';
-		include_once __DIR__ . '/class-wc-helper-orders-api.php';
-		include_once __DIR__ . '/class-wc-product-usage-notice.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -55,6 +55,7 @@ class WC_Helper {
 	 */
 	protected static function includes() {
 		include_once __DIR__ . '/class-wc-helper-admin.php';
+		include_once __DIR__ . '/class-wc-helper-api.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-plugin-api-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-plugin-api-updater.php
@@ -17,8 +17,6 @@ class WC_Plugin_Api_Updater {
 	 * Loads the class, runs on init.
 	 */
 	public static function load() {
-		add_filter( 'plugins_api', array( __CLASS__, 'plugins_api' ), 20, 3 );
-		add_filter( 'themes_api', array( __CLASS__, 'themes_api' ), 20, 3 );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-product-usage-notice.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-product-usage-notice.php
@@ -69,10 +69,6 @@ class WC_Product_Usage_Notice {
 	 * @return void
 	 */
 	public static function load() {
-		add_action( 'current_screen', array( __CLASS__, 'maybe_show_product_usage_notice' ) );
-
-		add_action( 'wp_ajax_woocommerce_dismiss_product_usage_notice', array( __CLASS__, 'ajax_dismiss' ) );
-		add_action( 'wp_ajax_woocommerce_remind_later_product_usage_notice', array( __CLASS__, 'ajax_remind_later' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-woo-update-manager-plugin.php
@@ -28,7 +28,6 @@ class WC_Woo_Update_Manager_Plugin {
 	 * @return void
 	 */
 	public static function load(): void {
-		add_action( 'admin_notices', array( __CLASS__, 'show_woo_update_manager_install_notice' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -21,7 +21,8 @@ class WC_Autoloader {
 	private $include_path = '';
 
 	private static array $known_classes_paths = array(
-
+		'WC_Product_Usage' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage.php',
+		'WC_Product_Usage_Rule_Set' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-rule-set.php',
 	);
 
 	/**
@@ -67,12 +68,12 @@ class WC_Autoloader {
 	 * @param string $class Class name.
 	 */
 	public function autoload( $class ) {
-		$class = strtolower( $class );
-
 		if ( isset( self::$known_classes_paths[ $class ] ) ) {
 			$this->load_file( self::$known_classes_paths[ $class ] );
 			return;
 		}
+
+		$class = strtolower( $class );
 
 		if ( 0 !== strpos( $class, 'wc_' ) ) {
 			return;

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -20,6 +20,10 @@ class WC_Autoloader {
 	 */
 	private $include_path = '';
 
+	private static array $known_classes_paths = array(
+
+	);
+
 	/**
 	 * The Constructor.
 	 */
@@ -64,6 +68,11 @@ class WC_Autoloader {
 	 */
 	public function autoload( $class ) {
 		$class = strtolower( $class );
+
+		if ( isset( self::$known_classes_paths[ $class ] ) ) {
+			$this->load_file( self::$known_classes_paths[ $class ] );
+			return;
+		}
 
 		if ( 0 !== strpos( $class, 'wc_' ) ) {
 			return;

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -73,7 +73,7 @@ class WC_Autoloader {
 	 */
 	private function load_file( $path ) {
 		if ( $path && is_readable( $path ) ) {
-			include_once $path;
+			require $path;
 			return true;
 		}
 		return false;

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -23,6 +23,18 @@ class WC_Autoloader {
 	private static array $known_classes_paths = array(
 		'WC_Product_Usage' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage.php',
 		'WC_Product_Usage_Rule_Set' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-rule-set.php',
+		'WC_WCCOM_Site' => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php',
+		'WC_Helper' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php',
+		'WC_Helper_Options' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php',
+		'WC_Helper_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php',
+		'WC_Woo_Update_Manager_Plugin' => WC_ABSPATH . 'includes/admin/helper/class-wc-woo-update-manager-plugin.php',
+		'WC_Helper_Updater' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-updater.php',
+		'WC_Plugin_Api_Updater' => WC_ABSPATH . 'includes/admin/helper/class-wc-plugin-api-updater.php',
+		'WC_Helper_Compat' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-compat.php',
+		'WC_WCCOM_Site_Installer' => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php',
+		'WC_Helper_Subscriptions_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-subscriptions-api.php',
+		'WC_Helper_Orders_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-orders-api.php',
+		'WC_Product_Usage_Notice' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-notice.php',
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -34,7 +34,7 @@ class WC_Autoloader {
 		'WC_WCCOM_Site_Installer' => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php',
 		'WC_Helper_Subscriptions_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-subscriptions-api.php',
 		'WC_Helper_Orders_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-orders-api.php',
-		'WC_Product_Usage_Notice' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-notice.php',
+		'WC_Product_Usage_Notice' => WC_ABSPATH . 'includes/admin/helper/class-wc-product-usage-notice.php',
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -20,21 +20,26 @@ class WC_Autoloader {
 	 */
 	private $include_path = '';
 
+	/**
+	 * Known class names and their file paths for autoloading.
+	 *
+	 * @var array
+	 */
 	private static array $known_classes_paths = array(
-		'WC_Product_Usage' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage.php',
-		'WC_Product_Usage_Rule_Set' => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-rule-set.php',
-		'WC_WCCOM_Site' => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php',
-		'WC_Helper' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php',
-		'WC_Helper_Options' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php',
-		'WC_Helper_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php',
+		'WC_Product_Usage'             => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage.php',
+		'WC_Product_Usage_Rule_Set'    => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-rule-set.php',
+		'WC_WCCOM_Site'                => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php',
+		'WC_Helper'                    => WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php',
+		'WC_Helper_Options'            => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php',
+		'WC_Helper_API'                => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php',
 		'WC_Woo_Update_Manager_Plugin' => WC_ABSPATH . 'includes/admin/helper/class-wc-woo-update-manager-plugin.php',
-		'WC_Helper_Updater' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-updater.php',
-		'WC_Plugin_Api_Updater' => WC_ABSPATH . 'includes/admin/helper/class-wc-plugin-api-updater.php',
-		'WC_Helper_Compat' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-compat.php',
-		'WC_WCCOM_Site_Installer' => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php',
-		'WC_Helper_Subscriptions_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-subscriptions-api.php',
-		'WC_Helper_Orders_API' => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-orders-api.php',
-		'WC_Product_Usage_Notice' => WC_ABSPATH . 'includes/admin/helper/class-wc-product-usage-notice.php',
+		'WC_Helper_Updater'            => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-updater.php',
+		'WC_Plugin_Api_Updater'        => WC_ABSPATH . 'includes/admin/helper/class-wc-plugin-api-updater.php',
+		'WC_Helper_Compat'             => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-compat.php',
+		'WC_WCCOM_Site_Installer'      => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php',
+		'WC_Helper_Subscriptions_API'  => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-subscriptions-api.php',
+		'WC_Helper_Orders_API'         => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-orders-api.php',
+		'WC_Product_Usage_Notice'      => WC_ABSPATH . 'includes/admin/helper/class-wc-product-usage-notice.php',
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-autoloader.php
+++ b/plugins/woocommerce/includes/class-wc-autoloader.php
@@ -28,8 +28,6 @@ class WC_Autoloader {
 	private static array $known_classes_paths = array(
 		'WC_Product_Usage'             => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage.php',
 		'WC_Product_Usage_Rule_Set'    => WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-rule-set.php',
-		'WC_WCCOM_Site'                => WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php',
-		'WC_Helper'                    => WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php',
 		'WC_Helper_Options'            => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php',
 		'WC_Helper_API'                => WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php',
 		'WC_Woo_Update_Manager_Plugin' => WC_ABSPATH . 'includes/admin/helper/class-wc-woo-update-manager-plugin.php',

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -8,6 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\HooksRegistry;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\ComingSoon\ComingSoonAdminBarBadge;
@@ -707,7 +708,7 @@ final class WooCommerce {
 		 */
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
 
-		\Automattic\WooCommerce\HooksRegistry::load_hooks();
+		HooksRegistry::load_hooks();
 
 		/**
 		 * Libraries and packages.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -714,7 +714,6 @@ final class WooCommerce {
 		 */
 		include_once WC_ABSPATH . 'packages/action-scheduler/action-scheduler.php';
 
-
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
 		}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -707,10 +707,13 @@ final class WooCommerce {
 		 */
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
 
+		\Automattic\WooCommerce\HooksRegistry::load_hooks();
+
 		/**
 		 * Libraries and packages.
 		 */
 		include_once WC_ABSPATH . 'packages/action-scheduler/action-scheduler.php';
+
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -708,11 +708,6 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
 
 		/**
-		 * Product Usage
-		 */
-		include_once WC_ABSPATH . 'includes/product-usage/class-wc-product-usage.php';
-
-		/**
 		 * Libraries and packages.
 		 */
 		include_once WC_ABSPATH . 'packages/action-scheduler/action-scheduler.php';

--- a/plugins/woocommerce/includes/product-usage/class-wc-product-usage.php
+++ b/plugins/woocommerce/includes/product-usage/class-wc-product-usage.php
@@ -33,7 +33,6 @@ class WC_Product_Usage {
 	 * @since 9.3.0
 	 */
 	protected static function includes() {
-		require_once WC_ABSPATH . 'includes/product-usage/class-wc-product-usage-rule-set.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
+++ b/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
@@ -27,10 +27,6 @@ class WC_WCCOM_Site {
 	 */
 	public static function load() {
 		self::includes();
-
-		add_action( 'woocommerce_wccom_install_products', array( 'WC_WCCOM_Site_Installer', 'install' ) );
-		add_filter( 'determine_current_user', array( __CLASS__, 'authenticate_wccom' ), 14 );
-		add_action( 'woocommerce_rest_api_get_rest_namespaces', array( __CLASS__, 'register_rest_namespace' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
+++ b/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
@@ -40,7 +40,6 @@ class WC_WCCOM_Site {
 	 */
 	protected static function includes() {
 		require_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
-		require_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php';
 	}
 
 	/**

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -30,7 +30,8 @@ class HooksRegistry {
 		array( 'themes_api', array( 'WC_Plugin_Api_Updater', 'themes_api' ), 20, 3 ),
 
 		array( 'woocommerce_helper_loaded', array( 'WC_Helper_Compat', 'helper_loaded' ) ),
-
+		array( 'woocommerce_wccom_install_products', array( 'WC_WCCOM_Site_Installer', 'install' ) ),
+		array( 'woocommerce_rest_api_get_rest_namespaces', array( 'WC_WCCOM_Site', 'register_rest_namespace' ) ),
 	);
 
 	/**
@@ -41,7 +42,7 @@ class HooksRegistry {
 	private static array $all_request_filters = array(
 		array( 'rest_api_init', array( 'WC_Helper_Subscriptions_API', 'register_rest_routes' ) ),
 		array( 'rest_api_init', array( 'WC_Helper_Orders_API', 'register_rest_routes' ) ),
-
+		array( 'determine_current_user', array( 'WC_WCCOM_Site', 'authenticate_wccom' ), 14 ),
 	);
 
 	/**

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce;
 
 /**
- * This class list and register core hooks for WooCommerce, without loading the file that contains the hooks. Classes that provides these hooks should be loaded by an Autoloader.
+ * This class list and register core hooks for WooCommerce, without loading the file that contains the hooks. Classes that provides these hooks should be loaded by an Autoloader or already loaded.
  */
 class HooksRegistry {
 
+	/**
+	 * Whether the hooks are already loaded or not.
+	 *
+	 * @var bool $hooks_loaded
+	 */
+	public static bool $hooks_loaded = false;
+
+	/**
+	 * List of all actions that should be registered for all requests.
+	 *
+	 * @var array[] $all_request_actions
+	 */
 	private static array $all_request_actions = array(
 		array( 'pre_set_site_transient_update_plugins', array( 'WC_Helper_Updater', 'transient_update_plugins' ), 21, 1 ),
 		array( 'pre_set_site_transient_update_themes', array( 'WC_Helper_Updater', 'transient_update_themes' ), 21, 1 ),
@@ -21,20 +33,36 @@ class HooksRegistry {
 
 	);
 
+	/**
+	 * List of all filters that should be registered for all requests.
+	 *
+	 * @var array[] $all_request_filters
+	 */
 	private static array $all_request_filters = array(
 		array( 'rest_api_init', array( 'WC_Helper_Subscriptions_API', 'register_rest_routes' ) ),
 		array( 'rest_api_init', array( 'WC_Helper_Orders_API', 'register_rest_routes' ) ),
 
 	);
 
-	private static array $frontend_actions = array(
+	/**
+	 * List of actions that should be registered for frontend requests.
+	 *
+	 * @var array $frontend_actions
+	 */
+	private static array $frontend_actions = array();
 
-	);
+	/**
+	 * List of filters that should be registered for frontend requests.
+	 *
+	 * @var array $frontend_filters
+	 */
+	private static array $frontend_filters = array();
 
-	private static array $frontend_filters = array(
-
-	);
-
+	/**
+	 * List of actions that should be registered for admin requests.
+	 *
+	 * @var array[] $admin_actions
+	 */
 	private static array $admin_actions = array(
 		array( 'admin_notices', array( 'WC_Woo_Update_Manager_Plugin', 'show_woo_update_manager_install_notice' ) ),
 		array( 'admin_init', array( 'WC_Helper_Updater', 'add_hook_for_modifying_update_notices' ) ),
@@ -44,8 +72,89 @@ class HooksRegistry {
 		array( 'woocommerce_helper_loaded', array( 'WC_Helper_Compat', 'helper_loaded' ) ),
 	);
 
-	private static array $admin_filters = array(
+	/**
+	 * List of filters that should be registered for admin requests.
+	 *
+	 * @var array $admin_filters
+	 */
+	private static array $admin_filters = array();
 
-	);
+	/**
+	 * Load all registered hooks.
+	 */
+	public static function load_hooks() {
+		if ( self::$hooks_loaded ) {
+			wc_doing_it_wrong( 'HooksRegistry::load_hooks', 'HooksRegistry is already loaded.', '9.5.0' );
+			return;
+		}
 
+		if ( is_admin() ) {
+			foreach ( self::$admin_actions as $action ) {
+				add_action( ...$action );
+			}
+
+			foreach ( self::$admin_filters as $filter ) {
+				add_filter( ...$filter );
+			}
+		}
+
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
+			foreach ( self::$frontend_actions as $action ) {
+				add_action( ...$action );
+			}
+
+			foreach ( self::$frontend_filters as $filter ) {
+				add_filter( ...$filter );
+			}
+		}
+
+		foreach ( self::$all_request_actions as $action ) {
+			add_action( ...$action );
+		}
+
+		foreach ( self::$all_request_filters as $filter ) {
+			add_filter( ...$filter );
+		}
+
+		self::$hooks_loaded = true;
+	}
+
+	/**
+	 * DANGEROUS: This method is used for testing and benchmarking. Do not call, unless you really know what you are doing.
+	 */
+	public static function unload_hooks() {
+		if ( ! self::$hooks_loaded ) {
+			return;
+		}
+
+		if ( is_admin() ) {
+			foreach ( self::$admin_actions as $action ) {
+				remove_action( ...$action );
+			}
+
+			foreach ( self::$admin_filters as $filter ) {
+				remove_filter( ...$filter );
+			}
+		}
+
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
+			foreach ( self::$frontend_actions as $action ) {
+				remove_action( ...$action );
+			}
+
+			foreach ( self::$frontend_filters as $filter ) {
+				remove_filter( ...$filter );
+			}
+		}
+
+		foreach ( self::$all_request_actions as $action ) {
+			remove_action( ...$action );
+		}
+
+		foreach ( self::$all_request_filters as $filter ) {
+			remove_filter( ...$filter );
+		}
+
+		self::$hooks_loaded = false;
+	}
 }

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -9,10 +9,21 @@ namespace Automattic\WooCommerce;
 class HooksRegistry {
 
 	private static array $all_request_actions = array(
+		array( 'pre_set_site_transient_update_plugins', array( 'WC_Helper_Updater', 'transient_update_plugins' ), 21, 1 ),
+		array( 'pre_set_site_transient_update_themes', array( 'WC_Helper_Updater', 'transient_update_themes' ), 21, 1 ),
+		array( 'upgrader_process_complete', array( 'WC_Helper_Updater', 'upgrader_process_complete' ) ),
+		array( 'upgrader_pre_download', array( 'WC_Helper_Updater', 'block_expired_updates' ), 10, 2 ),
+
+		array( 'plugins_api', array( 'WC_Plugin_Api_Updater', 'plugins_api' ), 20, 3 ),
+		array( 'themes_api', array( 'WC_Plugin_Api_Updater', 'themes_api' ), 20, 3 ),
+
+		array( 'woocommerce_helper_loaded', array( 'WC_Helper_Compat', 'helper_loaded' ) ),
 
 	);
 
 	private static array $all_request_filters = array(
+		array( 'rest_api_init', array( 'WC_Helper_Subscriptions_API', 'register_rest_routes' ) ),
+		array( 'rest_api_init', array( 'WC_Helper_Orders_API', 'register_rest_routes' ) ),
 
 	);
 
@@ -25,7 +36,12 @@ class HooksRegistry {
 	);
 
 	private static array $admin_actions = array(
-
+		array( 'admin_notices', array( 'WC_Woo_Update_Manager_Plugin', 'show_woo_update_manager_install_notice' ) ),
+		array( 'admin_init', array( 'WC_Helper_Updater', 'add_hook_for_modifying_update_notices' ) ),
+		array( 'current_screen', array( 'WC_Product_Usage_Notice', 'maybe_show_product_usage_notice' ) ),
+		array( 'wp_ajax_woocommerce_dismiss_product_usage_notice', array( 'WC_Product_Usage_Notice', 'ajax_dismiss' ) ),
+		array( 'wp_ajax_woocommerce_remind_later_product_usage_notice', array( 'WC_Product_Usage_Notice', 'ajax_remind_later' ) ),
+		array( 'woocommerce_helper_loaded', array( 'WC_Helper_Compat', 'helper_loaded' ) ),
 	);
 
 	private static array $admin_filters = array(

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -8,27 +8,27 @@ namespace Automattic\WooCommerce;
  */
 class HooksRegistry {
 
-	static array $all_request_actions = array(
+	private static array $all_request_actions = array(
 
 	);
 
-	static array $all_request_filters = array(
+	private static array $all_request_filters = array(
 
 	);
 
-	static array $frontend_actions = array(
+	private static array $frontend_actions = array(
 
 	);
 
-	static array $frontend_filters = array(
+	private static array $frontend_filters = array(
 
 	);
 
-	static array $admin_actions = array(
+	private static array $admin_actions = array(
 
 	);
 
-	static array $admin_filters = array(
+	private static array $admin_filters = array(
 
 	);
 

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce;
+
+/**
+ * This class list and register core hooks for WooCommerce, without loading the file that contains the hooks. Classes that provides these hooks should be loaded by an Autoloader.
+ */
+class HooksRegistry {
+
+	static array $all_request_actions = array(
+
+	);
+
+	static array $all_request_filters = array(
+
+	);
+
+	static array $frontend_actions = array(
+
+	);
+
+	static array $frontend_filters = array(
+
+	);
+
+	static array $admin_actions = array(
+
+	);
+
+	static array $admin_filters = array(
+
+	);
+
+}

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -84,37 +84,28 @@ class HooksRegistry {
 	 * Load all registered hooks.
 	 */
 	public static function load_hooks() {
-		if ( self::$hooks_loaded ) {
-			wc_doing_it_wrong( 'HooksRegistry::load_hooks', 'HooksRegistry is already loaded.', '9.5.0' );
-			return;
-		}
-
-		if ( is_admin() ) {
-			foreach ( self::$admin_actions as $action ) {
-				add_action( ...$action );
-			}
-
-			foreach ( self::$admin_filters as $filter ) {
-				add_filter( ...$filter );
-			}
-		}
-
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
-			foreach ( self::$frontend_actions as $action ) {
-				add_action( ...$action );
-			}
-
-			foreach ( self::$frontend_filters as $filter ) {
-				add_filter( ...$filter );
-			}
-		}
-
 		foreach ( self::$all_request_actions as $action ) {
-			add_action( ...$action );
+			call_user_func_array( 'add_action', $action );
 		}
 
 		foreach ( self::$all_request_filters as $filter ) {
-			add_filter( ...$filter );
+			call_user_func_array( 'add_filter', $filter );
+		}
+
+		foreach ( self::$admin_actions as $action ) {
+			call_user_func_array( 'add_action', $action );
+		}
+
+		foreach ( self::$admin_filters as $filter ) {
+			call_user_func_array( 'add_filter', $filter );
+		}
+
+		foreach ( self::$frontend_actions as $action ) {
+			call_user_func_array( 'add_action', $action );
+		}
+
+		foreach ( self::$frontend_filters as $filter ) {
+			call_user_func_array( 'add_filter', $filter );
 		}
 
 		self::$hooks_loaded = true;
@@ -130,30 +121,30 @@ class HooksRegistry {
 
 		if ( is_admin() ) {
 			foreach ( self::$admin_actions as $action ) {
-				remove_action( ...$action );
+				call_user_func_array( 'remove_action', $action );
 			}
 
 			foreach ( self::$admin_filters as $filter ) {
-				remove_filter( ...$filter );
+				call_user_func_array( 'remove_filter', $filter );
 			}
 		}
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			foreach ( self::$frontend_actions as $action ) {
-				remove_action( ...$action );
+				call_user_func_array( 'remove_action', $action );
 			}
 
 			foreach ( self::$frontend_filters as $filter ) {
-				remove_filter( ...$filter );
+				call_user_func_array( 'remove_filter', $filter );
 			}
 		}
 
 		foreach ( self::$all_request_actions as $action ) {
-			remove_action( ...$action );
+			call_user_func_array( 'remove_action', $action );
 		}
 
 		foreach ( self::$all_request_filters as $filter ) {
-			remove_filter( ...$filter );
+			call_user_func_array( 'remove_filter', $filter );
 		}
 
 		self::$hooks_loaded = false;

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -14,17 +14,17 @@ class HooksRegistry {
 	 * @var array[] $all_request_actions
 	 */
 	private static array $all_request_actions = array(
-		array( 'pre_set_site_transient_update_plugins', array( 'WC_Helper_Updater', 'transient_update_plugins' ), 21, 1 ),
-		array( 'pre_set_site_transient_update_themes', array( 'WC_Helper_Updater', 'transient_update_themes' ), 21, 1 ),
-		array( 'upgrader_process_complete', array( 'WC_Helper_Updater', 'upgrader_process_complete' ) ),
-		array( 'upgrader_pre_download', array( 'WC_Helper_Updater', 'block_expired_updates' ), 10, 2 ),
+		array( 'pre_set_site_transient_update_plugins', array( \WC_Helper_Updater::class, 'transient_update_plugins' ), 21, 1 ),
+		array( 'pre_set_site_transient_update_themes', array( \WC_Helper_Updater::class, 'transient_update_themes' ), 21, 1 ),
+		array( 'upgrader_process_complete', array( \WC_Helper_Updater::class, 'upgrader_process_complete' ) ),
+		array( 'upgrader_pre_download', array( \WC_Helper_Updater::class, 'block_expired_updates' ), 10, 2 ),
 
-		array( 'plugins_api', array( 'WC_Plugin_Api_Updater', 'plugins_api' ), 20, 3 ),
-		array( 'themes_api', array( 'WC_Plugin_Api_Updater', 'themes_api' ), 20, 3 ),
+		array( 'plugins_api', array( \WC_Plugin_Api_Updater::class, 'plugins_api' ), 20, 3 ),
+		array( 'themes_api', array( \WC_Plugin_Api_Updater::class, 'themes_api' ), 20, 3 ),
 
-		array( 'woocommerce_helper_loaded', array( 'WC_Helper_Compat', 'helper_loaded' ) ),
-		array( 'woocommerce_wccom_install_products', array( 'WC_WCCOM_Site_Installer', 'install' ) ),
-		array( 'woocommerce_rest_api_get_rest_namespaces', array( 'WC_WCCOM_Site', 'register_rest_namespace' ) ),
+		array( 'woocommerce_helper_loaded', array( \WC_Helper_Compat::class, 'helper_loaded' ) ),
+		array( 'woocommerce_wccom_install_products', array( \WC_WCCOM_Site_Installer::class, 'install' ) ),
+		array( 'woocommerce_rest_api_get_rest_namespaces', array( \WC_WCCOM_Site::class, 'register_rest_namespace' ) ),
 	);
 
 	/**
@@ -33,9 +33,9 @@ class HooksRegistry {
 	 * @var array[] $all_request_filters
 	 */
 	private static array $all_request_filters = array(
-		array( 'rest_api_init', array( 'WC_Helper_Subscriptions_API', 'register_rest_routes' ) ),
-		array( 'rest_api_init', array( 'WC_Helper_Orders_API', 'register_rest_routes' ) ),
-		array( 'determine_current_user', array( 'WC_WCCOM_Site', 'authenticate_wccom' ), 14 ),
+		array( 'rest_api_init', array( \WC_Helper_Subscriptions_API::class, 'register_rest_routes' ) ),
+		array( 'rest_api_init', array( \WC_Helper_Orders_API::class, 'register_rest_routes' ) ),
+		array( 'determine_current_user', array( \WC_WCCOM_Site::class, 'authenticate_wccom' ), 14 ),
 	);
 
 	/**
@@ -58,12 +58,12 @@ class HooksRegistry {
 	 * @var array[] $admin_actions
 	 */
 	private static array $admin_actions = array(
-		array( 'admin_notices', array( 'WC_Woo_Update_Manager_Plugin', 'show_woo_update_manager_install_notice' ) ),
-		array( 'admin_init', array( 'WC_Helper_Updater', 'add_hook_for_modifying_update_notices' ) ),
-		array( 'current_screen', array( 'WC_Product_Usage_Notice', 'maybe_show_product_usage_notice' ) ),
-		array( 'wp_ajax_woocommerce_dismiss_product_usage_notice', array( 'WC_Product_Usage_Notice', 'ajax_dismiss' ) ),
-		array( 'wp_ajax_woocommerce_remind_later_product_usage_notice', array( 'WC_Product_Usage_Notice', 'ajax_remind_later' ) ),
-		array( 'woocommerce_helper_loaded', array( 'WC_Helper_Compat', 'helper_loaded' ) ),
+		array( 'admin_notices', array( \WC_Woo_Update_Manager_Plugin::class, 'show_woo_update_manager_install_notice' ) ),
+		array( 'admin_init', array( \WC_Helper_Updater::class, 'add_hook_for_modifying_update_notices' ) ),
+		array( 'current_screen', array( \WC_Product_Usage_Notice::class, 'maybe_show_product_usage_notice' ) ),
+		array( 'wp_ajax_woocommerce_dismiss_product_usage_notice', array( \WC_Product_Usage_Notice::class, 'ajax_dismiss' ) ),
+		array( 'wp_ajax_woocommerce_remind_later_product_usage_notice', array( \WC_Product_Usage_Notice::class, 'ajax_remind_later' ) ),
+		array( 'woocommerce_helper_loaded', array( \WC_Helper_Compat::class, 'helper_loaded' ) ),
 	);
 
 	/**

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -9,13 +9,6 @@ namespace Automattic\WooCommerce;
 class HooksRegistry {
 
 	/**
-	 * Whether the hooks are already loaded or not.
-	 *
-	 * @var bool $hooks_loaded
-	 */
-	public static bool $hooks_loaded = false;
-
-	/**
 	 * List of all actions that should be registered for all requests.
 	 *
 	 * @var array[] $all_request_actions
@@ -107,18 +100,12 @@ class HooksRegistry {
 		foreach ( self::$frontend_filters as $filter ) {
 			call_user_func_array( 'add_filter', $filter );
 		}
-
-		self::$hooks_loaded = true;
 	}
 
 	/**
 	 * DANGEROUS: This method is used for testing and benchmarking. Do not call, unless you really know what you are doing.
 	 */
 	public static function unload_hooks() {
-		if ( ! self::$hooks_loaded ) {
-			return;
-		}
-
 		if ( is_admin() ) {
 			foreach ( self::$admin_actions as $action ) {
 				call_user_func_array( 'remove_action', $action );
@@ -146,7 +133,5 @@ class HooksRegistry {
 		foreach ( self::$all_request_filters as $filter ) {
 			call_user_func_array( 'remove_filter', $filter );
 		}
-
-		self::$hooks_loaded = false;
 	}
 }

--- a/plugins/woocommerce/src/HooksRegistry.php
+++ b/plugins/woocommerce/src/HooksRegistry.php
@@ -106,24 +106,19 @@ class HooksRegistry {
 	 * DANGEROUS: This method is used for testing and benchmarking. Do not call, unless you really know what you are doing.
 	 */
 	public static function unload_hooks() {
-		if ( is_admin() ) {
-			foreach ( self::$admin_actions as $action ) {
-				call_user_func_array( 'remove_action', $action );
-			}
-
-			foreach ( self::$admin_filters as $filter ) {
-				call_user_func_array( 'remove_filter', $filter );
-			}
+		foreach ( self::$admin_actions as $action ) {
+			call_user_func_array( 'remove_action', $action );
 		}
 
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
-			foreach ( self::$frontend_actions as $action ) {
-				call_user_func_array( 'remove_action', $action );
-			}
+		foreach ( self::$admin_filters as $filter ) {
+			call_user_func_array( 'remove_filter', $filter );
+		}
+		foreach ( self::$frontend_actions as $action ) {
+			call_user_func_array( 'remove_action', $action );
+		}
 
-			foreach ( self::$frontend_filters as $filter ) {
-				call_user_func_array( 'remove_filter', $filter );
-			}
+		foreach ( self::$frontend_filters as $filter ) {
+			call_user_func_array( 'remove_filter', $filter );
 		}
 
 		foreach ( self::$all_request_actions as $action ) {

--- a/plugins/woocommerce/tests/php/src/HooksRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/HooksRegistryTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests;
+
+use Automattic\WooCommerce\HooksRegistry;
+
+/**
+ * Test HooksRegistry class.
+ */
+class HooksRegistryTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testDox Make sure hooks are loaded as expected
+	 */
+	public function test_load_hooks() {
+		$all_request_action = array( 'upgrader_process_complete', array( 'WC_Helper_Updater', 'upgrader_process_complete' ) );
+		$all_request_filter = array( 'rest_api_init', array( 'WC_Helper_Subscriptions_API', 'register_rest_routes' ) );
+		HooksRegistry::unload_hooks();
+		$this->assertFalse( has_filter( ...$all_request_action ) );
+		$this->assertFalse( has_filter( ...$all_request_filter ) );
+
+		HooksRegistry::load_hooks();
+		$this->assertEquals( 10, has_filter( ...$all_request_action ) );
+		$this->assertEquals( 10, has_filter( ...$all_request_filter ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds foundational work for removing a number of classes that we load on every request, by adding a mechanism to move several always-loaded classes to load on demand. Note that PR provides a framework to do it with few examples, but ultimately bulk of performance improvements will be provided by #51416 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

We will test two things as part of this PR:

1. If all the classes that we were loading earlier in the trunk are still available. The classes we have moved here should not be available by default, but should be autoloadable.
2. All the hooks that we had previously are still registered as expected.

### Testing whether all the classes that we were loading earlier are still available.
1. Switch to trunk, we are going to generate list of all the available classes and save it in a file. Run the following command to do that:
`wp --allow-root eval 'array_map( function ($classname) { echo $classname . PHP_EOL;}, get_declared_classes() );' > /tmp/class-trunk.list`
This will generate a list of classes and store it in the `/tmp/class-trunk.list` file.
2. Switch to this branch, and rebase the branch from trunk. Note that rebasing is important otherwise new classes added to the trunk won't be listed. Also run composer dump-autoload. So essentially, run following commands:
```shell
git rebase trunk
cd plugins/woocommerce
composer dump-autoload
```
3. Run the similar command from step 1 to generate another list of classes, like so:
` wp eval 'array_map( function ($classname) { echo $classname . PHP_EOL;}, get_declared_classes() );' > /tmp/class-perf.list`
This will create a file in /tmp/class-perf.list with all the classes available now.
4. Diff the two files, for example, by using the `comm` command like so:
`comm -23 <(sort /tmp/class-trunk.list) <(sort /tmp/class-perf.list)`
You should see a strict subset like the following list that we have moved now to autoload:
```
WC_Helper_API
WC_Helper_Compat
WC_Helper_Options
WC_Helper_Updater
WC_Plugin_Api_Updater
WC_Product_Usage
WC_Product_Usage_Notice
WC_Product_Usage_Rule_Set
WC_WCCOM_Site_Installer
WC_Woo_Update_Manager_Plugin
```
5. Let's try loading the files that are not loaded by default. First save the list into another file like so:
`comm -23 <(sort /tmp/class-trunk.list) <(sort /tmp/class-perf.list) > diff.list`
6. Open a shell using `wp shell` and run following commands to test:
```php
// Open file
$t = new SplFileObject( "./diff.list" );
// Loop through file and print 1 for every class loaded:
while ( ! $t->eof() ) { $c = '\\' . trim( $t->fgets(), PHP_EOL ); echo $c && assert( class_exists( $c, true ), "Unable to load " . $c ); }
```
you should see an output like so, there will be a `1` for each file:
`1111111111`

### Testing whether all actions and filters are registered as expected.
1. We will use the same approach as above. Switch back to trunk, and run following two commands:
```shell
wp eval 'print_r($GLOBALS["wp_actions"]);' > /tmp/trunk-actions.list
wp eval 'print_r($GLOBALS["wp_filters"]);' > /tmp/trunk-filters.list
```
2. Switch to this branch, make sure that this branch is up to date with trunk and run similar commands but with different files like so:
```
wp --allow-root eval 'print_r($GLOBALS["wp_filters"]);' > /tmp/perf-filters.list
wp --allow-root eval 'print_r($GLOBALS["wp_actions"]);' > /tmp/perf-actions.list
```
3. Let's compare the actions and filters across branches, to make sure we are registering everything:
```
comm -23 <(sort /tmp/trunk-filters.list) <(sort /tmp/perf-filters.list)
```
Same for actions:
```
comm -23 <(sort /tmp/trunk-actions.list) <(sort /tmp/perf-actions.list)
```
Output for both these commands should be empty.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
