### PR TITLE
Fix a type mismatch in UpdateProducts.php

### DIFF
--- a/plugins/woocommerce/changelog/fix-type-mismatch-updateproducts
+++ b/plugins/woocommerce/changelog/fix-type-mismatch-updateproducts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix a type mismatch in UpdateProducts.php
+
+

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\AIContent;
 
 use Automattic\WooCommerce\Blocks\AI\Connection;
 use WP_Error;
+
 /**
  * Pattern Images class.
  *
@@ -473,11 +474,11 @@ class UpdateProducts {
 	/**
 	 * Update the product with the new content.
 	 *
-	 * @param \WC_Product $product The product.
-	 * @param int         $product_image_id The product image ID.
-	 * @param string      $product_title The product title.
-	 * @param string      $product_description The product description.
-	 * @param int         $product_price The product price.
+	 * @param \WC_Product   $product The product.
+	 * @param int|\WP_Error $product_image_id The product image ID.
+	 * @param string        $product_title The product title.
+	 * @param string        $product_description The product description.
+	 * @param int           $product_price The product price.
 	 *
 	 * @return int|\WP_Error
 	 */

--- a/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
+++ b/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php
@@ -474,11 +474,11 @@ class UpdateProducts {
 	/**
 	 * Update the product with the new content.
 	 *
-	 * @param \WC_Product   $product The product.
-	 * @param int|\WP_Error $product_image_id The product image ID.
-	 * @param string        $product_title The product title.
-	 * @param string        $product_description The product description.
-	 * @param int           $product_price The product price.
+	 * @param \WC_Product         $product The product.
+	 * @param int|string|WP_Error $product_image_id The product image ID.
+	 * @param string              $product_title The product title.
+	 * @param string              $product_description The product description.
+	 * @param int                 $product_price The product price.
 	 *
 	 * @return int|\WP_Error
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the `UpdateProducts::product_update()` doc block, which contained a type mismatch. The `$product_image_id` param comes from [this method](https://github.com/woocommerce/woocommerce/blob/77a17e48b77dc84193867c570b2db22b8e4340da/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php#L298-L319), which might return an int, a string or a WP_Error.

### How to test the changes in this Pull Request:

This PR only updates a PHP comment, so there is no need for any manual testing.