### PR TITLE
Add load more button in-app

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/constants.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/constants.ts
@@ -10,7 +10,7 @@ export const MARKETPLACE_SEARCH_API_PATH =
 	'/wp-json/wccom-extensions/1.0/search';
 export const MARKETPLACE_CATEGORY_API_PATH =
 	'/wp-json/wccom-extensions/1.0/categories';
-export const MARKETPLACE_ITEMS_PER_PAGE = 60;
+export const MARKETPLACE_ITEMS_PER_PAGE = 60; // This should match the number of results returned by the API
 export const MARKETPLACE_SEARCH_RESULTS_PER_PAGE = 8;
 export const MARKETPLACE_CART_PATH = MARKETPLACE_HOST + '/cart/';
 export const MARKETPLACE_RENEW_SUBSCRIPTON_PATH =

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -48,6 +48,7 @@ export default function Content(): JSX.Element {
 		useState( 1 );
 
 	const {
+		isLoading,
 		setIsLoading,
 		selectedTab,
 		setHasBusinessServices,
@@ -338,30 +339,27 @@ export default function Content(): JSX.Element {
 		setCurrentPage( 1 );
 	}, [ selectedTab, query?.category, query?.term ] );
 
+	const getProductType = ( tab: string ): ProductType => {
+		switch ( tab ) {
+			case 'themes':
+				return ProductType.theme;
+			case 'business-services':
+				return ProductType.businessService;
+			default:
+				return ProductType.extension;
+		}
+	};
+
 	const renderContent = (): JSX.Element => {
 		switch ( selectedTab ) {
 			case 'extensions':
-				return (
-					<Products
-						products={ filteredProducts }
-						categorySelector={ true }
-						type={ ProductType.extension }
-					/>
-				);
 			case 'themes':
-				return (
-					<Products
-						products={ filteredProducts }
-						categorySelector={ true }
-						type={ ProductType.theme }
-					/>
-				);
 			case 'business-services':
 				return (
 					<Products
 						products={ filteredProducts }
 						categorySelector={ true }
-						type={ ProductType.businessService }
+						type={ getProductType( selectedTab ) }
 					/>
 				);
 			case 'discover':
@@ -411,7 +409,7 @@ export default function Content(): JSX.Element {
 			) }
 
 			{ renderContent() }
-			{ shouldShowLoadMoreButton() && (
+			{ shouldShowLoadMoreButton() && ! isLoading && (
 				<LoadMoreButton onLoadMore={ loadMoreProducts } />
 			) }
 		</div>

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -10,6 +10,7 @@ import {
 import { useQuery } from '@woocommerce/navigation';
 import { speak } from '@wordpress/a11y';
 import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -151,6 +151,7 @@ export default function Content(): JSX.Element {
 		currentPage,
 		query.category,
 		query.term,
+		query.tab,
 		setIsLoadingMore,
 		setSearchResultsCount,
 	] );
@@ -350,17 +351,6 @@ export default function Content(): JSX.Element {
 		setFirstNewProductId( 0 );
 	}, [ selectedTab, query?.category, query?.term ] );
 
-	const getProductType = ( tab: string ): ProductType => {
-		switch ( tab ) {
-			case 'themes':
-				return ProductType.theme;
-			case 'business-services':
-				return ProductType.businessService;
-			default:
-				return ProductType.extension;
-		}
-	};
-
 	// Maintain product focus for accessibility
 	useEffect( () => {
 		if ( firstNewProductId ) {
@@ -374,6 +364,17 @@ export default function Content(): JSX.Element {
 			}, 0 );
 		}
 	}, [ firstNewProductId ] );
+
+	const getProductType = ( tab: string ): ProductType => {
+		switch ( tab ) {
+			case 'themes':
+				return ProductType.theme;
+			case 'business-services':
+				return ProductType.businessService;
+			default:
+				return ProductType.extension;
+		}
+	};
 
 	const renderContent = (): JSX.Element => {
 		switch ( selectedTab ) {

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -77,6 +77,10 @@ export default function Content(): JSX.Element {
 			params.append( 'category', query.category );
 		}
 
+		if ( query.tab === 'themes' || query.tab === 'business-services' ) {
+			params.append( 'category', query.tab );
+		}
+
 		if ( query.term ) {
 			params.append( 'term', query.term );
 		}
@@ -357,6 +361,7 @@ export default function Content(): JSX.Element {
 		}
 	};
 
+	// Maintain product focus for accessibility
 	useEffect( () => {
 		if ( firstNewProductId ) {
 			setTimeout( () => {

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -21,7 +21,7 @@ import Discover from '../discover/discover';
 import Products from '../products/products';
 import MySubscriptions from '../my-subscriptions/my-subscriptions';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
-import { fetchSearchResults } from '../../utils/functions';
+import { fetchSearchResults, getProductType } from '../../utils/functions';
 import { SubscriptionsContextProvider } from '../../contexts/subscriptions-context';
 import { SearchResultsCountType } from '../../contexts/types';
 import {
@@ -51,6 +51,7 @@ export default function Content(): JSX.Element {
 	const [ isLoadingMore, setIsLoadingMore ] = useState( false );
 
 	const {
+		isLoading,
 		setIsLoading,
 		selectedTab,
 		setHasBusinessServices,
@@ -365,17 +366,6 @@ export default function Content(): JSX.Element {
 		}
 	}, [ firstNewProductId ] );
 
-	const getProductType = ( tab: string ): ProductType => {
-		switch ( tab ) {
-			case 'themes':
-				return ProductType.theme;
-			case 'business-services':
-				return ProductType.businessService;
-			default:
-				return ProductType.extension;
-		}
-	};
-
 	const renderContent = (): JSX.Element => {
 		switch ( selectedTab ) {
 			case 'extensions':
@@ -435,7 +425,7 @@ export default function Content(): JSX.Element {
 			) }
 
 			{ renderContent() }
-			{ shouldShowLoadMoreButton() && (
+			{ ! isLoading && shouldShowLoadMoreButton() && (
 				<LoadMoreButton
 					onLoadMore={ loadMoreProducts }
 					isBusy={ isLoadingMore }

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -85,15 +85,15 @@ export default function Content(): JSX.Element {
 
 			fetchSearchResults( params, abortControllers[ 0 ].signal )
 				.then( ( productList ) => {
-					setAllProducts( productList );
+					setAllProducts( productList.products );
 					setSearchResultsCount( {
-						extensions: productList.filter(
+						extensions: productList.products.filter(
 							( p ) => p.type === ProductType.extension
 						).length,
-						themes: productList.filter(
+						themes: productList.products.filter(
 							( p ) => p.type === ProductType.theme
 						).length,
-						'business-services': productList.filter(
+						'business-services': productList.products.filter(
 							( p ) => p.type === ProductType.businessService
 						).length,
 					} );
@@ -129,7 +129,7 @@ export default function Content(): JSX.Element {
 						abortControllers[ index ].signal
 					).then( ( productList ) => {
 						const typedProducts = tagProductsWithType(
-							productList,
+							productList.products,
 							type
 						);
 						if ( category === 'business-services' ) {

--- a/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { queueRecordEvent } from '@woocommerce/tracks';
+
+interface LoadMoreProps {
+	variant?: Button.ButtonVariant;
+	onLoadMore: () => void;
+}
+
+export default function LoadMoreButton( props: LoadMoreProps ) {
+	function handleClick() {
+		queueRecordEvent( 'marketplace_load_more_button_clicked', {} );
+		props.onLoadMore();
+	}
+
+	return (
+		<Button
+			className="woocommerce-marketplace__load-more"
+			variant={ props.variant ?? 'secondary' }
+			onClick={ handleClick }
+		>
+			{ __( 'Load more', 'woocommerce' ) }
+		</Button>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { queueRecordEvent } from '@woocommerce/tracks';
 
 interface LoadMoreProps {
-	variant?: Button.ButtonVariant;
 	onLoadMore: () => void;
 }
 
@@ -19,7 +18,7 @@ export default function LoadMoreButton( props: LoadMoreProps ) {
 	return (
 		<Button
 			className="woocommerce-marketplace__load-more"
-			variant={ props.variant ?? 'secondary' }
+			variant={ 'secondary' }
 			onClick={ handleClick }
 		>
 			{ __( 'Load more', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
@@ -19,6 +19,10 @@ export default function LoadMoreButton( props: LoadMoreProps ) {
 		onLoadMore();
 	}
 
+	if ( isBusy ) {
+		speak( __( 'Loading more products', 'woocommerce' ) );
+	}
+
 	return (
 		<Button
 			className="woocommerce-marketplace__load-more"
@@ -27,7 +31,6 @@ export default function LoadMoreButton( props: LoadMoreProps ) {
 			isBusy={ isBusy }
 			disabled={ disabled }
 		>
-			{ isBusy && speak( __( 'Loading more products', 'woocommerce' ) ) }
 			{ __( 'Load more', 'woocommerce' ) }
 		</Button>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/load-more-button/load-more-button.tsx
@@ -3,16 +3,20 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import { queueRecordEvent } from '@woocommerce/tracks';
 
 interface LoadMoreProps {
 	onLoadMore: () => void;
+	isBusy: boolean;
+	disabled: boolean;
 }
 
 export default function LoadMoreButton( props: LoadMoreProps ) {
+	const { onLoadMore, isBusy, disabled } = props;
 	function handleClick() {
 		queueRecordEvent( 'marketplace_load_more_button_clicked', {} );
-		props.onLoadMore();
+		onLoadMore();
 	}
 
 	return (
@@ -20,7 +24,10 @@ export default function LoadMoreButton( props: LoadMoreProps ) {
 			className="woocommerce-marketplace__load-more"
 			variant={ 'secondary' }
 			onClick={ handleClick }
+			isBusy={ isBusy }
+			disabled={ disabled }
 		>
+			{ isBusy && speak( __( 'Loading more products', 'woocommerce' ) ) }
 			{ __( 'Load more', 'woocommerce' ) }
 		</Button>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
@@ -191,6 +191,8 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 	return (
 		<Card
 			className={ classNames }
+			id={ `product-${ product.id }` }
+			tabIndex={ -1 }
 			aria-hidden={ isLoading }
 			style={ inlineCss() }
 		>

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list/types.ts
@@ -1,5 +1,6 @@
 export type SearchAPIJSONType = {
 	products: Array< SearchAPIProductType >;
+	total_pages: number;
 };
 
 export type SearchAPIProductType = {

--- a/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/products/products.tsx
@@ -24,7 +24,6 @@ import ProductListContent from '../product-list-content/product-list-content';
 import ProductLoader from '../product-loader/product-loader';
 import NoResults from '../product-list-content/no-results';
 import { Product, ProductType, SearchResultType } from '../product-list/types';
-import { MARKETPLACE_ITEMS_PER_PAGE } from '../constants';
 import { ADMIN_URL } from '~/utils/admin-settings';
 import { ThemeSwitchWarningModal } from '~/customize-store/intro/warning-modals';
 
@@ -58,7 +57,6 @@ export default function Products( props: ProductsProps ) {
 	const label = LABELS[ props.type ].label;
 	const query = useQuery();
 	const category = query?.category;
-	const perPage = props.perPage ?? MARKETPLACE_ITEMS_PER_PAGE;
 	interface Theme {
 		stylesheet?: string;
 	}
@@ -93,7 +91,7 @@ export default function Products( props: ProductsProps ) {
 	}
 
 	// Store the total number of products before we slice it later.
-	const products = props.products?.slice( 0, perPage ) ?? [];
+	const products = props.products ?? [];
 
 	const labelForClassName =
 		label === 'business services' ? 'business-services' : label;

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -107,7 +107,10 @@ async function fetchJsonWithCache(
 async function fetchSearchResults(
 	params: URLSearchParams,
 	abortSignal?: AbortSignal
-): Promise< Product[] > {
+): Promise< {
+	products: Product[];
+	totalPages: number;
+} > {
 	const url =
 		MARKETPLACE_HOST +
 		MARKETPLACE_SEARCH_API_PATH +
@@ -151,9 +154,10 @@ async function fetchSearchResults(
 						};
 					}
 				);
-				resolve( products );
+				const totalPages = ( json as SearchAPIJSONType ).total_pages;
+				resolve( { products, totalPages } );
 			} )
-			.catch( () => reject );
+			.catch( reject );
 	} );
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -178,6 +178,17 @@ async function fetchDiscoverPageData(): Promise< ProductGroup[] > {
 	}
 }
 
+function getProductType( tab: string ): ProductType {
+	switch ( tab ) {
+		case 'themes':
+			return ProductType.theme;
+		case 'business-services':
+			return ProductType.businessService;
+		default:
+			return ProductType.extension;
+	}
+}
+
 function fetchCategories( type: ProductType ): Promise< CategoryAPIItem[] > {
 	const url = new URL( MARKETPLACE_HOST + MARKETPLACE_CATEGORY_API_PATH );
 
@@ -482,6 +493,7 @@ export {
 	fetchCategories,
 	fetchDiscoverPageData,
 	fetchSearchResults,
+	getProductType,
 	fetchSubscriptions,
 	refreshSubscriptions,
 	getInstallUrl,

--- a/plugins/woocommerce/changelog/51434-add-wccom-21568-in-app-load-more-button
+++ b/plugins/woocommerce/changelog/51434-add-wccom-21568-in-app-load-more-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added a Load More button to product lists on the Extensions page, to request additional search results from WooCommerce.com.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
Currently we only show a limited number of products in the in-app marketplace. We're adding the ability to load additional products to enable merchants to search/browser the full list of products available on WooCommerce.com

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/21568

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch
2. Go to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
3. Visit the [in-app marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions) and click on the Extensions tab
4. Scroll down to the bottom and confirm you see a Load More button
5. Click the button, and you should see additional products loaded on the page
6. If navigating via keyboard, if you press Tab after new products appear, focus should go to the first new product.
7. Confirm the same behaviour is present on the Themes tab, and also when filtering by category
8. Search for a specific term, e.g. `payments`. You should see a load more button, but it should disappear after you click it the third time (there are currently only four pages of results for that search term)
9. Confirm when switching from a paginated tab/filter/result to another option, that you're back on page 1 each time.
10. Look for anything that feels broken.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Added a Load More button to product lists on the Extensions page, to request additional search results from WooCommerce.com.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
