### PR TITLE
Hook sample products into the Rest API instead of creating them

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/services.ts
@@ -193,23 +193,6 @@ const installFontFamilies = async () => {
 	}
 };
 
-const createProducts = async () => {
-	try {
-		const { success } = await apiFetch< {
-			success: boolean;
-		} >( {
-			path: `/wc-admin/onboarding/products`,
-			method: 'POST',
-		} );
-
-		if ( ! success ) {
-			throw new Error( 'Product creation failed' );
-		}
-	} catch ( error ) {
-		throw error;
-	}
-};
-
 export const enableTracking = async () => {
 	try {
 		await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
@@ -225,7 +208,6 @@ export const services = {
 	assembleSite,
 	browserPopstateHandler,
 	installAndActivateTheme,
-	createProducts,
 	installFontFamilies,
 	installPatterns,
 	updateGlobalStylesWithDefaultValues,

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -245,26 +245,6 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 									success: { type: 'final' },
 								},
 							},
-							createProducts: {
-								initial: 'pending',
-								states: {
-									pending: {
-										invoke: {
-											src: 'createProducts',
-											onDone: {
-												target: 'success',
-											},
-											onError: {
-												actions:
-													'redirectToIntroWithError',
-											},
-										},
-									},
-									success: {
-										type: 'final',
-									},
-								},
-							},
 							installFontFamilies: {
 								initial: installFontFamiliesState.initial,
 								states: {

--- a/plugins/woocommerce-admin/client/customize-store/design-without-ai/tests/state-machine.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-without-ai/tests/state-machine.test.ts
@@ -102,18 +102,12 @@ describe( 'Design Without AI state machine', () => {
 				Promise.reject()
 			);
 			const assembleSiteMock = jest.fn( () => Promise.resolve() );
-			const createProductsMock = jest.fn( () =>
-				Promise.resolve( {
-					success: true,
-				} )
-			);
 			const redirectToIntroWithErrorMock = jest.fn();
 
 			const machine = createMockMachine( {
 				services: {
 					installAndActivateTheme: installAndActivateThemeMock,
 					assembleSite: assembleSiteMock,
-					createProducts: createProductsMock,
 				},
 				actions: {
 					redirectToIntroWithError: redirectToIntroWithErrorMock,
@@ -140,17 +134,11 @@ describe( 'Design Without AI state machine', () => {
 				Promise.resolve()
 			);
 			const assembleSiteMock = jest.fn( () => Promise.resolve() );
-			const createProductsMock = jest.fn( () =>
-				Promise.resolve( {
-					success: true,
-				} )
-			);
 
 			const machine = createMockMachine( {
 				services: {
 					installAndActivateTheme: installAndActivateThemeMock,
 					assembleSite: assembleSiteMock,
-					createProducts: createProductsMock,
 				},
 			} );
 
@@ -183,11 +171,6 @@ describe( 'Design Without AI state machine', () => {
 			const initialState = 'preAssembleSite.assembleSite';
 
 			const assembleSiteMock = jest.fn( () => Promise.reject() );
-			const createProductsMock = jest.fn( () => {
-				return Promise.resolve( {
-					success: true,
-				} );
-			} );
 			const installAndActivateThemeMock = jest.fn( () =>
 				Promise.resolve()
 			);
@@ -197,7 +180,6 @@ describe( 'Design Without AI state machine', () => {
 			const machine = createMockMachine( {
 				services: {
 					assembleSite: assembleSiteMock,
-					createProducts: createProductsMock,
 					installAndActivateTheme: installAndActivateThemeMock,
 				},
 				actions: {
@@ -226,16 +208,10 @@ describe( 'Design Without AI state machine', () => {
 			const installAndActivateThemeMock = jest.fn( () =>
 				Promise.resolve()
 			);
-			const createProductsMock = jest.fn( () =>
-				Promise.resolve( {
-					success: true,
-				} )
-			);
 
 			const machine = createMockMachine( {
 				services: {
 					assembleSite: assembleSiteMock,
-					createProducts: createProductsMock,
 					installAndActivateTheme: installAndActivateThemeMock,
 				},
 				actions: {
@@ -254,84 +230,6 @@ describe( 'Design Without AI state machine', () => {
 			expect( assembleSiteMock ).toHaveBeenCalled();
 
 			expect( finalState.matches( 'showAssembleHub' ) ).toBeTruthy();
-		} );
-
-		it( 'should invoke `redirectToIntroWithError` when `createProducts` service fails', async () => {
-			const initialState =
-				'preAssembleSite.preApiCallLoader.createProducts';
-
-			const createProductsMock = jest.fn( () => Promise.reject() );
-			const assembleSiteMock = jest.fn( () => Promise.resolve() );
-			const installAndActivateThemeMock = jest.fn( () =>
-				Promise.resolve()
-			);
-
-			const redirectToIntroWithErrorMock = jest.fn();
-
-			const machine = createMockMachine( {
-				services: {
-					createProducts: createProductsMock,
-					assembleSite: assembleSiteMock,
-					installAndActivateTheme: installAndActivateThemeMock,
-				},
-				actions: {
-					redirectToIntroWithError: redirectToIntroWithErrorMock,
-				},
-			} );
-
-			const state = machine.getInitialState( initialState );
-
-			const actor = interpret( machine ).start( state );
-
-			await waitFor( actor, ( currentState ) => {
-				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.pending'
-				);
-			} );
-
-			expect( createProductsMock ).toHaveBeenCalled();
-			expect( redirectToIntroWithErrorMock ).toHaveBeenCalled();
-		} );
-
-		it( 'should invoke `createProducts` service', async () => {
-			const initialState =
-				'preAssembleSite.preApiCallLoader.createProducts';
-
-			const createProductsMock = jest.fn( () =>
-				Promise.resolve( {
-					success: true,
-				} )
-			);
-
-			const machine = createMockMachine( {
-				services: {
-					createProducts: createProductsMock,
-				},
-			} );
-
-			const state = machine.getInitialState( initialState );
-
-			const actor = interpret( machine ).start( state );
-
-			await waitFor( actor, ( currentState ) => {
-				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.pending'
-				);
-			} );
-
-			expect( createProductsMock ).toHaveBeenCalled();
-
-			const finalState = await waitFor( actor, ( currentState ) => {
-				return currentState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.success'
-				);
-			} );
-
-			expect(
-				finalState.matches(
-					'preAssembleSite.preApiCallLoader.createProducts.success'
-				)
-			).toBeTruthy();
 		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/update-cys-hook-sample-products
+++ b/plugins/woocommerce/changelog/update-cys-hook-sample-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+During the CYS flow, don't store sample products in the database

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -327,7 +327,7 @@ class CustomizeStore extends Task {
 	 * @return array An array of post objects, potentially including sample products.
 	 */
 	public function add_sample_products_to_query( $posts, $query ) {
-		if ( 'product' !== $query->query['post_type'] || ! WC()->is_rest_api_request() || ! empty( $posts ) ) {
+		if ( 'product' !== $query->query['post_type'] || ! empty( $posts ) ) {
 			return $posts;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -13,6 +13,15 @@ use WP_Post;
  */
 class CustomizeStore extends Task {
 
+	/**
+	 * Array of sample products for the Customize Your Store task.
+	 *
+	 * This array contains sample product data used to populate the patterns
+	 * with example products when no real products exist. Each product
+	 * includes a title, image filename, description, and price.
+	 *
+	 * @var array
+	 */
 	private $sample_products = array(
 		array(
 			'title'       => 'Vintage Typewriter',
@@ -73,8 +82,8 @@ class CustomizeStore extends Task {
 		add_action( 'customize_save_after', array( $this, 'mark_task_as_complete_classic_theme' ) );
 
 		if ( WC()->is_rest_api_request() ) {
-			$referring_url = $_SERVER['HTTP_REFERER'];
-			$parsed_url    = parse_url( $referring_url );
+			$referring_url = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+			$parsed_url    = wp_parse_url( $referring_url );
 
 			// phpcs:disable WordPress.Security.NonceVerification.Recommended
 			$is_assembler_hub = (

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -198,6 +198,36 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 		);
 	} );
 
+	test( 'Product patterns display products', async ( {
+		pageObject,
+		baseURL,
+	} ) => {
+		await prepareAssembler( pageObject, baseURL );
+		const assembler = await pageObject.getAssembler();
+		const editor = await pageObject.getEditor();
+
+		await deleteAllPatterns( editor, assembler );
+
+		await assembler.getByText( 'Featured selling' ).click();
+
+		const productCollectionPattern = assembler
+			.locator( '.block-editor-block-patterns-list__item[aria-label="Product Collection 4 Columns"]' )
+			.first();
+
+		await productCollectionPattern.click();
+
+		const insertedPatternContent = await editor
+			.locator(
+				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+			)
+			.first()
+			.textContent();
+
+		await expect( insertedPatternContent ).toContain(
+			'3-Speed Bike'
+		);
+	} );
+
 	test( 'Clicking on a pattern should always scroll the page to the inserted pattern', async ( {
 		pageObject,
 		baseURL,

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -82,7 +82,6 @@ test.describe( 'Assembler - Loading Page', { tag: '@gutenberg' }, () => {
 		expect( Object.values( requestToSetupStore ) ).toEqual( [
 			true,
 			true,
-			true,
 		] );
 
 		await pageObject.waitForLoadingScreenFinish();
@@ -141,7 +140,6 @@ test.describe( 'Assembler - Loading Page', { tag: '@gutenberg' }, () => {
 		}
 
 		expect( Object.values( requestToSetupStore ) ).toEqual( [
-			false,
 			false,
 			false,
 		] );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.utils.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.utils.js
@@ -13,7 +13,6 @@ const setupRequestInterceptor = ( page, requestToSetupStore ) => {
 
 const createRequestsToSetupStoreDictionary = () => ( {
 	'onboarding/themes/install?theme=twentytwentyfour': false,
-	'onboarding/products': false,
 	'themes/activate?theme=twentytwentyfour&theme_switch_via_cys_ai_loader': false,
 } );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #50586.

This PR changes how we approach sample products in the CYS flow. Instead of creating each individual product and updating images for each one of them, we now hook into the Rest API requests that populate the Product Collection block and inject the sample products there. This is much faster and it means we don't pollute the site with sample products/images. At the same time, it means that sample products are only visible during the CYS flow and are never visible in the frontend.

### How to test the changes in this Pull Request:

0. Make sure your store has no products.
0. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
1. In the admin, go to WooCommerce > Customize Your Store > Create your own theme.
2. Open the _Design your homepage_ task.
3. Add some patterns under the _Featured selling_ category and make sure they display sample products.

![imatge](https://github.com/user-attachments/assets/9e5ad64c-1a76-4b2a-88cb-aec3334d8293)

4. Complete designing your store.
5. Go to _All products_ (`/wp-admin/edit.php?post_type=product`) and verify there are no products created. Go to the _Media_ library (`/wp-admin/upload.php`) and verify there are no files.
