### PR TITLE
Fetch promotions in a WP Cron job

### DIFF
--- a/plugins/woocommerce/changelog/update-wccom-21774-update-promotions-async
+++ b/plugins/woocommerce/changelog/update-wccom-21774-update-promotions-async
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Changed how we fetch WooCommerce promotions. We're doing it async so as not to affect the loading of wp-admin.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -89,7 +89,7 @@ class WC_Admin_Marketplace_Promotions {
 	 *
 	 * @return void
 	 */
-	private static function update_promotions() {
+	public static function update_promotions() {
 		// Fetch promotions from the API.
 		$promotions = self::fetch_marketplace_promotions();
 		set_transient( self::TRANSIENT_NAME, $promotions, self::TRANSIENT_LIFE_SPAN );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Marketplace_Promotions {
 
+	const CRON_NAME		   	  = 'woocommerce_marketplace_cron_fetch_promotions';
 	const TRANSIENT_NAME      = 'woocommerce_marketplace_promotions_v2';
 	const TRANSIENT_LIFE_SPAN = DAY_IN_SECONDS;
 	const PROMOTIONS_API_URL  = 'https://woocommerce.com/wp-json/wccom-extensions/3.0/promotions';
@@ -39,7 +40,16 @@ class WC_Admin_Marketplace_Promotions {
 	public static function init() {
 		// A legacy hook that can be triggered by action scheduler.
 		add_action( 'woocommerce_marketplace_fetch_promotions', array( __CLASS__, 'clear_deprecated_action' ) );
-		add_action( 'woocommerce_marketplace_fetch_promotions_clear', array( __CLASS__, 'clear_scheduled_event' ) );
+		add_action(
+			'woocommerce_marketplace_fetch_promotions_clear',
+			array(
+				__CLASS__,
+				'clear_deprecated_scheduled_event',
+			)
+		);
+
+		// Fetch promotions from the API and store them in a transient.
+		add_action( self::CRON_NAME, array( __CLASS__, 'update_promotions' ) );
 
 		if (
 			defined( 'DOING_AJAX' ) && DOING_AJAX
@@ -53,24 +63,33 @@ class WC_Admin_Marketplace_Promotions {
 			return;
 		}
 
-		self::maybe_update_promotions();
+		self::schedule_cron_event();
+
+		register_deactivation_hook( WC_PLUGIN_FILE, array( __CLASS__, 'clear_cron_event' ) );
 
 		self::$locale = ( self::$locale ?? get_user_locale() ) ?? 'en_US';
 		self::maybe_show_bubble_promotions();
 	}
 
 	/**
-	 * Fetch promotions from the API and store them in a transient.
-	 * Fetching can be suppressed by the `woocommerce_marketplace_suppress_promotions` filter.
+	 * Schedule a daily cron event to fetch promotions.
+	 *
+	 * @version	9.5.0
 	 *
 	 * @return void
 	 */
-	private static function maybe_update_promotions() {
-		// Fetch promotions if they're not in the transient.
-		if ( false !== get_transient( self::TRANSIENT_NAME ) ) {
-			return;
+	private static function schedule_cron_event() {
+		if ( ! wp_next_scheduled( self::CRON_NAME ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_NAME );
 		}
+	}
 
+	/**
+	 * Fetch promotions from the API and store them in a transient.
+	 *
+	 * @return void
+	 */
+	private static function update_promotions() {
 		// Fetch promotions from the API.
 		$promotions = self::fetch_marketplace_promotions();
 		set_transient( self::TRANSIENT_NAME, $promotions, self::TRANSIENT_LIFE_SPAN );
@@ -326,12 +345,24 @@ class WC_Admin_Marketplace_Promotions {
 	}
 
 	/**
-	 * Clear the scheduled action that was used to fetch promotions in WooCommerce 8.8.
-	 * It's no longer needed as a transient is used to store the data.
+	 * When WooCommerce is disabled, clear the WP Cron event we use to fetch promotions.
+	 *
+	 * @version 9.5.0
 	 *
 	 * @return void
 	 */
-	public static function clear_scheduled_event() {
+	public static function clear_cron_event() {
+		$timestamp = wp_next_scheduled( self::CRON_NAME );
+		wp_unschedule_event( $timestamp, self::CRON_NAME );
+	}
+
+	/**
+	 * Clear deprecated scheduled action that was used to fetch promotions in WooCommerce 8.8.
+	 * Replaced with a transient in WooCommerce 9.0.
+	 *
+	 * @return void
+	 */
+	public static function clear_deprecated_scheduled_event() {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( 'woocommerce_marketplace_fetch_promotions' );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-marketplace-promotions.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Marketplace_Promotions {
 
-	const CRON_NAME		   	  = 'woocommerce_marketplace_cron_fetch_promotions';
+	const CRON_NAME           = 'woocommerce_marketplace_cron_fetch_promotions';
 	const TRANSIENT_NAME      = 'woocommerce_marketplace_promotions_v2';
 	const TRANSIENT_LIFE_SPAN = DAY_IN_SECONDS;
 	const PROMOTIONS_API_URL  = 'https://woocommerce.com/wp-json/wccom-extensions/3.0/promotions';
@@ -74,7 +74,7 @@ class WC_Admin_Marketplace_Promotions {
 	/**
 	 * Schedule a daily cron event to fetch promotions.
 	 *
-	 * @version	9.5.0
+	 * @version 9.5.0
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes 21774-gh-Automattic/woocommerce.com.

We don't want the request to the promotions endpoint to affect the loading of wp-admin. Therefore we should make the request async. See https://github.com/woocommerce/woocommerce/pull/47262#pullrequestreview-2241835763.

For sites on hosts that disable WP-Cron, like GoDaddy, the request won't be made.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) in your WooCommerce environment, so you can view WP-Cron events.
3. You can inspect the action at `wp-admin/tools.php?page=crontrol_admin_manage_page&s=woocommerce_marketplace_cron_fetch_promotions`.

<p>
<img width="500" alt="image" src="https://github.com/user-attachments/assets/320b9abc-9814-40c8-b903-94e1056da994">
</p>

4. Apply this patch: [promotions-patch.txt](https://github.com/user-attachments/files/17116968/promotions-patch.txt). This sets the cron interval to 5 minutes, and points the callback to an endpoint with dummy data.
5. View the cron job. It should be set to run in under 5 minutes.
6. Wait 5 minutes, and refresh any page.
7. View wp-admin > WooCommerce. You should see a `Sale` bubble on the "Extensions" menu item, and notices on the Discover, Browse and Themes tabs of the in-app marketplace.
8. Change line 144 of `class-wc-admin-marketplace-promotions.php` to `$raw_promotions = wp_safe_remote_get( 'https://gist.githubusercontent.com/andfinally/1c687ed2ed55cf78e9a8ee8d9fa5c205/raw/promotions.json' );`. This is an endpoint returning an empty array.
9. Wait for the cron job to run again.
10. View wp-admin > WooCommerce again. The menu item bubble and notices should have disappeared.
11. Disable WooCommerce in plugins admin.
12. Check that no `woocommerce_marketplace_cron_fetch_promotions` WP-Cron job is scheduled.
13. Please test around this change.

### Screenshots

<img width="500" alt="image" src="https://github.com/user-attachments/assets/13cede99-f32c-4965-b27c-5641216175c8">


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>