### PR TITLE
Cart Shortcode: `wc_get_cart_url` should only return current URL if on the cart page

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-url-page-check-50524
+++ b/plugins/woocommerce/changelog/fix-cart-url-page-check-50524
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+wc_get_cart_url should only return current URL if on the cart page. This excludes the usage of WOOCOMMERCE_CART.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1484,7 +1484,11 @@ function wc_transaction_query( $type = 'start', $force = false ) {
  * @return string Url to cart page
  */
 function wc_get_cart_url() {
-	if ( is_cart() && isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
+	// We don't use is_cart() here because that also checks for a defined constant. We are only interested in the page.
+	$page_id      = wc_get_page_id( 'cart' );
+	$is_cart_page = ( $page_id && is_page( $page_id ) ) || wc_post_content_has_shortcode( 'woocommerce_cart' );
+
+	if ( $is_cart_page && isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
 		$protocol    = is_ssl() ? 'https' : 'http';
 		$current_url = esc_url_raw( $protocol . '://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ) );
 		$cart_url    = remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), $current_url );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adjusts when the current URL is used for the cart form. Previously we used `is_cart()` but this also returns true when using an AJAX endpoint that sets the `WOOCOMMERCE_CART` constant. See https://github.com/woocommerce/woocommerce/pull/50524#issuecomment-2349210848

The solution is the check the page directly.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

These are the same instructions as the previous PR. 

1. Create 2 cart pages. Shortcode Cart containing a cart shortcode, and Block Cart containing the cart block.
2. Under WC > Settings > Advanced set the cart page to Shortcode Cart
3. Add an item to the cart and go to the Shortcode Cart page.
4. Test updating quantites, applying coupons, removing coupons, changing shipping rates, removing cart items, and undoing removing cart items. Under all circumstances ensure the page contents refresh after updates successfully.
5. Under WC > Settings > Advanced set the cart page to Block Cart
6. Repeat testing steps 3 and 4. Updates should continue to work.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
