### PR TITLE
[beta tester] Simulate core error early in the request lifecycle before WP fully loaded.

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/dev-simulate-error-before-wp-loaded
+++ b/plugins/woocommerce-beta-tester/changelog/dev-simulate-error-before-wp-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve remote logging tool to simulate core error early in the request lifecycle before wp fully loaded

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -143,10 +143,25 @@ add_action(
 /**
  * Simulate a WooCommerce error for remote logging testing.
  *
- * @throws Exception A simulated WooCommerce error if the option is set.
+ * This function adds a filter to the 'woocommerce_template_path' hook
+ * that throws an exception, then triggers the filter by calling WC()->template_path().
+ *
+ * @throws Exception A simulated WooCommerce error for testing purposes.
  */
 function simulate_woocommerce_error() {
-	throw new Exception( 'Simulated WooCommerce error for remote logging test' );
+	// Return if WooCommerce is not loaded.
+	if ( ! function_exists( 'WC' ) || ! class_exists( 'WooCommerce' ) ) {
+		return;
+	}
+
+	add_filter(
+		'woocommerce_template_path',
+		function() {
+			throw new Exception( 'Simulated WooCommerce error for remote logging test' );
+		}
+	);
+
+	WC()->template_path();
 }
 
 $simulate_error = get_option( 'wc_beta_tester_simulate_woocommerce_php_error', false );
@@ -155,7 +170,8 @@ if ( $simulate_error ) {
 	delete_option( 'wc_beta_tester_simulate_woocommerce_php_error' );
 
 	if ( 'core' === $simulate_error ) {
-		add_action( 'woocommerce_loaded', 'simulate_woocommerce_error' );
+		// Hook into the plugin_loaded action to simulate the error early before WP fully initializes.
+		add_action( 'plugin_loaded', 'simulate_woocommerce_error' );
 	} elseif ( 'beta-tester' === $simulate_error ) {
 		throw new Exception( 'Test PHP exception from WooCommerce Beta Tester' );
 	}

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -154,6 +154,11 @@ function simulate_woocommerce_error() {
 		return;
 	}
 
+	// Define a constant to prevent the error from being caught by the WP Error Handler.
+	if ( ! defined( 'WP_SANDBOX_SCRAPING' ) ) {
+		define( 'WP_SANDBOX_SCRAPING', true );
+	}
+
 	add_filter(
 		'woocommerce_template_path',
 		function() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51317


> In https://github.com/woocommerce/woocommerce/issues/51301, it was determined the remote error logging feature may fall into a failing state when it reports on errors thrown before WordPress has loaded.
To help test fixes for this, the beta tester tooling adding in https://github.com/woocommerce/woocommerce/pull/50425 could be refined to simulate an error early in the request lifecycle before WordPress is available.


This PR updates the beta tester tool to hook into the `plugin_loaded` action and adds a filter to the `woocommerce_template_path` hook to throw an exception, then triggers the filter by calling WC()->template_path().

**lifecycle**

```
_ beta tester plugin loaded
- do_action( 'plugin_loaded', {Beta Tester} );  <--- simulate an error here, after wc loaded but before loading WP pluggable functions
- woocommerce plugin loaded 
- do_action( 'plugin_loaded', {WC} );  <--- simulate an error here, after wc loaded but before loading WP pluggable functions

- WP Load pluggable functions
- do_action( 'plugins_loaded' );
```
- See https://github.com/WordPress/wordpress-develop/blob/47122105f20624e5a6b8ed151d732157f2f2605c/src/wp-settings.php#L519-L538

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally.
2. cd to `plugins/woocommerce-beta-tester` and run `pnpm run build:zip`
3. Create a new JN site with this [woocommerce.zip](https://github.com/user-attachments/files/16988899/woocommerce.zip) build
4. Add `define( 'WP_ENVIRONMENT_TYPE', 'production' );` to `wp-config.php`
5. Skip Core profiler
6. Upload and activate `woocommerce-beta-tester.zip`
7. Go to `Tools -> WCA Test Helper -> Remote Logging`
8. Enable remote logging
9. Click on PHP `Simulate Core Exception`, refresh the page and confirm it throws an error
10. Confirm `Fatal error: Uncaught Error: Call to undefined function Automattic\WooCommerce\Internal\Logging\wp_get_current_user() in` (https://github.com/woocommerce/woocommerce/issues/51301) is logged in debug.log

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
