### PR TITLE
add: hide coming soon admin bar

### DIFF
--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -163,23 +163,26 @@ const SiteVisibility = () => {
 					}
 				) }
 			</p>
-			<ToggleControl
-				label={ __( 'Hide admin bar badge', 'woocommerce' ) }
-				help={ __(
-					'Hide the site visibility badge from the admin bar.',
-					'woocommerce'
-				) }
-				checked={ hideAdminBarBadge === 'yes' }
-				onChange={ ( checked ) => {
-					setHideAdminBarBadge( checked ? 'yes' : 'no' );
-					recordEvent(
-						'site_visibility_hide_admin_bar_badge_toggle',
-						{
-							enabled: checked,
-						}
-					);
-				} }
-			/>
+			<div className="site-visibility-settings-slotfill-section">
+				<h3>{ __( 'Admin bar badge', 'woocommerce' ) }</h3>
+				<ToggleControl
+					label={ __( 'Hide admin bar badge', 'woocommerce' ) }
+					help={ __(
+						'Hide the site visibility badge from the admin bar.',
+						'woocommerce'
+					) }
+					checked={ hideAdminBarBadge === 'yes' }
+					onChange={ ( checked ) => {
+						setHideAdminBarBadge( checked ? 'yes' : 'no' );
+						recordEvent(
+							'site_visibility_hide_admin_bar_badge_toggle',
+							{
+								enabled: checked,
+							}
+						);
+					} }
+				/>
+			</div>
 			<div className="site-visibility-settings-slotfill-section">
 				<RadioControl
 					onChange={ () => {

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -66,33 +66,36 @@ const SiteVisibility = () => {
 		}
 	}, [] );
 
-	useEffect( () => {
-		const initValues = {
-			comingSoon: setting.woocommerce_coming_soon,
-			storePagesOnly: setting.woocommerce_store_pages_only,
-			privateLink: setting.woocommerce_private_link || 'no',
-			hideAdminBarBadge:
-				setting.woocommerce_coming_soon_hide_admin_bar_badge || 'no',
-		};
+	// Using a lazy initializer to store initial values on page render
+	const [ initialSettings ] = useState( () => ( {
+		comingSoon: setting.woocommerce_coming_soon,
+		storePagesOnly: setting.woocommerce_store_pages_only,
+		privateLink: setting.woocommerce_private_link || 'no',
+		hideAdminBarBadge:
+			setting.woocommerce_coming_soon_hide_admin_bar_badge || 'no',
+	} ) );
 
-		const currentValues = {
-			comingSoon,
-			storePagesOnly,
-			privateLink,
-			hideAdminBarBadge,
-		};
+	useEffect( () => {
 		const saveButton = document.getElementsByClassName(
 			'woocommerce-save-button'
 		)[ 0 ];
 		if ( saveButton ) {
 			saveButton.disabled =
-				initValues.comingSoon === currentValues.comingSoon &&
-				initValues.storePagesOnly === currentValues.storePagesOnly &&
-				initValues.privateLink === currentValues.privateLink &&
-				initValues.hideAdminBarBadge ===
-					currentValues.hideAdminBarBadge;
+				initialSettings.comingSoon === comingSoon &&
+				initialSettings.storePagesOnly === storePagesOnly &&
+				initialSettings.privateLink === privateLink &&
+				initialSettings.hideAdminBarBadge === hideAdminBarBadge;
 		}
-	}, [ comingSoon, storePagesOnly, privateLink, hideAdminBarBadge ] );
+	}, [
+		comingSoon,
+		storePagesOnly,
+		privateLink,
+		hideAdminBarBadge,
+		initialSettings.comingSoon,
+		initialSettings.storePagesOnly,
+		initialSettings.privateLink,
+		initialSettings.hideAdminBarBadge,
+	] );
 
 	const copyLink = __( 'Copy link', 'woocommerce' );
 	const copied = __( 'Copied!', 'woocommerce' );

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -48,7 +48,7 @@ const SiteVisibility = () => {
 		setting?.woocommerce_private_link || 'no'
 	);
 	const [ hideAdminBarBadge, setHideAdminBarBadge ] = useState(
-		setting?.woocommerce_hide_admin_bar_badge || 'no'
+		setting?.woocommerce_coming_soon_hide_admin_bar_badge || 'no'
 	);
 	const formRef = useRef( null );
 	const saveButtonRef = useRef( null );
@@ -71,10 +71,16 @@ const SiteVisibility = () => {
 			comingSoon: setting.woocommerce_coming_soon,
 			storePagesOnly: setting.woocommerce_store_pages_only,
 			privateLink: setting.woocommerce_private_link || 'no',
-			hideAdminBarBadge: setting.woocommerce_hide_admin_bar_badge || 'no',
+			hideAdminBarBadge:
+				setting.woocommerce_coming_soon_hide_admin_bar_badge || 'no',
 		};
 
-		const currentValues = { comingSoon, storePagesOnly, privateLink, hideAdminBarBadge };
+		const currentValues = {
+			comingSoon,
+			storePagesOnly,
+			privateLink,
+			hideAdminBarBadge,
+		};
 		const saveButton = document.getElementsByClassName(
 			'woocommerce-save-button'
 		)[ 0 ];
@@ -83,7 +89,8 @@ const SiteVisibility = () => {
 				initValues.comingSoon === currentValues.comingSoon &&
 				initValues.storePagesOnly === currentValues.storePagesOnly &&
 				initValues.privateLink === currentValues.privateLink &&
-				initValues.hideAdminBarBadge === currentValues.hideAdminBarBadge;
+				initValues.hideAdminBarBadge ===
+					currentValues.hideAdminBarBadge;
 		}
 	}, [ comingSoon, storePagesOnly, privateLink, hideAdminBarBadge ] );
 
@@ -138,7 +145,7 @@ const SiteVisibility = () => {
 			<input
 				type="hidden"
 				value={ hideAdminBarBadge }
-				name="woocommerce_hide_admin_bar_badge"
+				name="woocommerce_coming_soon_hide_admin_bar_badge"
 			/>
 			<h2>{ __( 'Site visibility', 'woocommerce' ) }</h2>
 			<p className="site-visibility-settings-slotfill-description">
@@ -158,13 +165,19 @@ const SiteVisibility = () => {
 			</p>
 			<ToggleControl
 				label={ __( 'Hide admin bar badge', 'woocommerce' ) }
-				help={ __( 'Hide the site visibility badge from the admin bar.', 'woocommerce' ) }
+				help={ __(
+					'Hide the site visibility badge from the admin bar.',
+					'woocommerce'
+				) }
 				checked={ hideAdminBarBadge === 'yes' }
 				onChange={ ( checked ) => {
 					setHideAdminBarBadge( checked ? 'yes' : 'no' );
-					recordEvent( 'site_visibility_hide_admin_bar_badge_toggle', {
-						enabled: checked,
-					} );
+					recordEvent(
+						'site_visibility_hide_admin_bar_badge_toggle',
+						{
+							enabled: checked,
+						}
+					);
 				} }
 			/>
 			<div className="site-visibility-settings-slotfill-section">

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -47,6 +47,9 @@ const SiteVisibility = () => {
 	const [ privateLink, setPrivateLink ] = useState(
 		setting?.woocommerce_private_link || 'no'
 	);
+	const [ hideAdminBarBadge, setHideAdminBarBadge ] = useState(
+		setting?.woocommerce_hide_admin_bar_badge || 'no'
+	);
 	const formRef = useRef( null );
 	const saveButtonRef = useRef( null );
 
@@ -68,9 +71,10 @@ const SiteVisibility = () => {
 			comingSoon: setting.woocommerce_coming_soon,
 			storePagesOnly: setting.woocommerce_store_pages_only,
 			privateLink: setting.woocommerce_private_link || 'no',
+			hideAdminBarBadge: setting.woocommerce_hide_admin_bar_badge || 'no',
 		};
 
-		const currentValues = { comingSoon, storePagesOnly, privateLink };
+		const currentValues = { comingSoon, storePagesOnly, privateLink, hideAdminBarBadge };
 		const saveButton = document.getElementsByClassName(
 			'woocommerce-save-button'
 		)[ 0 ];
@@ -78,9 +82,10 @@ const SiteVisibility = () => {
 			saveButton.disabled =
 				initValues.comingSoon === currentValues.comingSoon &&
 				initValues.storePagesOnly === currentValues.storePagesOnly &&
-				initValues.privateLink === currentValues.privateLink;
+				initValues.privateLink === currentValues.privateLink &&
+				initValues.hideAdminBarBadge === currentValues.hideAdminBarBadge;
 		}
-	}, [ comingSoon, storePagesOnly, privateLink ] );
+	}, [ comingSoon, storePagesOnly, privateLink, hideAdminBarBadge ] );
 
 	const copyLink = __( 'Copy link', 'woocommerce' );
 	const copied = __( 'Copied!', 'woocommerce' );
@@ -130,6 +135,11 @@ const SiteVisibility = () => {
 				value={ privateLink }
 				name="woocommerce_private_link"
 			/>
+			<input
+				type="hidden"
+				value={ hideAdminBarBadge }
+				name="woocommerce_hide_admin_bar_badge"
+			/>
 			<h2>{ __( 'Site visibility', 'woocommerce' ) }</h2>
 			<p className="site-visibility-settings-slotfill-description">
 				{ createInterpolateElement(
@@ -146,6 +156,17 @@ const SiteVisibility = () => {
 					}
 				) }
 			</p>
+			<ToggleControl
+				label={ __( 'Hide admin bar badge', 'woocommerce' ) }
+				help={ __( 'Hide the site visibility badge from the admin bar.', 'woocommerce' ) }
+				checked={ hideAdminBarBadge === 'yes' }
+				onChange={ ( checked ) => {
+					setHideAdminBarBadge( checked ? 'yes' : 'no' );
+					recordEvent( 'site_visibility_hide_admin_bar_badge_toggle', {
+						enabled: checked,
+					} );
+				} }
+			/>
 			<div className="site-visibility-settings-slotfill-section">
 				<RadioControl
 					onChange={ () => {

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -309,11 +309,17 @@ const SiteVisibility = () => {
 			<div className="site-visibility-settings-slotfill-section">
 				<h4>{ __( 'Admin bar badge', 'woocommerce' ) }</h4>
 				<ToggleControl
-					label={ __( 'Hide admin bar badge', 'woocommerce' ) }
-					help={ __(
-						'Hide the site visibility badge from the admin bar.',
-						'woocommerce'
-					) }
+					label={
+						<>
+							{ __( 'Hide admin bar badge', 'woocommerce' ) }
+							<p>
+								{ __(
+									'Hide the site visibility badge from the admin bar.',
+									'woocommerce'
+								) }
+							</p>
+						</>
+					}
 					checked={ hideAdminBarBadge === 'yes' }
 					onChange={ ( checked ) => {
 						setHideAdminBarBadge( checked ? 'yes' : 'no' );

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -164,26 +164,6 @@ const SiteVisibility = () => {
 				) }
 			</p>
 			<div className="site-visibility-settings-slotfill-section">
-				<h3>{ __( 'Admin bar badge', 'woocommerce' ) }</h3>
-				<ToggleControl
-					label={ __( 'Hide admin bar badge', 'woocommerce' ) }
-					help={ __(
-						'Hide the site visibility badge from the admin bar.',
-						'woocommerce'
-					) }
-					checked={ hideAdminBarBadge === 'yes' }
-					onChange={ ( checked ) => {
-						setHideAdminBarBadge( checked ? 'yes' : 'no' );
-						recordEvent(
-							'site_visibility_hide_admin_bar_badge_toggle',
-							{
-								enabled: checked,
-							}
-						);
-					} }
-				/>
-			</div>
-			<div className="site-visibility-settings-slotfill-section">
 				<RadioControl
 					onChange={ () => {
 						setComingSoon( 'yes' );
@@ -322,6 +302,26 @@ const SiteVisibility = () => {
 						'woocommerce'
 					) }
 				</p>
+			</div>
+			<div className="site-visibility-settings-slotfill-section">
+				<h3>{ __( 'Admin bar badge', 'woocommerce' ) }</h3>
+				<ToggleControl
+					label={ __( 'Hide admin bar badge', 'woocommerce' ) }
+					help={ __(
+						'Hide the site visibility badge from the admin bar.',
+						'woocommerce'
+					) }
+					checked={ hideAdminBarBadge === 'yes' }
+					onChange={ ( checked ) => {
+						setHideAdminBarBadge( checked ? 'yes' : 'no' );
+						recordEvent(
+							'site_visibility_hide_admin_bar_badge_toggle',
+							{
+								enabled: checked,
+							}
+						);
+					} }
+				/>
 			</div>
 			{ formRef.current && saveButtonRef.current ? (
 				<ConfirmationModal

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -307,7 +307,7 @@ const SiteVisibility = () => {
 				</p>
 			</div>
 			<div className="site-visibility-settings-slotfill-section">
-				<h3>{ __( 'Admin bar badge', 'woocommerce' ) }</h3>
+				<h4>{ __( 'Admin bar badge', 'woocommerce' ) }</h4>
 				<ToggleControl
 					label={ __( 'Hide admin bar badge', 'woocommerce' ) }
 					help={ __(

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/slotfill.js
@@ -203,7 +203,7 @@ const SiteVisibility = () => {
 				</p>
 				<div
 					className={ clsx(
-						'site-visibility-settings-slotfill-section-content',
+						'site-visibility-settings-slotfill-section-content indent-one-level',
 						{
 							'is-hidden': comingSoon !== 'yes',
 						}
@@ -308,29 +308,35 @@ const SiteVisibility = () => {
 			</div>
 			<div className="site-visibility-settings-slotfill-section">
 				<h4>{ __( 'Admin bar badge', 'woocommerce' ) }</h4>
-				<ToggleControl
-					label={
-						<>
-							{ __( 'Hide admin bar badge', 'woocommerce' ) }
-							<p>
-								{ __(
-									'Hide the site visibility badge from the admin bar.',
-									'woocommerce'
-								) }
-							</p>
-						</>
-					}
-					checked={ hideAdminBarBadge === 'yes' }
-					onChange={ ( checked ) => {
-						setHideAdminBarBadge( checked ? 'yes' : 'no' );
-						recordEvent(
-							'site_visibility_hide_admin_bar_badge_toggle',
-							{
-								enabled: checked,
-							}
-						);
-					} }
-				/>
+				<div
+					className={ clsx(
+						'site-visibility-settings-slotfill-section-content'
+					) }
+				>
+					<ToggleControl
+						label={
+							<>
+								{ __( 'Hide admin bar badge', 'woocommerce' ) }
+								<p>
+									{ __(
+										'Hide the site visibility badge from the admin bar.',
+										'woocommerce'
+									) }
+								</p>
+							</>
+						}
+						checked={ hideAdminBarBadge === 'yes' }
+						onChange={ ( checked ) => {
+							setHideAdminBarBadge( checked ? 'yes' : 'no' );
+							recordEvent(
+								'site_visibility_hide_admin_bar_badge_toggle',
+								{
+									enabled: checked,
+								}
+							);
+						} }
+					/>
+				</div>
 			</div>
 			{ formRef.current && saveButtonRef.current ? (
 				<ConfirmationModal

--- a/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
+++ b/plugins/woocommerce-admin/client/launch-your-store/settings/style.scss
@@ -107,7 +107,10 @@
 			gap: 16px;
 			display: flex;
 			flex-direction: column;
-			margin: 16px 0 0 30px;
+
+			&.indent-one-level {
+				margin: 16px 0 0 30px;
+			}
 
 			&.is-hidden {
 				display: none;

--- a/plugins/woocommerce/changelog/add-lys-admin-bar-hide
+++ b/plugins/woocommerce/changelog/add-lys-admin-bar-hide
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds the option to hide the coming soon admin bar badge

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -137,7 +137,7 @@ class LaunchYourStore {
 		add_option( 'woocommerce_store_pages_only', $store_pages_only );
 		add_option( 'woocommerce_private_link', $private_link );
 		add_option( 'woocommerce_share_key', $share_key );
-		add_option( 'woocommerce_coming_soon_hide_admin_bar_badge', 'no');
+		add_option( 'woocommerce_coming_soon_hide_admin_bar_badge', 'no' );
 
 		wc_admin_record_tracks_event(
 			'launch_your_store_initialize_coming_soon',

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -137,6 +137,7 @@ class LaunchYourStore {
 		add_option( 'woocommerce_store_pages_only', $store_pages_only );
 		add_option( 'woocommerce_private_link', $private_link );
 		add_option( 'woocommerce_share_key', $share_key );
+		add_option( 'woocommerce_coming_soon_hide_admin_bar_badge', 'no');
 
 		wc_admin_record_tracks_event(
 			'launch_your_store_initialize_coming_soon',

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -219,6 +219,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_admin_customize_store_completed_theme_id',
 			'woocommerce_admin_customize_store_survey_completed',
 			'woocommerce_coming_soon',
+			'woocommerce_coming_soon_hide_admin_bar_badge',
 			'woocommerce_store_pages_only',
 			'woocommerce_private_link',
 			'woocommerce_share_key',

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -219,7 +219,6 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_admin_customize_store_completed_theme_id',
 			'woocommerce_admin_customize_store_survey_completed',
 			'woocommerce_coming_soon',
-			'woocommerce_coming_soon_hide_admin_bar_badge',
 			'woocommerce_store_pages_only',
 			'woocommerce_private_link',
 			'woocommerce_share_key',

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -41,6 +41,7 @@ class LaunchYourStore {
 			'woocommerce_coming_soon'      => array( 'yes', 'no' ),
 			'woocommerce_store_pages_only' => array( 'yes', 'no' ),
 			'woocommerce_private_link'     => array( 'yes', 'no' ),
+			'woocommerce_coming_soon_hide_admin_bar_badge'     => array( 'yes', 'no' ),
 		);
 
 		$event_data = array();
@@ -124,6 +125,7 @@ class LaunchYourStore {
 				'woocommerce_store_pages_only' => get_option( 'woocommerce_store_pages_only' ),
 				'woocommerce_private_link'     => get_option( 'woocommerce_private_link' ),
 				'woocommerce_share_key'        => get_option( 'woocommerce_share_key' ),
+				'woocommerce_coming_soon_hide_admin_bar_badge'        => get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -38,10 +38,10 @@ class LaunchYourStore {
 
 		// options to allowed update and their allowed values.
 		$options = array(
-			'woocommerce_coming_soon'      => array( 'yes', 'no' ),
-			'woocommerce_store_pages_only' => array( 'yes', 'no' ),
-			'woocommerce_private_link'     => array( 'yes', 'no' ),
-			'woocommerce_coming_soon_hide_admin_bar_badge'     => array( 'yes', 'no' ),
+			'woocommerce_coming_soon'                      => array( 'yes', 'no' ),
+			'woocommerce_store_pages_only'                 => array( 'yes', 'no' ),
+			'woocommerce_private_link'                     => array( 'yes', 'no' ),
+			'woocommerce_coming_soon_hide_admin_bar_badge' => array( 'yes', 'no' ),
 		);
 
 		$event_data = array();
@@ -125,7 +125,7 @@ class LaunchYourStore {
 				'woocommerce_store_pages_only' => get_option( 'woocommerce_store_pages_only' ),
 				'woocommerce_private_link'     => get_option( 'woocommerce_private_link' ),
 				'woocommerce_share_key'        => get_option( 'woocommerce_share_key' ),
-				'woocommerce_coming_soon_hide_admin_bar_badge'        => get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ),
+				'woocommerce_coming_soon_hide_admin_bar_badge' => get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -23,6 +23,15 @@ class ComingSoonAdminBarBadge {
 	}
 
 	/**
+	 * Check if the admin bar badge should be hidden.
+	 *
+	 * @return bool True if the badge should be hidden, false otherwise.
+	 */
+	private function is_admin_bar_badge_hidden() {
+		return get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ) === 'yes';
+	}
+
+	/**
 	 * Add site visibility cache badge to WP admin bar.
 	 *
 	 * @internal
@@ -30,7 +39,7 @@ class ComingSoonAdminBarBadge {
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
 		// Early exit if LYS feature is disabled or if the badge is hidden.
-		if ( ! Features::is_enabled( 'launch-your-store' ) || get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ) === 'yes' ) {
+		if ( ! Features::is_enabled( 'launch-your-store' ) || $this->is_admin_bar_badge_hidden() ) {
 			return;
 		}
 
@@ -67,8 +76,8 @@ class ComingSoonAdminBarBadge {
 	 * @internal
 	 */
 	public function output_css() {
-		// Early exit if LYS feature is disabled.
-		if ( ! Features::is_enabled( 'launch-your-store' ) || get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ) === 'yes' ) {
+		// Early exit if LYS feature is disabled or if the badge is hidden.
+		if ( ! Features::is_enabled( 'launch-your-store' ) || $this->is_admin_bar_badge_hidden() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -30,7 +30,7 @@ class ComingSoonAdminBarBadge {
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
 		// Early exit if LYS feature is disabled or if the badge is hidden.
-		if ( ! Features::is_enabled( 'launch-your-store' ) || get_option( 'woocommerce_hide_admin_bar_badge' ) === 'yes' ) {
+		if ( ! Features::is_enabled( 'launch-your-store' ) || get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ) === 'yes' ) {
 			return;
 		}
 
@@ -68,7 +68,7 @@ class ComingSoonAdminBarBadge {
 	 */
 	public function output_css() {
 		// Early exit if LYS feature is disabled.
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+		if ( ! Features::is_enabled( 'launch-your-store' ) || get_option( 'woocommerce_coming_soon_hide_admin_bar_badge' ) === 'yes' ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -29,8 +29,8 @@ class ComingSoonAdminBarBadge {
 	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
-		// Early exit if LYS feature is disabled.
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+		// Early exit if LYS feature is disabled or if the badge is hidden.
+		if ( ! Features::is_enabled( 'launch-your-store' ) || get_option( 'woocommerce_hide_admin_bar_badge' ) === 'yes' ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51389

We've received feedback that there should be some way to hide the admin bar badge for the Coming Soon feature, as some users find it unnecessarily distracting.

Initially I considered using a filter, but I quickly realised that using a filter means the user has no way to override the decision of whoever implemented the filter. The reason why there isn't both a filter and a setting is because that makes it complicated to decide whether the filter should take priority or the setting should take priority.

In any case it is possible to programmatically set the option, mitigating the lack of a filter hook.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

###### Manual Configuration
 
1. Set up a WooCommerce site. Either skip or go through the Core Profiler, which turns on the Coming Soon feature
2. You should see the Coming soon badge
3. Go to the Site Visibility settings tab in WC Settings
4. Toggle on the 'hide admin bar badge' 
5. Save
6. Should no longer see the badge

<img width="853" alt="image" src="https://github.com/user-attachments/assets/b7008ce3-44c6-4f64-a09d-bdceae40398f">

<img width="824" alt="image" src="https://github.com/user-attachments/assets/01093783-486e-4a73-b074-1fe1da827ff6">



###### Programmatic Configuration

1. `wp option update woocommerce_coming_soon_hide_admin_bar_badge yes`
2. Should not see the badge

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
