### PR TITLE
[e2e] External - Make themes util compatible with external envs and unskip relevant tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-external-fix-activate-theme-util
+++ b/plugins/woocommerce/changelog/e2e-external-fix-activate-theme-util
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+E2E tests - fixing activateTheme util to work on wp env and external envs

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -3,6 +3,10 @@
 echo -e 'Activate default theme \n'
 wp-env run tests-cli wp theme activate twentytwentythree
 
+echo -e 'Install twentytwenty and storefront themes \n'
+wp-env run tests-cli wp theme install twentytwenty
+wp-env run tests-cli wp theme install storefront
+
 echo -e 'Update URL structure \n'
 wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
 

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
@@ -155,6 +155,10 @@ function get_environment_info() {
 function activate_theme( WP_REST_Request $request ) {
 	$theme_name = sanitize_text_field( $request['theme_name'] );
 
+	if ( empty( $theme_name ) ) {
+		return new WP_REST_Response( array( 'message' => 'Theme name is empty.' ), 400 );
+	}
+
 	if ( wp_get_theme( $theme_name )->exists() ) {
 		switch_theme( $theme_name );
 		return new WP_REST_Response( array( 'message' => "Theme '$theme_name' activated successfully." ), 200 );

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
@@ -154,7 +154,7 @@ function get_environment_info() {
  */
 function activate_theme_via_api( WP_REST_Request $request ) {
 	$theme_name = sanitize_text_field( $request['theme_name'] );
-	
+
 	if ( wp_get_theme( $theme_name )->exists() ) {
 		switch_theme( $theme_name );
 		return new WP_REST_Response( array( 'message' => "Theme '$theme_name' activated successfully." ), 200 );

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
@@ -50,7 +50,7 @@ function register_helper_api() {
 		'/activate',
 		array(
 			'methods'             => 'POST',
-			'callback'            => 'activate_theme_via_api',
+			'callback'            => 'activate_theme',
 			'permission_callback' => 'is_allowed',
 		)
 	);
@@ -152,7 +152,7 @@ function get_environment_info() {
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response
  */
-function activate_theme_via_api( WP_REST_Request $request ) {
+function activate_theme( WP_REST_Request $request ) {
 	$theme_name = sanitize_text_field( $request['theme_name'] );
 
 	if ( wp_get_theme( $theme_name )->exists() ) {

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-helper-apis.php
@@ -44,6 +44,16 @@ function register_helper_api() {
 			'permission_callback' => 'is_allowed',
 		)
 	);
+
+	register_rest_route(
+		'e2e-theme',
+		'/activate',
+		array(
+			'methods'             => 'POST',
+			'callback'            => 'activate_theme_via_api',
+			'permission_callback' => 'is_allowed',
+		)
+	);
 }
 
 add_action( 'rest_api_init', 'register_helper_api' );
@@ -135,4 +145,20 @@ function get_environment_info() {
 	}
 
 	return new WP_REST_Response( $data, 200 );
+}
+
+/**
+ * Activate a theme via the REST API.
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response
+ */
+function activate_theme_via_api( WP_REST_Request $request ) {
+	$theme_name = sanitize_text_field( $request['theme_name'] );
+	
+	if ( wp_get_theme( $theme_name )->exists() ) {
+		switch_theme( $theme_name );
+		return new WP_REST_Response( array( 'message' => "Theme '$theme_name' activated successfully." ), 200 );
+	} else {
+		return new WP_REST_Response( array( 'message' => "Theme '$theme_name' does not exist." ), 400 );
+	}
 }

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
@@ -30,7 +30,7 @@ test.describe(
 					'woocommerce_customize_store_onboarding_tour_hidden',
 					'yes'
 				);
-				await activateTheme( 'twentytwentyfour' );
+				await activateTheme( baseURL, 'twentytwentyfour' );
 			} catch ( error ) {
 				console.log( 'Store completed option not updated' );
 			}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
@@ -260,7 +260,7 @@ test.describe( 'Assembler -> Color Pickers', { tag: '@gutenberg' }, () => {
 			);
 
 			// Reset theme back to default.
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 			await customizeStorePageObject.resetCustomizeStoreChanges(
 				baseURL
 			);

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -99,7 +99,7 @@ test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
 			);
 
 			// Reset theme back to default.
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
@@ -51,7 +51,7 @@ test.describe( 'Assembler -> Footers', { tag: '@gutenberg' }, () => {
 				'no'
 			);
 			// Reset theme back to default.
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 				'no'
 			);
 
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
@@ -51,7 +51,7 @@ test.describe( 'Assembler -> headers', { tag: '@gutenberg' }, () => {
 				'no'
 			);
 
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -64,7 +64,7 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 				'no'
 			);
 
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -60,7 +60,7 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 				baseURL
 			);
 			// Reset theme back to default.
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -58,24 +58,21 @@ test.describe(
 			);
 		} );
 
-		test(
-			'it shows the "offline banner" when the network is offline',
-			{ tag: '@skip-on-default-pressable' },
-			async ( { page, context } ) => {
-				await page.goto( CUSTOMIZE_STORE_URL );
-				await expect(
-					page.locator( 'text=Design your own' )
-				).toBeVisible();
-				await context.setOffline( true );
+		test( 'it shows the "offline banner" when the network is offline', async ( {
+			page,
+			context,
+		} ) => {
+			await page.goto( CUSTOMIZE_STORE_URL );
+			await expect(
+				page.locator( 'text=Design your own' )
+			).toBeVisible();
+			await context.setOffline( true );
 
-				await expect( page.locator( '.offline-banner' ) ).toBeVisible();
-				await expect(
-					page.locator(
-						'text=Looking to design your store using AI?'
-					)
-				).toBeVisible();
-			}
-		);
+			await expect( page.locator( '.offline-banner' ) ).toBeVisible();
+			await expect(
+				page.locator( 'text=Looking to design your store using AI?' )
+			).toBeVisible();
+		} );
 
 		test( 'it shows the "no AI" banner on Core when the task is not completed', async ( {
 			page,
@@ -118,38 +115,34 @@ test.describe(
 			).toBeVisible();
 		} );
 
-		test(
-			'it shows the "non default block theme" banner when the theme is a block theme different than TT4',
-			{ tag: '@skip-on-default-pressable' },
-			async ( { page } ) => {
-				await activateTheme( 'twentytwentythree' );
+		test( 'it shows the "non default block theme" banner when the theme is a block theme different than TT4', async ( {
+			page,
+		} ) => {
+			await activateTheme( 'twentytwentythree' );
 
-				await page.goto( CUSTOMIZE_STORE_URL );
+			await page.goto( CUSTOMIZE_STORE_URL );
 
-				await expect( page.locator( 'h1' ) ).toHaveText(
-					'Customize your theme'
-				);
-				await expect(
-					page.getByRole( 'button', { name: 'Go to the Editor' } )
-				).toBeVisible();
-			}
-		);
+			await expect( page.locator( 'h1' ) ).toHaveText(
+				'Customize your theme'
+			);
+			await expect(
+				page.getByRole( 'button', { name: 'Go to the Editor' } )
+			).toBeVisible();
+		} );
 
-		test(
-			'clicking on "Go to the Customizer" with a classic theme should go to the customizer',
-			{ tag: '@skip-on-default-pressable' },
-			async ( { page } ) => {
-				await activateTheme( 'twentytwenty' );
+		test( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
+			page,
+		} ) => {
+			await activateTheme( 'twentytwenty' );
 
-				await page.goto( CUSTOMIZE_STORE_URL );
+			await page.goto( CUSTOMIZE_STORE_URL );
 
-				await page
-					.getByRole( 'button', { name: 'Go to the Customizer' } )
-					.click();
+			await page
+				.getByRole( 'button', { name: 'Go to the Customizer' } )
+				.click();
 
-				await page.waitForNavigation();
-				await expect( page.url() ).toContain( 'customize.php' );
-			}
-		);
+			await page.waitForNavigation();
+			await expect( page.url() ).toContain( 'customize.php' );
+		} );
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -29,7 +29,7 @@ test.describe(
 			);
 
 			// Need a block enabled theme to test
-			await activateTheme( 'twentytwentyfour' );
+			await activateTheme( baseURL, 'twentytwentyfour' );
 		} );
 
 		test.beforeEach( async ( { baseURL } ) => {
@@ -47,7 +47,7 @@ test.describe(
 
 		test.afterAll( async ( { baseURL } ) => {
 			// Reset theme to the default.
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 
 			// Reset tour to visible.
 			await setOption(
@@ -117,8 +117,9 @@ test.describe(
 
 		test( 'it shows the "non default block theme" banner when the theme is a block theme different than TT4', async ( {
 			page,
+			baseURL,
 		} ) => {
-			await activateTheme( 'twentytwentythree' );
+			await activateTheme( baseURL, 'twentytwentythree' );
 
 			await page.goto( CUSTOMIZE_STORE_URL );
 
@@ -130,10 +131,11 @@ test.describe(
 			).toBeVisible();
 		} );
 
-		test( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
+		test.only( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
 			page,
+			baseURL,
 		} ) => {
-			await activateTheme( 'twentytwenty' );
+			await activateTheme( baseURL, 'twentytwenty' );
 
 			await page.goto( CUSTOMIZE_STORE_URL );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -131,7 +131,7 @@ test.describe(
 			).toBeVisible();
 		} );
 
-		test.only( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
+		test( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
 			page,
 			baseURL,
 		} ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -54,7 +54,7 @@ test.describe( 'Assembler - Loading Page', { tag: '@gutenberg' }, () => {
 				'no'
 			);
 
-			await activateTheme( 'twentynineteen' );
+			await activateTheme( baseURL, 'twentynineteen' );
 		} catch ( error ) {
 			console.log( 'Store completed option not updated' );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -60,20 +60,17 @@ test.describe(
 			);
 		} );
 
-		test(
-			'Accessing the transitional page when the CYS flow is not completed should redirect to the Intro page',
-			{ tag: '@skip-on-default-pressable' },
-			async ( { page, baseURL } ) => {
-				await page.goto( TRANSITIONAL_URL );
+		test( 'Accessing the transitional page when the CYS flow is not completed should redirect to the Intro page', async ( {
+			page,
+			baseURL,
+		} ) => {
+			await page.goto( TRANSITIONAL_URL );
 
-				const locator = page.locator( 'h1:visible' );
-				await expect( locator ).not.toHaveText(
-					'Your store looks great!'
-				);
+			const locator = page.locator( 'h1:visible' );
+			await expect( locator ).not.toHaveText( 'Your store looks great!' );
 
-				await expect( page.url() ).toBe( `${ baseURL }${ INTRO_URL }` );
-			}
-		);
+			await expect( page.url() ).toBe( `${ baseURL }${ INTRO_URL }` );
+		} );
 
 		test( 'Clicking on "Finish customizing" in the assembler should go to the transitional page', async ( {
 			pageObject,

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -31,7 +31,7 @@ test.describe(
 			);
 
 			// Need a block enabled theme to test
-			await activateTheme( 'twentytwentyfour' );
+			await activateTheme( baseURL, 'twentytwentyfour' );
 		} );
 
 		test.beforeEach( async ( { baseURL } ) => {
@@ -49,7 +49,7 @@ test.describe(
 
 		test.afterAll( async ( { baseURL } ) => {
 			// Reset theme back to default.
-			await activateTheme( DEFAULT_THEME );
+			await activateTheme( baseURL, DEFAULT_THEME );
 
 			// Reset tour to visible.
 			await setOption(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
@@ -74,7 +74,7 @@ async function runComingSoonTests( themeContext = '' ) {
 
 test.describe(
 	'Launch Your Store front end - logged out',
-	{ tag: [ '@skip-on-default-wpcom', '@skip-on-default-pressable' ] },
+	{ tag: '@skip-on-default-wpcom' },
 	() => {
 		test.afterAll( async ( { baseURL } ) => {
 			try {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
@@ -90,11 +90,11 @@ test.describe(
 		} );
 
 		test.describe( 'Block Theme (Twenty Twenty Four)', () => {
-			test.beforeAll( async ( baseURL ) => {
+			test.beforeAll( async ( { baseURL } ) => {
 				await activateTheme( baseURL, 'twentytwentyfour' );
 			} );
 
-			test.afterAll( async ( baseURL ) => {
+			test.afterAll( async ( { baseURL } ) => {
 				// Reset theme to the default.
 				await activateTheme( baseURL, DEFAULT_THEME );
 			} );
@@ -103,11 +103,11 @@ test.describe(
 		} );
 
 		test.describe( 'Classic Theme (Storefront)', () => {
-			test.beforeAll( async ( baseURL ) => {
+			test.beforeAll( async ( { baseURL } ) => {
 				await activateTheme( baseURL, 'storefront' );
 			} );
 
-			test.afterAll( async ( baseURL ) => {
+			test.afterAll( async ( { baseURL } ) => {
 				// Reset theme to the default.
 				await activateTheme( baseURL, DEFAULT_THEME );
 			} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
@@ -90,26 +90,26 @@ test.describe(
 		} );
 
 		test.describe( 'Block Theme (Twenty Twenty Four)', () => {
-			test.beforeAll( async () => {
-				await activateTheme( 'twentytwentyfour' );
+			test.beforeAll( async ( baseURL ) => {
+				await activateTheme( baseURL, 'twentytwentyfour' );
 			} );
 
-			test.afterAll( async () => {
+			test.afterAll( async ( baseURL ) => {
 				// Reset theme to the default.
-				await activateTheme( DEFAULT_THEME );
+				await activateTheme( baseURL, DEFAULT_THEME );
 			} );
 
 			runComingSoonTests( test.step, test.use );
 		} );
 
 		test.describe( 'Classic Theme (Storefront)', () => {
-			test.beforeAll( async () => {
-				await activateTheme( 'storefront' );
+			test.beforeAll( async ( baseURL ) => {
+				await activateTheme( baseURL, 'storefront' );
 			} );
 
-			test.afterAll( async () => {
+			test.afterAll( async ( baseURL ) => {
 				// Reset theme to the default.
-				await activateTheme( DEFAULT_THEME );
+				await activateTheme( baseURL, DEFAULT_THEME );
 			} );
 
 			runComingSoonTests(

--- a/plugins/woocommerce/tests/e2e-pw/utils/themes.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/themes.js
@@ -1,18 +1,61 @@
 const { exec } = require( 'node:child_process' );
+const { encodeCredentials } = require( '../utils/plugin-utils' );
+const https = require( 'https' );
+const { admin } = require( '../test-data/data' );
+const { BASE_URL } = process.env;
 
 export const DEFAULT_THEME = 'twentytwentythree';
 
 export const activateTheme = ( themeName ) => {
 	return new Promise( ( resolve, reject ) => {
-		const command = `wp-env run tests-cli wp theme install ${ themeName } --activate`;
+		const isLocalhost = BASE_URL.includes( 'localhost' );
+		if ( isLocalhost ) {
+			// Command for local environment
+			const command = `wp-env run tests-cli wp theme install ${ themeName } --activate`;
 
-		exec( command, ( error, stdout ) => {
-			if ( error ) {
-				console.error( `Error executing command: ${ error }` );
-				return reject( error );
-			}
+			exec( command, ( error, stdout ) => {
+				if ( error ) {
+					console.error( `Error executing command: ${ error }` );
+					return reject( error );
+				}
+				resolve( stdout );
+			} );
+		} else {
+			// HTTPS request for external environment
+			const url = new URL( BASE_URL );
+			const options = {
+				hostname: url.hostname,
+				port: url.port || 443,
+				path: '/wp-json/custom/v1/activate-theme',
+				method: 'POST',
+				headers: {
+					Authorization: `Basic ${ encodeCredentials(
+						admin.username,
+						admin.password
+					) }`,
+					'Content-Type': 'application/json',
+				},
+			};
 
-			resolve( stdout );
-		} );
+			const req = https.request( options, ( res ) => {
+				let data = '';
+
+				res.on( 'data', ( chunk ) => {
+					data += chunk;
+				} );
+
+				res.on( 'end', () => {
+					resolve( JSON.parse( data ).message );
+				} );
+			} );
+
+			req.on( 'error', ( error ) => {
+				reject( error );
+			} );
+
+			// Send the request body
+			req.write( JSON.stringify( { theme_name: themeName } ) );
+			req.end();
+		}
 	} );
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/themes.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/themes.js
@@ -26,7 +26,7 @@ export const activateTheme = ( themeName ) => {
 			const options = {
 				hostname: url.hostname,
 				port: url.port || 443,
-				path: '/wp-json/custom/v1/activate-theme',
+				path: '/wp-json/e2e-theme/activate',
 				method: 'POST',
 				headers: {
 					Authorization: `Basic ${ encodeCredentials(

--- a/plugins/woocommerce/tests/e2e-pw/utils/themes.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/themes.js
@@ -16,13 +16,27 @@ export const activateTheme = async ( baseURL, theme ) => {
 		},
 	} );
 
-	return await requestContext
-		.post( '/wp-json/e2e-theme/activate', {
-			data: {
-				theme_name: theme,
-			},
-		} )
-		.then( ( response ) => {
-			return response.json();
-		} );
+	try {
+		const response = await requestContext.post(
+			'/wp-json/e2e-theme/activate',
+			{
+				data: {
+					theme_name: theme,
+				},
+			}
+		);
+
+		const result = await response.json();
+
+		if ( ! response.ok() ) {
+			throw new Error( `Failed to activate theme: ${ result.message }` );
+		}
+
+		return result;
+	} catch ( error ) {
+		console.error( 'Error activating theme:', error );
+		throw error;
+	} finally {
+		await requestContext.dispose(); // Clean up
+	}
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/themes.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/themes.js
@@ -1,6 +1,6 @@
-const { exec } = require( 'node:child_process' );
 const { encodeCredentials } = require( '../utils/plugin-utils' );
 const https = require( 'https' );
+const http = require( 'http' );
 const { admin } = require( '../test-data/data' );
 const { BASE_URL } = process.env;
 
@@ -8,54 +8,41 @@ export const DEFAULT_THEME = 'twentytwentythree';
 
 export const activateTheme = ( themeName ) => {
 	return new Promise( ( resolve, reject ) => {
-		const isLocalhost = BASE_URL.includes( 'localhost' );
-		if ( isLocalhost ) {
-			// Command for local environment
-			const command = `wp-env run tests-cli wp theme install ${ themeName } --activate`;
+		const url = new URL( BASE_URL );
+		const isHttp = url.protocol === 'http:';
+		const requestModule = isHttp ? http : https;
 
-			exec( command, ( error, stdout ) => {
-				if ( error ) {
-					console.error( `Error executing command: ${ error }` );
-					return reject( error );
-				}
-				resolve( stdout );
-			} );
-		} else {
-			// HTTPS request for external environment
-			const url = new URL( BASE_URL );
-			const options = {
-				hostname: url.hostname,
-				port: url.port || 443,
-				path: '/wp-json/e2e-theme/activate',
-				method: 'POST',
-				headers: {
-					Authorization: `Basic ${ encodeCredentials(
-						admin.username,
-						admin.password
-					) }`,
-					'Content-Type': 'application/json',
-				},
-			};
+		const options = {
+			hostname: url.hostname,
+			port: url.port || ( isHttp ? 80 : 443 ),
+			path: '/wp-json/e2e-theme/activate',
+			method: 'POST',
+			headers: {
+				Authorization: `Basic ${ encodeCredentials(
+					admin.username,
+					admin.password
+				) }`,
+				'Content-Type': 'application/json',
+			},
+		};
 
-			const req = https.request( options, ( res ) => {
-				let data = '';
+		const req = requestModule.request( options, ( res ) => {
+			let data = '';
 
-				res.on( 'data', ( chunk ) => {
-					data += chunk;
-				} );
-
-				res.on( 'end', () => {
-					resolve( JSON.parse( data ).message );
-				} );
+			res.on( 'data', ( chunk ) => {
+				data += chunk;
 			} );
 
-			req.on( 'error', ( error ) => {
-				reject( error );
+			res.on( 'end', () => {
+				resolve( JSON.parse( data ).message );
 			} );
+		} );
 
-			// Send the request body
-			req.write( JSON.stringify( { theme_name: themeName } ) );
-			req.end();
-		}
+		req.on( 'error', ( error ) => {
+			reject( error );
+		} );
+
+		req.write( JSON.stringify( { theme_name: themeName } ) );
+		req.end();
 	} );
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/themes.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/themes.js
@@ -16,27 +16,17 @@ export const activateTheme = async ( baseURL, theme ) => {
 		},
 	} );
 
-	try {
-		const response = await requestContext.post(
-			'/wp-json/e2e-theme/activate',
-			{
-				data: {
-					theme_name: theme,
-				},
-			}
-		);
+	const response = await requestContext.post( '/wp-json/e2e-theme/activate', {
+		data: {
+			theme_name: theme,
+		},
+	} );
 
-		const result = await response.json();
+	const result = await response.json();
 
-		if ( ! response.ok() ) {
-			throw new Error( `Failed to activate theme: ${ result.message }` );
-		}
-
-		return result;
-	} catch ( error ) {
-		console.error( 'Error activating theme:', error );
-		throw error;
-	} finally {
-		await requestContext.dispose(); // Clean up
+	if ( ! response.ok() ) {
+		throw new Error( `Failed to activate theme: ${ result.message }` );
 	}
+
+	return result;
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/themes.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/themes.js
@@ -1,48 +1,28 @@
+const { request } = require( '@playwright/test' );
 const { encodeCredentials } = require( '../utils/plugin-utils' );
-const https = require( 'https' );
-const http = require( 'http' );
 const { admin } = require( '../test-data/data' );
-const { BASE_URL } = process.env;
 
 export const DEFAULT_THEME = 'twentytwentythree';
 
-export const activateTheme = ( themeName ) => {
-	return new Promise( ( resolve, reject ) => {
-		const url = new URL( BASE_URL );
-		const isHttp = url.protocol === 'http:';
-		const requestModule = isHttp ? http : https;
-
-		const options = {
-			hostname: url.hostname,
-			port: url.port || ( isHttp ? 80 : 443 ),
-			path: '/wp-json/e2e-theme/activate',
-			method: 'POST',
-			headers: {
-				Authorization: `Basic ${ encodeCredentials(
-					admin.username,
-					admin.password
-				) }`,
-				'Content-Type': 'application/json',
-			},
-		};
-
-		const req = requestModule.request( options, ( res ) => {
-			let data = '';
-
-			res.on( 'data', ( chunk ) => {
-				data += chunk;
-			} );
-
-			res.on( 'end', () => {
-				resolve( JSON.parse( data ).message );
-			} );
-		} );
-
-		req.on( 'error', ( error ) => {
-			reject( error );
-		} );
-
-		req.write( JSON.stringify( { theme_name: themeName } ) );
-		req.end();
+export const activateTheme = async ( baseURL, theme ) => {
+	const requestContext = await request.newContext( {
+		baseURL,
+		extraHTTPHeaders: {
+			Authorization: `Basic ${ encodeCredentials(
+				admin.username,
+				admin.password
+			) }`,
+			cookie: '',
+		},
 	} );
+
+	return await requestContext
+		.post( '/wp-json/e2e-theme/activate', {
+			data: {
+				theme_name: theme,
+			},
+		} )
+		.then( ( response ) => {
+			return response.json();
+		} );
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51327

There are a plenty of tests in `/assembler/` that use `activateTheme` from `themes.js` util, so they also should be fine, but when reviewing them I have seen `activateTheme` setting theme back to default theme in the `afterAll` without actually changing the theme in the tests. This might be worth investigating separately to see why and if we could remove that from the tests. One example is [here](https://github.com/woocommerce/woocommerce/blob/df37ccf8c596b42840af895ff9458418de353b8e/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js#L6).

~~Additionally, for this implementation to work on external sites, I created  a plugin called [Theme Activator API](https://d.pr/i/5zV6xw) and installed it on Pressable and WPCOM sites.~~

~~Here is the code added into plugin:~~

```
//withdrawn
```
Update: Added the code to `test-helper-apis.php` instead.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Optionally run those tests from the local against Pressable env:
```
pnpm test:e2e:with-env default-pressable tests/e2e-pw/tests/shopper/launch-your-store.spec.js
```
```
pnpm test:e2e:with-env default-pressable tests/e2e-pw/tests/customize-store/intro.spec.js
```
```
pnpm test:e2e:with-env default-pressable tests/e2e-pw/tests/customize-store/transitional.spec.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
