### PR TITLE
Resolved fatal error when applying Brands-restricted coupon

### DIFF
--- a/plugins/woocommerce/changelog/51577-issue-1570
+++ b/plugins/woocommerce/changelog/51577-issue-1570
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved fatal error when applying Brands-restricted coupon

--- a/plugins/woocommerce/includes/class-wc-brands-coupons.php
+++ b/plugins/woocommerce/includes/class-wc-brands-coupons.php
@@ -69,17 +69,17 @@ class WC_Brands_Coupons {
 
 		// 1) Coupon has a brand requirement but no products in the cart have the brand.
 		if ( ! $included_brands_match && ! empty( $brand_coupon_settings['included_brands'] ) ) {
-			throw new Exception( WC_Coupon::E_WC_COUPON_NOT_APPLICABLE ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( $coupon->get_coupon_error( WC_Coupon::E_WC_COUPON_NOT_APPLICABLE ), WC_Coupon::E_WC_COUPON_NOT_APPLICABLE ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
 		// 2) All products in the cart match brand exclusion rule.
 		if ( count( $items ) === $excluded_brands_matches ) {
-			throw new Exception( self::E_WC_COUPON_EXCLUDED_BRANDS ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( __( 'Sorry, this coupon is not applicable to the brands of selected products.', 'woocommerce' ), self::E_WC_COUPON_EXCLUDED_BRANDS ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
 		// 3) For a cart discount, there is at least one product in cart that matches exclusion rule.
 		if ( $coupon->is_type( 'fixed_cart' ) && $excluded_brands_matches > 0 ) {
-			throw new Exception( self::E_WC_COUPON_EXCLUDED_BRANDS ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( __( 'Sorry, this coupon is not applicable to the brands of selected products.', 'woocommerce' ), self::E_WC_COUPON_EXCLUDED_BRANDS ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
 		return $valid;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR resolves a fatal error that was triggered when applying a Brands-rectricted coupon with cart discount due to invalid argument types passed to `throw new Exception`. 

Closes #51570 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out WooCommerce `trunk`.
2. Install the following snippet to enable Brands functionality:

```
add_action( 'init', function() {
    update_option( 'wc_feature_woocommerce_brands_enabled', 'yes' );
    update_option( 'woocommerce_remote_variant_assignment', 2 );
} );
```
3. Go to **Marketing > Coupons**.
4. Create a coupon with a 'Fixed Cart Discount'.
5. Go to the Usage Restriction tab.
6. In **Product Brands**, select a brand -- if your store doesn't have any brands, [here's how to create one](https://woocommerce.com/document/woocommerce-brands/#creating-brands).
7. Add a product to the cart that doesn't belong to that brand.
8. Apply the coupon you created.
9. See the fatal error. 
10. Apply the patch. 
11. Re-fresh the cart page. 
12. Re-apply the coupon. 
13. Ensure that a proper notice explaining that the coupon is invalid is displayed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Resolved fatal error when applying Brands-restricted coupon

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
