### PR TITLE
Unhardcode menu titles for in page header

### DIFF
--- a/plugins/woocommerce-admin/client/header/index.js
+++ b/plugins/woocommerce-admin/client/header/index.js
@@ -31,12 +31,16 @@ export const PAGE_TITLE_FILTER = 'woocommerce_admin_header_page_title';
 
 export const getPageTitle = ( sections ) => {
 	let pageTitle;
-	const pagesWithTabs = [ 'Settings', 'Reports', 'Status' ];
+	const pagesWithTabs = [
+		'admin.php?page=wc-settings',
+		'admin.php?page=wc-reports',
+		'admin.php?page=wc-status',
+	];
 
 	if (
 		sections.length > 2 &&
 		Array.isArray( sections[ 1 ] ) &&
-		pagesWithTabs.includes( sections[ 1 ][ 1 ] )
+		pagesWithTabs.includes( sections[ 1 ][ 0 ] )
 	) {
 		pageTitle = sections[ 1 ][ 1 ];
 	} else {

--- a/plugins/woocommerce/changelog/tweak-unhardcode-tabbed-page-name
+++ b/plugins/woocommerce/changelog/tweak-unhardcode-tabbed-page-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix page header for subpages with tabs.

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -126,12 +126,16 @@ class Loader {
 		$sections = is_array( $sections ) ? $sections : array( $sections );
 
 		$page_title      = '';
-		$pages_with_tabs = array( 'Settings', 'Reports', 'Status' );
+		$pages_with_tabs = array(
+			'admin.php?page=wc-settings',
+			'admin.php?page=wc-reports',
+			'admin.php?page=wc-status',
+		);
 
 		if (
 			count( $sections ) > 2 &&
 			is_array( $sections[1] ) &&
-			in_array( $sections[1][1], $pages_with_tabs, true )
+			in_array( $sections[1][0], $pages_with_tabs, true )
 		) {
 			$page_title = $sections[1][1];
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the page title is generated (for both React and PHP pages), we check the breadcrumbs and look for pages with tabs. Currently, we compare menu item titles to the list of hardcoded English names.

This will easily fail if the many items are translated into any other language (we use `__()` for those items) or simply changed.


~Currently, all WooCommerce submenu items are not localized to the languages I have checked (PL, ES, JP, FR). I don't know why, maybe because of this bug~

We can mimic that behavior, though.

The issue was introduced in https://github.com/woocommerce/woocommerce/pull/46450

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use `trunk` branch first to check for the issue.
2. go to `/wp-admin/admin.php?page=wc-settings`
3. :green_circle: You should see the "Settings" header
	![image](https://github.com/user-attachments/assets/3d70b232-f826-4179-bb57-567f33ba1579)

2. Change site language to one that localizes the menu item titles in https://github.com/woocommerce/woocommerce/blob/282c2ffe2e82c19aef6a50a4bb83112669138864/plugins/woocommerce/includes/react-admin/connect-existing-pages.php#L35:L35.  Update the translations, if needed  (Go to WP Admin > Dashboard > Updates and click the Update Translations button)
   or
   Change that line manually to 
	```php
		'title' => __( 'Ustawienia', 'woocommerce' ),
	```
4. Reload  `/wp-admin/admin.php?page=wc-settings`
5. :bug: It shows the tab title.
	![image](https://github.com/user-attachments/assets/b35efde5-f9d1-411b-b206-2963f19a709a)
6. Checkout this branch
7. Redo steps above
	![image](https://github.com/user-attachments/assets/b76a5361-2543-473e-a429-361939e19062)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
