### PR TITLE
Product CSV Importer > Restore expected default number of lines-to-import per batch

### DIFF
--- a/plugins/woocommerce/changelog/fix-pr51344-csv-import-batch-size
+++ b/plugins/woocommerce/changelog/fix-pr51344-csv-import-batch-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the previous default for `woocommerce_product_import_batch_size` (process 30 lines per batch when importing product CSV data).

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -371,7 +371,7 @@ class WC_Product_CSV_Importer_Controller {
 				 *
 				 * @since 3.1.0
 				 */
-				'lines'              => apply_filters( 'woocommerce_product_import_batch_size', 1 ),
+				'lines'              => apply_filters( 'woocommerce_product_import_batch_size', 30 ),
 				'parse'              => true,
 			);
 


### PR DESCRIPTION
Since 9.3.x was released, customers have complained that product CSV imports are much slower. This is especially obvious when importing large datasets (hundreds of lines of CSV upwards).

It seems there was an oversight, and a change that may have been introduced to make debug and testing easier (a default of [1 line of CSV per batch](https://github.com/woocommerce/woocommerce/pull/51344/files#diff-282f3ed4f338cfa822da18762ba20d85560bd714c2a7da96a59996a2c021e75dL244)) made its way past us and into production. This PR restores the previous default (30 lines of CSV per batch), which is much faster in most cases.

Relates to #51344.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Prepare some product CSV data. You don't actually need a lot to see the problem and the fix, but I'd recommend at least 60 products in order to give ample opportunity to observe the batches being processed.
2. Navigate to **Products ‣ All Products ‣ Import** and upload your CSV. Complete the mappings and then, before you proceed, open your browser's developer tools. The network tab in particular may be handy.
3. Proceed and perform the import. Pay attention to any `admin-ajax.php` requests where the action is `woocommerce_do_ajax_product_import`:
    - Before this change (with 9.3.2) you should see that far more import-related `admin-ajax.php` requests take place. Additionally, the response will contain JSON which, if you inspect it, will reveal via the various import counts that only one product (or variation) is being imported per batch.
    - *With* this change, we get back to importing in batches of 30.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
