### PR TITLE
Add missing wp block woocommerce classname

### DIFF
--- a/plugins/woocommerce/changelog/update-49739_add_missing_wp_block_woocommerce_classname
+++ b/plugins/woocommerce/changelog/update-49739_add_missing_wp_block_woocommerce_classname
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update the Catalog searching, average rating, product button and no results collection blocks to make sure they render with the wp-block-<block-name> class.
+Update the Catalog searching, average rating, and product button blocks to make sure they render with the wp-block-<block-name> class.

--- a/plugins/woocommerce/changelog/update-49739_add_missing_wp_block_woocommerce_classname
+++ b/plugins/woocommerce/changelog/update-49739_add_missing_wp_block_woocommerce_classname
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the Catalog searching, average rating, product button and no results collection blocks to make sure they render with the wp-block-<block-name> class.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
@@ -34,14 +34,22 @@ class CatalogSorting extends AbstractBlock {
 			return;
 		}
 
-		$classname          = isset( $attributes['className'] ) ? $attributes['className'] : '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => implode( ' ', array_filter(
+					[ 
+						'woocommerce wc-block-catalog-sorting',
+						esc_attr( $classes_and_styles['classes'] ),
+					]
+				) ),
+				'style' => esc_attr( $styles_and_classes['styles'] ?? '' ),
+			)
+		);
 
 		return sprintf(
-			'<div class="woocommerce wc-block-catalog-sorting %1$s %2$s" style="%3$s">%4$s</div>',
-			esc_attr( $classes_and_styles['classes'] ),
-			esc_attr( $classname ),
-			esc_attr( $classes_and_styles['styles'] ),
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
 			$catalog_sorting
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/CatalogSorting.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
@@ -37,12 +38,15 @@ class CatalogSorting extends AbstractBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'class' => implode( ' ', array_filter(
-					[ 
-						'woocommerce wc-block-catalog-sorting',
-						esc_attr( $classes_and_styles['classes'] ),
-					]
-				) ),
+				'class' => implode(
+					' ',
+					array_filter(
+						[
+							'woocommerce wc-block-catalog-sorting',
+							esc_attr( $classes_and_styles['classes'] ),
+						]
+					)
+				),
 				'style' => esc_attr( $styles_and_classes['styles'] ?? '' ),
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductAverageRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductAverageRating.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
@@ -93,13 +95,16 @@ class ProductAverageRating extends AbstractBlock {
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'class' => implode( ' ', array_filter(
-					[ 
-						'wc-block-components-product-average-rating-counter',
-						esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
-						esc_attr( $styles_and_classes['classes'] )
-					]
-				) ),
+				'class' => implode(
+					' ',
+					array_filter(
+						[
+							'wc-block-components-product-average-rating-counter',
+							esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
+							esc_attr( $styles_and_classes['classes'] ),
+						]
+					)
+				),
 				'style' => esc_attr( $styles_and_classes['styles'] ?? '' ),
 			)
 		);
@@ -111,4 +116,3 @@ class ProductAverageRating extends AbstractBlock {
 		);
 	}
 }
-

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductAverageRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductAverageRating.php
@@ -91,11 +91,22 @@ class ProductAverageRating extends AbstractBlock {
 		$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 		$text_align_styles_and_classes = StyleAttributesUtils::get_text_align_class_and_style( $attributes );
 
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => implode( ' ', array_filter(
+					[ 
+						'wc-block-components-product-average-rating-counter',
+						esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
+						esc_attr( $styles_and_classes['classes'] )
+					]
+				) ),
+				'style' => esc_attr( $styles_and_classes['styles'] ?? '' ),
+			)
+		);
+
 		return sprintf(
-			'<div class="wc-block-components-product-average-rating-counter %1$s %2$s" style="%3$s">%4$s</div>',
-			esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
-			esc_attr( $styles_and_classes['classes'] ),
-			esc_attr( $styles_and_classes['styles'] ?? '' ),
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
 			$product->get_average_rating()
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -189,6 +189,18 @@ class ProductButton extends AbstractBlock {
 				data-wc-layout-init="callbacks.syncTemporaryNumberOfItemsOnLoad"
 			';
 
+			$wrapper_attributes = get_block_wrapper_attributes(
+				array(
+					'class' => implode( ' ', array_filter(
+						[ 
+							'wp-block-button wc-block-components-product-button',
+							esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
+							esc_attr( $classname . ' ' . $custom_width_classes . ' ' . $custom_align_classes )
+						]
+					) ),
+				)
+			);
+
 			/**
 			 * Filters the add to cart button class.
 			 *
@@ -199,7 +211,7 @@ class ProductButton extends AbstractBlock {
 			return apply_filters(
 				'woocommerce_loop_add_to_cart_link',
 				strtr(
-					'<div class="wp-block-button wc-block-components-product-button {classes} {custom_classes}"
+					'<div {wrapper_attributes}
 						{div_directives}
 					>
 						<{html_element}
@@ -214,8 +226,7 @@ class ProductButton extends AbstractBlock {
 						{view_cart_html}
 					</div>',
 					array(
-						'{classes}'                => esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
-						'{custom_classes}'         => esc_attr( $classname . ' ' . $custom_width_classes . ' ' . $custom_align_classes ),
+						'{wrapper_attributes}'	   => $wrapper_attributes,
 						'{html_element}'           => $html_element,
 						'{add_to_cart_url}'        => esc_url( $product->add_to_cart_url() ),
 						'{button_classes}'         => isset( $args['class'] ) ? esc_attr( $args['class'] . ' wc-interactive' ) : 'wc-interactive',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
@@ -191,13 +193,16 @@ class ProductButton extends AbstractBlock {
 
 			$wrapper_attributes = get_block_wrapper_attributes(
 				array(
-					'class' => implode( ' ', array_filter(
-						[ 
-							'wp-block-button wc-block-components-product-button',
-							esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
-							esc_attr( $classname . ' ' . $custom_width_classes . ' ' . $custom_align_classes )
-						]
-					) ),
+					'class' => implode(
+						' ',
+						array_filter(
+							[
+								'wp-block-button wc-block-components-product-button',
+								esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
+								esc_attr( $classname . ' ' . $custom_width_classes . ' ' . $custom_align_classes ),
+							]
+						)
+					),
 				)
 			);
 
@@ -226,7 +231,7 @@ class ProductButton extends AbstractBlock {
 						{view_cart_html}
 					</div>',
 					array(
-						'{wrapper_attributes}'	   => $wrapper_attributes,
+						'{wrapper_attributes}'     => $wrapper_attributes,
 						'{html_element}'           => $html_element,
 						'{add_to_cart_url}'        => esc_url( $product->add_to_cart_url() ),
 						'{button_classes}'         => isset( $args['class'] ) ? esc_attr( $args['class'] . ' wc-interactive' ) : 'wc-interactive',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the list of blocks below to include the `wp-block-<block name >` class on render:
- catalog-sorting
- product-average-rating
- product-button

Related to: https://github.com/woocommerce/woocommerce/issues/49739

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Tests for each block**
**Catalog sorting**
1. Create a new WooCommerce store and add some products, make sure to use a blockified theme
2. Go to the **Shop** page 
3. Find the **Default sorting** dropdown and inspect it.
4. Make sure the parent div ( `data-block-name="woocommerce/catalog-sorting"` ) includes the `wp-block-woocommerce-catalog-sorting` class name.

**product-average-rating**

1. Add a new page or edit an existing page and add a **Single product** block and select a product
2. Nested from the **single product** block add the **Product Average Rating (Beta)** block
3. Save the product and make sure to add at-least one review to the product.
4. View the page and inspect the average rating ( it should just be a number ). 
5. It should include the `wp-block-woocommerce-product-average-rating` class.

**Product Button**

1. Go to the **Shop** page
2. Inspect the **Add to cart** button
3. Make sure the parent block element (`data-block-name="woocommerce/product-button"`) contains the **wp-block-woocommerce-product-button**

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
