### PR TITLE
Add 3rd arg to woocommerce_update_product hook at class-wc-product…

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -271,8 +271,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			->maybe_schedule_adjust_download_permissions( $product );
 
 		$product->apply_changes();
-
-		do_action( 'woocommerce_update_product', $product->get_id(), $product );
+		// hook with 3 arguments
+		do_action( 'woocommerce_update_product', $product->get_id(), $product, $changes );
 	}
 
 	/**


### PR DESCRIPTION
…-data-store-cpt.php

Add 3rd argument $changes to woocommerce_update_product hook, line 275. The $changes variable is defined at the beginning of the function, line 203 and is available at the time of the hook activation: do_action( 'woocommerce_update_product', $product->get_id(), $product, $changes );
The use of this 3rd argument helps developers check the changes of the product object, when the hook is fired, and write better code.
Adding back the 3rd argument does not cause any problems as the variable $changes is defined at the begining of the method. Existing plugins that use this hook will not be affected as, at the declaration of their hook, always declare the number of the arguments they need to use.
See Issue https://github.com/woocommerce/woocommerce/issues/51343

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Added 3rd argument $changes to 	woocommerce_update_product hook, line 275.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Testing instructions 
Code review is probably sufficient for this change. However, it should be possible to confirm there are no regressions by running through the following steps: 
1. Create a test plugin at wp-content/plugins/test/test.php . 
2. It should contain the following code: 

/**  Plugin name: Test Code 
* Description: Can be used to test pull request "Add 3rd arg to woocommerce_update_product hook"
* Remove after use 
* WC Tested up to: 9.2.3 
*/ 

add_action( 'woocommerce_update_product', 'geonolis_update_product', 10, 3);

public function geonolis_update_product( $product_id, $product, $changes ) {
  // If there was change in price, stock, etc then do some stuff
  if ( array_intersect( array( 'stock_quantity', 'sale_price', 'price', 'tax_class', 'stock_status', 'shipping_class_id', 'regular_price' ), array_keys( $changes ) ) ) {
 // do some stuff
  }
}

3. Ensure WooCommerce is active, disable everything else, and then go ahead and activate the Test Code plugin. 
 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below



<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>
Add 3rd argument to woocommerce_update_product hook at class-wc-product-data-store-cpt.php
<details>



