### PR TITLE
Disable client-side nav in PC block when filters are inside

### DIFF
--- a/plugins/woocommerce/changelog/fix-50875-disable-client-side-nav-for-filters-in-pc-block
+++ b/plugins/woocommerce/changelog/fix-50875-disable-client-side-nav-for-filters-in-pc-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Collection: Disable client-side nav if filter blocks are detected inside

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -499,11 +499,18 @@ class ProductCollection extends AbstractBlock {
 	 */
 	private function is_block_compatible( $block_name ) {
 		// Check for explicitly unsupported blocks.
-		if (
-			'core/post-content' === $block_name ||
-			'woocommerce/mini-cart' === $block_name ||
-			'woocommerce/featured-product' === $block_name
-		) {
+		$unsupported_blocks = array(
+			'core/post-content',
+			'woocommerce/mini-cart',
+			'woocommerce/featured-product',
+			'woocommerce/active-filters',
+			'woocommerce/price-filter',
+			'woocommerce/stock-filter',
+			'woocommerce/attribute-filter',
+			'woocommerce/rating-filter',
+		);
+
+		if ( in_array($block_name, $unsupported_blocks) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -510,7 +510,7 @@ class ProductCollection extends AbstractBlock {
 			'woocommerce/rating-filter',
 		);
 
-		if ( in_array($block_name, $unsupported_blocks) ) {
+		if ( in_array( $block_name, $unsupported_blocks, true ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/issues/50875 user raised an issue that Filters are not loading correctly when placed inside Product Collection block and after navigation. This is due to filters being client-side rendered and they are incompatible with Interactivity API, hence after page change they may not be working fine.

With @dinhtungdu we determined the issue is not deterministic. But anyway, we're not planning on making the filters compatible, but what we should do instead is guarantee blocks are working fine together, hence in this PR I'm marking filters as blocks that disable client-side navigation in PC when detected inside.

Closes https://github.com/woocommerce/woocommerce/issues/50875

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Editor -> Product Catalog
2. Insert Product Collection block
3. Choose "create your own"
4. Insert "Product Filters" pattern in PC block (pattern contains all of the filter blocks)

<img width="352" alt="image" src="https://github.com/user-attachments/assets/144c98ef-e4d4-489f-a2f8-d8d98b2fd5b0">

5. Save and go to frontend
6. Change the page in PC block
7. **Expected:** There's a full-page reload, filters are displayed correctly

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
