### PR TITLE
Reducing Noise in Remote Logging

### DIFF
--- a/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
+++ b/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
@@ -100,7 +100,10 @@ function log_remote_event() {
 		time(),
 		'critical',
 		'Test PHP event from WC Beta Tester',
-		array( 'source' => 'wc-beta-tester' )
+		array(
+			'source'         => 'wc-beta-tester',
+			'remote-logging' => true,
+		)
 	);
 
 	if ( $result ) {

--- a/plugins/woocommerce-beta-tester/changelog/enhance-reduce-remote-logging-noise
+++ b/plugins/woocommerce-beta-tester/changelog/enhance-reduce-remote-logging-noise
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Set remote-logging context to true in log remote event method

--- a/plugins/woocommerce/changelog/enhance-reduce-remote-logging-noise
+++ b/plugins/woocommerce/changelog/enhance-reduce-remote-logging-noise
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Reducing noise in remote logging

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -384,8 +384,10 @@ final class WooCommerce {
 			unset( $error_copy['message'] );
 
 			$context = array(
-				'source' => 'fatal-errors',
-				'error'  => $error_copy,
+				'source'         => 'fatal-errors',
+				'error'          => $error_copy,
+				// Indicate that this error should be logged remotely if remote logging is enabled.
+				'remote-logging' => true,
 			);
 
 			if ( false !== strpos( $message, 'Stack trace:' ) ) {

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -306,9 +306,9 @@ class RemoteLogger extends \WC_Log_Handler {
 		if ( str_contains( $message, $wc_plugin_dir ) ) {
 			return false;
 		}
+
 		// Check if the backtrace contains the WooCommerce plugin directory.
 		foreach ( $context['backtrace'] as $trace ) {
-			$trace = $context['backtrace'][ $i ];
 			if ( is_string( $trace ) && str_contains( $trace, $wc_plugin_dir ) ) {
 				return false;
 			}

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -102,11 +102,14 @@ class RemoteLogger extends \WC_Log_Handler {
 		}
 
 		if ( isset( $context['error'] ) && is_array( $context['error'] ) && ! empty( $context['error']['file'] ) ) {
-			$context['error']['file'] = $this->sanitize( $context['error']['file'] );
+			$log_data['file'] = $this->sanitize( $context['error']['file'] );
+			unset( $context['error']['file'] );
 		}
 
 		$extra_attrs = $context['extra'] ?? array();
 		unset( $context['extra'] );
+		unset( $context['remote-logging'] );
+
 		// Merge the extra attributes with the remaining context since we can't send arbitrary fields to Logstash.
 		$log_data['extra'] = array_merge( $extra_attrs, $context );
 
@@ -166,9 +169,15 @@ class RemoteLogger extends \WC_Log_Handler {
 	 * @return bool True if the log should be handled.
 	 */
 	protected function should_handle( $level, $message, $context ) {
+		// Ignore logs that are not opted in for remote logging.
+		if ( ! isset( $context['remote-logging'] ) || false === $context['remote-logging'] ) {
+			return false;
+		}
+
 		if ( ! $this->is_remote_logging_allowed() ) {
 			return false;
 		}
+
 		// Ignore logs that are less severe than critical. This is temporary to prevent sending too many logs to the remote logging service. We can consider remove this if the remote logging service can handle more logs.
 		if ( WC_Log_Levels::get_level_severity( $level ) < WC_Log_Levels::get_level_severity( WC_Log_Levels::CRITICAL ) ) {
 			return false;

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -306,10 +306,8 @@ class RemoteLogger extends \WC_Log_Handler {
 		if ( str_contains( $message, $wc_plugin_dir ) ) {
 			return false;
 		}
-		// Check if any of the first three backtrace entries contain the WooCommerce plugin directory.
-		$backtrace_count = count( $context['backtrace'] );
-		$limit           = min( 3, $backtrace_count );
-		for ( $i = 0; $i < $limit; $i++ ) {
+		// Check if the backtrace contains the WooCommerce plugin directory.
+		foreach ( $context['backtrace'] as $trace ) {
 			$trace = $context['backtrace'][ $i ];
 			if ( is_string( $trace ) && str_contains( $trace, $wc_plugin_dir ) ) {
 				return false;

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -102,8 +102,7 @@ class RemoteLogger extends \WC_Log_Handler {
 		}
 
 		if ( isset( $context['error'] ) && is_array( $context['error'] ) && ! empty( $context['error']['file'] ) ) {
-			$log_data['file'] = $this->sanitize( $context['error']['file'] );
-			unset( $context['error']['file'] );
+			$context['error']['file'] = $this->sanitize( $context['error']['file'] );
 		}
 
 		$extra_attrs = $context['extra'] ?? array();
@@ -307,9 +306,11 @@ class RemoteLogger extends \WC_Log_Handler {
 		if ( str_contains( $message, $wc_plugin_dir ) ) {
 			return false;
 		}
-
-		// Check if the backtrace contains the WooCommerce plugin directory.
-		foreach ( $context['backtrace'] as $trace ) {
+		// Check if any of the first three backtrace entries contain the WooCommerce plugin directory.
+		$backtrace_count = count( $context['backtrace'] );
+		$limit           = min( 3, $backtrace_count );
+		for ( $i = 0; $i < $limit; $i++ ) {
+			$trace = $context['backtrace'][ $i ];
 			if ( is_string( $trace ) && str_contains( $trace, $wc_plugin_dir ) ) {
 				return false;
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -254,14 +254,6 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 						),
 					),
 				),
-				'log with error'            => array(
-					'error',
-					'Test error message',
-					array( 'error' => array( 'file' => ABSPATH . 'wp-content/plugins/woocommerce/file.php' ) ),
-					array(
-						'file' => '**/woocommerce/file.php',
-					),
-				),
 			);
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -254,6 +254,14 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 						),
 					),
 				),
+				'log with error'            => array(
+					'error',
+					'Test error message',
+					array( 'error' => array( 'file' => ABSPATH . 'wp-content/plugins/woocommerce/file.php' ) ),
+					array(
+						'file' => '**/woocommerce/file.php',
+					),
+				),
 			);
 		}
 
@@ -348,7 +356,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 
 			$setup( $this );
 
-			$result = $this->invoke_private_method( $this->sut, 'should_handle', array( $level, 'Test message', array() ) );
+			$result = $this->invoke_private_method( $this->sut, 'should_handle', array( $level, 'Test message', array( 'remote-logging' => true ) ) );
 			$this->assertEquals( $expected, $result );
 		}
 
@@ -378,6 +386,14 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 		}
 
 		/**
+		 * @testdox Test should_handle returns false without remote-logging context
+		 */
+		public function test_should_handle_no_remote_logging_context() {
+			$result = $this->invoke_private_method( $this->sut, 'should_handle', array( 'error', 'Test message', array() ) );
+			$this->assertFalse( $result, 'should_handle should return false without remote-logging context' );
+		}
+
+		/**
 		 * @testdox handle method applies filter and doesn't send logs when filtered to null
 		 */
 		public function test_handle_filtered_log_null() {
@@ -390,7 +406,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 			add_filter( 'woocommerce_remote_logger_formatted_log_data', fn() => null, 10, 4 );
 			add_filter( 'pre_http_request', fn() => $this->fail( 'wp_safe_remote_post should not be called' ), 10, 3 );
 
-			$this->assertFalse( $this->sut->handle( time(), 'error', 'Test message', array() ) );
+			$this->assertFalse( $this->sut->handle( time(), 'error', 'Test message', array( 'remote-logging' => true ) ) );
 		}
 
 		/**
@@ -404,7 +420,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 			$this->sut->set_is_dev_or_local( true );
 			$this->sut->method( 'is_remote_logging_allowed' )->willReturn( true );
 
-			$this->assertFalse( $this->sut->handle( time(), 'error', 'Test message', array() ) );
+			$this->assertFalse( $this->sut->handle( time(), 'error', 'Test message', array( 'remote-logging' => true ) ) );
 		}
 
 		/**
@@ -435,7 +451,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 				3
 			);
 
-			$this->assertTrue( $this->sut->handle( time(), 'critical', 'Test message', array() ) );
+			$this->assertTrue( $this->sut->handle( time(), 'critical', 'Test message', array( 'remote-logging' => true ) ) );
 			$this->assertTrue( WC_Rate_Limiter::retried_too_soon( RemoteLogger::RATE_LIMIT_ID ) );
 		}
 
@@ -462,7 +478,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 				3
 			);
 
-			$this->assertFalse( $this->sut->handle( time(), 'critical', 'Test message', array() ) );
+			$this->assertFalse( $this->sut->handle( time(), 'critical', 'Test message', array( 'remote-logging' => true ) ) );
 			$this->assertTrue( WC_Rate_Limiter::retried_too_soon( RemoteLogger::RATE_LIMIT_ID ) );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51354.

After checking the logs in Logstash, I noticed that there are a lot of irrelevant logs being sent to the server. This is because the any plugins log critical errors using the `wc_get_logger()->critical()` method are being sent to the server.

To improve this, this PR changes the logging behavior to only log when the parameter contains 'remote-logging' => true.

The current implementation allows logging like this:

```php
wc_get_logger()->critical(
    'Custom critical error message',
    ['source' => 'your-source-identifier']
);
```

 Change this to only log when the 'remote-logging' parameter is set to true:

```php
wc_get_logger()->critical(
    'Custom critical error message',
    [
        'source' => 'your-source-identifier',
        'remote-logging' => true
    ]
);
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new JN site with this branch
2. Skip Core profiler
3. Go to `Tools -> WCA Test Helper -> Remote Logging`
4. Enable remote logging
5. Click on PHP `Simulate Core Exception`, refresh the page and confirm it throws an error
6. See PCYsg-11XN-p2 for instructions on viewing the logs
7. Reset the PHP rate limit
8. Install and activate Code Snippets plugin
9. Add a new snippet with the following code:

```php
add_action( 'plugins_loaded', function() {
    wc_get_logger()->critical(
        'Custom critical error message',
        [
            'source' => 'your-source-identifier',
            'remote-logging' => false
        ]
    );
});
```

10. Confirm that the error is not logged

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
