### PR TITLE
Add missing `wp-block-` classnames to order confirmation blocks, Store Notices, and Breadcrumbs

### DIFF
--- a/plugins/woocommerce/changelog/add-missing-wp-block-classnames-49739
+++ b/plugins/woocommerce/changelog/add-missing-wp-block-classnames-49739
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added missing wp-block- classes to order confirmation, store notices, and breadcrumb blocks.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Breadcrumbs.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Breadcrumbs.php
@@ -34,14 +34,16 @@ class Breadcrumbs extends AbstractBlock {
 			return;
 		}
 
-		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		return sprintf(
-			'<div class="woocommerce wc-block-breadcrumbs %1$s %2$s" style="%3$s">%4$s</div>',
-			esc_attr( $classes_and_styles['classes'] ),
-			esc_attr( $classname ),
-			esc_attr( $classes_and_styles['styles'] ),
+			'<div %1$s>%2$s</div>',
+			get_block_wrapper_attributes(
+				array(
+					'class' => 'wc-block-breadcrumbs woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
+					'style' => $classes_and_styles['styles'],
+				)
+			),
 			$breadcrumb
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
@@ -55,11 +55,12 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 		}
 
 		return $block_content ? sprintf(
-			'<div class="wc-block-%4$s %1$s" style="%2$s">%3$s</div>',
+			'<div class="wp-block-%5$s-%4$s wc-block-%4$s %1$s" style="%2$s">%3$s</div>',
 			esc_attr( trim( $classname ) ),
 			esc_attr( $classes_and_styles['styles'] ),
 			$block_content,
-			esc_attr( $this->block_name )
+			esc_attr( $this->block_name ),
+			esc_attr( $this->namespace )
 		) : '';
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
@@ -45,17 +45,16 @@ class StoreNotices extends AbstractBlock {
 			return;
 		}
 
-		$classname          = isset( $attributes['className'] ) ? $attributes['className'] : '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
-
-		if ( isset( $attributes['align'] ) ) {
-			$classname .= " align{$attributes['align']}";
-		}
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => 'wc-block-store-notices woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
+			)
+		);
 
 		return sprintf(
-			'<div class="woocommerce wc-block-store-notices %1$s %2$s">%3$s</div>',
-			esc_attr( $classes_and_styles['classes'] ),
-			esc_attr( $classname ),
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
 			wc_kses_notice( $notices )
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/StoreNotices.php
@@ -46,15 +46,14 @@ class StoreNotices extends AbstractBlock {
 		}
 
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
-		$wrapper_attributes = get_block_wrapper_attributes(
-			array(
-				'class' => 'wc-block-store-notices woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
-			)
-		);
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',
-			$wrapper_attributes,
+			get_block_wrapper_attributes(
+				array(
+					'class' => 'wc-block-store-notices woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
+				)
+			),
 			wc_kses_notice( $notices )
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #49739 

Some blocks were missing the core `wp-block-` classes due to rendering the wrappers manually. I went through the block `render` methods to identify which were missing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using a block theme, go to the shop page
2. View source/use the browser inspector to inspect the breadcrumb. It should have a `wp-block-woocommerce-breadcrumbs` classname.
3. Add something to the cart.
4. View source/use the browser inspector to inspect the store notice that appears. It should have a `wp-block-woocommerce-store-notices` classname.
5. Go through checkout flow. On the order confirmation page, view source/use the browser inspector to inspect summary, status, order items etc blocks. Each should have a `wp-block-woocommerce-x` classname respectively. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
