### PR TITLE
CYS: Fix Looker dashboard data (Track & display average loading times)

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/editor.tsx
@@ -23,6 +23,7 @@ import { GlobalStylesRenderer } from '@wordpress/edit-site/build-module/componen
 /**
  * Internal dependencies
  */
+import { trackEvent } from '../tracking';
 import { editorIsLoaded } from '../utils';
 import { BlockEditorContainer } from './block-editor-container';
 
@@ -63,6 +64,7 @@ export const Editor = ( { isLoading }: { isLoading: boolean } ) => {
 	useEffect( () => {
 		if ( ! isLoading ) {
 			editorIsLoaded();
+			trackEvent( 'customize_your_store_assembler_hub_editor_loaded' );
 		}
 	}, [ isLoading ] );
 

--- a/plugins/woocommerce/changelog/add-50832-loading-time
+++ b/plugins/woocommerce/changelog/add-50832-loading-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Track customize_your_store_assembler_hub_editor_loaded event to measure CYS loading time


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50832

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Paste this code into the browser devtools Console (<kbd>F12</kbd>) to debug: `localStorage.setItem( 'debug', 'wc-admin:*' );` the triggered events.
2. `Reset Customize Your Store` if you have not done so yet under the `Tools` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to WooCommerce > Home > Customize Your Store > Start designing.
4. Verify the `wcadmin_customize_your_store_intro_design_without_ai_click` event is triggered.
5. After the editor loaded verify the `wcadmin_customize_your_store_assembler_hub_editor_loaded` event is triggered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
