### PR TITLE
 Refine PHP Fatal Error Counting

### DIFF
--- a/plugins/woocommerce/changelog/update-refine-error-counting
+++ b/plugins/woocommerce/changelog/update-refine-error-counting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Refine PHP Fatal Error Counting in MC Stat

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -27,7 +27,6 @@ use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Internal\Utilities\LegacyRestApiStub;
 use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
 use Automattic\WooCommerce\Internal\Admin\Marketplace;
-use Automattic\WooCommerce\Internal\McStats;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\{LoggingUtil, RestApiUtil, TimeUtil};
 use Automattic\WooCommerce\Internal\Logging\RemoteLogger;

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -407,12 +407,6 @@ final class WooCommerce {
 				$context
 			);
 
-			// Record fatal error stats.
-			$container = wc_get_container();
-			$mc_stats  = $container->get( McStats::class );
-			$mc_stats->add( 'error', 'fatal-errors-during-shutdown' );
-			$mc_stats->do_server_side_stats();
-
 			/**
 			 * Action triggered when there are errors during shutdown.
 			 *

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Internal\Logging;
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Internal\McStats;
 use WC_Rate_Limiter;
 use WC_Log_Levels;
 

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -178,6 +178,15 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 
+		try {
+			// Record fatal error stats.
+			$mc_stats = wc_get_container()->get( McStats::class );
+			$mc_stats->add( 'error', 'critical-errors' );
+			$mc_stats->do_server_side_stats();
+		} catch ( \Throwable $e ) {
+			error_log( 'Warning: Failed to record fatal error stats: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
+
 		if ( WC_Rate_Limiter::retried_too_soon( self::RATE_LIMIT_ID ) ) {
 			error_log( 'Remote logging throttled.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			return false;

--- a/plugins/woocommerce/src/Internal/McStats.php
+++ b/plugins/woocommerce/src/Internal/McStats.php
@@ -60,4 +60,17 @@ class McStats extends A8c_Mc_Stats {
 
 		return parent::do_server_side_stat( $url );
 	}
+
+	/**
+	 * Pings the stats server for the current stats and empty the stored stats from the object
+	 *
+	 * @return void
+	 */
+	public function do_server_side_stats() {
+		if ( ! \WC_Site_Tracking::is_tracking_enabled() ) {
+			return;
+		}
+
+		parent::do_server_side_stats();
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51356. 

We're using MC Stats to count PHP fatal errors, and it's set up to count any fatal errors that occur during shutdown. However, the current count doesn't seem to be providing helpful insights due to its broad scope.

This PR moves the MC Stats error counting logic to occur after the remote logging third-party check. This way, we can count only the fatal errors that occur during the remote logging process, which should provide more helpful insights for how many fatal errors related to WooCommerce core.

Also, unfortunately, we seems missed adding the `do_server_side_stats` method behind Tracking opt-it, so I've added a check to ensure that the method is only called when the tracking is enabled.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site using this branch 
2. Add the following to `./wp-includes/functions.php`

```php
function custom_wp_remote_get_debug( $response, $args, $url ) {
    if ( strpos( $url, 'https://pixel.wp.com' ) === 0 ) {
        // Print the request URL
        echo 'Request URL: ' . esc_url( $url ) . '<br>';

        // Check if the response is a WP_Error or not
        if ( is_wp_error( $response ) ) {
            echo 'Response: Failed<br>';
        } else {
            echo 'Response: Success<br>';
        }
    }
    return $response;
}

add_filter( 'http_response', 'custom_wp_remote_get_debug', 10, 3);
```

3. Go to `Tools -> WCA Test Helper -> Remote Logging`
4. Enable the remote logging
5. Click on PHP Simulate Core Exception, refresh the page and confirm it throws an error
6. Reload the page
7. Confirm that the screen shows the `Response: Success` 
8. Click on PHP Simulate Beta Tester Exception, refresh the page and confirm it throws an error
9. Confirm that the screen doesn't show the `Response: Success`

![Screenshot 2024-09-13 at 13 01 58](https://github.com/user-attachments/assets/50e0a031-49b5-425c-a727-5e0597db4c7b)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
