### PR TITLE
Allow setting the Shop page as the homepage in block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-45477-blocks-themes-shop-homepage
+++ b/plugins/woocommerce/changelog/fix-45477-blocks-themes-shop-homepage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow setting the Shop page as the homepage in block themes

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -356,7 +356,7 @@ class WC_Query {
 					$q->is_home = false;
 
 					// WP supporting themes show post type archive.
-					if ( current_theme_supports( 'woocommerce' ) ) {
+					if ( wc_current_theme_supports_woocommerce_or_fse() ) {
 						$q->set( 'post_type', 'product' );
 					} else {
 						$q->is_singular = true;
@@ -376,7 +376,7 @@ class WC_Query {
 		}
 
 		// Special check for shops with the PRODUCT POST TYPE ARCHIVE on front.
-		if ( current_theme_supports( 'woocommerce' ) && $q->is_page() && 'page' === get_option( 'show_on_front' ) && absint( $q->get( 'page_id' ) ) === wc_get_page_id( 'shop' ) ) {
+		if ( wc_current_theme_supports_woocommerce_or_fse() && $q->is_page() && 'page' === get_option( 'show_on_front' ) && absint( $q->get( 'page_id' ) ) === wc_get_page_id( 'shop' ) ) {
 			// This is a front-page shop.
 			$q->set( 'post_type', 'product' );
 			$q->set( 'page_id', '' );

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -300,7 +300,7 @@ class WC_Query {
 	private function filter_out_valid_front_page_query_vars( $query ) {
 		return array_filter(
 			$query,
-			function( $key ) {
+			function ( $key ) {
 				return ! $this->is_query_var_valid_on_front_page( $key );
 			},
 			ARRAY_FILTER_USE_KEY
@@ -815,7 +815,7 @@ class WC_Query {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$rating_filter = array_filter( array_map( 'absint', explode( ',', wp_unslash( $_GET['rating_filter'] ) ) ) );
 			$rating_terms  = array();
-			for ( $i = 1; $i <= 5; $i ++ ) {
+			for ( $i = 1; $i <= 5; $i++ ) {
 				if ( in_array( $i, $rating_filter, true ) && isset( $product_visibility_terms[ 'rated-' . $i ] ) ) {
 					$rating_terms[] = $product_visibility_terms[ 'rated-' . $i ];
 				}

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -6,6 +6,15 @@
 class WC_Query_Test extends \WC_Unit_Test_Case {
 
 	/**
+	 * Get a sample page ID for testing purposes.
+	 *
+	 * @return int The shop page ID.
+	 */
+	public function get_shop_page_id() {
+		return 123;
+	}
+
+	/**
 	 * @testdox 'price_filter_post_clauses' generates the proper 'where' clause when there are 'max_price' and 'min_price' arguments in the query.
 	 */
 	public function test_price_filter_post_clauses_creates_the_proper_where_clause() {
@@ -40,7 +49,8 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		switch_theme( 'twentytwentyfour' );
 
 		// Set the shop page as the homepage.
-		$shop_page_id          = wc_get_page_id( 'shop' );
+		add_filter( 'woocommerce_get_shop_page_id', array( $this, 'get_shop_page_id' ) );
+		$shop_page_id          = 123;
 		$default_show_on_front = get_option( 'show_on_front' );
 		$default_page_on_front = get_option( 'page_on_front' );
 		update_option( 'show_on_front', 'page' );
@@ -64,5 +74,6 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		$wp_the_query = $previous_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		update_option( 'show_on_front', $default_show_on_front );
 		update_option( 'page_on_front', $default_page_on_front );
+		remove_filter( 'woocommerce_get_shop_page_id', array( $this, 'get_shop_page_id' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -66,6 +66,15 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 		global $wp_the_query;
 		$previous_wp_the_query = $wp_the_query;
 		$wp_the_query          = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$GLOBALS['post']       = new WP_Post(
+			(object) array(
+				'ID'           => $shop_page_id,
+				'post_title'   => '',
+				'post_content' => '',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+			)
+		); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$query->get_posts();
 
 		$this->assertTrue( defined( 'SHOP_IS_ON_FRONT' ) && SHOP_IS_ON_FRONT );

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -32,4 +32,37 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected, $args['where'] );
 	}
+
+	/**
+	 * @testdox Shop page can be set as the homepage on block themes.
+	 */
+	public function test_shop_page_in_home_displays_correctly() {
+		switch_theme( 'twentytwentyfour' );
+
+		// Set the shop page as the homepage.
+		$shop_page_id          = wc_get_page_id( 'shop' );
+		$default_show_on_front = get_option( 'show_on_front' );
+		$default_page_on_front = get_option( 'page_on_front' );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $shop_page_id );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'page',
+				'page_id'   => $shop_page_id,
+			)
+		);
+		// Make it so it's the main query.
+		global $wp_the_query;
+		$previous_wp_the_query = $wp_the_query;
+		$wp_the_query          = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$query->get_posts();
+
+		$this->assertTrue( defined( 'SHOP_IS_ON_FRONT' ) && SHOP_IS_ON_FRONT );
+
+		// Reset main query and options.
+		$wp_the_query = $previous_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		update_option( 'show_on_front', $default_show_on_front );
+		update_option( 'page_on_front', $default_page_on_front );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -39,32 +39,30 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 	public function test_shop_page_in_home_displays_correctly() {
 		switch_theme( 'twentytwentyfour' );
 
-		// Create a page.
-		$shop_page_id = wp_insert_post(
+		// Create a page and use it as the Shop page.
+		$shop_page_id                     = wp_insert_post(
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'publish',
 				'post_title'  => 'Shop',
 			)
 		);
-
-		// Use the new page as the shop page.
 		$default_woocommerce_shop_page_id = get_option( 'woocommerce_shop_page_id' );
 		update_option( 'woocommerce_shop_page_id', $shop_page_id );
 
-		// Set the shop page as the homepage.
+		// Set the Shop page as the homepage.
 		$default_show_on_front = get_option( 'show_on_front' );
 		$default_page_on_front = get_option( 'page_on_front' );
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $shop_page_id );
 
+		// Simulate the main query.
 		$query = new WP_Query(
 			array(
 				'post_type' => 'page',
 				'page_id'   => $shop_page_id,
 			)
 		);
-		// Make it so it's the main query.
 		global $wp_the_query;
 		$previous_wp_the_query = $wp_the_query;
 		$wp_the_query          = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -3,10 +3,10 @@
 namespace Automattic\WooCommerce\Tests\Blocks\Templates;
 
 use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplate;
-use \WP_UnitTestCase;
+use WP_UnitTestCase;
 
 /**
- * Tests the SingleProductTemplateCompatibility class
+ * Tests the SingleProductTemplate class
  *
  */
 class SingleProductTemplateTests extends WP_UnitTestCase {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the logic that accounts for the _Shop_ page being used as the homepage. This way it supports block themes in addition to classic themes with explicit support for WooCommerce.

Closes #45477.
Part of #51433.

### How to test the changes in this Pull Request:

1. Activate a classic theme (e.g. Twenty Twenty-One).
2. Add some content to the _Shop_ page created by WooCommerce (page slug: `/shop`).
4. Ensure this _Shop_ page is set as your site's homepage. You can set it up in Settings > Reading.
5. Visit the site's homepage. Content added in the editor appears at the top, followed by the default product grid underneath.
6. Visit the `/shop` URL. The content should be the same.
7. Change the site's theme to a block theme (e.g. Twenty Twenty-Four).
8. Visit the site's homepage and the `/shop` page. Verify the content in both pages is the same: they display the product grid but don't display the contents of the Shop page added in step 3. Note: that's expected, in block themes we don't display the contents of the _Shop_ page in the product catalog.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/8e59ea0a-5f73-469a-a6f3-5148fefeb934) | ![image](https://github.com/user-attachments/assets/5ea03b43-b9bf-42a9-a9e3-d743ca2ffb33)