### PR TITLE
Exclude skipped e2e tests from auto-closure

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,51 +1,52 @@
 name: 'Process stale needs-feedback issues'
 on:
-  schedule:
-    - cron: '21 0 * * *'
-  workflow_dispatch:
+    schedule:
+        - cron: '21 0 * * *'
+    workflow_dispatch:
 
-permissions: { }
+permissions: {}
 
 jobs:
-  stale:
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Scan issues
-        uses: actions/stale@v9.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
-          close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
-          operations-per-run: 140
-          days-before-stale: -1
-          days-before-close: -1
-          days-before-issue-stale: 7
-          days-before-issue-close: 7
-          stale-issue-label: 'status: stale'
-          stale-pr-label: 'status: stale'
-          exempt-issue-labels: 'type: enhancement'
-          only-issue-labels: 'needs: author feedback'
-          close-issue-label: "status: can't reproduce"
-          ascending: true
-      - name: Process Stale Flaky Test Issues
-        uses: actions/stale@v9.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-issue-labels: 'metric: flaky e2e test'
-          days-before-stale: -1
-          days-before-close: -1
-          days-before-issue-stale: 5
-          days-before-issue-close: 2
-          stale-issue-label: 'status: stale'
-          stale-issue-message: 'This issue is being marked as stale due to inactivity. It will be auto-closed if no further activity occurs within the next 2 days.'
-          close-issue-message: 'Auto-closed due to inactivity. Please re-open if you believe this issue is still valid.'
-          close-issue-reason: 'not_planned'
-          remove-stale-when-updated: true
-          exempt-all-assignees: false
-          enable-statistics: true
-          ascending: true
-          operations-per-run: 120
+    stale:
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: write
+        steps:
+            - name: Scan issues
+              uses: actions/stale@v9.0.0
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
+                  close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
+                  operations-per-run: 140
+                  days-before-stale: -1
+                  days-before-close: -1
+                  days-before-issue-stale: 7
+                  days-before-issue-close: 7
+                  stale-issue-label: 'status: stale'
+                  stale-pr-label: 'status: stale'
+                  exempt-issue-labels: 'type: enhancement'
+                  only-issue-labels: 'needs: author feedback'
+                  close-issue-label: "status: can't reproduce"
+                  ascending: true
+            - name: Process Stale Flaky Test Issues
+              uses: actions/stale@v9.0.0
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  only-issue-labels: 'metric: flaky e2e test'
+                  exempt-issue-labels: 'metric: skipped test'
+                  days-before-stale: -1
+                  days-before-close: -1
+                  days-before-issue-stale: 5
+                  days-before-issue-close: 2
+                  stale-issue-label: 'status: stale'
+                  stale-issue-message: 'This issue is being marked as stale due to inactivity. It will be auto-closed if no further activity occurs within the next 2 days.'
+                  close-issue-message: 'Auto-closed due to inactivity. Please re-open if you believe this issue is still valid.'
+                  close-issue-reason: 'not_planned'
+                  remove-stale-when-updated: true
+                  exempt-all-assignees: false
+                  enable-statistics: true
+                  ascending: true
+                  operations-per-run: 120

--- a/plugins/woocommerce/changelog/e2e-fix-stalebot-ignore-skipped-test-issues
+++ b/plugins/woocommerce/changelog/e2e-fix-stalebot-ignore-skipped-test-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Exclude skipped e2e test issues from stale bot closure


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A stale bot runs in the monorepo closing flaky e2e test issues if there is no activity on them in 2 days.  Occasionally, we'll need to skip an e2e test because it has become flaky, but we don't have the capacity to address it immediately.  This change will ignore any issues with the label `metric: skipped test` applied to it.  We can apply that label manually to keep tests from being automatically closed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Verify config update.  Needs to be tested in production.

<!-- End testing instructions -->
