### PR TITLE
Redirect to canonical product permalink

### DIFF
--- a/plugins/woocommerce/changelog/fix-24244-custom-permalink
+++ b/plugins/woocommerce/changelog/fix-24244-custom-permalink
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Redirect arbitrary term values wto the canonical value when product_cat is part of the product permalink structure

--- a/plugins/woocommerce/changelog/fix-24244-custom-permalink
+++ b/plugins/woocommerce/changelog/fix-24244-custom-permalink
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Redirect arbitrary term values wto the canonical value when product_cat is part of the product permalink structure
+Redirect to the canonical single product URL if the wrong category slug has been used.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -283,6 +283,46 @@ function wc_product_post_type_link( $permalink, $post ) {
 add_filter( 'post_type_link', 'wc_product_post_type_link', 10, 2 );
 
 /**
+ * Ensure that the product_cat value determined in `wc_product_post_type_link` is the canonical value.
+ *
+ * If other values are used in this part of the permalink, it will be redirected.
+ *
+ * @return void
+ */
+function wc_product_canonical_redirect(): void {
+	global $wp_rewrite;
+
+	if (
+		! did_action( 'woocommerce_init' )
+		|| ! is_product()
+		|| ! is_a( $wp_rewrite, WP_Rewrite::class )
+	) {
+		return;
+	}
+
+	// In the event we are dealing with ugly permalinks, this will be empty.
+	$specified_category_slug = get_query_var( 'product_cat' );
+
+	if ( ! is_string( $specified_category_slug ) || strlen( $specified_category_slug ) < 1 ) {
+		return;
+	}
+
+	// What category slug did we expect? Normally this maps back to the first assigned product_cat
+	// term. However, this is filterable so we use the relevant helper function to figure this out.
+	$expected_category_slug = wc_product_post_type_link( '%product_cat%', get_post( get_the_ID() ) );
+
+	if ( $specified_category_slug === $expected_category_slug ) {
+		return;
+	}
+
+	$query_vars = isset( $_GET ) && is_array( $_GET ) ? $_GET : array();
+
+	wp_safe_redirect( add_query_arg( $query_vars, wc_get_product( get_the_ID() )->get_permalink() ), 301 );
+	exit();
+}
+add_action( 'template_redirect', 'wc_product_canonical_redirect', 5 );
+
+/**
  * Get the placeholder image URL either from media, or use the fallback image.
  *
  * @param string $size Thumbnail size to use.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -315,6 +315,7 @@ function wc_product_canonical_redirect(): void {
 		return;
 	}
 
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$query_vars = isset( $_GET ) && is_array( $_GET ) ? $_GET : array();
 
 	wp_safe_redirect( add_query_arg( $query_vars, wc_get_product( get_the_ID() )->get_permalink() ), 301 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This ensures that if product permalinks are set to include the `%product_cat%` replacement token, arbitrary values for that part of the URL will redirect to the canonical product category value, rather than successfully loading the single product page.

This changeset is largely based on the gist linked to in [this comment](https://github.com/woocommerce/woocommerce/issues/24244#issuecomment-2359635024). (props @barryhughes). I decided to go with `301` for the http status code, because presumably a product's categories won't change that often.

I haven't been able to think of a good way to unit test this, since it involves making requests to permalinks and doing template redirects (cURL doesn't seem to work in the test environment), but I'm open to ideas.

Fixes #24244

### How to test the changes in this Pull Request:

1. Before checking out this branch, follow the reproduction steps in #24244 to see the behavior without this change.
2. After checking out this branch, try the same steps. This time it should redirect to the correct URL whenever you try to put something arbitrary in the `%product_cat%` part of the URL.

Other things to try:

* Try changing the URL for a product that has a single product category term that is the child of another term. And even one where the term is nested multiple levels deep.
* Update the permalink setting so that `%product_cat%` is somewhere else in the URL structure besides at the end, and see if the redirection still works.
* Try changing the case of some of the characters in the `%product_cat%` value and see if it still redirects (it should).
* Try some other views besides single product view (e.g. post type or taxonomy archive) and make sure the redirect isn't happening in unexpected places.
* What else could cause this to break or cause an endless redirect loop?
