### PR TITLE
Check if button element exists when triggering added_to_cart

### DIFF
--- a/plugins/woocommerce/changelog/51449-dev-harden-added-to-cart
+++ b/plugins/woocommerce/changelog/51449-dev-harden-added-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug where manually triggering `added_to_cart` event without a button element caused an Exception.

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
@@ -222,19 +222,23 @@ jQuery( function( $ ) {
 	 * Update cart live region message after add/remove cart events.
 	 */
 	AddToCartHandler.prototype.alertCartUpdated = function( e, fragments, cart_hash, $button ) {
-		var message = $button.data( 'success_message' );
+		$button = typeof $button === 'undefined' ? false : $button;
 
-		if ( !message ) {
-			return;
-		}
+		if ( $button ) {
+			var message = $button.data( 'success_message' );
+
+			if ( !message ) {
+				return;
+			}
 		
-		// If the response after adding/removing an item to/from the cart is really fast,
-		// screen readers may not have time to identify the changes in the live region element. 
-		// So, we add a delay to ensure an interval between messages.
-		e.data.addToCartHandler.$liveRegion
-			.delay(1000)
-			.text( message )
-			.attr( 'aria-relevant', 'all' );
+			// If the response after adding/removing an item to/from the cart is really fast,
+			// screen readers may not have time to identify the changes in the live region element. 
+			// So, we add a delay to ensure an interval between messages.
+			e.data.addToCartHandler.$liveRegion
+				.delay(1000)
+				.text( message )
+				.attr( 'aria-relevant', 'all' );
+		}
 	};
 
 	/**

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
@@ -173,6 +173,8 @@ jQuery( function( $ ) {
 	 * Update cart page elements after add to cart events.
 	 */
 	AddToCartHandler.prototype.updateButton = function( e, fragments, cart_hash, $button ) {
+		// Some themes and plugins manually trigger added_to_cart without passing a button element, which in turn calls this function.
+		// If there is no button we don't want to crash.
 		$button = typeof $button === 'undefined' ? false : $button;
 
 		if ( $button ) {
@@ -222,6 +224,8 @@ jQuery( function( $ ) {
 	 * Update cart live region message after add/remove cart events.
 	 */
 	AddToCartHandler.prototype.alertCartUpdated = function( e, fragments, cart_hash, $button ) {
+		// Some themes and plugins manually trigger added_to_cart without passing a button element, which in turn calls this function.
+		// If there is no button we don't want to crash.
 		$button = typeof $button === 'undefined' ? false : $button;
 
 		if ( $button ) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Recently we introduced #48295 to add screen reader support for adding items to cart.

In some themes and plugins, they will manually trigger the `added_to_cart` event but they won't pass a button element. It seems in the past we were aware of this possibility and defended against it but we didn't comment it so it wasn't obvious to any dev working in that area that this is necessary to allow 3PDs to trigger this event without having to provide a button element.

This PR fixes the issue by checking for presence of the `$button` argument before trying to do anything, avoiding fatal errors when this event is triggered without passing `$button`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

On `trunk` you can see this error combined with the WooCommerce Product Disclaimer plugin. You must be using a **non-block theme** such as Twenty Eleven to see the issue.

1. Install the product disclaimer plugin (https://woocommerce.com/products/woocommerce-product-disclaimer/)
2. Create a new disclaimer: WCPD -> Add New. Anything will do. Save it/ publish it.
3. Go to frontend as shopper and go to any single product page
4. Click "add to cart"
5. Check the browser's developer console and you should see an error stack trace like:
```
add-to-cart.js?ver=9.4.0:296 Uncaught TypeError: Cannot read properties of undefined (reading 'data')
    at AddToCartHandler.alertCartUpdated (add-to-cart.js?ver=9.4.0:296:25)
    at AddToCartHandler.onAddedToCart (add-to-cart.js?ver=9.4.0:344:27)
   ...
 ```
 
 6. Now check out this branch, rebuild the JS (ie via `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build`
 7. Now repeat 1-4
 8. You should not see any console error in the developer console this time.   

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix bug where manually triggering `added_to_cart` event without a button element caused an Exception.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
