### PR TITLE
[Store API] Add validation hook during checkout to allow developers to register custom validations

### DIFF
--- a/plugins/woocommerce/changelog/51513-checkout-custom-validation-hook
+++ b/plugins/woocommerce/changelog/51513-checkout-custom-validation-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds a hook for custom checkout validation after the standard validations (email, coupons, etc) have passed. Allows developers to add their own checkout validation logic conditionally.

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -183,7 +183,7 @@ class OrderController {
 	 * Allows plugins to perform custom validation before payment.
 	 *
 	 * @param \WC_Order $order Order object.
-	 * @throws RouteException Exceptionif validation fails.
+	 * @throws RouteException Exception if validation fails.
 	 */
 	protected function perform_custom_order_validation( \WC_Order $order ) {
 		$validation_errors = new \WP_Error();

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -195,7 +195,7 @@ class OrderController {
 		 *
 		 * @param \WC_Order $order             The order object.
 		 * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
-		 * @since 9.3.4
+		 * @since 9.5.0
 		 */
 		do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -173,12 +173,25 @@ class OrderController {
 		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 		$this->validate_addresses( $order );
 
+    // Perform custom validations
+    $this->perform_custom_order_validation( $order );
+}
 
-    // Create a WP_Error object for custom validation
+/**
+ * Perform custom order validation via WooCommerce hooks.
+ *
+ * Allows plugins to perform custom validation before payment.
+ *
+ * @param \WC_Order $order Order object.
+ * @throws RouteException if validation fails.
+ */
+protected function perform_custom_order_validation( \WC_Order $order ) {
     $validation_errors = new \WP_Error();
 
     /**
      * Allow plugins to perform custom validation before payment.
+     *
+     * Plugins can add errors to the $validation_errors object.
      *
      * @param \WC_Order $order             The order object.
      * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
@@ -187,14 +200,13 @@ class OrderController {
 
     // Check if there are any errors after custom validation
     if ( $validation_errors->has_errors() ) {
-        $error_messages = $validation_errors->get_error_messages();
-        $error_message = implode( ' ', $error_messages );
         throw new RouteException(
             'woocommerce_rest_checkout_custom_validation_error',
-            $error_message,
+            implode( ' ', $validation_errors->get_error_messages() ),
             400
         );
     }
+}
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -195,7 +195,7 @@ class OrderController {
 		 *
 		 * @param \WC_Order $order             The order object.
 		 * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
-		 * @since 9.5.0
+		 * @since 9.9.0
 		 */
 		do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -172,6 +172,29 @@ class OrderController {
 		$this->validate_email( $order );
 		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 		$this->validate_addresses( $order );
+
+
+    // Create a WP_Error object for custom validation
+    $validation_errors = new \WP_Error();
+
+    /**
+     * Allow plugins to perform custom validation before payment.
+     *
+     * @param \WC_Order $order             The order object.
+     * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
+     */
+    do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
+
+    // Check if there are any errors after custom validation
+    if ( $validation_errors->has_errors() ) {
+        $error_messages = $validation_errors->get_error_messages();
+        $error_message = implode( ' ', $error_messages );
+        throw new RouteException(
+            'woocommerce_rest_checkout_custom_validation_error',
+            $error_message,
+            400
+        );
+    }
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -203,7 +203,7 @@ class OrderController {
 		if ( $validation_errors->has_errors() ) {
 			throw new RouteException(
 				'woocommerce_rest_checkout_custom_validation_error',
-				implode( ' ', $validation_errors->get_error_messages() ),
+				esc_html( implode( ' ', $validation_errors->get_error_messages() ) ),
 				400
 			);
 		}

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -173,7 +173,7 @@ class OrderController {
 		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 		$this->validate_addresses( $order );
 
-		// Perform custom validations
+		// Perform custom validations.
 		$this->perform_custom_order_validation( $order );
 	}
 
@@ -183,7 +183,7 @@ class OrderController {
 	 * Allows plugins to perform custom validation before payment.
 	 *
 	 * @param \WC_Order $order Order object.
-	 * @throws RouteException if validation fails.
+	 * @throws RouteException Exceptionif validation fails.
 	 */
 	protected function perform_custom_order_validation( \WC_Order $order ) {
 		$validation_errors = new \WP_Error();
@@ -195,10 +195,11 @@ class OrderController {
 		 *
 		 * @param \WC_Order $order             The order object.
 		 * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
+		 * @since 9.3.4
 		 */
 		do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
 
-		// Check if there are any errors after custom validation
+		// Check if there are any errors after custom validation.
 		if ( $validation_errors->has_errors() ) {
 			throw new RouteException(
 				'woocommerce_rest_checkout_custom_validation_error',

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -173,40 +173,39 @@ class OrderController {
 		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 		$this->validate_addresses( $order );
 
-    // Perform custom validations
-    $this->perform_custom_order_validation( $order );
-}
+		// Perform custom validations
+		$this->perform_custom_order_validation( $order );
+	}
 
-/**
- * Perform custom order validation via WooCommerce hooks.
- *
- * Allows plugins to perform custom validation before payment.
- *
- * @param \WC_Order $order Order object.
- * @throws RouteException if validation fails.
- */
-protected function perform_custom_order_validation( \WC_Order $order ) {
-    $validation_errors = new \WP_Error();
+	/**
+	 * Perform custom order validation via WooCommerce hooks.
+	 *
+	 * Allows plugins to perform custom validation before payment.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @throws RouteException if validation fails.
+	 */
+	protected function perform_custom_order_validation( \WC_Order $order ) {
+		$validation_errors = new \WP_Error();
 
-    /**
-     * Allow plugins to perform custom validation before payment.
-     *
-     * Plugins can add errors to the $validation_errors object.
-     *
-     * @param \WC_Order $order             The order object.
-     * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
-     */
-    do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
+		/**
+		 * Allow plugins to perform custom validation before payment.
+		 *
+		 * Plugins can add errors to the $validation_errors object.
+		 *
+		 * @param \WC_Order $order             The order object.
+		 * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
+		 */
+		do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
 
-    // Check if there are any errors after custom validation
-    if ( $validation_errors->has_errors() ) {
-        throw new RouteException(
-            'woocommerce_rest_checkout_custom_validation_error',
-            implode( ' ', $validation_errors->get_error_messages() ),
-            400
-        );
-    }
-}
+		// Check if there are any errors after custom validation
+		if ( $validation_errors->has_errors() ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_custom_validation_error',
+				implode( ' ', $validation_errors->get_error_messages() ),
+				400
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2809,7 +2809,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			$this->expectException(RouteException::class);
 			$this->expectExceptionMessage('This is a custom validation error');
 
-			$method->invoke($order_controller, $order);
+			$method->invoke( $order_controller, $order );
 
 			// Clean up the test action
 			remove_all_actions( 'woocommerce_checkout_validate_order_before_payment' );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2807,7 +2807,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 
 			// Use reflection to make the protected method accessible.
 			$reflection = new ReflectionClass( $order_controller );
-			$method = $reflection->getMethod( 'perform_custom_order_validation' );
+			$method =     $reflection->getMethod( 'perform_custom_order_validation' );
 			$method->setAccessible( true );
 
 			// Assert that the method throws a RouteException with our custom error.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2796,9 +2796,14 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			$order =            new WC_Order();
 
 			// Set up a test action to add a custom validation error.
-			add_action('woocommerce_checkout_validate_order_before_payment', function($order, $errors) {
-					$errors->add('custom_error', 'This is a custom validation error');
-			}, 10, 2);
+			add_action(
+			    'woocommerce_checkout_validate_order_before_payment', 
+			    function ( $order, $errors ) {
+					$errors->add( 'custom_error', 'This is a custom validation error' );
+			    },
+			    10,
+			    2
+			);
 
 			// Use reflection to make the protected method accessible.
 			$reflection = new ReflectionClass( $order_controller );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2795,7 +2795,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			$order_controller = new OrderController();
 			$order = new WC_Order();
 
-			// Set up a test action to add a custom validation error
+			// Set up a test action to add a custom validation error.
 			add_action('woocommerce_checkout_validate_order_before_payment', function($order, $errors) {
 					$errors->add('custom_error', 'This is a custom validation error');
 			}, 10, 2);

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2801,9 +2801,9 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			}, 10, 2);
 
 			// Use reflection to make the protected method accessible
-			$reflection = new ReflectionClass($order_controller);
-			$method = $reflection->getMethod('perform_custom_order_validation');
-			$method->setAccessible(true);
+			$reflection = new ReflectionClass( $order_controller );
+			$method = $reflection->getMethod( 'perform_custom_order_validation' );
+			$method->setAccessible( true );
 
 			// Assert that the method throws a RouteException with our custom error
 			$this->expectException(RouteException::class);

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2793,21 +2793,21 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	 */
 	public function test_perform_custom_order_validation() {
 			$order_controller = new \Automattic\WooCommerce\StoreApi\Utilities\OrderController();
-			$order =            new WC_Order();
+			$order            = new WC_Order();
 
 			// Set up a test action to add a custom validation error.
 			add_action(
-			    'woocommerce_checkout_validate_order_before_payment', 
-			    function ( $order, $errors ) {
+				'woocommerce_checkout_validate_order_before_payment',
+				function ( $order, $errors ) {
 					$errors->add( 'custom_error', 'This is a custom validation error' );
-			    },
-			    10,
-			    2
+				},
+				10,
+				2
 			);
 
 			// Use reflection to make the protected method accessible.
 			$reflection = new \ReflectionClass( $order_controller );
-			$method =     $reflection->getMethod( 'perform_custom_order_validation' );
+			$method     = $reflection->getMethod( 'perform_custom_order_validation' );
 			$method->setAccessible( true );
 
 			// Assert that the method throws a RouteException with our custom error.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2806,8 +2806,8 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			$method->setAccessible( true );
 
 			// Assert that the method throws a RouteException with our custom error
-			$this->expectException(RouteException::class);
-			$this->expectExceptionMessage('This is a custom validation error');
+			$this->expectException( RouteException::class );
+			$this->expectExceptionMessage( 'This is a custom validation error' );
 
 			$method->invoke( $order_controller, $order );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2787,6 +2787,34 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
 	}
 
+
+	/**
+	 * @testDox Test that perform_custom_order_validation throws a RouteException with a custom error.
+	 */
+	public function test_perform_custom_order_validation() {
+			$order_controller = new OrderController();
+			$order = new WC_Order();
+
+			// Set up a test action to add a custom validation error
+			add_action('woocommerce_checkout_validate_order_before_payment', function($order, $errors) {
+					$errors->add('custom_error', 'This is a custom validation error');
+			}, 10, 2);
+
+			// Use reflection to make the protected method accessible
+			$reflection = new ReflectionClass($order_controller);
+			$method = $reflection->getMethod('perform_custom_order_validation');
+			$method->setAccessible(true);
+
+			// Assert that the method throws a RouteException with our custom error
+			$this->expectException(RouteException::class);
+			$this->expectExceptionMessage('This is a custom validation error');
+
+			$method->invoke($order_controller, $order);
+
+			// Clean up the test action
+			remove_all_actions('woocommerce_checkout_validate_order_before_payment');
+	}
+
 	/**
 	 * @testDox Checks that order new/updated hooks are fired at appropriate times in HPOS (vs CPT).
 	 * @testWith [true]

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2812,7 +2812,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			$method->invoke($order_controller, $order);
 
 			// Clean up the test action
-			remove_all_actions('woocommerce_checkout_validate_order_before_payment');
+			remove_all_actions( 'woocommerce_checkout_validate_order_before_payment' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2792,7 +2792,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	 * @testDox Test that perform_custom_order_validation throws a RouteException with a custom error.
 	 */
 	public function test_perform_custom_order_validation() {
-			$order_controller = new OrderController();
+			$order_controller = new \Automattic\WooCommerce\StoreApi\Utilities\OrderController();
 			$order = new WC_Order();
 
 			// Set up a test action to add a custom validation error.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2811,7 +2811,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 
 			$method->invoke( $order_controller, $order );
 
-			// Clean up the test action
+			// Clean up the test action.
 			remove_all_actions( 'woocommerce_checkout_validate_order_before_payment' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2806,7 +2806,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			);
 
 			// Use reflection to make the protected method accessible.
-			$reflection = new ReflectionClass( $order_controller );
+			$reflection = new \ReflectionClass( $order_controller );
 			$method =     $reflection->getMethod( 'perform_custom_order_validation' );
 			$method->setAccessible( true );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2800,7 +2800,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 					$errors->add('custom_error', 'This is a custom validation error');
 			}, 10, 2);
 
-			// Use reflection to make the protected method accessible
+			// Use reflection to make the protected method accessible.
 			$reflection = new ReflectionClass( $order_controller );
 			$method = $reflection->getMethod( 'perform_custom_order_validation' );
 			$method->setAccessible( true );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2787,39 +2787,6 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
 	}
 
-
-	/**
-	 * @testDox Test that perform_custom_order_validation throws a RouteException with a custom error.
-	 */
-	public function test_perform_custom_order_validation() {
-			$order_controller = new \Automattic\WooCommerce\StoreApi\Utilities\OrderController();
-			$order            = new WC_Order();
-
-			// Set up a test action to add a custom validation error.
-			add_action(
-				'woocommerce_checkout_validate_order_before_payment',
-				function ( $order, $errors ) {
-					$errors->add( 'custom_error', 'This is a custom validation error' );
-				},
-				10,
-				2
-			);
-
-			// Use reflection to make the protected method accessible.
-			$reflection = new \ReflectionClass( $order_controller );
-			$method     = $reflection->getMethod( 'perform_custom_order_validation' );
-			$method->setAccessible( true );
-
-			// Assert that the method throws a RouteException with our custom error.
-			$this->expectException( RouteException::class );
-			$this->expectExceptionMessage( 'This is a custom validation error' );
-
-			$method->invoke( $order_controller, $order );
-
-			// Clean up the test action.
-			remove_all_actions( 'woocommerce_checkout_validate_order_before_payment' );
-	}
-
 	/**
 	 * @testDox Checks that order new/updated hooks are fired at appropriate times in HPOS (vs CPT).
 	 * @testWith [true]

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2793,7 +2793,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 	 */
 	public function test_perform_custom_order_validation() {
 			$order_controller = new \Automattic\WooCommerce\StoreApi\Utilities\OrderController();
-			$order = new WC_Order();
+			$order =            new WC_Order();
 
 			// Set up a test action to add a custom validation error.
 			add_action('woocommerce_checkout_validate_order_before_payment', function($order, $errors) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2805,7 +2805,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 			$method = $reflection->getMethod( 'perform_custom_order_validation' );
 			$method->setAccessible( true );
 
-			// Assert that the method throws a RouteException with our custom error
+			// Assert that the method throws a RouteException with our custom error.
 			$this->expectException( RouteException::class );
 			$this->expectExceptionMessage( 'This is a custom validation error' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This introduces a new hook that is emitted during checkout, after the normal validations on email, coupons, etc.

This allows plugin developers to register their own validation logic into the checkout process.

At this time, the classic shortcode checkout supports the `woocommerce_after_checkout_validation` but there's no such equivalent in the new blocks checkout supported by the Store API.


[Conversation from the WooCommerce Community Slack Channel.](https://woocommercecommunity.slack.com/archives/C1KAZ91E3/p1726675955274889)
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. As a store owner, change the checkout to the blocks checkout
2. As a plugin developer, subscribe to the `woocommerce_checkout_validate_order_before_payment` hook and add an error:

```php

add_action("woocommerce_checkout_validate_order_before_payment", "my_validation", 2, 10);

function my_validation($order, $error) {
  // register an error as a test:
  $error->add(1, "Validation failed (test)");
}

```
3. As a customer, attempt to checkout an item, observe validation error

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds a hook for custom checkout validation after the standard validations (email, coupons, etc) have passed. Allows developers to add their own checkout validation logic conditionally.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
