### PR TITLE
Marketplace: update category selector

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.scss
@@ -1,13 +1,17 @@
 @import "../../stylesheets/_variables.scss";
 
 .woocommerce-marketplace__category-selector {
+	position: relative;
 	display: flex;
 	align-items: stretch;
-	margin: $grid-unit-20 0 0 0;
+	margin: 0;
+	overflow-x: auto;
 }
 
 .woocommerce-marketplace__category-item {
 	cursor: pointer;
+	white-space: nowrap;
+	margin-bottom: 0;
 
 	.components-dropdown {
 		height: 100%;
@@ -50,7 +54,6 @@
 
 .woocommerce-marketplace__category-selector--full-width {
 	display: none;
-	margin-top: $grid-unit-15;
 }
 
 @media screen and (max-width: $break-medium) {
@@ -121,4 +124,23 @@
 		color: $white;
 		background-color: $gray-900;
 	}
+}
+
+.woocommerce-marketplace__category-navigation-button {
+    border: none;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	height: 100%;
+	width: 72px;
+}
+
+.woocommerce-marketplace__category-navigation-button--prev {
+	background: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+	left: 0;
+}
+
+.woocommerce-marketplace__category-navigation-button--next {
+	background: linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+	right: 0;
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.scss
@@ -132,7 +132,7 @@
 	top: 0;
 	bottom: 0;
 	height: 100%;
-	width: 72px;
+	width: 50px;
 }
 
 .woocommerce-marketplace__category-navigation-button--prev {

--- a/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
@@ -256,6 +256,7 @@ export default function CategorySelector(
 						className="woocommerce-marketplace__category-navigation-button woocommerce-marketplace__category-navigation-button--prev"
 						hidden={ scrollPosition === 'start' }
 						aria-label="Scroll to previous categories"
+						tabIndex={ -1 }
 					>
 						<Icon icon="arrow-left-alt2" />
 					</button>
@@ -264,6 +265,7 @@ export default function CategorySelector(
 						className="woocommerce-marketplace__category-navigation-button woocommerce-marketplace__category-navigation-button--next"
 						hidden={ scrollPosition === 'end' }
 						aria-label="Scroll to next categories"
+						tabIndex={ -1 }
 					>
 						<Icon icon="arrow-right-alt2" />
 					</button>

--- a/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
@@ -1,20 +1,21 @@
 /**
  * External dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { useQuery } from '@woocommerce/navigation';
-import clsx from 'clsx';
+import { Icon } from '@wordpress/components';
+import { useDebounce } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import CategoryLink from './category-link';
-import CategoryDropdown from './category-dropdown';
 import { Category, CategoryAPIItem } from './types';
 import { fetchCategories } from '../../utils/functions';
-import './category-selector.scss';
 import { ProductType } from '../product-list/types';
+import CategoryDropdown from './category-dropdown';
+import './category-selector.scss';
 
 const ALL_CATEGORIES_SLUGS = {
 	[ ProductType.extension ]: '_all',
@@ -29,31 +30,20 @@ interface CategorySelectorProps {
 export default function CategorySelector(
 	props: CategorySelectorProps
 ): JSX.Element {
-	const [ visibleItems, setVisibleItems ] = useState< Category[] >( [] );
-	const [ dropdownItems, setDropdownItems ] = useState< Category[] >( [] );
 	const [ selected, setSelected ] = useState< Category >();
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ categoriesToShow, setCategoriesToShow ] = useState< Category[] >(
+		[]
+	);
+	const [ isOverflowing, setIsOverflowing ] = useState( false );
+	const [ scrollPosition, setScrollPosition ] = useState<
+		'start' | 'middle' | 'end'
+	>( 'start' );
+
+	const categorySelectorRef = useRef< HTMLUListElement >( null );
+	const selectedCategoryRef = useRef< HTMLLIElement >( null );
 
 	const query = useQuery();
-
-	useEffect( () => {
-		// If no category is selected, show All as selected
-		let categoryToSearch = ALL_CATEGORIES_SLUGS[ props.type ];
-
-		if ( query.category ) {
-			categoryToSearch = query.category;
-		}
-
-		const allCategories = visibleItems.concat( dropdownItems );
-
-		const selectedCategory = allCategories.find(
-			( category ) => category.slug === categoryToSearch
-		);
-
-		if ( selectedCategory ) {
-			setSelected( selectedCategory );
-		}
-	}, [ query.category, props.type, visibleItems, dropdownItems ] );
 
 	useEffect( () => {
 		setIsLoading( true );
@@ -72,21 +62,125 @@ export default function CategorySelector(
 						return category.slug !== '_featured';
 					} );
 
-				// Split array into two from 7th item
-				const visibleCategoryItems = categories.slice( 0, 7 );
-				const dropdownCategoryItems = categories.slice( 7 );
-
-				setVisibleItems( visibleCategoryItems );
-				setDropdownItems( dropdownCategoryItems );
+				setCategoriesToShow( categories );
 			} )
 			.catch( () => {
-				setVisibleItems( [] );
-				setDropdownItems( [] );
+				setCategoriesToShow( [] );
 			} )
 			.finally( () => {
 				setIsLoading( false );
 			} );
-	}, [ props.type ] );
+	}, [ props.type, setCategoriesToShow ] );
+
+	useEffect( () => {
+		// If no category is selected, show All as selected
+		let categoryToSearch = ALL_CATEGORIES_SLUGS[ props.type ];
+
+		if ( query.category ) {
+			categoryToSearch = query.category;
+		}
+
+		const selectedCategory = categoriesToShow.find(
+			( category ) => category.slug === categoryToSearch
+		);
+
+		if ( selectedCategory ) {
+			setSelected( selectedCategory );
+		}
+	}, [ query.category, props.type, categoriesToShow ] );
+
+	useEffect( () => {
+		if ( selectedCategoryRef.current ) {
+			selectedCategoryRef.current.scrollIntoView( {
+				block: 'nearest',
+				inline: 'center',
+			} );
+		}
+	}, [ selected ] );
+
+	function checkOverflow() {
+		if (
+			categorySelectorRef.current &&
+			categorySelectorRef.current.parentElement?.scrollWidth
+		) {
+			const isContentOverflowing =
+				categorySelectorRef.current.scrollWidth >
+				categorySelectorRef.current.parentElement.scrollWidth;
+
+			setIsOverflowing( isContentOverflowing );
+		}
+	}
+
+	function checkScrollPosition() {
+		const ulElement = categorySelectorRef.current;
+
+		if ( ! ulElement ) {
+			return;
+		}
+
+		const { scrollLeft, scrollWidth, clientWidth } = ulElement;
+
+		if ( scrollLeft < 10 ) {
+			setScrollPosition( 'start' );
+
+			return;
+		}
+
+		if ( scrollLeft + clientWidth < scrollWidth ) {
+			setScrollPosition( 'middle' );
+
+			return;
+		}
+
+		if ( scrollLeft + clientWidth === scrollWidth ) {
+			setScrollPosition( 'end' );
+		}
+	}
+
+	const debouncedCheckOverflow = useDebounce( checkOverflow, 300 );
+	const debouncedScrollPosition = useDebounce( checkScrollPosition, 100 );
+
+	function scrollCategories( scrollAmount: number ) {
+		if ( categorySelectorRef.current ) {
+			categorySelectorRef.current.scrollTo( {
+				left: categorySelectorRef.current.scrollLeft + scrollAmount,
+				behavior: 'smooth',
+			} );
+		}
+	}
+
+	function scrollToNextCategories() {
+		scrollCategories( 200 );
+	}
+
+	function scrollToPrevCategories() {
+		scrollCategories( -200 );
+	}
+
+	useEffect( () => {
+		window.addEventListener( 'resize', debouncedCheckOverflow );
+
+		const ulElement = categorySelectorRef.current;
+
+		if ( ulElement ) {
+			ulElement.addEventListener( 'scroll', debouncedScrollPosition );
+		}
+
+		return () => {
+			window.removeEventListener( 'resize', debouncedCheckOverflow );
+
+			if ( ulElement ) {
+				ulElement.removeEventListener(
+					'scroll',
+					debouncedScrollPosition
+				);
+			}
+		};
+	}, [ debouncedCheckOverflow, debouncedScrollPosition ] );
+
+	useEffect( () => {
+		checkOverflow();
+	}, [ categoriesToShow ] );
 
 	function mobileCategoryDropdownLabel() {
 		const allCategoriesText = __( 'All Categories', 'woocommerce' );
@@ -100,16 +194,6 @@ export default function CategorySelector(
 		}
 
 		return selected.label;
-	}
-
-	function isSelectedInDropdown() {
-		if ( ! selected ) {
-			return false;
-		}
-
-		return dropdownItems.find(
-			( category ) => category.slug === selected.slug
-		);
 	}
 
 	if ( isLoading ) {
@@ -131,50 +215,60 @@ export default function CategorySelector(
 
 	return (
 		<>
-			<ul className="woocommerce-marketplace__category-selector">
-				{ visibleItems.map( ( category ) => (
+			<ul
+				className="woocommerce-marketplace__category-selector"
+				aria-label="Categories"
+				ref={ categorySelectorRef }
+			>
+				{ categoriesToShow.map( ( category ) => (
 					<li
 						className="woocommerce-marketplace__category-item"
 						key={ category.slug }
+						ref={
+							category.slug === selected?.slug
+								? selectedCategoryRef
+								: null
+						}
 					>
 						<CategoryLink
 							{ ...category }
 							selected={ category.slug === selected?.slug }
+							aria-current={ category.slug === selected?.slug }
 						/>
 					</li>
 				) ) }
-				<li className="woocommerce-marketplace__category-item">
-					{ dropdownItems.length > 0 && (
-						<CategoryDropdown
-							type={ props.type }
-							label={ __( 'More', 'woocommerce' ) }
-							categories={ dropdownItems }
-							buttonClassName={ clsx(
-								'woocommerce-marketplace__category-item-button',
-								{
-									'woocommerce-marketplace__category-item-button--selected':
-										isSelectedInDropdown(),
-								}
-							) }
-							contentClassName="woocommerce-marketplace__category-item-content"
-							arrowIconSize={ 20 }
-							selected={ selected }
-						/>
-					) }
-				</li>
 			</ul>
-
 			<div className="woocommerce-marketplace__category-selector--full-width">
 				<CategoryDropdown
 					type={ props.type }
 					label={ mobileCategoryDropdownLabel() }
-					categories={ visibleItems.concat( dropdownItems ) }
+					categories={ categoriesToShow }
 					buttonClassName="woocommerce-marketplace__category-dropdown-button"
 					className="woocommerce-marketplace__category-dropdown"
 					contentClassName="woocommerce-marketplace__category-dropdown-content"
 					selected={ selected }
 				/>
 			</div>
+			{ isOverflowing && (
+				<>
+					<button
+						onClick={ scrollToPrevCategories }
+						className="woocommerce-marketplace__category-navigation-button woocommerce-marketplace__category-navigation-button--prev"
+						hidden={ scrollPosition === 'start' }
+						aria-label="Scroll to previous categories"
+					>
+						<Icon icon="arrow-left-alt2" />
+					</button>
+					<button
+						onClick={ scrollToNextCategories }
+						className="woocommerce-marketplace__category-navigation-button woocommerce-marketplace__category-navigation-button--next"
+						hidden={ scrollPosition === 'end' }
+						aria-label="Scroll to next categories"
+					>
+						<Icon icon="arrow-right-alt2" />
+					</button>
+				</>
+			) }
 		</>
 	);
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.scss
@@ -9,10 +9,20 @@
 	}
 }
 
+
 .woocommerce-marketplace__sub-header {
 	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 32px;
+}
 
-	.woocommerce-marketplace__customize-your-store-button {
-		margin: 16px 0 6px auto;
-	}
+.woocommerce-marketplace__sub-header__categories {
+	flex: 1;
+	overflow-x: auto;
+	position: relative;
+}
+
+.woocommerce-marketplace__customize-your-store-button {
+	flex-shrink: 0;
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -143,11 +143,6 @@ export default function Products( props: ProductsProps ) {
 
 	return (
 		<div className={ containerClassName }>
-			{ selectedTab === 'search' && (
-				<h2 className={ productListTitleClassName }>
-					{ isLoading ? ' ' : title }
-				</h2>
-			) }
 			<nav className="woocommerce-marketplace__sub-header">
 				<div className="woocommerce-marketplace__sub-header__categories">
 					{ props.categorySelector && (

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -143,10 +143,17 @@ export default function Products( props: ProductsProps ) {
 
 	return (
 		<div className={ containerClassName }>
-			<div className="woocommerce-marketplace__sub-header">
-				{ props.categorySelector && (
-					<CategorySelector type={ props.type } />
-				) }
+			{ selectedTab === 'search' && (
+				<h2 className={ productListTitleClassName }>
+					{ isLoading ? ' ' : title }
+				</h2>
+			) }
+			<nav className="woocommerce-marketplace__sub-header">
+				<div className="woocommerce-marketplace__sub-header__categories">
+					{ props.categorySelector && (
+						<CategorySelector type={ props.type } />
+					) }
+				</div>
 				{ props.type === 'theme' && (
 					<Button
 						className="woocommerce-marketplace__customize-your-store-button"
@@ -163,7 +170,7 @@ export default function Products( props: ProductsProps ) {
 						} }
 					/>
 				) }
-			</div>
+			</nav>
 			{ isModalOpen && (
 				<ThemeSwitchWarningModal
 					setIsModalOpen={ setIsModalOpen }

--- a/plugins/woocommerce/changelog/51309-update-21591-in-app-category-selector
+++ b/plugins/woocommerce/changelog/51309-update-21591-in-app-category-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update In-App Marketplace category selector


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove the dropdown on the desktop view and show all items, even if overflowing. Added helper buttons to scroll to the right to show more.

Closes https://github.com/Automattic/woocommerce.com/issues/21591.

### How to test the changes in this Pull Request:

1. Checkout this branch and get a new build
2. Load the [In-App Marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions) and move over to the Extensions tab. Confirm category selector loads. 
3. Narrow the viewport so that the category selector overflows. Confirm button to indicate scroll appears. 
4. Scroll using the helper button, when you arrive at to the **Marketing** category, the button should disappear. A new button should appear at the start position to take you back to the **All** category. 
5. Scroll using the scrollbar (if you can see it). Also, enable touch simulation and scroll using the flick of your mouse. 
6. Select a category and confirm the page reloads with relevant results. 
7. Switch over to the **Themes** tab and confirm the category selector continues to work there. 
8. Switch over to the **Business Services** tab and confirm the category selector continues to work there. 
9. Test all tabs using a mobile viewport. This size doesn't have the scrollable category selector but just has the old dropdown as usual.
10. Delete or install the Woo Update Manager to see the margins look good with or without it. I don't have WUM but to get rid of the notice, I returned early [from `PluginInstallNotice`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/marketplace/components/woo-update-manager-plugin/plugin-install-notice.tsx#L21)
11. Load the My Subscriptions page and confirm it continues to load. 
12. Please test around this issue. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Update In-App Marketplace category selector

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
