### PR TITLE
Add screen reader text for ratings data on product cards

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card-footer.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card-footer.tsx
@@ -234,7 +234,7 @@ function ProductCardFooter( props: { product: Product } ) {
 							<span aria-hidden>({ product.reviewsCount })</span>
 							<span className="screen-reader-text">
 								{ sprintf(
-									// translators: %d: average rating
+									// translators: %d: rating count
 									__( 'from %d reviews', 'woocommerce' ),
 									product.reviewsCount
 								) }

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card-footer.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card-footer.tsx
@@ -173,10 +173,24 @@ function ProductCardFooter( props: { product: Product } ) {
 							<Icon icon={ 'star-filled' } size={ 16 } />
 						</span>
 						<span className="woocommerce-marketplace__product-card__rating-average">
-							{ product.averageRating }
+							<span aria-hidden>{ product.averageRating }</span>
+							<span className="screen-reader-text">
+								{ sprintf(
+									// translators: %.1f: average rating
+									__( '%.1f stars', 'woocommerce' ),
+									product.averageRating
+								) }
+							</span>
 						</span>
 						<span className="woocommerce-marketplace__product-card__rating-count">
-							({ product.reviewsCount })
+							<span aria-hidden>({ product.reviewsCount })</span>
+							<span className="screen-reader-text">
+								{ sprintf(
+									// translators: %d: average rating
+									__( 'from %d reviews', 'woocommerce' ),
+									product.reviewsCount
+								) }
+							</span>
 						</span>
 					</>
 				) }

--- a/plugins/woocommerce/changelog/51571-update-wccom-21779-in-app-ratings-a11y
+++ b/plugins/woocommerce/changelog/51571-update-wccom-21779-in-app-ratings-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve screen reader text for ratings data on Extensions screen product cards.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
Ratings data on product cards on the Extensions screen are being read out as numbers without any additional context. This PR adds more detailed screen reader text to make it clear what is being announced.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/21779

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch
2. Go to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
3. Visit the [in-app marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).
4. On either the Discover or Extensions tab, find a card that displays a rating
5. Use the Tab key to get focus on one of the links in that card. Then, with VoiceOver on, use Ctrl-Opt-left-arrow to read through the non-tabbable content of the card. Confirm the rating is being read out correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Improve screen reader text for ratings data on Extensions screen product cards.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
