### PR TITLE
fix: add check for wp_get_current_user() before calling it

### DIFF
--- a/plugins/woocommerce/changelog/fix-remote-logger-undefined-wp-current-user
+++ b/plugins/woocommerce/changelog/fix-remote-logger-undefined-wp-current-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adds a function_exists() check so that we don't add a secondary fatal in remote logging if wp_get_current_user does not exist yet

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -233,7 +233,7 @@ class RemoteLogger extends \WC_Log_Handler {
 			}
 
 			return true;
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			// Log the error locally if the remote logging fails.
 			error_log( 'Remote logging failed: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			return false;

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -88,7 +88,7 @@ class RemoteLogger extends \WC_Log_Handler {
 			unset( $context['tags'] );
 		}
 
-		if ( class_exists( '\WC_Tracks' ) ) {
+		if ( class_exists( '\WC_Tracks' ) && function_exists( 'wp_get_current_user' ) ) {
 			$user         = wp_get_current_user();
 			$blog_details = \WC_Tracks::get_blog_details( $user->ID );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51301

The direct cause of the bug above has been addressed by adding a check for the function's existence before calling it, and secondarily, the try-catch around it has been enhanced to catch PHP errors so that it does not obscure the original error.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I'm not sure how to reproduce the situation where `wp_get_current_user()` is undefined, but an inspection of the code should be satisfactory. 
2. Test that it still works correctly by using WC Beta Tester to simulate an error. See PCYsg-11XN-p2 for instructions on viewing the logs
3. Using `./wp-admin/plugin-editor.php`, Modify [./src/Internal/Logging/RemoteLogger.php](https://github.com/woocommerce/woocommerce/blob/393b18b760714c8d150cbf0c792054e21efcf7f5/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php#L92) on L92 so that `wp_get_current_user()` becomes an non-existent function - e.g `aaaaaaaaa()`
4. Reset the rate limiting and trigger the error again
5. Should see two lines of logs in debug.log (use a plugin like "Debug log manager" or ssh into the site to see view it)

```
[12-Sep-2024 07:22:17 UTC] PHP Fatal error:  Uncaught Exception: Simulated WooCommerce error for remote logging test in /srv/htdocs/wp-content/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php:148
Stack trace:
#0 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): simulate_woocommerce_error('')
#1 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#2 /srv/htdocs/__wp__/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /srv/htdocs/wp-content/plugins/wc_beta_tester_live_branch_9.4.0-dev-10824980923-gfa486af/includes/class-woocommerce.php(259): do_action('woocommerce_loa...')
#4 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(324): WooCommerce->on_plugins_loaded('')
#5 /srv/htdocs/__wp__/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#6 /srv/htdocs/__wp__/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#7 /srv/htdocs/__wp__/wp-settings.php(555): do_action('plugins_loaded')
#8 /srv/htdocs/wp-config.php(85): require_once('/srv/htdocs/__w...')
#9 /srv/htdocs/__wp__/wp-load.php(55): require_once('/srv/htdocs/wp-...')
#10 /srv/htdocs/__wp__/wp-admin/admin.php(34): require_once('/srv/htdocs/__w...')
#11 {main}
  thrown in /srv/htdocs/wp-content/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php on line 148
[12-Sep-2024 07:22:17 UTC] Remote logging failed: Call to undefined function Automattic\WooCommerce\Internal\Logging\wp_get_current_userz()
```
The first line is the original error log, and the second line would be the error that was caught within the Remote Logging feature

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>