### PR TITLE
Fix: "Import file path is invalid" in Windows

### DIFF
--- a/plugins/woocommerce/changelog/pr-51456
+++ b/plugins/woocommerce/changelog/pr-51456
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix invalid path error in product importer in Windows

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -125,6 +125,7 @@ class WC_Product_CSV_Importer_Controller {
 
 		// Check that file is within an allowed location.
 		if ( $is_valid_file ) {
+			$normalized_path   = wp_normalize_path( $path );
 			$in_valid_location = false;
 			$valid_locations   = array();
 			$valid_locations[] = ABSPATH;
@@ -135,7 +136,8 @@ class WC_Product_CSV_Importer_Controller {
 			}
 
 			foreach ( $valid_locations as $valid_location ) {
-				if ( 0 === stripos( $path, trailingslashit( realpath( $valid_location ) ) ) ) {
+				$normalized_location = wp_normalize_path( realpath( $valid_location ) );
+				if ( 0 === stripos( $normalized_path, trailingslashit( $normalized_location ) ) ) {
 					$in_valid_location = true;
 					break;
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the CSV product import that was broken for Windows servers since WooCommerce 9.3.

Closes #51415.


### How to test the changes in this Pull Request:

1. On a Windows server go to WooCommerce - Products, click "Import", select a CSV file and click "Continue". Without this fix you'll get a "File path provided for import is invalid" error, with the fix you'll land in the column mapping editor as expected. Follow all the steps and verify that the import succeeds. 
2. Test that the import continues working on Linux servers too.

Alternatively, if there isn't a Windows server at hand the change can be tested via WP CLI, but some changes will be needed to mock the WordPress configuration and the file system access. So this is what should be done:

1. Change the visibility of the `WC_Product_CSV_Importer_Controller::check_file_path` method to `public`.
2. Remove the two usages of `realpath`.
3. Remove this line: `$is_valid_file = $is_valid_file && is_readable( $path );`.
4. Replace `$upload_dir = wp_get_upload_dir();` with `$upload_dir = ['basedir' => 'c:/wordpress/uploads', 'error' => false];` (forward slashes in the path on purpose, that's how `wp_get_upload_dir` actually works in Windows).
5. In `wp shell` run the following, without the fix you'll get an exception, with the fix nothing happens:

```
include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
include_once WC_ABSPATH . 'includes/admin/importers/class-wc-product-csv-importer-controller.php';
WC_Product_CSV_Importer_Controller::check_file_path("c:\\wordpress\\uploads\\the_file.csv")
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
