### PR TITLE
Reduce dependency of remote logging on WC_Tracks

### DIFF
--- a/plugins/woocommerce/changelog/enhance-remote-logging-reduce-dependency
+++ b/plugins/woocommerce/changelog/enhance-remote-logging-reduce-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Reduce dependency of remote logging on WC_Tracks

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
 use WC_Rate_Limiter;
 use WC_Log_Levels;
+use Jetpack_Options;
 
 /**
  * WooCommerce Remote Logger
@@ -66,13 +67,21 @@ class RemoteLogger extends \WC_Log_Handler {
 			'message'    => $this->sanitize( $message ),
 			'host'       => wp_parse_url( home_url(), PHP_URL_HOST ),
 			'tags'       => array( 'woocommerce', 'php' ),
+			'store_id'   => null,
 			'properties' => array(
 				'wc_version'  => WC()->version,
 				'php_version' => phpversion(),
 				'wp_version'  => get_bloginfo( 'version' ),
 				'request_uri' => $this->sanitize_request_uri( filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL ) ),
+				'store_id'    => get_option( \WC_Install::STORE_ID_OPTION, null ),
 			),
 		);
+
+		$blog_id = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
+
+		if ( $blog_id && is_int( $blog_id ) ) {
+			$log_data['blog_id'] = $blog_id;
+		}
 
 		if ( isset( $context['backtrace'] ) ) {
 			if ( is_array( $context['backtrace'] ) || is_string( $context['backtrace'] ) ) {
@@ -86,19 +95,6 @@ class RemoteLogger extends \WC_Log_Handler {
 		if ( isset( $context['tags'] ) && is_array( $context['tags'] ) ) {
 			$log_data['tags'] = array_merge( $log_data['tags'], $context['tags'] );
 			unset( $context['tags'] );
-		}
-
-		if ( class_exists( '\WC_Tracks' ) && function_exists( 'wp_get_current_user' ) ) {
-			$user         = wp_get_current_user();
-			$blog_details = \WC_Tracks::get_blog_details( $user->ID );
-
-			if ( is_numeric( $blog_details['blog_id'] ) && $blog_details['blog_id'] > 0 ) {
-				$log_data['blog_id'] = $blog_details['blog_id'];
-			}
-
-			if ( ! empty( $blog_details['store_id'] ) ) {
-				$log_data['properties']['store_id'] = $blog_details['store_id'];
-			}
 		}
 
 		if ( isset( $context['error'] ) && is_array( $context['error'] ) && ! empty( $context['error']['file'] ) ) {

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -78,7 +78,7 @@ class RemoteLogger extends \WC_Log_Handler {
 
 		$blog_id = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
 
-		if ( $blog_id && is_int( $blog_id ) ) {
+		if ( ! empty( $blog_id ) && is_int( $blog_id ) ) {
 			$log_data['blog_id'] = $blog_id;
 		}
 

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -67,7 +67,6 @@ class RemoteLogger extends \WC_Log_Handler {
 			'message'    => $this->sanitize( $message ),
 			'host'       => wp_parse_url( home_url(), PHP_URL_HOST ),
 			'tags'       => array( 'woocommerce', 'php' ),
-			'store_id'   => null,
 			'properties' => array(
 				'wc_version'  => WC()->version,
 				'php_version' => phpversion(),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51310.


As suggested, this PR reduces our dependency on WC_Tracks entirely and determine blog_id and store_id values independently.

The `Jetpack_Options::get_option` method apply a filter and did a few checks to get option value so I didn't change code to call to WP get_option directly. I thhink it should be fine since we've checked the class exists before calling the method.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with this branch
2. Complete Core Profiler -> Connect your site with Jetpack
3. Go to `Tools -> WCA Test Helper -> Remote Logging
4. Enable the remote logging
5. Click on PHP Simulate Core Exception, refresh the page and confirm it throws an error
6. See PCYsg-11XN-p2 for instructions on viewing the logs
7. Confirm blog_id and properties.store_id are logged

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
