### PR TITLE
Fix postcode validation within the legacy cart show_shipping method

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-postcode-50800
+++ b/plugins/woocommerce/changelog/fix-shipping-postcode-50800
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix postcode validation within the legacy cart show_shipping method.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1597,7 +1597,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			 */
 			$postcode_enabled  = apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true );
 			$postcode_required = isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'];
-			if ( $postcode_enabled && $postcode_required && ! $this->get_customer()->get_shipping_postcode() ) {
+			if ( $postcode_enabled && $postcode_required && '' === $this->get_customer()->get_shipping_postcode() ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There are cases where in the legacy cart/checkout (not blocks/Store API) you could enter `0` as a postcode and have your order go through with the default shipping method without selecting shipping.

This appears to be due to the `show_shipping` method returning false if the `postcode` is a false value. `0` is falsey.

The fix is to compare it against an empty string instead.

Closes #50800

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Under WC > Settings > Shipping > Local PIckup, turn it off.
2. Under WC > Settings Shipping > Options, turn on "Hide shipping costs until an address is entered"
3. In a clean guest session add something to cart and go to legacy/shortcode checkout
4. Choose Qatar as your country and fill out all fields except postcode; set that to `0`.
5. Confirm shipping methods are displayed, then place the order.

Before this fix, shipping methods would not be displayed after step 5.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
