### PR TITLE
Fix min_amount check in WC_Shipping_Free_Shipping

### DIFF
--- a/plugins/woocommerce/changelog/fix-46558
+++ b/plugins/woocommerce/changelog/fix-46558
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix min amount check in is_available method of WC_Shipping_Free_Shipping class

--- a/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -195,9 +195,14 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				}
 			}
 
+			// Prepare min_amount for comparison
+			$min_amount = str_replace( wc_get_price_decimal_separator(), '.', $this->min_amount );
+			$min_amount = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ), wc_get_price_thousand_separator(), ), '', $min_amount );
+
+			$min_amount = NumberUtil::round( $min_amount, wc_get_price_decimals() );
 			$total = NumberUtil::round( $total, wc_get_price_decimals() );
 
-			if ( $total >= $this->min_amount ) {
+			if ( $total >= $min_amount ) {
 				$has_met_min_amount = true;
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the min_amount check in WC_Shipping_Free_Shipping::is_available by converting the min_amount from string to a proper float.

Closes #46558 #46875 #45797.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Shipping > Shipping zones.
2. Create a shipping zone with a free shipping method.
[image](https://github.com/user-attachments/assets/91a7ec50-f911-4bab-b2bc-8825a0aeb685)
3. Select a requirement which involves a minimum order amount.
4. Add a minimum order amount with the decimal symbol you use under the General tab.
[image](https://github.com/user-attachments/assets/aa0145d2-810c-42ba-9154-3bb6dc03890e) 
5. Add a product to your cart and exceed or stay beneath that min amount.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
