### PR TITLE
[Coming Soon] Add a filter to remove admin bar badge

### DIFF
--- a/plugins/woocommerce/changelog/51464-add-disable-coming-soon-badgea
+++ b/plugins/woocommerce/changelog/51464-add-disable-coming-soon-badgea
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Adds a woocommerce_disable_coming_soon_admin_bar_badge filter to remove the Coming Soon admin bar badge.

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -29,6 +29,13 @@ class ComingSoonAdminBarBadge {
 	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
+		/**
+		 * Allows removal of Coming Soon admin bar badge.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param boolean
+		 */
 		if ( apply_filters( 'woocommerce_disable_coming_soon_admin_bar_badge', false ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -29,6 +29,9 @@ class ComingSoonAdminBarBadge {
 	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
+		if ( apply_filters( 'woocommerce_disable_coming_soon_admin_bar_badge', false ) ) {
+			return;
+		}
 		// Early exit if LYS feature is disabled.
 		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
 			return;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a filter `woocommerce_disable_coming_soon_admin_bar_badge` to allow removal of the admin bar badge. Note, this does not disable any functionality about Coming Soon, but only allows the badge to be hidden.

<img width="222" alt="image" src="https://github.com/user-attachments/assets/5d41e54d-16d3-4db0-a398-79c7fcbdb47f"> 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See the Coming Soon admin bar badge render normally.
2. Add this code somewhere it will run, like `woocommerce.php` and see the badge not render.
```php
add_filter( 'woocommerce_disable_coming_soon_admin_bar_badge', function() {
	return false;
} );
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds a woocommerce_disable_coming_soon_admin_bar_badge filter to remove the Coming Soon admin bar badge.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
