### PR TITLE
Fix deprecation notice in coming soon and store-only mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-51472-fix-deprecation-notice
+++ b/plugins/woocommerce/changelog/fix-51472-fix-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Wrap parse_str under a check to resolve deprecation notice

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -154,11 +154,13 @@ class WCAdminHelper {
 			'post_type' => 'product',
 		);
 
-		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $url_params );
-
-		foreach ( $params as $key => $param ) {
-			if ( isset( $url_params[ $key ] ) && $url_params[ $key ] === $param ) {
-				return true;
+		$query_string = wp_parse_url( $url, PHP_URL_QUERY );
+		if ( $query_string ) {
+			parse_str( $query_string, $url_params );
+			foreach ( $params as $key => $param ) {
+				if ( isset( $url_params[ $key ] ) && $url_params[ $key ] === $param ) {
+					return true;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #51472, fix the deprecation notice by adding a check prior running `parse_str` and the subsequent loop.

### How to test the changes in this Pull Request:

1. Pull down these changes to your development environment where deprecation notices are shown
3. Navigate to `WooCommerce -> Settings -> Site Visibility` and choose `Coming soon` with `Apply to store pages only`
4. Navigate to `Settings -> Permalinks` and change `Permalink structure` to `Plain`
5. Open an incognito session and navigate to the frontend (homepage).
6. Observe no deprecation notice is shown.

#### Regression test

1. Click `Shop` from the menu.
1. Confirm the coming soon page is rendered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
