### PR TITLE
Fix and improve k6 perf test My Account Open Order

### DIFF
--- a/plugins/woocommerce/changelog/k6-performance-fix-my-account-open-orders-test
+++ b/plugins/woocommerce/changelog/k6-performance-fix-my-account-open-orders-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix k6 performance test that checks for incorrect title when viewing order page

--- a/plugins/woocommerce/tests/performance/README.md
+++ b/plugins/woocommerce/tests/performance/README.md
@@ -75,6 +75,7 @@ admin_username | username for admin user | yes `__ENV.A_USER`
 admin_password | password for admin user | yes `__ENV.A_PW`
 admin_acc_login | set to true if site needs to use my account for admin login | yes `__ENV.A_ACC_LOGIN`
 customer_username | username for customer user | yes `__ENV.C_USER`
+customer_email | email for customer user | yes `__ENV.C_EMAIL`
 customer_password | password for customer user | yes `__ENV.C_PW`
 customer_user_id | user id for customer user | yes `__ENV.C_UID`
 hpos_status | set to true if site is using order tables | yes `__ENV.HPOS`

--- a/plugins/woocommerce/tests/performance/config.js
+++ b/plugins/woocommerce/tests/performance/config.js
@@ -9,10 +9,13 @@ export const admin_username = __ENV.A_USER || 'admin';
 export const admin_password = __ENV.A_PW || 'password';
 export const admin_acc_login = __ENV.A_ACC_LOGIN || false;
 
-export const customer_username =
-	__ENV.C_USER || 'customer@woocommercecoree2etestsuite.com';
+export const customer_username = __ENV.C_USER || 'customer';
+export const customer_email =
+	__ENV.C_EMAIL || 'customer@woocommercecoree2etestsuite.com';
 export const customer_password = __ENV.C_PW || 'password';
 export const customer_user_id = __ENV.C_UID || '2';
+export const customer_first_name = 'Jane';
+export const customer_last_name = 'Smith';
 
 export const hpos_status = __ENV.HPOS || false;
 

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -69,47 +69,9 @@ export function ordersAPI() {
 	const updateData = {
 		status: 'completed',
 	};
-	let customerId;
 	let post_id;
 	let post_ids;
 	let response;
-
-	group( 'API Retrieve Customer', function () {
-		response = http.get( `${ base_url }/wp-json/wc/v3/customers`, {
-			headers: requestHeaders,
-			tags: { name: 'API - Retrieve Customer' },
-		} );
-
-		check( response, {
-			'status is 200': ( r ) => r.status === 200,
-			'body contains customer data': ( r ) => r.body.includes( '"id":' ),
-		} );
-
-		customerId = findBetween( response.body, '"id":', ',' );
-	} );
-
-	const createCustomerOrderData = {
-		customer_id: customerId,
-		status: 'completed',
-	};
-
-	group( 'API Create Customer Order', function () {
-		response = http.post(
-			`${ base_url }/wp-json/wc/v3/orders`,
-			JSON.stringify( createCustomerOrderData ),
-			{
-				headers: requestHeaders,
-				tags: { name: 'API - Create Customer Order' },
-			}
-		);
-		check( response, {
-			'status is 201': ( r ) => r.status === 201,
-			"body contains: 'Completed' Status": ( r ) =>
-				r.body.includes( '"status":"completed"' ),
-		} );
-
-		post_id = findBetween( response.body, '{"id":', ',' );
-	} );
 
 	group( 'API Create Order', function () {
 		response = http.post(

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -82,7 +82,8 @@ export function ordersAPI() {
 
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains customer data': response.body.includes( '"id":' ),
+			'body contains customer data': ( response ) =>
+				response.body.includes( '"id":' ),
 		} );
 
 		customerId = findBetween( response.body, '"id":', ',' );
@@ -104,9 +105,8 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 201': ( r ) => r.status === 201,
-			"body contains: 'Completed' Status": response.body.includes(
-				'"status":"completed"'
-			),
+			"body contains: 'Completed' Status": ( response ) =>
+				response.body.includes( '"status":"completed"' ),
 		} );
 
 		post_id = findBetween( response.body, '{"id":', ',' );
@@ -123,7 +123,7 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 201': ( r ) => r.status === 201,
-			"body contains: 'Pending' Status":
+			"body contains: 'Pending' Status": ( response ) =>
 				response.body.includes( '"status":"pending"' ),
 		} );
 
@@ -141,9 +141,8 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': response.body.includes(
-					`"id":${ post_id }`
-				),
+				'body contains: Order ID': ( response ) =>
+					response.body.includes( `"id":${ post_id }` ),
 			} );
 		}
 	} );
@@ -156,7 +155,8 @@ export function ordersAPI() {
 			} );
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': response.body.includes( '[{"id":' ),
+				'body contains: Order ID': ( response ) =>
+					response.body.includes( '[{"id":' ),
 			} );
 		}
 	} );
@@ -173,9 +173,8 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				"body contains: 'Completed' Status": response.body.includes(
-					'"status":"completed"'
-				),
+				"body contains: 'Completed' Status": ( response ) =>
+					response.body.includes( '"status":"completed"' ),
 			} );
 		}
 	} );
@@ -192,9 +191,8 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': response.body.includes(
-					`"id":${ post_id }`
-				),
+				'body contains: Order ID': ( response ) =>
+					response.body.includes( `"id":${ post_id }` ),
 			} );
 		}
 	} );
@@ -217,7 +215,7 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains: Create batch prefix':
+			'body contains: Create batch prefix': ( response ) =>
 				response.body.includes( 'create":[{"id"' ),
 		} );
 
@@ -255,7 +253,7 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains: Update batch prefix':
+			'body contains: Update batch prefix': ( response ) =>
 				response.body.includes( 'update":[{"id"' ),
 		} );
 	} );

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -84,7 +84,7 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 201': ( r ) => r.status === 201,
-			"body contains: 'Pending' Status": ( response ) =>
+			"body contains: 'Pending' Status":
 				response.body.includes( '"status":"pending"' ),
 		} );
 
@@ -102,8 +102,9 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': ( response ) =>
-					response.body.includes( `"id":${ post_id }` ),
+				'body contains: Order ID': response.body.includes(
+					`"id":${ post_id }`
+				),
 			} );
 		}
 	} );
@@ -116,8 +117,7 @@ export function ordersAPI() {
 			} );
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': ( response ) =>
-					response.body.includes( '[{"id":' ),
+				'body contains: Order ID': response.body.includes( '[{"id":' ),
 			} );
 		}
 	} );
@@ -134,8 +134,9 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				"body contains: 'Completed' Status": ( response ) =>
-					response.body.includes( '"status":"completed"' ),
+				"body contains: 'Completed' Status": response.body.includes(
+					'"status":"completed"'
+				),
 			} );
 		}
 	} );
@@ -152,8 +153,9 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': ( response ) =>
-					response.body.includes( `"id":${ post_id }` ),
+				'body contains: Order ID': response.body.includes(
+					`"id":${ post_id }`
+				),
 			} );
 		}
 	} );
@@ -176,7 +178,7 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains: Create batch prefix': ( response ) =>
+			'body contains: Create batch prefix':
 				response.body.includes( 'create":[{"id"' ),
 		} );
 
@@ -214,7 +216,7 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains: Update batch prefix': ( response ) =>
+			'body contains: Update batch prefix':
 				response.body.includes( 'update":[{"id"' ),
 		} );
 	} );

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -194,7 +194,7 @@ export function ordersAPI() {
 			updateBatchItem = {
 				id: `${ post_ids[ index ] }`,
 				status: 'completed',
-				customer_id: 1,
+				customer_id: 2,
 			};
 			updateBatchData.push( updateBatchItem );
 		}

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -232,7 +232,6 @@ export function ordersAPI() {
 			updateBatchItem = {
 				id: `${ post_ids[ index ] }`,
 				status: 'completed',
-				customer_id: 2,
 			};
 			updateBatchData.push( updateBatchItem );
 		}

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -82,8 +82,7 @@ export function ordersAPI() {
 
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains customer data': ( response ) =>
-				response.body.includes( '"id":' ),
+			'body contains customer data': ( r ) => r.body.includes( '"id":' ),
 		} );
 
 		customerId = findBetween( response.body, '"id":', ',' );
@@ -105,8 +104,8 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 201': ( r ) => r.status === 201,
-			"body contains: 'Completed' Status": ( response ) =>
-				response.body.includes( '"status":"completed"' ),
+			"body contains: 'Completed' Status": ( r ) =>
+				r.body.includes( '"status":"completed"' ),
 		} );
 
 		post_id = findBetween( response.body, '{"id":', ',' );
@@ -123,8 +122,8 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 201': ( r ) => r.status === 201,
-			"body contains: 'Pending' Status": ( response ) =>
-				response.body.includes( '"status":"pending"' ),
+			"body contains: 'Pending' Status": ( r ) =>
+				r.body.includes( '"status":"pending"' ),
 		} );
 
 		post_id = findBetween( response.body, '{"id":', ',' );
@@ -141,8 +140,8 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': ( response ) =>
-					response.body.includes( `"id":${ post_id }` ),
+				'body contains: Order ID': ( r ) =>
+					r.body.includes( `"id":${ post_id }` ),
 			} );
 		}
 	} );
@@ -155,8 +154,8 @@ export function ordersAPI() {
 			} );
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': ( response ) =>
-					response.body.includes( '[{"id":' ),
+				'body contains: Order ID': ( r ) =>
+					r.body.includes( '[{"id":' ),
 			} );
 		}
 	} );
@@ -173,8 +172,8 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				"body contains: 'Completed' Status": ( response ) =>
-					response.body.includes( '"status":"completed"' ),
+				"body contains: 'Completed' Status": ( r ) =>
+					r.body.includes( '"status":"completed"' ),
 			} );
 		}
 	} );
@@ -191,8 +190,8 @@ export function ordersAPI() {
 			);
 			check( response, {
 				'status is 200': ( r ) => r.status === 200,
-				'body contains: Order ID': ( response ) =>
-					response.body.includes( `"id":${ post_id }` ),
+				'body contains: Order ID': ( r ) =>
+					r.body.includes( `"id":${ post_id }` ),
 			} );
 		}
 	} );
@@ -215,8 +214,8 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains: Create batch prefix': ( response ) =>
-				response.body.includes( 'create":[{"id"' ),
+			'body contains: Create batch prefix': ( r ) =>
+				r.body.includes( 'create":[{"id"' ),
 		} );
 
 		post_ids = findBetween( response.body, '{"id":', ',"parent_id', true );
@@ -253,8 +252,8 @@ export function ordersAPI() {
 		);
 		check( response, {
 			'status is 200': ( r ) => r.status === 200,
-			'body contains: Update batch prefix': ( response ) =>
-				response.body.includes( 'update":[{"id"' ),
+			'body contains: Update batch prefix': ( r ) =>
+				r.body.includes( 'update":[{"id"' ),
 		} );
 	} );
 }

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -194,6 +194,7 @@ export function ordersAPI() {
 			updateBatchItem = {
 				id: `${ post_ids[ index ] }`,
 				status: 'completed',
+				customer_id: 1,
 			};
 			updateBatchData.push( updateBatchItem );
 		}

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -69,9 +69,48 @@ export function ordersAPI() {
 	const updateData = {
 		status: 'completed',
 	};
+	let customerId;
 	let post_id;
 	let post_ids;
 	let response;
+
+	group( 'API Retrieve Customer', function () {
+		response = http.get( `${ base_url }/wp-json/wc/v3/customers`, {
+			headers: requestHeaders,
+			tags: { name: 'API - Retrieve Customer' },
+		} );
+
+		check( response, {
+			'status is 200': ( r ) => r.status === 200,
+			'body contains customer data': response.body.includes( '"id":' ),
+		} );
+
+		customerId = findBetween( response.body, '"id":', ',' );
+	} );
+
+	const createCustomerOrderData = {
+		customer_id: customerId,
+		status: 'completed',
+	};
+
+	group( 'API Create Customer Order', function () {
+		response = http.post(
+			`${ base_url }/wp-json/wc/v3/orders`,
+			JSON.stringify( createCustomerOrderData ),
+			{
+				headers: requestHeaders,
+				tags: { name: 'API - Create Customer Order' },
+			}
+		);
+		check( response, {
+			'status is 201': ( r ) => r.status === 201,
+			"body contains: 'Completed' Status": response.body.includes(
+				'"status":"completed"'
+			),
+		} );
+
+		post_id = findBetween( response.body, '{"id":', ',' );
+	} );
 
 	group( 'API Create Order', function () {
 		response = http.post(

--- a/plugins/woocommerce/tests/performance/requests/shopper/checkout-customer-login.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/checkout-customer-login.js
@@ -14,7 +14,7 @@ import {
  */
 import {
 	base_url,
-	customer_username,
+	customer_email,
 	customer_password,
 	addresses_customer_billing_first_name,
 	addresses_customer_billing_last_name,
@@ -139,7 +139,7 @@ export function checkoutCustomerLogin() {
 		const response = http.post(
 			`${ base_url }/checkout`,
 			{
-				username: `${ customer_username }`,
+				username: `${ customer_email }`,
 				password: `${ customer_password }`,
 				'woocommerce-login-nonce': `${ woocommerce_login_nonce }`,
 				_wp_http_referer: '%2Fcheckout',

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
@@ -100,7 +100,7 @@ export function myAccountOrders() {
 
 		checkResponse( response, 200, {
 			title: `Order #${ my_account_order_id } – ${ STORE_NAME }`,
-			body: my_account_order_id,
+			body: `Order #${ my_account_order_id } was placed`,
 			footer: FOOTER_TEXT,
 		} );
 	} );

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
@@ -99,7 +99,7 @@ export function myAccountOrders() {
 		);
 
 		checkResponse( response, 200, {
-			title: `My account – ${ STORE_NAME }`,
+			title: `Order #${ my_account_order_id } – ${ STORE_NAME }`,
 			body: my_account_order_id,
 			footer: FOOTER_TEXT,
 		} );

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
@@ -29,6 +29,7 @@ import { checkResponse } from '../../utils.js';
 
 export function myAccountOrders() {
 	let my_account_order_id;
+	let response;
 
 	group( 'My Account', function () {
 		const requestHeaders = Object.assign(
@@ -39,7 +40,7 @@ export function myAccountOrders() {
 			commonNonStandardHeaders
 		);
 
-		const response = http.get( `${ base_url }/my-account`, {
+		response = http.get( `${ base_url }/my-account`, {
 			headers: requestHeaders,
 			tags: { name: 'Shopper - My Account' },
 		} );
@@ -61,7 +62,7 @@ export function myAccountOrders() {
 			commonNonStandardHeaders
 		);
 
-		const response = http.get( `${ base_url }/my-account/orders/`, {
+		response = http.get( `${ base_url }/my-account/orders/`, {
 			headers: requestHeaders,
 			tags: { name: 'Shopper - My Account Orders' },
 		} );
@@ -90,7 +91,7 @@ export function myAccountOrders() {
 			commonNonStandardHeaders
 		);
 
-		const response = http.get(
+		response = http.get(
 			`${ base_url }/my-account/view-order/${ my_account_order_id }`,
 			{
 				headers: requestHeaders,
@@ -100,7 +101,7 @@ export function myAccountOrders() {
 
 		checkResponse( response, 200, {
 			title: `Order #${ my_account_order_id } – ${ STORE_NAME }`,
-			body: `Order #${ my_account_order_id } was placed`,
+			body: `Order #<mark class="order-number">${ my_account_order_id }</mark> was placed`,
 			footer: FOOTER_TEXT,
 		} );
 	} );

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { sleep, group } from 'k6';
+import { sleep, group, check } from 'k6';
 import http from 'k6/http';
 import {
 	randomIntBetween,
@@ -97,6 +97,13 @@ export function myAccountOrders() {
 				tags: { name: 'Shopper - My Account Open Order' },
 			}
 		);
+
+		check( my_account_order_id, {
+			'order ID is not undefined': () => {
+				console.log( `order id: ${ my_account_order_id }` );
+				return !! my_account_order_id;
+			},
+		} );
 
 		checkResponse( response, 200, {
 			title: `Order #${ my_account_order_id } – ${ STORE_NAME }`,

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
@@ -29,7 +29,6 @@ import { checkResponse } from '../../utils.js';
 
 export function myAccountOrders() {
 	let my_account_order_id;
-	let response;
 
 	group( 'My Account', function () {
 		const requestHeaders = Object.assign(
@@ -40,7 +39,7 @@ export function myAccountOrders() {
 			commonNonStandardHeaders
 		);
 
-		response = http.get( `${ base_url }/my-account`, {
+		const response = http.get( `${ base_url }/my-account`, {
 			headers: requestHeaders,
 			tags: { name: 'Shopper - My Account' },
 		} );
@@ -62,7 +61,7 @@ export function myAccountOrders() {
 			commonNonStandardHeaders
 		);
 
-		response = http.get( `${ base_url }/my-account/orders/`, {
+		const response = http.get( `${ base_url }/my-account/orders/`, {
 			headers: requestHeaders,
 			tags: { name: 'Shopper - My Account Orders' },
 		} );
@@ -91,7 +90,7 @@ export function myAccountOrders() {
 			commonNonStandardHeaders
 		);
 
-		response = http.get(
+		const response = http.get(
 			`${ base_url }/my-account/view-order/${ my_account_order_id }`,
 			{
 				headers: requestHeaders,

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account-orders.js
@@ -100,7 +100,6 @@ export function myAccountOrders() {
 
 		check( my_account_order_id, {
 			'order ID is not undefined': () => {
-				console.log( `order id: ${ my_account_order_id }` );
 				return !! my_account_order_id;
 			},
 		} );

--- a/plugins/woocommerce/tests/performance/requests/shopper/my-account.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/my-account.js
@@ -11,7 +11,7 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
  */
 import {
 	base_url,
-	customer_username,
+	customer_email,
 	customer_password,
 	think_time_min,
 	think_time_max,
@@ -74,7 +74,7 @@ export function myAccount() {
 		response = http.post(
 			`${ base_url }/my-account`,
 			{
-				username: `${ customer_username }`,
+				username: `${ customer_email }`,
 				password: `${ customer_password }`,
 				'woocommerce-login-nonce': `${ woocommerce_login_nonce }`,
 				_wp_http_referer: '/my-account',

--- a/plugins/woocommerce/tests/performance/setup/add-customer-order.js
+++ b/plugins/woocommerce/tests/performance/setup/add-customer-order.js
@@ -1,0 +1,52 @@
+/* eslint-disable jsdoc/require-property-description */
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable import/no-unresolved */
+/**
+ * k6 dependencies
+ */
+import encoding from 'k6/encoding';
+import http from 'k6/http';
+import { findBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+
+/**
+ * Internal dependencies
+ */
+import { base_url, admin_username, admin_password } from '../config.js';
+
+/**
+ * Convert Cart & Checkout pages to shortcode.
+ */
+export function addCustomerOrder() {
+	function addOrderToCustomer() {
+		let response;
+
+		const credentials = `${ admin_username }:${ admin_password }`;
+		const encodedCredentials = encoding.b64encode( credentials );
+		const requestHeaders = {
+			Authorization: `Basic ${ encodedCredentials }`,
+			'Content-Type': 'application/json',
+		};
+
+		response = http.get( `${ base_url }/wp-json/wc/v3/customers`, {
+			headers: requestHeaders,
+			tags: { name: 'API - Retrieve Customer' },
+		} );
+
+		const customerId = findBetween( response.body, '"id":', ',' );
+
+		const createCustomerOrderData = {
+			customer_id: customerId,
+			status: 'completed',
+		};
+		response = http.post(
+			`${ base_url }/wp-json/wc/v3/orders`,
+			JSON.stringify( createCustomerOrderData ),
+			{
+				headers: requestHeaders,
+				tags: { name: 'API - Create Customer Order' },
+			}
+		);
+	}
+
+	addOrderToCustomer();
+}

--- a/plugins/woocommerce/tests/performance/setup/add-customer-order.js
+++ b/plugins/woocommerce/tests/performance/setup/add-customer-order.js
@@ -6,7 +6,6 @@
  */
 import encoding from 'k6/encoding';
 import http from 'k6/http';
-import { findBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 /**
  * Internal dependencies
@@ -17,36 +16,49 @@ import { base_url, admin_username, admin_password } from '../config.js';
  * Convert Cart & Checkout pages to shortcode.
  */
 export function addCustomerOrder() {
-	function addOrderToCustomer() {
-		let response;
+	let response;
+	const customerUsername = 'customer';
 
-		const credentials = `${ admin_username }:${ admin_password }`;
-		const encodedCredentials = encoding.b64encode( credentials );
-		const requestHeaders = {
-			Authorization: `Basic ${ encodedCredentials }`,
-			'Content-Type': 'application/json',
-		};
+	const credentials = `${ admin_username }:${ admin_password }`;
+	const encodedCredentials = encoding.b64encode( credentials );
+	const requestHeaders = {
+		Authorization: `Basic ${ encodedCredentials }`,
+		'Content-Type': 'application/json',
+	};
 
-		response = http.get( `${ base_url }/wp-json/wc/v3/customers`, {
-			headers: requestHeaders,
-			tags: { name: 'API - Retrieve Customer' },
-		} );
+	// Fetch the list of customers
+	response = http.get( `${ base_url }/wp-json/wc/v3/customers`, {
+		headers: requestHeaders,
+	} );
 
-		const customerId = findBetween( response.body, '"id":', ',' );
+	// Parse the response body as JSON to find the customer by username
+	const customers = JSON.parse( response.body );
+	let customerId = null;
 
-		const createCustomerOrderData = {
-			customer_id: customerId,
-			status: 'completed',
-		};
-		response = http.post(
-			`${ base_url }/wp-json/wc/v3/orders`,
-			JSON.stringify( createCustomerOrderData ),
-			{
-				headers: requestHeaders,
-				tags: { name: 'API - Create Customer Order' },
-			}
+	for ( let i = 0; i < customers.length; i++ ) {
+		if ( customers[ i ].username === customerUsername ) {
+			customerId = customers[ i ].id;
+			break;
+		}
+	}
+
+	// If the customer isn't found, throw an error
+	if ( ! customerId ) {
+		throw new Error(
+			`Customer with username ${ customerUsername } not found`
 		);
 	}
 
-	addOrderToCustomer();
+	// Create a new order for the identified customer
+	const createCustomerOrderData = {
+		customer_id: customerId,
+		status: 'completed',
+	};
+	response = http.post(
+		`${ base_url }/wp-json/wc/v3/orders`,
+		JSON.stringify( createCustomerOrderData ),
+		{
+			headers: requestHeaders,
+		}
+	);
 }

--- a/plugins/woocommerce/tests/performance/setup/add-customer-order.js
+++ b/plugins/woocommerce/tests/performance/setup/add-customer-order.js
@@ -10,7 +10,16 @@ import http from 'k6/http';
 /**
  * Internal dependencies
  */
-import { base_url, admin_username, admin_password } from '../config.js';
+import {
+	base_url,
+	admin_username,
+	admin_password,
+	customer_username,
+	customer_email,
+	customer_password,
+	customer_first_name,
+	customer_last_name,
+} from '../config.js';
 
 /**
  * Add a customer order specifically for my-account-orders.js test
@@ -42,10 +51,25 @@ export function addCustomerOrder() {
 		}
 	}
 
-	// If the customer isn't found, throw an error
+	// If customer doesn't exist, create the customer
 	if ( ! customerId ) {
-		throw new Error(
-			`Customer with username ${ customerUsername } not found`
+		console.log(
+			`Customer with username ${ customer_username } not found. Creating new customer...`
+		);
+		const createCustomerData = {
+			username: customer_username,
+			password: customer_password,
+			email: customer_email,
+			first_name: customer_first_name,
+			last_name: customer_last_name,
+		};
+
+		response = http.post(
+			`${ base_url }/wp-json/wc/v3/customers`,
+			JSON.stringify( createCustomerData ),
+			{
+				headers: requestHeaders,
+			}
 		);
 	}
 

--- a/plugins/woocommerce/tests/performance/setup/add-customer-order.js
+++ b/plugins/woocommerce/tests/performance/setup/add-customer-order.js
@@ -13,7 +13,7 @@ import http from 'k6/http';
 import { base_url, admin_username, admin_password } from '../config.js';
 
 /**
- * Convert Cart & Checkout pages to shortcode.
+ * Add a customer order specifically for my-account-orders.js test
  */
 export function addCustomerOrder() {
 	let response;

--- a/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
+++ b/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsdoc/require-property-description */
+/* eslint-disable @woocommerce/dependency-group */
 /* eslint-disable import/no-unresolved */
 /**
  * k6 dependencies

--- a/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
+++ b/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 /**
  * k6 dependencies
  */

--- a/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
+++ b/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
@@ -13,9 +13,10 @@ import { base_url, admin_username, admin_password } from '../config.js';
 /**
  * Convert Cart & Checkout pages to shortcode.
  */
-export function useCartCheckoutShortcodes() {
+export function setCartCheckoutShortcodes() {
 	/**
 	 * A WordPress page.
+	 *
 	 * @typedef {Object} WPPage
 	 * @property {number} id
 	 * @property {string} slug

--- a/plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
@@ -21,6 +21,7 @@ import { ordersSearch } from '../requests/merchant/orders-search.js';
 import { addOrder } from '../requests/merchant/add-order.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
+import { addCustomerOrder } from '../setup/add-customer-order.js';
 
 const shopper_request_threshold = 'p(95)<10000';
 const merchant_request_threshold = 'p(95)<10000';
@@ -246,6 +247,10 @@ export const options = {
 		],
 	},
 };
+
+export function setup() {
+	addCustomerOrder();
+}
 
 export function shopperBrowseFlow() {
 	homePage();

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -277,7 +277,12 @@ export function cartFlow() {
 }
 export function allMerchantFlow() {
 	wpLogin();
-	homeWCAdmin( { other: false, orders: false, reviews: false, products: false} );
+	homeWCAdmin( {
+		other: false,
+		orders: false,
+		reviews: false,
+		products: false,
+	} );
 	addOrder();
 	orders();
 	ordersSearch();

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -23,6 +23,7 @@ import { addOrder } from '../requests/merchant/add-order.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
 import { setCartCheckoutShortcodes } from '../setup/cart-checkout-shortcode.js';
+import { addCustomerOrder } from '../setup/add-customer-order.js';
 
 const shopper_request_threshold = 'p(95)<10000';
 const merchant_request_threshold = 'p(95)<10000';
@@ -251,6 +252,7 @@ export const options = {
 
 export function setup() {
 	setCartCheckoutShortcodes();
+	addCustomerOrder();
 }
 
 export function shopperBrowseFlow() {

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -22,7 +22,7 @@ import { ordersFilter } from '../requests/merchant/orders-filter.js';
 import { addOrder } from '../requests/merchant/add-order.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
-import { useCartCheckoutShortcodes } from '../setup/cart-checkout-shortcode.js';
+import { setCartCheckoutShortcodes } from '../setup/cart-checkout-shortcode.js';
 
 const shopper_request_threshold = 'p(95)<10000';
 const merchant_request_threshold = 'p(95)<10000';
@@ -250,7 +250,7 @@ export const options = {
 };
 
 export function setup() {
-	useCartCheckoutShortcodes();
+	setCartCheckoutShortcodes();
 }
 
 export function shopperBrowseFlow() {

--- a/plugins/woocommerce/tests/performance/tests/hpos-baseline-load.js
+++ b/plugins/woocommerce/tests/performance/tests/hpos-baseline-load.js
@@ -25,6 +25,7 @@ import { myAccountMerchantLogin } from '../requests/merchant/my-account-merchant
 import { wpLogin } from '../requests/merchant/wp-login.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { admin_acc_login } from '../config.js';
+import { addCustomerOrder } from '../setup/add-customer-order.js';
 
 const shopper_request_threshold = 'p(95)<100000';
 const merchant_request_threshold = 'p(95)<100000';
@@ -256,6 +257,10 @@ export const options = {
 	},
 };
 
+export function setup() {
+	addCustomerOrder();
+}
+
 // Use myAccountMerchantLogin() instead of wpLogin() if having issues with login.
 export function merchantOrderFlows() {
 	if ( admin_acc_login === true ) {
@@ -277,7 +282,12 @@ export function merchantOtherFlows() {
 		wpLogin();
 	}
 	homeWCAdmin( { other: false, products: false, reviews: false } );
-	addProduct( { heartbeat: false, other: false, permalink: false, update: false } );
+	addProduct( {
+		heartbeat: false,
+		other: false,
+		permalink: false,
+		update: false,
+	} );
 	coupons();
 }
 export function shopperBrowsingFlows() {

--- a/plugins/woocommerce/tests/performance/tests/simple-all-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/simple-all-requests.js
@@ -25,6 +25,7 @@ import { wpLogin } from '../requests/merchant/wp-login.js';
 import { myAccountMerchantLogin } from '../requests/merchant/my-account-merchant.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { admin_acc_login } from '../config.js';
+import { addCustomerOrder } from '../setup/add-customer-order.js';
 
 const shopper_request_threshold = 'p(95)<10000';
 const merchant_request_threshold = 'p(95)<10000';
@@ -250,6 +251,10 @@ export const options = {
 		],
 	},
 };
+
+export function setup() {
+	addCustomerOrder();
+}
 
 export function shopperBrowseFlow() {
 	homePage();

--- a/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js
+++ b/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js
@@ -26,6 +26,7 @@ import { myAccountMerchantLogin } from '../requests/merchant/my-account-merchant
 import { wpLogin } from '../requests/merchant/wp-login.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { admin_acc_login } from '../config.js';
+import { addCustomerOrder } from '../setup/add-customer-order.js';
 
 const shopper_request_threshold = 'p(95)<100000';
 const merchant_request_threshold = 'p(95)<100000';
@@ -281,6 +282,10 @@ export const options = {
 		],
 	},
 };
+
+export function setup() {
+	addCustomerOrder();
+}
 
 // Use myAccountMerchantLogin() instead of wpLogin() if having issues with login.
 export function merchantOrderFlows() {

--- a/plugins/woocommerce/tests/performance/tests/wc-regression-test-load.js
+++ b/plugins/woocommerce/tests/performance/tests/wc-regression-test-load.js
@@ -26,6 +26,7 @@ import { myAccountMerchantLogin } from '../requests/merchant/my-account-merchant
 import { wpLogin } from '../requests/merchant/wp-login.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { admin_acc_login } from '../config.js';
+import { addCustomerOrder } from '../setup/add-customer-order.js';
 
 const shopper_request_threshold = 'p(95)<100000';
 const merchant_request_threshold = 'p(95)<100000';
@@ -281,6 +282,10 @@ export const options = {
 		],
 	},
 };
+
+export function setup() {
+	addCustomerOrder();
+}
 
 // Use myAccountMerchantLogin() instead of wpLogin() if having issues with login.
 export function merchantOrderFlows() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51234

This turned to be a much more worse problem with this test and not flakiness.

The first issue was related to no order creation for the customer when viewing the order via `/view-order/[id]`
The second issue was that the test itself contained `const response` that didn't allow user to see it as logged in customer, but as a guest.
The check response in the test allowed the test to pass with empty order ID.

Additionally, I fixed linting issues as it forced me locally when saving the file.

I had to update view places for this test to pass correctly.
This also includes linting issues in the test file `cart-checkout-shortcode.js` and disabling `jsdoc/require-property-description`, `@woocommerce/dependency-group` and `import/no-unresolved` (which one is disabled in every test file already).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. All checks are green
2. The specific test should pass on CI with newly added assertions like new title with order and and the body:
 █ My Account Open Order
       ✓ is status 200
       ✓ title is: "Order # 97 – WooCommerce Core E2E Test Suite"
       ✓ body contains: Order #<mark class="order-number">97</mark> was placed
       ✓ footer contains: Built with WooCommerce

This means the changes were good and we finally test the My Account > View Order properly with a strong check in the body.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
