### PR TITLE
Fix script tag handling for inner blocks in the cart

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/render-parent-block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/render-parent-block.tsx
@@ -179,6 +179,11 @@ const renderInnerBlocks = ( {
 				return null;
 			}
 
+			// Return scripts without manipulation.
+			if ( parsedElement?.type === 'script' ) {
+				return parsedElement;
+			}
+
 			const renderedChildren = node.childNodes.length
 				? renderInnerBlocks( {
 						block,

--- a/plugins/woocommerce/changelog/fix-inner-block-script-handling-51155
+++ b/plugins/woocommerce/changelog/fix-inner-block-script-handling-51155
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix script tag handling for inner blocks in the cart


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The HTML of inner blocks is parsed by `html-react-parser` then mapped to React Components on the frontend. This breaks `script` tags (inserted by third parties) because it mixes `children` prop and `dangerouslySetInnerHTML`.

```
Error: Can only set one of `children` or `props.dangerouslySetInnerHTML`.
```

We can avoid this by skipping script tags when parsing. We never need to convert a script tag to a component.

Closes #51155

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testers only need smoke test the cart block with and without items in the cart to check for rendering issues.

Developers can test using the following snippet:

```php
add_filter( 'woocommerce_blocks_product_grid_item_html', 'test_script_tag_product_grid_items', 10, 2 );

function test_script_tag_product_grid_items( $html, $data ) {

	if ( is_admin() ) {
		return $html;
	}

	if ( substr( $html, -5 ) === '</li>' ) {

		$script = "<script>console.log('" . $data->title . "');</script>";

		return substr( $html, 0, -5 ) . $script . '</li>';
	}

	return $html;
}
```

Then view the cart empty state and confirm you see some console logs and no errors.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
