### PR TITLE
Use Product Gallery (Beta) in Single Product block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
@@ -105,6 +105,8 @@ const TEMPLATE: InnerBlockTemplate[] = [
 	],
 ];
 
+const CUSTOM_PRODUCT_TEMPLATE_ID = 'woocommerce/custom-product-template';
+
 const getMode = ( currentTemplateId: string, templateType: string ) => {
 	if (
 		templateType === 'wp_template_part' &&
@@ -128,8 +130,11 @@ export const Edit = ( {
 
 	const { currentTemplateId, templateType } = useSelect(
 		( select ) => ( {
-			currentTemplateId: select( 'core/edit-site' ).getEditedPostId(),
-			templateType: select( 'core/edit-site' ).getEditedPostType(),
+			currentTemplateId:
+				select( 'core/edit-site' )?.getEditedPostId() ??
+				CUSTOM_PRODUCT_TEMPLATE_ID,
+			templateType:
+				select( 'core/edit-site' )?.getEditedPostType() ?? 'wp_block',
 		} ),
 		[]
 	);
@@ -154,7 +159,13 @@ export const Edit = ( {
 		templateType,
 	] );
 
-	if ( attributes.productGalleryClientId !== clientId ) {
+	const isUsingCustomProductTemplate =
+		CUSTOM_PRODUCT_TEMPLATE_ID === currentTemplateId;
+
+	if (
+		attributes.productGalleryClientId !== clientId &&
+		! isUsingCustomProductTemplate
+	) {
 		const error = {
 			message: __(
 				'productGalleryClientId and clientId codes mismatch.',

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/constants.tsx
@@ -25,20 +25,7 @@ export const DEFAULT_INNER_BLOCKS: InnerBlockTemplate[] = [
 		'core/columns',
 		{},
 		[
-			[
-				'core/column',
-				{},
-				[
-					[
-						'woocommerce/product-image',
-						{
-							showSaleBadge: false,
-							isDescendentOfSingleProductBlock: true,
-							imageSizing: ImageSizing.SINGLE,
-						},
-					],
-				],
-			],
+			[ 'core/column', {}, [ [ 'woocommerce/product-gallery' ] ] ],
 			[
 				'core/column',
 				{},

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -458,7 +458,6 @@ final class BlockTypesController {
 					'OrderConfirmation\AdditionalInformation',
 					'OrderConfirmation\AdditionalFieldsWrapper',
 					'OrderConfirmation\AdditionalFields',
-					'ProductGallery',
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to use `Product Gallery (Beta)` in the `Single Product` block instead of `Product Image` block.

This PR shouldn't be merged before addressing https://github.com/woocommerce/woocommerce/issues/44483 and https://github.com/woocommerce/woocommerce/issues/47569. More context [here](https://github.com/woocommerce/woocommerce/issues/47926#issuecomment-2368338979).

Closes #47926.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Having `WooCommerce Beta Tester` enabled.
2. Make sure `experimental-blocks` is enabled under Tools > WCA Test Helper > Features.
3. Create a product with an image gallery.
4. Create a new page under Pages > Add New Page.
5. Add a `Single Product` block and select your created product.
6. Verify the `Product Gallery (Beta)` is included in the first column.
7. Save the `Page` and verify the gallery looks good.
8. Go to Appearance > Editor > Patterns > Add New Pattern. Give it a name and click on _Add_.
9. Open the inserter and search for _gallery_.
10. Add the `Product Gallery (Beta)` block to the pattern.

![imatge](https://github.com/user-attachments/assets/2ac637c1-b1ad-4e3e-879f-7f0d3c46e168)

11. No error should be shown in the browser's console.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
