### PR TITLE
Check if the order needs shipping before validating shipping address

### DIFF
--- a/plugins/woocommerce/changelog/fix-additional-fields-virtual
+++ b/plugins/woocommerce/changelog/fix-additional-fields-virtual
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue where virtual products could not be purchased when using the Additional Fields API

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -201,6 +201,7 @@ class Checkout extends AbstractCartRoute {
 
 		$address_fields = $this->additional_fields_controller->get_fields_for_location( 'address' );
 		if ( ! empty( $address_fields ) ) {
+			$needs_shipping = WC()->cart->needs_shipping();
 			foreach ( $address_fields as $field_key => $address_field ) {
 				if ( $address_field['required'] && ! isset( $request['billing_address'][ $field_key ] ) ) {
 					throw new RouteException(
@@ -210,7 +211,7 @@ class Checkout extends AbstractCartRoute {
 						400
 					);
 				}
-				if ( $address_field['required'] && ! isset( $request['shipping_address'][ $field_key ] ) ) {
+				if ( $needs_shipping && $address_field['required'] && ! isset( $request['shipping_address'][ $field_key ] ) ) {
 					throw new RouteException(
 						'woocommerce_rest_checkout_missing_required_field',
 						/* translators: %s: is the field label */

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -72,6 +72,15 @@ class AdditionalFields extends MockeryTestCase {
 					'weight'        => 10,
 				)
 			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Virtual Test Product 3',
+					'stock_status'  => 'instock',
+					'regular_price' => 10,
+					'weight'        => 10,
+					'virtual'       => true,
+				)
+			),
 		);
 		$this->reset_session();
 	}
@@ -1680,6 +1689,54 @@ class AdditionalFields extends MockeryTestCase {
 
 		// Ensures the field isn't registered.
 		$this->assertFalse( $this->controller->is_field( $id ), \sprintf( '%s is still registered', $id ) );
+	}
+
+	/**
+	 * Ensures an order for a virtual product can be placed without a shipping address.
+	 */
+	public function test_place_virtual_product_order() {
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $this->products[2]->get_id(), 2 );
+		$id    = 'plugin-namespace/my-required-field';
+		$label = 'My Required Field';
+		\woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => $id,
+				'label'    => $label,
+				'location' => 'address',
+				'type'     => 'text',
+				'required' => true,
+			)
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'   => (object) array(
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'email'                              => 'testaccount@test.com',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'req. field',
+				),
+				'payment_method'    => 'bacs',
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => 'engineering',
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/50028 we added a check to prevent orders being placed with empty fields, this did not account for orders that did not require shipping.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51619
Closes #51543

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


<details>
<summary>Code Snippet</summary>

```php
<?php
woocommerce_register_additional_checkout_field(
	array(
		'id'         => 'test/test-field',
		'label'      => 'Test',
		'type'       => 'text',
		'location'   => 'address',
		'required'   => true,
		'attributes' => array(
			'autocomplete' => 'off',
			'title'        => 'Test',
		),
	),
);
add_action(
	'woocommerce_sanitize_additional_field',
	function ( $field_value, $field_key ) {
		if ( 'test/test-field' === $field_key ) {
			$field_value = str_replace( ' ', '', $field_value );
		}
		return $field_value;
	},
	10,
	2
);

add_action(
	'woocommerce_validate_additional_field',
	function ( WP_Error $errors, $field_key, $field_value ) {
		if ( 'test/test-field' === $field_key ) {
			if ( ! $field_value ) {
				$errors->add( 'invalid_crypto_address', sprintf( __( '%s is a required field.', 'woocommerce' ), '<strong>' . esc_html( 'Test' ) . '</strong>' ) );
			}
		}
	},
	10,
	3
);

```

</details>

#### Happy path testing

1. Add a custom `address` field using the snippet above.
2. Create a virtual product
3. Put it into cart
4. Go to the Checkout page
5. Fill in all fields required
6. Press the "Place Order" button
7. Verify the order is placed successfully and no errors occur.
8. Add a **physical** product to your cart (i.e. one that requires shipping)
9. Go to the Checkout block and fill in your shipping address. Leave a required field blank e.g. address 1.
10. Try to check out, ensure you cannot place the order.
11. Fix the problem with the address and ensure you can check out successfully.

#### Store API testing (developer only)

1. Test using Store API
2. Add a virtual item to the cart using the `/cart/add-item` endpoint
3. Try to check out using the `checkout` endpoint but do not pass a shipping address in the payload.
4. Ensure the request succeeds and the order is placed.
5. Repeat with a physical product. Ensure the order is not placed, and an error message is returned.
6. Repeat, but add a shipping address to the payload. Ensure the order is placed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
