### PR TITLE
If local pickup text is not set, save an empty string to allow fallback to work

### DIFF
--- a/plugins/woocommerce/changelog/fix-empty-local-pickup-title
+++ b/plugins/woocommerce/changelog/fix-empty-local-pickup-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a bug where the Local Pickup title in the Shipping Method block would not save correctly if it was the same as the default "Pickup"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -287,8 +287,7 @@ class Checkout extends AbstractBlock {
 		$post_blocks = parse_blocks( $post->post_content );
 		$title       = $this->find_local_pickup_text_in_checkout_block( $post_blocks );
 
-		// Set the title to be an empty string if it wasn't found, or is whitespace.
-		// This will make it fall back to the default value.
+		// Set the title to be an empty string if it isn't a string. This will make it fall back to the default value of "Pickup".
 		if ( ! is_string( $title ) ) {
 			$title = '';
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -287,10 +287,14 @@ class Checkout extends AbstractBlock {
 		$post_blocks = parse_blocks( $post->post_content );
 		$title       = $this->find_local_pickup_text_in_checkout_block( $post_blocks );
 
-		if ( $title ) {
-			$pickup_location_settings['title'] = $title;
-			update_option( 'woocommerce_pickup_location_settings', $pickup_location_settings );
+		// Set the title to be an empty string if it wasn't found, or is whitespace.
+		// This will make it fall back to the default value.
+		if ( ! is_string( $title ) ) {
+			$title = '';
 		}
+
+		$pickup_location_settings['title'] = $title;
+		update_option( 'woocommerce_pickup_location_settings', $pickup_location_settings );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/Checkout.php
@@ -67,6 +67,41 @@ class Checkout extends \WP_UnitTestCase {
 		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings( 'edit' );
 		$this->assertEquals( 'Changed pickup', $pickup_location_settings['title'] );
 
+		// Updates the pickup title with the default value.
+		$updated_content = '<!-- wp:woocommerce/checkout {"showOrderNotes":false} --> <div class="wp-block-woocommerce-checkout is-loading"> <!-- wp:woocommerce/checkout-shipping-method-block {"localPickupText":"Pickup"} --> <div class="wp-block-woocommerce-checkout-shipping-method-block"></div> <!-- /wp:woocommerce/checkout-shipping-method-block --></div> <!-- /wp:woocommerce/checkout -->';
+		wp_update_post(
+			[
+				'ID'           => $page_id,
+				'post_content' => $updated_content,
+			]
+		);
+
+		// Now the post was saved with an updated localPickupText attribute, the title on Local Pickup settings should be updated.
+		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings( 'edit' );
+		$this->assertEquals( 'Pickup', $pickup_location_settings['title'] );
+
+		// Updates the pickup title with an empty value.
+		$updated_content = '<!-- wp:woocommerce/checkout {"showOrderNotes":false} --> <div class="wp-block-woocommerce-checkout is-loading"> <!-- wp:woocommerce/checkout-shipping-method-block {"localPickupText":""} --> <div class="wp-block-woocommerce-checkout-shipping-method-block"></div> <!-- /wp:woocommerce/checkout-shipping-method-block --></div> <!-- /wp:woocommerce/checkout -->';
+		wp_update_post(
+			[
+				'ID'           => $page_id,
+				'post_content' => $updated_content,
+			]
+		);
+
+		// Now the post was saved with an updated localPickupText attribute, the title on Local Pickup settings should be updated.
+		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings( 'edit' );
+		$this->assertEquals( 'Pickup', $pickup_location_settings['title'] );
+
+		// Updates the pickup title back to "Changed pickup" to test AssetDataRegistry.
+		$updated_content = '<!-- wp:woocommerce/checkout {"showOrderNotes":false} --> <div class="wp-block-woocommerce-checkout is-loading"> <!-- wp:woocommerce/checkout-shipping-method-block {"localPickupText":"Changed pickup"} --> <div class="wp-block-woocommerce-checkout-shipping-method-block"></div> <!-- /wp:woocommerce/checkout-shipping-method-block --></div> <!-- /wp:woocommerce/checkout -->';
+		wp_update_post(
+			[
+				'ID'           => $page_id,
+				'post_content' => $updated_content,
+			]
+		);
+
 		// Create a new Checkout block class with the mocked AssetDataRegistry. This is so we can inspect it after the change.
 		$checkout = new CheckoutMock( $this->asset_api, $this->registry, $this->integration_registry, 'checkout-mock' );
 		$checkout->mock_enqueue_data();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is based on `remove/flaky-pickup-test` #51554 as it contains some tests relevant to this.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When no value, or the same value as the default text is entered in the Shipping Method block, the `localPickupText` now correctly falls back to the default value (Pickup).

Closes #48243

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Local Pickup (WooCommerce -> Settings -> Shipping -> Local Pickup) and add a location.
2. Go to the Checkout block and find the "Pickup" button.
3. Change the text in this button by entering your cursor in the word "Pickup" and typing as usual.
4. Save the page.
5. Go to local pickup settings (WooCommerce -> Settings -> Shipping -> Local Pickup) and verify the value you entered in the block was saved in these settings.
6. Go to the block and edit the text again and enter "Pickup". Save the block.
7. Repeat step 5.
8. Go to the block and edit the text again and delete all text in the button. It should show the placeholder. Sae the block.
9. Repeat step 5, verify the title is "Pickup".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
