### PR TITLE
fix: added pre-API call permissions check on APIs being called on non-admin accessible screens

### DIFF
--- a/packages/js/data/changelog/fix-no-permissions-api-error
+++ b/packages/js/data/changelog/fix-no-permissions-api-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added pre-API call permission checks for some API calls that were being called on non-admin accessible screens

--- a/packages/js/data/src/notes/resolvers.ts
+++ b/packages/js/data/src/notes/resolvers.ts
@@ -10,11 +10,14 @@ import { apiFetch } from '@wordpress/data-controls';
 import { NAMESPACE } from '../constants';
 import { setNotes, setNotesQuery, setError } from './actions';
 import { NoteQuery, Note } from './types';
+import { checkUserCapability } from '../utils';
 
 export function* getNotes( query: NoteQuery = {} ) {
 	const url = addQueryArgs( `${ NAMESPACE }/admin/notes`, query );
 
 	try {
+		yield checkUserCapability( 'manage_woocommerce' );
+
 		const notes: Note[] = yield apiFetch( {
 			path: url,
 		} );

--- a/packages/js/data/src/onboarding/resolvers.ts
+++ b/packages/js/data/src/onboarding/resolvers.ts
@@ -31,6 +31,7 @@ import {
 	TaskListType,
 } from './types';
 import { Plugin } from '../plugins/types';
+import { checkUserCapability } from '../utils';
 
 const resolveSelect =
 	controls && controls.resolveSelect ? controls.resolveSelect : select;
@@ -68,6 +69,8 @@ export function* getEmailPrefill() {
 export function* getTaskLists() {
 	const deprecatedTasks = new DeprecatedTasks();
 	try {
+		yield checkUserCapability( 'manage_woocommerce' );
+
 		const results: TaskListType[] = yield apiFetch( {
 			path: WC_ADMIN_NAMESPACE + '/onboarding/tasks',
 			method: deprecatedTasks.hasDeprecatedTasks() ? 'POST' : 'GET',

--- a/packages/js/data/src/plugins/resolvers.ts
+++ b/packages/js/data/src/plugins/resolvers.ts
@@ -27,6 +27,7 @@ import {
 	RecommendedTypes,
 	JetpackConnectionDataResponse,
 } from './types';
+import { checkUserCapability } from '../utils';
 
 // Can be removed in WP 5.9, wp.data is supported in >5.7.
 const resolveSelect =
@@ -61,6 +62,8 @@ type ConnectJetpackResponse = {
 export function* getActivePlugins() {
 	yield setIsRequesting( 'getActivePlugins', true );
 	try {
+		yield checkUserCapability( 'manage_woocommerce' );
+
 		const url = WC_ADMIN_NAMESPACE + '/plugins/active';
 		const results: PluginGetResponse = yield apiFetch( {
 			path: url,
@@ -77,6 +80,8 @@ export function* getInstalledPlugins() {
 	yield setIsRequesting( 'getInstalledPlugins', true );
 
 	try {
+		yield checkUserCapability( 'manage_woocommerce' );
+
 		const url = WC_ADMIN_NAMESPACE + '/plugins/installed';
 		const results: PluginGetResponse = yield apiFetch( {
 			path: url,
@@ -111,6 +116,8 @@ export function* getJetpackConnectionData() {
 	yield setIsRequesting( 'getJetpackConnectionData', true );
 
 	try {
+		yield checkUserCapability( 'manage_woocommerce' );
+
 		const url = JETPACK_NAMESPACE + '/connection/data';
 
 		const results: JetpackConnectionDataResponse = yield apiFetch( {

--- a/packages/js/data/src/utils.ts
+++ b/packages/js/data/src/utils.ts
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { apiFetch } from '@wordpress/data-controls';
+import { apiFetch, select } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
  */
 import { BaseQueryParams } from './types/query-params';
 import { fetchWithHeaders } from './controls';
-
+import { USER_STORE_NAME } from './user';
+import { WCUser } from './user/types';
 function replacer( _: string, value: unknown ) {
 	if ( value ) {
 		if ( Array.isArray( value ) ) {
@@ -98,5 +99,22 @@ export function* request< Query extends BaseQueryParams, DataType >(
 		);
 
 		return { items: response.data, totalCount };
+	}
+}
+
+/**
+ * Utility function to check if the current user has a specific capability.
+ *
+ * @param {string} capability - The capability to check (e.g. 'manage_woocommerce').
+ * @throws {Error} If the user does not have the required capability.
+ */
+export function* checkUserCapability( capability: string ) {
+	const currentUser: WCUser< 'capabilities' > = yield select(
+		USER_STORE_NAME,
+		'getCurrentUser'
+	);
+
+	if ( ! currentUser.capabilities[ capability ] ) {
+		throw new Error( `User does not have ${ capability } capability.` );
 	}
 }

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -269,7 +269,8 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			visible:
 				( isEmbedded || ! isHomescreen ) &&
 				! isPerformingSetupTask() &&
-				! isProductScreen(),
+				! isProductScreen() &&
+				currentUserCan( 'manage_woocommerce' ),
 		};
 
 		const feedback = {

--- a/plugins/woocommerce/changelog/fix-no-permissions-api-error
+++ b/plugins/woocommerce/changelog/fix-no-permissions-api-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added pre-API call permission checks for some API calls that were being called on non-admin accessible screens


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48124.

In #48124 it was noted that in some non-standard configuration where roles without the manage_woocommerce permissions but with editing permissions would see HTTP errors in their console. While it is an unexpected use case, it is a valid use case. 

The Order management screen had some WC Admin components which assumed that the user would have 'manage_woocommerce' permissions and made some API calls with that expectation. This resulted in HTTP errors since the calls would fail as they are permission checked in the backend.

This PR adds frontend permission checks to match, so that the API calls are not made. There should not be any additional error handling logic needed as the original failed API call would have triggered the same error handling pathway.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set up WooCommerce
2. Note that the home screen and the Activity Panel in the Orders page should still work as expected for the admin user.

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/c77a6bcb-7f56-4cf9-8e2e-96bf257a0040">

<img width="1361" alt="image" src="https://github.com/user-attachments/assets/fd73c64a-4012-413a-9e78-0fbeb8b8aaa0">

3. Add a new role or modify the existing editor role (you can use [user role editor](https://wordpress.org/plugins/user-role-editor/)), such that it does not have manage_woocommerce but has edit_others_shop_orders, edit_posts, edit_shop_order, edit_shop_orders, read, read_shop_order
4. Note that you should be able to see the Orders screen with this user, and there should not be the buttons for the Activity and Inbox

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/6f3f592e-7026-4346-872c-106702fd5a6b">

5. Observe that there should not be API call related errors in the browser console (there may be some other errors but that's not within the scope of this PR)



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
