### PR TITLE
Refactored Single Product Block Context Delivery

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
@@ -58,7 +58,8 @@
 	"usesContext": [
 		"templateSlug",
 		"postId",
-		"singleProduct"
+		"singleProduct",
+		"productCollectionLocation"
 	],
 	"supports": {
 		"align": [

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
@@ -55,7 +55,11 @@
 		"collection": "collection",
 		"__privateProductCollectionPreviewState": "__privatePreviewState"
 	},
-	"usesContext": [ "templateSlug", "postId" ],
+	"usesContext": [
+		"templateSlug",
+		"postId",
+		"singleProduct"
+	],
 	"supports": {
 		"align": [
 			"wide",

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/layout-editor.tsx
@@ -79,7 +79,11 @@ const LayoutEditor = ( {
 				</InspectorControls>
 				<div className={ baseClassName }>
 					<BlockContextProvider
-						value={ { postId: product?.id, postType: 'product' } }
+						value={ {
+							postId: product?.id,
+							postType: 'product',
+							singleProduct: true,
+						} }
 					>
 						<InnerBlocks
 							template={ DEFAULT_INNER_BLOCKS }

--- a/plugins/woocommerce/changelog/fix-51352-single-product-block-context
+++ b/plugins/woocommerce/changelog/fix-51352-single-product-block-context
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: major
 Type: fix
 
 The Single Product block now correctly passes context to children and sets the global post state for inner blocks.

--- a/plugins/woocommerce/changelog/fix-51352-single-product-block-context
+++ b/plugins/woocommerce/changelog/fix-51352-single-product-block-context
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+The Single Product block now correctly passes context to children and sets the global post state for inner blocks.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -90,7 +90,7 @@ class ProductCollection extends AbstractBlock {
 		add_filter( 'rest_product_collection_params', array( $this, 'extend_rest_query_allowed_params' ), 10, 1 );
 
 		// Provide location context into block's context.
-		add_filter( 'render_block_context', array( $this, 'provide_location_context_for_inner_blocks' ), 11, 1 );
+		add_filter( 'render_block_context', array( $this, 'provide_location_context_for_inner_blocks' ), 11, 2 );
 
 		// Disable block render if the ProductTemplate block is empty.
 		add_filter(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -163,8 +163,6 @@ class ProductCollection extends AbstractBlock {
 		);
 	}
 
-
-
 	/**
 	 * Provides the location context to each inner block of the product collection block.
 	 * Hint: Only blocks using the 'query' context will be affected.
@@ -181,7 +179,9 @@ class ProductCollection extends AbstractBlock {
 	 *   'sourceData' => array( 'productId' => 123 ),
 	 * )
 	 *
-	 * @param array $context  The block context.
+	 * @param array $context      The block context.
+	 * @param array $parsed_block The parsed block.
+	 *
 	 * @return array $context {
 	 *     The block context including the product collection location context.
 	 *
@@ -191,15 +191,14 @@ class ProductCollection extends AbstractBlock {
 	 *     }
 	 * }
 	 */
-	public function provide_location_context_for_inner_blocks( $context ) {
-		// Run only on frontend.
-		// This is needed to avoid SSR renders while in editor. @see https://github.com/woocommerce/woocommerce/issues/45181.
-		if ( is_admin() || \WC()->is_rest_api_request() ) {
+	public function provide_location_context_for_inner_blocks( $context, $parsed_block ) {
+		if ( 'woocommerce/product-collection' !== $parsed_block['blockName'] ) {
 			return $context;
 		}
 
-		// Target only product collection's inner blocks that use the 'query' context.
-		if ( ! isset( $context['query'] ) || ! isset( $context['query']['isProductCollectionBlock'] ) || ! $context['query']['isProductCollectionBlock'] ) {
+		// Run only on frontend.
+		// This is needed to avoid SSR renders while in editor. @see https://github.com/woocommerce/woocommerce/issues/45181.
+		if ( is_admin() || \WC()->is_rest_api_request() ) {
 			return $context;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
@@ -13,22 +13,6 @@ class SingleProduct extends AbstractBlock {
 	protected $block_name = 'single-product';
 
 	/**
-	 * Product ID of the current product to be displayed in the Single Product block.
-	 * This is used to replace the global post for the Single Product inner blocks.
-	 *
-	 * @var int
-	 */
-	protected $product_id = 0;
-
-	/**
-	 * Single Product inner blocks names.
-	 * This is used to map all the inner blocks for a Single Product block.
-	 *
-	 * @var array
-	 */
-	protected $single_product_inner_blocks_names = [];
-
-	/**
 	 * Initialize the block and Hook into the `render_block_context` filter
 	 * to update the context with the correct data.
 	 *
@@ -36,32 +20,8 @@ class SingleProduct extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
-		add_filter( 'render_block_context', [ $this, 'update_context' ], 10, 3 );
-		add_filter( 'render_block_core/post-excerpt', [ $this, 'restore_global_post' ], 10, 3 );
-		add_filter( 'render_block_core/post-title', [ $this, 'restore_global_post' ], 10, 3 );
-	}
-
-	/**
-	 * Restore the global post variable right before generating the render output for the post title and/or post excerpt blocks.
-	 *
-	 * This is required due to the changes made via the replace_post_for_single_product_inner_block method.
-	 * It is a temporary fix to ensure these blocks work as expected until Gutenberg versions 15.2 and 15.6 are part of the core of WordPress.
-	 *
-	 * @see https://github.com/WordPress/gutenberg/pull/48001
-	 * @see https://github.com/WordPress/gutenberg/pull/49495
-	 *
-	 * @param  string    $block_content  The block content.
-	 * @param  array     $parsed_block  The full block, including name and attributes.
-	 * @param  \WP_Block $block_instance  The block instance.
-	 *
-	 * @return mixed
-	 */
-	public function restore_global_post( $block_content, $parsed_block, $block_instance ) {
-		if ( isset( $block_instance->context['singleProduct'] ) && $block_instance->context['singleProduct'] ) {
-			wp_reset_postdata();
-		}
-
-		return $block_content;
+		// Use an early priority to ensure other context hooks have access to the context provided here.
+		add_filter( 'render_block_context', [ $this, 'update_context' ], 0, 3 );
 	}
 
 	/**
@@ -75,80 +35,20 @@ class SingleProduct extends AbstractBlock {
 	 * @return array Updated block context.
 	 */
 	public function update_context( $context, $block, $parent_block ) {
-		if ( 'woocommerce/single-product' === $block['blockName']
-			&& isset( $block['attrs']['productId'] ) ) {
-				$this->product_id = $block['attrs']['productId'];
-
-				$this->single_product_inner_blocks_names = array_reverse(
-					$this->extract_single_product_inner_block_names( $block )
-				);
+		if ( 'woocommerce/single-product' !== $block['blockName'] ) {
+			return $context;
 		}
 
-		$this->replace_post_for_single_product_inner_block( $block, $context );
+		$id = $block['attrs']['productId'] ?? null;
+		if ( ! isset( $id ) ) {
+			return $context;
+		}
 
+		// Override the context with the selected product.
+		$context['postId']        = $id;
+		$context['postType']      = get_post_type( $id );
+		$context['singleProduct'] = true;
 		return $context;
-	}
-
-	/**
-	 * Extract the inner block names for the Single Product block. This way it's possible
-	 * to map all the inner blocks for a Single Product block and manipulate the data as needed.
-	 *
-	 * @param array $block The Single Product block or its inner blocks.
-	 * @param array $result Array of inner block names.
-	 *
-	 * @return array Array containing all the inner block names of a Single Product block.
-	 */
-	protected function extract_single_product_inner_block_names( $block, &$result = [] ) {
-		if ( isset( $block['blockName'] ) ) {
-			$result[] = $block['blockName'];
-		}
-
-		if ( isset( $block['innerBlocks'] ) ) {
-			foreach ( $block['innerBlocks'] as $inner_block ) {
-				$this->extract_single_product_inner_block_names( $inner_block, $result );
-			}
-		}
-		return $result;
-	}
-
-	/**
-	 * Replace the global post for the Single Product inner blocks and reset it after.
-	 *
-	 * This is needed because some of the inner blocks may use the global post
-	 * instead of fetching the product through the `productId` attribute, so even if the
-	 * `productId` is passed to the inner block, it will still use the global post.
-	 *
-	 * @param array $block Block attributes.
-	 * @param array $context Block context.
-	 */
-	protected function replace_post_for_single_product_inner_block( $block, &$context ) {
-		if ( $this->single_product_inner_blocks_names ) {
-			$block_name = array_pop( $this->single_product_inner_blocks_names );
-
-			if ( $block_name === $block['blockName'] ) {
-				/**
-				 * This is a temporary fix to ensure the Post Title and Excerpt blocks work as expected
-				 * until Gutenberg versions 15.2 and 15.6 are included in the core of WordPress.
-				 *
-				 * Important: the original post data is restored in the restore_global_post method.
-				 *
-				 * @see https://github.com/WordPress/gutenberg/pull/48001
-				 * @see https://github.com/WordPress/gutenberg/pull/49495
-				 */
-				if ( 'core/post-excerpt' === $block_name || 'core/post-title' === $block_name ) {
-					global $post;
-					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-					$post = get_post( $this->product_id );
-
-					if ( $post instanceof \WP_Post ) {
-						setup_postdata( $post );
-					}
-				}
-
-				$context['postId']        = $this->product_id;
-				$context['singleProduct'] = true;
-			}
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
@@ -13,6 +13,14 @@ class SingleProduct extends AbstractBlock {
 	protected $block_name = 'single-product';
 
 	/**
+	 * While the block is actively overriding the global post state,
+	 * this will contain the previous post set as the global state.
+	 *
+	 * @var WP_Post|null
+	 */
+	protected $overridden_post = null;
+
+	/**
 	 * Initialize the block and Hook into the `render_block_context` filter
 	 * to update the context with the correct data.
 	 *
@@ -21,20 +29,25 @@ class SingleProduct extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 		// Use an early priority to ensure other context hooks have access to the context provided here.
-		add_filter( 'render_block_context', [ $this, 'update_context' ], 0, 3 );
+		add_filter( 'render_block_context', [ $this, 'update_context' ], 0, 2 );
+
+		// In order to ensure that inner blocks have access to the correct post data,
+		// we're going to hook into block rendering to set the global post state.
+		// The `pre_render_block` hook should be as early as possible and is run
+		// before any rendering takes place. A late hook on `render_block` will
+		// make sure that all of the rendering for the block has taken place.
+		add_filter( 'pre_render_block', [ $this, 'update_post' ], 0, 2 );
+		add_filter( 'render_block_woocommerce/single-product', [ $this, 'reset_post' ], 100, 3 );
 	}
 
 	/**
 	 * Update the context by injecting the correct post data
 	 * for each one of the Single Product inner blocks.
 	 *
-	 * @param array    $context Block context.
-	 * @param array    $block Block attributes.
-	 * @param WP_Block $parent_block Block instance.
-	 *
-	 * @return array Updated block context.
+	 * @param array $context Block context.
+	 * @param array $block Block attributes.
 	 */
-	public function update_context( $context, $block, $parent_block ) {
+	public function update_context( $context, $block ) {
 		if ( 'woocommerce/single-product' !== $block['blockName'] ) {
 			return $context;
 		}
@@ -49,6 +62,74 @@ class SingleProduct extends AbstractBlock {
 		$context['postType']      = get_post_type( $id );
 		$context['singleProduct'] = true;
 		return $context;
+	}
+
+	/**
+	 * Updates the global post state to the selected product.
+	 *
+	 * @param string|null $pre_render   Any pre-rendered content.
+	 * @param array       $parsed_block A representation of the block being rendered.
+	 */
+	public function update_post( $pre_render, $parsed_block ) {
+		if ( 'woocommerce/single-product' !== $parsed_block['blockName'] ) {
+			return $pre_render;
+		}
+
+		// When `pre_render_block` returns a non-null value, WordPress short-circuits
+		// block rendering since it assumes the block has already been rendered. If
+		// this is the case, we shouldn't set the global post state since we
+		// can't hook into the `render_block` hook to reset the post state.
+		if ( isset( $pre_render ) ) {
+			return $pre_render;
+		}
+
+		$id = $parsed_block['attrs']['productId'] ?? null;
+		if ( ! isset( $id ) ) {
+			return $pre_render;
+		}
+
+		$selected_product = get_post( $parsed_block['attrs']['productId'] );
+		if ( ! isset( $selected_product ) ) {
+			return $pre_render;
+		}
+
+		// Before rendering our inner blocks we need to set the global post state
+		// to the selected product. This ensures that inner blocks have access
+		// to the correct post data.
+		global $post;
+		$this->overridden_post = $post;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post = $selected_product;
+		setup_postdata( $post );
+
+		return $pre_render;
+	}
+
+	/**
+	 * Resets the global post state after rendering the inner blocks.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $parsed_block  The parsed block data.
+	 */
+	public function reset_post( $block_content, $parsed_block ) {
+		if ( 'woocommerce/single-product' !== $parsed_block['blockName'] ) {
+			return $block_content;
+		}
+
+		// We don't want to reset anything if we didn't set it in the first place.
+		if ( isset( $this->overridden_post ) ) {
+			return $block_content;
+		}
+
+		// Replace the global post with the one that was set prior to us
+		// overriding it with the selected product.
+		global $post;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post = $this->overridden_post;
+		setup_postdata( $post );
+		$this->overridden_post = null;
+
+		return $block_content;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/SingleProduct.php
@@ -88,18 +88,18 @@ class SingleProduct extends AbstractBlock {
 			return $pre_render;
 		}
 
-		$selected_product = get_post( $parsed_block['attrs']['productId'] );
-		if ( ! isset( $selected_product ) ) {
-			return $pre_render;
-		}
-
 		// Before rendering our inner blocks we need to set the global post state
 		// to the selected product. This ensures that inner blocks have access
 		// to the correct post data.
+		$selected_product_post = get_post( $parsed_block['attrs']['productId'] );
+		if ( ! ( $selected_product_post instanceof \WP_Post ) ) {
+			return $pre_render;
+		}
+
 		global $post;
 		$this->overridden_post = $post;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$post = $selected_product;
+		$post = $selected_product_post;
 		setup_postdata( $post );
 
 		return $pre_render;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By its nature, any context that a block provides will be passed from parent to child. Previously we were setting the context on _all_ inner blocks of a Single Product block. In cases where a block was being passed a `postId` by a parent, this filter would override that value. This manifested in the Product Collection block where the first product shown in the block was being overridden with the Single Product block's selection.

After reviewing relevant code in Gutenberg I discovered that last year [the Post Template block changed the way it passed context to inner blocks](https://github.com/WordPress/gutenberg/blob/8a815ee716341372cf32b51d62dbbf9ddd174a4f/packages/block-library/src/post-template/index.php#L113-L124). Using this as inspiration:

- Changed the Product Template block to replicate Gutenberg's behavior. 
- Reworked the Single Product block's context passing so that Gutenberg handles cascading it to children. This keeps us from setting the `postId` on products that may have their own plans for it. I also added the missing `singleProduct` context to the editor.
- Strengthened the Single Product block's global post override to apply to _all_ inner blocks. This makes sure all inner blocks have the correct post set when rendering in case they use the post or functions that return information about the global post.

#### Backward Compatibility Concerns

This does come with some caveats:

- The `postId` and `singleProduct` context is _not_ available unless a block explicitly declares it in the `block.json` as `usesContext`.
  - Anyone relying on the presence of this context without declaring it will no longer receive it.
- The `postId` will now cascade from the Post Template block to _all_ inner blocks.
  - Inner blocks of the Product Collection will now have the overridden `postId` passed correctly through the block hierarchy.
- The global post will now be overridden for _all_ children of the Single Product block, rather than just the post title and excerpt.

In my opinion these risks are worth accepting. The proposed behavior is better aligned with Gutenberg and ensures that inner blocks of both the Single Product and Product Collection blocks have the correct context and global post. We shouldn't encourage people to rely on secret runtime context that is automatically injected into every block.

Closes #51352.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new post.
2. Add a "Single Product" block to the page and select a product.
3. Confirm that the editor displays the correct product.
4. Confirm that the frontend displays the correct product.
5. Add a "Product Collection" block as an inner block somewhere in the "Single Product" block.
6. Confirm that the editor displays the collection correctly.
7. Confirm that the frontend displays the collection correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
