### PR TITLE
Legacy reports: Decouple the dependency between the legacy reports and the WooCommerce Status widget on the dashboard page

### DIFF
--- a/plugins/woocommerce/changelog/tweak-decouple-legacy-reports-and-dashboard-status-widget
+++ b/plugins/woocommerce/changelog/tweak-decouple-legacy-reports-and-dashboard-status-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Decouple the dependency between the WooCommerce legacy reports and the WooCommerce Status widget on the dashboard page.

--- a/plugins/woocommerce/client/legacy/js/admin/reports.js
+++ b/plugins/woocommerce/client/legacy/js/admin/reports.js
@@ -50,60 +50,6 @@ jQuery(function( $ ) {
 		}
 	});
 
-	$( '.wc_sparkline.bars' ).each( function() {
-		var chart_data = $( this ).data( 'sparkline' );
-
-		var options = {
-			grid: {
-				show: false
-			}
-		};
-
-		// main series
-		var series = [{
-			data: chart_data,
-			color: $( this ).data( 'color' ),
-			bars: {
-				fillColor: $( this ).data( 'color' ),
-				fill: true,
-				show: true,
-				lineWidth: 1,
-				barWidth: $( this ).data( 'barwidth' ),
-				align: 'center'
-			},
-			shadowSize: 0
-		}];
-
-		// draw the sparkline
-		$.plot( $( this ), series, options );
-	});
-
-	$( '.wc_sparkline.lines' ).each( function() {
-		var chart_data = $( this ).data( 'sparkline' );
-
-		var options = {
-			grid: {
-				show: false
-			}
-		};
-
-		// main series
-		var series = [{
-			data: chart_data,
-			color: $( this ).data( 'color' ),
-			lines: {
-				fill: false,
-				show: true,
-				lineWidth: 1,
-				align: 'center'
-			},
-			shadowSize: 0
-		}];
-
-		// draw the sparkline
-		$.plot( $( this ), series, options );
-	});
-
 	var dates = $( '.range_datepicker' ).datepicker({
 		changeMonth: true,
 		changeYear: true,

--- a/plugins/woocommerce/client/legacy/js/admin/wc-status-widget.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-status-widget.js
@@ -33,4 +33,62 @@
 	$( '.out-of-stock a' ).on( 'click', function() {
 		recordEvent( 'out-of-stock' );
 	});
+
+	$( '.wc_sparkline.bars' ).each( function () {
+		const chartData = $( this ).data( 'sparkline' );
+
+		const options = {
+			grid: {
+				show: false,
+			},
+		};
+
+		// main series
+		const series = [
+			{
+				data: chartData,
+				color: $( this ).data( 'color' ),
+				bars: {
+					fillColor: $( this ).data( 'color' ),
+					fill: true,
+					show: true,
+					lineWidth: 1,
+					barWidth: $( this ).data( 'barwidth' ),
+					align: 'center',
+				},
+				shadowSize: 0,
+			},
+		];
+
+		// draw the sparkline
+		$.plot( $( this ), series, options );
+	} );
+
+	$( '.wc_sparkline.lines' ).each( function () {
+		const chartData = $( this ).data( 'sparkline' );
+
+		const options = {
+			grid: {
+				show: false,
+			},
+		};
+
+		// main series
+		const series = [
+			{
+				data: chartData,
+				color: $( this ).data( 'color' ),
+				lines: {
+					fill: false,
+					show: true,
+					lineWidth: 1,
+					align: 'center',
+				},
+				shadowSize: 0,
+			},
+		];
+
+		// draw the sparkline
+		$.plot( $( this ), series, options );
+	} );
 })( jQuery );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -472,7 +472,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			// Reports Pages.
 			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
+			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports' ) ) ) ) {
 				wp_register_script( 'wc-reports', WC()->plugin_url() . '/assets/js/admin/reports' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker' ), $version );
 
 				wp_enqueue_script( 'wc-reports' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$suffix  = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
 			$version = Constants::get_constant( 'WC_VERSION' );
 
-			wp_enqueue_script( 'wc-status-widget', WC()->plugin_url() . '/assets/js/admin/wc-status-widget' . $suffix . '.js', array( 'jquery' ), $version, true );
+			wp_enqueue_script( 'wc-status-widget', WC()->plugin_url() . '/assets/js/admin/wc-status-widget' . $suffix . '.js', array( 'jquery', 'flot' ), $version, true );
 
 			include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -548,11 +548,11 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		 * Prepares the data for a sparkline to show sales in the last X days.
 		 *
 		 * @param  int    $id ID of the product to show. Blank to get all orders.
-		 * @param  int    $days Days of stats to get.
+		 * @param  int    $days Days of stats to get. Default to 7 days.
 		 * @param  string $type Type of sparkline to get. Ignored if ID is not set.
 		 * @return array
 		 */
-		private function get_sales_sparkline( $id = '', $days, $type = 'sales' ) {
+		private function get_sales_sparkline( $id = '', $days = 7, $type = 'sales' ) {
 			$sales_endpoint = '/wc-analytics/reports/revenue/stats';
 			$start_date     = gmdate( 'Y-m-d 00:00:00', current_time( 'timestamp' ) - ( ( $days - 1 ) * DAY_IN_SECONDS ) );
 			$end_date       = gmdate( 'Y-m-d 23:59:59', current_time( 'timestamp' ) );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -146,7 +146,6 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				'outofstock_link'     => 'admin.php?page=wc-admin&type=outofstock&path=%2Fanalytics%2Fstock',
 				'report_data'         => null,
 				'get_sales_sparkline' => array( $this, 'get_sales_sparkline' ),
-				'legacy_report'       => null,
 			);
 
 			if ( $is_wc_admin_disabled ) {
@@ -229,7 +228,15 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				$this->status_widget_stock_rows( $status_widget_reports['lowstock_link'], $status_widget_reports['outofstock_link'] );
 			}
 
-			$reports = $status_widget_reports['legacy_report'];
+			/**
+			 * Filter to change the first argument passed to the `woocommerce_after_dashboard_status_widget` action.
+			 *
+			 * Please note that this filter is mainly for backward compatibility with the legacy reports.
+			 * It's not recommended to use this filter as it will soon be deprecated along with the retiring of the legacy reports.
+			 *
+			 * @since 9.5.0
+			 */
+			$reports = apply_filters( 'woocommerce_after_dashboard_status_widget_parameter', null );
 			do_action( 'woocommerce_after_dashboard_status_widget', $reports );
 			echo '</ul>';
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -363,7 +363,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			}
 			?>
 			<li class="low-in-stock">
-			<a href="<?php echo esc_url( $lowstock_url ); ?>">
+				<a href="<?php echo esc_url( $lowstock_url ); ?>">
 				<?php
 					printf(
 						/* translators: %s: order count */

--- a/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
@@ -27,7 +27,18 @@ class WC_Admin_Reports {
 	 * Register the proper hook handlers.
 	 */
 	public static function register_hook_handlers() {
+		add_filter( 'woocommerce_after_dashboard_status_widget_parameter', array( __CLASS__, 'get_report_instance' ) );
 		add_filter( 'woocommerce_dashboard_status_widget_reports', array( __CLASS__, 'replace_dashboard_status_widget_reports' ) );
+	}
+
+	/**
+	 * Get an instance of WC_Admin_Report.
+	 *
+	 * @return WC_Admin_Report
+	 */
+	public static function get_report_instance() {
+		include_once __DIR__ . '/reports/class-wc-admin-report.php';
+		return new WC_Admin_Report();
 	}
 
 	/**
@@ -36,10 +47,10 @@ class WC_Admin_Reports {
 	 * @param array $status_widget_reports The data to display in the status widget.
 	 */
 	public static function replace_dashboard_status_widget_reports( $status_widget_reports ) {
-		include_once __DIR__ . '/reports/class-wc-admin-report.php';
+		$report = self::get_report_instance();
+
 		include_once __DIR__ . '/reports/class-wc-report-sales-by-date.php';
 
-		$report                        = new WC_Admin_Report();
 		$sales_by_date                 = new WC_Report_Sales_By_Date();
 		$sales_by_date->start_date     = strtotime( gmdate( 'Y-m-01', current_time( 'timestamp' ) ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 		$sales_by_date->end_date       = strtotime( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
@@ -52,7 +63,6 @@ class WC_Admin_Reports {
 		$status_widget_reports['outofstock_link']     = 'admin.php?page=wc-reports&tab=stock&report=out_of_stock';
 		$status_widget_reports['report_data']         = $sales_by_date->get_report_data();
 		$status_widget_reports['get_sales_sparkline'] = array( $report, 'get_sales_sparkline' );
-		$status_widget_reports['legacy_report']       = $report;
 
 		return $status_widget_reports;
 	}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
@@ -26,7 +26,36 @@ class WC_Admin_Reports {
 	/**
 	 * Register the proper hook handlers.
 	 */
-	public static function register_hook_handlers() {}
+	public static function register_hook_handlers() {
+		add_filter( 'woocommerce_dashboard_status_widget_reports', array( __CLASS__, 'replace_dashboard_status_widget_reports' ) );
+	}
+
+	/**
+	 * Filter handler for replacing the data of the status widget on the Dashboard page.
+	 *
+	 * @param array $status_widget_reports The data to display in the status widget.
+	 */
+	public static function replace_dashboard_status_widget_reports( $status_widget_reports ) {
+		include_once __DIR__ . '/reports/class-wc-admin-report.php';
+		include_once __DIR__ . '/reports/class-wc-report-sales-by-date.php';
+
+		$report                        = new WC_Admin_Report();
+		$sales_by_date                 = new WC_Report_Sales_By_Date();
+		$sales_by_date->start_date     = strtotime( gmdate( 'Y-m-01', current_time( 'timestamp' ) ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+		$sales_by_date->end_date       = strtotime( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
+		$sales_by_date->chart_groupby  = 'day';
+		$sales_by_date->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
+
+		$status_widget_reports['net_sales_link']      = 'admin.php?page=wc-reports&tab=orders&range=month';
+		$status_widget_reports['top_seller_link']     = 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=';
+		$status_widget_reports['lowstock_link']       = 'admin.php?page=wc-reports&tab=stock&report=low_in_stock';
+		$status_widget_reports['outofstock_link']     = 'admin.php?page=wc-reports&tab=stock&report=out_of_stock';
+		$status_widget_reports['report_data']         = $sales_by_date->get_report_data();
+		$status_widget_reports['get_sales_sparkline'] = array( $report, 'sales_sparkline' );
+		$status_widget_reports['legacy_report']       = $report;
+
+		return $status_widget_reports;
+	}
 
 	/**
 	 * Handles output of the reports page in admin.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
@@ -51,7 +51,7 @@ class WC_Admin_Reports {
 		$status_widget_reports['lowstock_link']       = 'admin.php?page=wc-reports&tab=stock&report=low_in_stock';
 		$status_widget_reports['outofstock_link']     = 'admin.php?page=wc-reports&tab=stock&report=out_of_stock';
 		$status_widget_reports['report_data']         = $sales_by_date->get_report_data();
-		$status_widget_reports['get_sales_sparkline'] = array( $report, 'sales_sparkline' );
+		$status_widget_reports['get_sales_sparkline'] = array( $report, 'get_sales_sparkline' );
 		$status_widget_reports['legacy_report']       = $report;
 
 		return $status_widget_reports;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
@@ -24,6 +24,11 @@ if ( class_exists( 'WC_Admin_Reports', false ) ) {
 class WC_Admin_Reports {
 
 	/**
+	 * Register the proper hook handlers.
+	 */
+	public static function register_hook_handlers() {}
+
+	/**
 	 * Handles output of the reports page in admin.
 	 */
 	public static function output() {

--- a/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
@@ -524,14 +524,14 @@ class WC_Admin_Report {
 	}
 
 	/**
-	 * Prepares a sparkline to show sales in the last X days.
+	 * Prepares the data for a sparkline to show sales in the last X days.
 	 *
 	 * @param  int    $id ID of the product to show. Blank to get all orders.
-	 * @param  int    $days Days of stats to get.
+	 * @param  int    $days Days of stats to get. Default to 7 days.
 	 * @param  string $type Type of sparkline to get. Ignored if ID is not set.
-	 * @return string
+	 * @return array
 	 */
-	public function sales_sparkline( $id = '', $days = 7, $type = 'sales' ) {
+	public function get_sales_sparkline( $id = '', $days = 7, $type = 'sales' ) {
 
 		// phpcs:disable WordPress.DateTime.RestrictedFunctions.date_date, WordPress.DateTime.CurrentTimeTimestamp.Requested
 
@@ -611,6 +611,28 @@ class WC_Admin_Report {
 			$total += $d->sparkline_value;
 		}
 
+		$sparkline_data = array_values( $this->prepare_chart_data( $data, 'post_date', 'sparkline_value', $days - 1, strtotime( 'midnight -' . ( $days - 1 ) . ' days', current_time( 'timestamp' ) ), 'day' ) );
+
+		// phpcs:enable WordPress.DateTime.RestrictedFunctions.date_date, WordPress.DateTime.CurrentTimeTimestamp.Requested
+
+		return array(
+			'total' => $total,
+			'data'  => $sparkline_data,
+		);
+	}
+
+	/**
+	 * Prepares the markup for a sparkline to show sales in the last X days.
+	 *
+	 * @param  int    $id ID of the product to show. Blank to get all orders.
+	 * @param  int    $days Days of stats to get. Default to 7 days.
+	 * @param  string $type Type of sparkline to get. Ignored if ID is not set.
+	 * @return string
+	 */
+	public function sales_sparkline( $id = '', $days = 7, $type = 'sales' ) {
+		$sparkline = $this->get_sales_sparkline( $id, $days, $type );
+		$total     = $sparkline['total'];
+
 		if ( 'sales' === $type ) {
 			/* translators: 1: total income 2: days */
 			$tooltip = sprintf( __( 'Sold %1$s worth in the last %2$d days', 'woocommerce' ), wp_strip_all_tags( wc_price( $total ) ), $days );
@@ -619,11 +641,9 @@ class WC_Admin_Report {
 			$tooltip = sprintf( _n( 'Sold %1$d item in the last %2$d days', 'Sold %1$d items in the last %2$d days', $total, 'woocommerce' ), $total, $days );
 		}
 
-		$sparkline_data = array_values( $this->prepare_chart_data( $data, 'post_date', 'sparkline_value', $days - 1, strtotime( 'midnight -' . ( $days - 1 ) . ' days', current_time( 'timestamp' ) ), 'day' ) );
+		$sparkline_data = $sparkline['data'];
 
 		return '<span class="wc_sparkline ' . ( ( 'sales' === $type ) ? 'lines' : 'bars' ) . ' tips" data-color="#777" data-tip="' . esc_attr( $tooltip ) . '" data-barwidth="' . 60 * 60 * 16 * 1000 . '" data-sparkline="' . wc_esc_json( wp_json_encode( $sparkline_data ) ) . '"></span>';
-
-		// phpcs:enable WordPress.DateTime.RestrictedFunctions.date_date, WordPress.DateTime.CurrentTimeTimestamp.Requested
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
@@ -626,7 +626,7 @@ class WC_Admin_Report {
 	 *
 	 * @param  int    $id ID of the product to show. Blank to get all orders.
 	 * @param  int    $days Days of stats to get. Default to 7 days.
-	 * @param  string $type Type of sparkline to get. Ignored if ID is not set.
+	 * @param  string $type Type of sparkline to get.
 	 * @return string
 	 */
 	public function sales_sparkline( $id = '', $days = 7, $type = 'sales' ) {

--- a/plugins/woocommerce/includes/admin/woocommerce-legacy-reports.php
+++ b/plugins/woocommerce/includes/admin/woocommerce-legacy-reports.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types = 1 );
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+// This will be the main plugin file after moving the legacy reports to a separate plugin.
+
+if ( ! function_exists( 'woocommerce_legacy_reports_init' ) ) {
+	/**
+	 * Initialize the WooCommerce legacy reports.
+	 */
+	function woocommerce_legacy_reports_init() {
+		require_once __DIR__ . '/class-wc-admin-reports.php';
+
+		WC_Admin_Reports::register_hook_handlers();
+	}
+
+	add_action( 'woocommerce_init', 'woocommerce_legacy_reports_init' );
+}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -723,6 +723,9 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
+			// Simulate loading plugin for the legacy reports.
+			// This will be removed after moving the legacy reports to a separate plugin.
+			include_once WC_ABSPATH . 'includes/admin/woocommerce-legacy-reports.php';
 		}
 
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/class-wc-tests-admin-dashboard.php
@@ -23,6 +23,7 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 
 		// Mock http request to performance endpoint.
 		add_filter( 'rest_pre_dispatch', array( $this, 'mock_rest_responses' ), 10, 3 );
+		add_filter( 'woocommerce_dashboard_status_widget_reports', array( $this, 'mock_replace_dashboard_status_widget_reports' ) );
 	}
 
 	/**
@@ -31,6 +32,7 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 	public function tearDown(): void {
 		parent::tearDown();
 		remove_filter( 'rest_pre_dispatch', array( $this, 'mock_rest_responses' ), 10 );
+		remove_filter( 'woocommerce_dashboard_status_widget_reports', array( $this, 'mock_replace_dashboard_status_widget_reports' ) );
 	}
 
 	/**
@@ -118,5 +120,29 @@ class WC_Tests_Admin_Dashboard extends WC_Unit_Test_Case {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Helper method to replace the data to to display in the status widget.
+	 *
+	 * @param array $status_widget_reports The data to display in the status widget.
+	 */
+	public function mock_replace_dashboard_status_widget_reports( $status_widget_reports ) {
+		$report_data            = new stdClass();
+		$report_data->net_sales = 123;
+
+		$status_widget_reports['net_sales_link']      = 'admin.php?page=wc-reports&tab=orders&range=month';
+		$status_widget_reports['top_seller_link']     = 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=';
+		$status_widget_reports['lowstock_link']       = 'admin.php?page=wc-reports&tab=stock&report=low_in_stock';
+		$status_widget_reports['outofstock_link']     = 'admin.php?page=wc-reports&tab=stock&report=out_of_stock';
+		$status_widget_reports['report_data']         = $report_data;
+		$status_widget_reports['get_sales_sparkline'] = function () {
+			return array(
+				'total' => 50,
+				'data'  => array(),
+			);
+		};
+
+		return $status_widget_reports;
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -83,7 +83,7 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Parameters borrowed from WC_Admin_Dashboard::get_sales_report_data().
+		// Parameters borrowed from WC_Admin_Reports::replace_dashboard_status_widget_reports().
 		$report                 = new WC_Report_Sales_By_Date();
 		$report->start_date     = strtotime( date( 'Y-m-01', current_time( 'timestamp' ) ) );
 		$report->end_date       = current_time( 'timestamp' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is one of the preparations for gradually retiring the WooCommerce legacy reports.

It focuses on decoupling the dependency between the legacy reports and the WooCommerce Status widget on the dashboard page.

- Reverse the dependency on drawing sparklines in the legacy reports from the WooCommerce Status widget on the dashboard page.
- Decouple the dependency between the legacy reports and the WooCommerce Status widget on the dashboard page.
- Break down the method of forming HTML for the sparkline in Dashboard widget to avoid directly outputting HTML via a filtered callback.

In addition, It adds the new file `woocommerce-legacy-reports.php` to simulate the loading plugin for the legacy reports. In this way, we can move other dependencies of legacy reports to the new file in subsequent PRs.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### View the WooCommerce Status widget before this PR

1. Checkout the current `trunk`, and run `pnpm install` and `pnpm build`
2. Place some orders if there is no order in this month
3. Go to the admin page of *WooCommerce > Settings > Advanced > Features*. Disable **WooCommerce Analytics**
   - You may need to sync order or enable compatibility mode for Order data storage
4. Go to the admin page of *Dashboard*
5. View the **WooCommerce Status** widget
    ![1](https://github.com/user-attachments/assets/d4146fdc-4183-4f77-8775-1e340abdff6b)
   - Two sparklines
   - Four hyperlinks to the pages of legacy reports
6. Enable **WooCommerce Analytics** and refresh the Dashboard page
7. View the **WooCommerce Status** widget
   - Two sparklines (might be a bit difference from the ones in the above step because their queries are not exactly the same)
   - Four hyperlinks to the pages of Analytics

#### Check the WooCommerce Status widget after this PR changes

1. Checkout this PR, and run `pnpm install` and `pnpm build`
2. Run `pnpm install` and `pnpm build`
3. Repeat steps 3-7 in the above section of testing instructions
4. Check if the sparklines and hyperlinks are the same after this PR changes

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
