### PR TITLE
Fix: Prevent "is-descendent-of-single-product-block" from being added to external product URLs.

### DIFF
--- a/plugins/woocommerce/changelog/51369-fix-50695-add-to-cart-block-unexpected-parameter-passed-to-external-product-url
+++ b/plugins/woocommerce/changelog/51369-fix-50695-add-to-cart-block-unexpected-parameter-passed-to-external-product-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Prevent `is-descendent-of-single-product-block=false` from being added to external product URLs.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -73,6 +73,8 @@ class AddToCartForm extends AbstractBlock {
 			return '';
 		}
 
+		$is_external_product_with_url = $product instanceof \WC_Product_External && $product->get_product_url();
+
 		ob_start();
 
 		/**
@@ -92,7 +94,10 @@ class AddToCartForm extends AbstractBlock {
 
 		$parsed_attributes                     = $this->parse_attributes( $attributes );
 		$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
-		$product                               = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
+
+		if ( ! $is_external_product_with_url ) {
+			$product                               = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
+		}
 
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -96,7 +96,7 @@ class AddToCartForm extends AbstractBlock {
 		$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
 
 		if ( ! $is_external_product_with_url ) {
-			$product                               = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
+			$product = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
 		}
 
 		$classname          = $attributes['className'] ?? '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50695

This PR addresses an issue where a hidden input field was being added unnecessarily to external product forms that already have a URL. The changes include:

1. Adding a check to determine if the product is an external product with a URL.
2. Only adding the hidden input field for products that are not external products with URLs.

This fix ensures that external product forms with URLs maintain their intended functionality without the addition of unnecessary form elements.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add an external product with a URL
2. Ensure the single product template using Add to Cart with Options block.
3. View the product on the front end.
4. Click on the buy button.
5. You will be redirected to the external product URL.
	- Verify that `is-descendent-of-single-product-block=false` isn't part of the URL.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Prevent `is-descendent-of-single-product-block=false` from being added to external product URLs.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
