### PR TITLE
Marketplace: bring back the loading state

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -130,6 +130,17 @@ export default function Products( props: ProductsProps ) {
 		baseContainerClass + 'button-' + labelForClassName
 	);
 
+	if ( isLoading ) {
+		return (
+			<>
+				{ props.categorySelector && (
+					<CategorySelector type={ props.type } />
+				) }
+				<ProductLoader hasTitle={ false } type={ props.type } />
+			</>
+		);
+	}
+
 	if ( products.length === 0 ) {
 		let type = SearchResultType.all;
 
@@ -153,17 +164,6 @@ export default function Products( props: ProductsProps ) {
 			? 'woocommerce-marketplace__product-list-content--collapsed'
 			: ''
 	);
-
-	if ( isLoading ) {
-		return (
-			<>
-				{ props.categorySelector && (
-					<CategorySelector type={ props.type } />
-				) }
-				<ProductLoader hasTitle={ false } type={ props.type } />
-			</>
-		);
-	}
 
 	return (
 		<div className={ containerClassName }>

--- a/plugins/woocommerce/changelog/51342-fix-21596-search-loading-state
+++ b/plugins/woocommerce/changelog/51342-fix-21596-search-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the loading state for the In-App Marketplace search


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We used to have a loading state but now it's not appearing. This PR fixes that issue. 

Closes #https://github.com/Automattic/woocommerce.com/issues/21596.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to any Marketplace page and start a search. Confirm you get a loading state first and then the results. 
2. Perform this with any search query with no results and confirm you get to see the no results screen with the message "Try searching again using a different term, or take a look at our recommendations below.".
3. Please test around this issue 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix the loading state for the In-App Marketplace search

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

#### Screenshot
[Screencast from 2024-09-12 21-39-52.webm](https://github.com/user-attachments/assets/c9af875e-ffd4-4cbf-adbe-9448e9a64ffe)

