### PR TITLE
Fix add missing WP block class for variations

### DIFF
--- a/plugins/woocommerce/changelog/fix-49739_add_missing_wp-block_class_for_variations
+++ b/plugins/woocommerce/changelog/fix-49739_add_missing_wp-block_class_for_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where variation blocks didn't include the wp-block-<block name> class name.

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Admin\Features\Features;
@@ -126,7 +128,7 @@ final class BlockTypesController {
 		if ( ! array_key_exists( $attribute, $block['attrs'] ) ) {
 			return false;
 		}
-		$attribute_value = $block['attrs'][$attribute];
+		$attribute_value = $block['attrs'][ $attribute ];
 		if ( is_array( $value ) && is_array( $attribute_value ) ) {
 			$diff = array_diff_assoc( $value, $attribute_value );
 			return empty( $diff );
@@ -297,13 +299,13 @@ final class BlockTypesController {
 	 * @param array  $block Parsed block data.
 	 * @return string
 	 */
-	function add_block_class_name_for_block_variations( $content, $block ) {
-		$content = trim( $content );
+	public function add_block_class_name_for_block_variations( $content, $block ) {
+		$content               = trim( $content );
 		$variation_block_types = $this->get_variation_block_types();
-		$variation_key = array_search( $block['blockName'], array_column( $variation_block_types, 'block_name' ), true );
+		$variation_key         = array_search( $block['blockName'], array_column( $variation_block_types, 'block_name' ), true );
 
 		if ( false !== $variation_key ) {
-			$variation_block = $variation_block_types[ $variation_key ];
+			$variation_block    = $variation_block_types[ $variation_key ];
 			$matching_attribute = array_key_first( $variation_block['attributes'] );
 			if ( $this->has_block_variation( $block, $matching_attribute, $variation_block['attributes'][ $matching_attribute ] ) ) {
 				$processor = new \WP_HTML_Tag_Processor( $content );
@@ -533,14 +535,14 @@ final class BlockTypesController {
 	protected function get_variation_block_types() {
 		return array(
 			array(
-				'block_name' => 'core/search',
+				'block_name'     => 'core/search',
 				'variation_name' => 'woocommerce/product-search',
-				'attributes' => array(
+				'attributes'     => array(
 					'query' => array(
-						'post_type' => 'product'
-					)
+						'post_type' => 'product',
+					),
 				),
-			)
+			),
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds the `wp-block-<block name>` class to block variations. In particular the `product-search` which is a variation of `core/search`.
One outstanding question is that although this applies the theme styles on the front-end, the `wp-block-<block name>` class for the variation name does not get added to the site editor. Meaning is this something we should encourage. although it does look like this is something that WP does with its variation blocks ( see the youtube embed, it includes the `wp-block-embed-youtube` class on the front-end but not within the editor, there only the `wp-block-embed` ).

Related to: #49739


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Have a site with the **Twenty Twenty-Four** theme enabled
2. Go to **Tools > Theme File Editor** and select the `theme.json` file -> **Twenty Twenty-Four: Theme Styles & Block Settings**
3. Scroll down to the `"styles"` key and under `"blocks"` insert something like this:
```
"woocommerce/product-search": {
"color": {
      "text": "red",
      "background": "blue"
   }
},
```
4. Create a new page and add the **Product search** block and publish it
5. Preview the page, the above colours should be applied, you can also scroll down to the footer and see if the colours are also applied to the search there ( as we use the product search there as well ).

**Test if the changes in `has_block_variation` didn't break anything**
1. Create a new page
6. Insert the classic checkout block
7. Add something to your cart and visit the new page
8. Confirm it looks correct and you can place an order
9. Repeat for the classic cart block on another new page

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
