### PR TITLE
WooCommerce > Block themes: Remove underline from sale prices

### DIFF
--- a/plugins/woocommerce/changelog/51462-fix-42585-remove-underline-from-sale-prices-in-woocommerce-block-themes
+++ b/plugins/woocommerce/changelog/51462-fix-42585-remove-underline-from-sale-prices-in-woocommerce-block-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove underline from sale prices in WooCommerce block themes

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -153,6 +153,15 @@
 		text-decoration: none;
 	}
 
+	.woocommerce-grouped-product-list-item__price ins,
+	bdi {
+		text-decoration: none;
+	}
+
+	.wc-block-components-product-price ins {
+		text-decoration: none;
+	}
+
 	span.onsale {
 		// Style "On Sale" badge in theme colors by default.
 		background-color: var(--wp--preset--color--foreground, $highlight);

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -146,20 +146,12 @@
 		}
 	}
 
-	.price ins,
-	bdi {
-		// Ensure discounted prices aren't underlined.
-		// For details see https://github.com/woocommerce/woocommerce-blocks/pull/5684.
-		text-decoration: none;
-	}
-
-	.woocommerce-grouped-product-list-item__price ins,
-	bdi {
-		text-decoration: none;
-	}
-
-	.wc-block-components-product-price ins {
-		text-decoration: none;
+	.price, .woocommerce-grouped-product-list-item__price, .wc-block-components-product-price {
+		ins, bdi {
+			// Ensure discounted prices aren't underlined.
+			// For details see https://github.com/woocommerce/woocommerce-blocks/pull/5684.
+			text-decoration: none;
+		}
 	}
 
 	span.onsale {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #42585.

This PR prevents underlined discounted prices on the shop homepage and grouped products.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Twenty-twenty Four theme

1. Navigate to the Themes (Appearance > Themes).
2. Select and activate the Twenty-twenty Four theme.
3. Visit the Shop page (/shop).
4. Make sure that the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 36 54@2x](https://github.com/user-attachments/assets/206f6335-8482-4798-ac3d-a9d897389f2a) | ![CleanShot 2024-09-18 at 13 53 35@2x](https://github.com/user-attachments/assets/968e407d-c33d-4e92-b89a-874246015adc) | 

5. Visit a grouped product (if you're using the `sample-data` that comes with WooCommerce, you can visit the Logo Collection product).
6. Make sure the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 39 05@2x](https://github.com/user-attachments/assets/427bc261-015a-4f67-9649-13d5686667fa) | ![CleanShot 2024-09-18 at 13 53 52@2x](https://github.com/user-attachments/assets/efb7ea9d-a9ea-48ae-8d8f-8d3cfc5d09e9) |  

---

### Blockbase theme

1. Navigate to the Themes (Appearance > Themes).
2. Install and activate the Blockbase theme.
3. Visit the Shop page (/shop).
4. Make sure that the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 45 59@2x](https://github.com/user-attachments/assets/9c02a589-d917-48da-b3cd-cd9ad9bd7a65) | ![CleanShot 2024-09-18 at 13 53 00@2x](https://github.com/user-attachments/assets/0fe1d78f-bbdd-470f-a769-3c99a190f8cd) | 

5. Visit a grouped product (if you're using the `sample-data` that comes with WooCommerce, you can visit the Logo Collection product).
6. Make sure the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 46 31@2x](https://github.com/user-attachments/assets/72dc7fba-b566-4dc7-afa9-dd4cb9558581) | ![CleanShot 2024-09-18 at 13 52 39@2x](https://github.com/user-attachments/assets/a8e86d29-fc81-45be-8972-ecd9f7122561) |  

---

### Clove theme

1. Navigate to the Themes (Appearance > Themes).
2. Install and activate the Blockbase theme.
3. Visit the Shop page (/shop).
4. Make sure that the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 47 55@2x](https://github.com/user-attachments/assets/2fa763fa-e8f6-499f-a519-52cafa922962) | ![CleanShot 2024-09-18 at 13 51 49@2x](https://github.com/user-attachments/assets/c6cb4357-3c9e-41e8-9676-73d9a88548f7) | 

5. Visit a grouped product (if you're using the `sample-data` that comes with WooCommerce, you can visit the Logo Collection product).
6. Make sure the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 47 19@2x](https://github.com/user-attachments/assets/f95e771c-4385-4386-9397-0a22966a9581) | ![CleanShot 2024-09-18 at 13 52 13@2x](https://github.com/user-attachments/assets/d2ca35ed-f261-436d-a5d6-73859f396acc) |  

---

### Archeo theme

1. Navigate to the Themes (Appearance > Themes).
2. Install and activate the Blockbase theme.
3. Visit the Shop page (/shop).
4. Make sure that the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 48 43@2x](https://github.com/user-attachments/assets/c7c6efa2-ccdd-4a5d-87a4-036c5f74e8fa) | ![CleanShot 2024-09-18 at 13 51 01@2x](https://github.com/user-attachments/assets/118827fe-48e9-48f0-9f6b-37f07578b24e) | 

5. Visit a grouped product (if you're using the `sample-data` that comes with WooCommerce, you can visit the Logo Collection product).
6. Make sure the discounted prices are NOT underlined.

| Before | After |
|--------|--------|
| ![CleanShot 2024-09-18 at 13 49 06@2x](https://github.com/user-attachments/assets/858a2ebe-3a4b-4a8d-a2bd-48be88f76ee8) | ![CleanShot 2024-09-18 at 13 50 23@2x](https://github.com/user-attachments/assets/65a8ff7d-3135-4d44-b3ab-3cd73816ab80) |  

---

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove underline from sale prices in WooCommerce block themes

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
