### PR TITLE
Fix tax_code in the report export for removed rates

### DIFF
--- a/plugins/woocommerce/changelog/fix-49759-removed-taxname-export
+++ b/plugins/woocommerce/changelog/fix-49759-removed-taxname-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve performance of tax report export generation and fix tax_code for removed rates.

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -244,7 +244,15 @@ class Controller extends GenericController implements ExportableInterface {
 	 */
 	public function prepare_item_for_export( $item ) {
 		return array(
-			'tax_code'     => \WC_Tax::get_rate_code( $item['tax_rate_id'] ),
+			'tax_code'     => \WC_Tax::get_rate_code(
+				(object) array(
+					'tax_rate_id'       => $item['tax_rate_id'],
+					'tax_rate_country'  => $item['country'],
+					'tax_rate_state'    => $item['state'],
+					'tax_rate_name'     => $item['name'],
+					'tax_rate_priority' => $item['priority'],
+				)
+			),
 			'rate'         => $item['tax_rate'],
 			'total_tax'    => self::csv_number_format( $item['total_tax'] ),
 			'order_tax'    => self::csv_number_format( $item['order_tax'] ),


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix tax_code in the report export for removed rates, and also improve performance by reducing n queries. Forward a tax object directly to `WC_Tax::get_rate_code` instead of querying by ID. 
Most importantly, such a query will not provide the required (and already available) data for removed rates.

Address part of https://github.com/woocommerce/woocommerce/issues/49759

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a few tax rates (at least 10 to get email generated asynchronously).
2. Make a few sample purchases where various tax rates apply.
3. Remove one of the tax rates.
4. Generate a tax report under Analytics > Taxes --> you should see that the removed tax rate is still listed by name
5. click to download the report --> you should see the message "your taxes report will be emailed to you" 
6. Check the email (if [the email generation fix](https://github.com/woocommerce/woocommerce/pull/51270) gets merged), or check filesystem of the site and go to `wp-content/uploads/woocommerce_uploads/reports` to manually download the report
7. see that the report has names generated for removed taxes as in the table on the live site.

##### Before
![image](https://github.com/user-attachments/assets/ec81ff6b-ca32-4513-b533-59773ef2e73b)

##### After
![image](https://github.com/user-attachments/assets/f505f8e2-e0ba-4eeb-8ddd-30e12c0e2b7e)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
