### PR TITLE
Fix reference to `WC_Site_Tracking`

### DIFF
--- a/plugins/woocommerce/changelog/fix-unqualified-wc_site_tracking
+++ b/plugins/woocommerce/changelog/fix-unqualified-wc_site_tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatals resulting from incorrect reference to `WC_Site_Tracking` during admin notes API requests.

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Admin\Notes;
 
+use WC_Site_Tracking;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }


### PR DESCRIPTION
Within namespaced class `Automattic\WooCommerce\Admin\Notes\Notes` we try to call a method of `WC_Site_Tracking`. However, that latter class is not imported and the reference is not fully qualified, so it can lead to a fatal error.

Closes #51524.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

We can try and simulate the actual problem if we are careful. However, I'd warn this is a little finnicky and *possibly* best left to developers. Set-up:

1. Login as an admin, navigate to **WooCommerce ‣ Settings ‣ Advanced ‣ WooCommerce.com** and ensure you have **enabled tracking**.
2. You will need one or more inbox notes. Visit **WooCommerce ‣ Home** and look at the **Inbox** widget. Confirm this has at least a few messages (even on a brand new test install it ought to be quickly populated with some entries, but if it does not ... reach out and let's figure out a solution to this).
3. Finally, to make it easier to test this, add the following code to a mu-plugin, such as `wp-content/mu-plugins/test-bug-51524.php`:

```php
<?php

add_filter( 'woocommerce_rest_check_permissions', fn () => true );
```

With that done, we should be ready to test:

1. In your browser, visit `/wp-json/wc-analytics/admin/notes` (you should still be logged in/authenticated as an admin user for these steps) and you should get back a JSON array of note objects.
2. Pick the first object, or the first suitable object, and note down the note ID (the actual ID field is simply called `id`) and also note down the `id` property of one of the objects within its `actions` array.

![note-id-action-id](https://github.com/user-attachments/assets/d48c5fb6-4edc-43d2-bf7e-8f07da1dd2b0)

3. Form a new request looking like `/wp-json/wc-analytics/admin/notes/<NOTE_ID>/action/<ACTION_ID>?_method=PUT` (replacing those placeholders with the actual ID you captured).
4. Without this change, a fatal error as detailed in the linked issue should take place. With this change, there should be no fatal error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
