### PR TITLE
add: tax task completion filter

### DIFF
--- a/plugins/woocommerce/changelog/add-tax-task-completion-filter
+++ b/plugins/woocommerce/changelog/add-tax-task-completion-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Adds a filter for third party tax plugins to indicate that they have completed the tax task

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -112,6 +112,7 @@ class Tax extends Task {
 			$wc_connect_taxes_enabled = get_option( 'wc_connect_taxes_enabled' );
 			$is_wc_connect_taxes_enabled = ( $wc_connect_taxes_enabled === 'yes' ) || ( $wc_connect_taxes_enabled === true ); // seems that in some places boolean is used, and other places 'yes' | 'no' is used
 
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			$third_party_complete = apply_filters( 'woocommerce_admin_third_party_tax_setup_complete', false );
 
 			$this->is_complete_result = $is_wc_connect_taxes_enabled ||

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -15,6 +15,7 @@ class Tax extends Task {
 
 	/**
 	 * Used to cache is_complete() method result.
+	 *
 	 * @var null
 	 */
 	private $is_complete_result = null;
@@ -109,10 +110,10 @@ class Tax extends Task {
 	 */
 	public function is_complete() {
 		if ( $this->is_complete_result === null ) {
-			$wc_connect_taxes_enabled = get_option( 'wc_connect_taxes_enabled' );
+			$wc_connect_taxes_enabled    = get_option( 'wc_connect_taxes_enabled' );
 			$is_wc_connect_taxes_enabled = ( $wc_connect_taxes_enabled === 'yes' ) || ( $wc_connect_taxes_enabled === true ); // seems that in some places boolean is used, and other places 'yes' | 'no' is used
 
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- We will replace this with a formal system by WC 9.6 so lets not advertise it yet.
 			$third_party_complete = apply_filters( 'woocommerce_admin_third_party_tax_setup_complete', false );
 
 			$this->is_complete_result = $is_wc_connect_taxes_enabled ||

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -112,9 +112,12 @@ class Tax extends Task {
 			$wc_connect_taxes_enabled = get_option( 'wc_connect_taxes_enabled' );
 			$is_wc_connect_taxes_enabled = ( $wc_connect_taxes_enabled === 'yes' ) || ( $wc_connect_taxes_enabled === true ); // seems that in some places boolean is used, and other places 'yes' | 'no' is used
 
+			$third_party_complete = apply_filters( 'woocommerce_admin_third_party_tax_setup_complete', false );
+
 			$this->is_complete_result = $is_wc_connect_taxes_enabled ||
 				count( TaxDataStore::get_taxes( array() ) ) > 0 ||
-				get_option( 'woocommerce_no_sales_tax' ) !== false;
+				get_option( 'woocommerce_no_sales_tax' ) !== false ||
+				$third_party_complete;
 		}
 
 		return $this->is_complete_result;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding a filter for third party tax calculation plugins to indicate that the merchant has completed tax setup, so that we can mark the onboarding Tax Task as complete.

This is a temporary solution until we implement a comprehensive tax plugin registration framework, sometime by the end of this year.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set up a store, do not install any tax related plugins such as WooCommerce Shipping and Taxes
2. Note that the tax task is not completed
3. Add a snippet (using Code Snippets or something) to implement the filter, e.g:
```
 add_filter( 'woocommerce_admin_third_party_tax_setup_complete', function( $complete ) {
     // Check if this plugin's tax setup is complete
     if ( /* plugin-specific completion check */ ) {
         return true;
     }
     return $complete;
 });
```
4. Observe that the tax task is now complete

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
