### PR TITLE
Replace setTimeout with callback function for more reliable E2E tests

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/plugins/register-product-collection-tester/index.js
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/register-product-collection-tester/index.js
@@ -49,14 +49,12 @@ __experimentalRegisterProductCollection( {
 			// console.log( 'Current attributes:', currentAttributes );
 			// console.log( 'Location:', location );
 
-			const timeoutID = setTimeout( () => {
+			window.__removePreview = () => {
 				setState( {
 					isPreview: false,
 					previewMessage: '',
 				} );
-			}, 1000 );
-
-			return () => clearTimeout( timeoutID );
+			};
 		},
 		initialPreviewState: {
 			isPreview: true,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -107,6 +107,12 @@ const collectionToButtonNameMap = {
 		'My Custom Collection - Multiple Contexts',
 };
 
+declare global {
+	interface Window {
+		__removePreview?: () => void;
+	}
+}
+
 class ProductCollectionPage {
 	private BLOCK_SLUG = 'woocommerce/product-collection';
 	private page: Page;
@@ -796,6 +802,14 @@ class ProductCollectionPage {
 		} else {
 			await this.initializeLocatorsForFrontend();
 		}
+	}
+
+	async removeAdvancedPreview() {
+		await this.page.evaluate( () => {
+			if ( window.__removePreview ) {
+				window.__removePreview();
+			}
+		} );
 	}
 
 	private async initializeLocatorsForEditor() {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -107,12 +107,6 @@ const collectionToButtonNameMap = {
 		'My Custom Collection - Multiple Contexts',
 };
 
-declare global {
-	interface Window {
-		__removePreview?: () => void;
-	}
-}
-
 class ProductCollectionPage {
 	private BLOCK_SLUG = 'woocommerce/product-collection';
 	private page: Page;
@@ -802,14 +796,6 @@ class ProductCollectionPage {
 		} else {
 			await this.initializeLocatorsForFrontend();
 		}
-	}
-
-	async removeAdvancedPreview() {
-		await this.page.evaluate( () => {
-			if ( window.__removePreview ) {
-				window.__removePreview();
-			}
-		} );
 	}
 
 	private async initializeLocatorsForEditor() {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -12,6 +12,12 @@ import ProductCollectionPage, {
 	SELECTORS,
 } from './product-collection.page';
 
+declare global {
+	interface Window {
+		__removePreview: () => void;
+	}
+}
+
 const test = base.extend< { pageObject: ProductCollectionPage } >( {
 	pageObject: async ( { page, admin, editor }, use ) => {
 		const pageObject = new ProductCollectionPage( {
@@ -220,6 +226,7 @@ test.describe( 'Product Collection registration', () => {
 		test( 'Clicking "My Custom Collection with Advanced Preview" should show preview and then replace it by the actual content', async ( {
 			pageObject,
 			editor,
+			page,
 		} ) => {
 			await pageObject.createNewPostAndInsertBlock(
 				'myCustomCollectionWithAdvancedPreview'
@@ -231,6 +238,10 @@ test.describe( 'Product Collection registration', () => {
 			// The preview button should be visible
 			await expect( previewButtonLocator ).toBeVisible();
 
+			await page.evaluate( () => {
+				window.__removePreview();
+			} );
+
 			// The preview button should be hidden
 			await expect( previewButtonLocator ).toBeHidden();
 		} );
@@ -238,6 +249,7 @@ test.describe( 'Product Collection registration', () => {
 		test( 'Should display properly in Product Catalog template', async ( {
 			pageObject,
 			editor,
+			page,
 		} ) => {
 			await pageObject.goToProductCatalogAndInsertCollection(
 				'myCustomCollectionWithAdvancedPreview'
@@ -260,7 +272,9 @@ test.describe( 'Product Collection registration', () => {
 				.locator( 'visible=true' );
 			await expect( products ).toHaveCount( 9 );
 
-			await pageObject.removeAdvancedPreview();
+			await page.evaluate( () => {
+				window.__removePreview();
+			} );
 
 			await expect( previewButtonLocator ).toBeHidden();
 		} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -235,7 +235,7 @@ test.describe( 'Product Collection registration', () => {
 			await expect( previewButtonLocator ).toBeHidden();
 		} );
 
-		test.skip( 'Should display properly in Product Catalog template', async ( {
+		test( 'Should display properly in Product Catalog template', async ( {
 			pageObject,
 			editor,
 		} ) => {
@@ -260,7 +260,8 @@ test.describe( 'Product Collection registration', () => {
 				.locator( 'visible=true' );
 			await expect( products ).toHaveCount( 9 );
 
-			// The preview button should be hidden after 1 second
+			await pageObject.removeAdvancedPreview();
+
 			await expect( previewButtonLocator ).toBeHidden();
 		} );
 	} );

--- a/plugins/woocommerce/changelog/fix-50040_flaky_product_collection_advanced_preview_test
+++ b/plugins/woocommerce/changelog/fix-50040_flaky_product_collection_advanced_preview_test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update product collection E2E test to be more reliable when testing the preview feature.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes a flaky E2E test that relied on a 1 second timeout. Instead I moved it to a callback so we can manually control this within the E2E test.

Closes #50040 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run E2E tests following these steps: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/tests/e2e/README.md#preparing-the-environment. and make sure they all pass.
2. Run the E2E tests also with the `--ui` flag to make sure they pass.
3. Check the GH actions of this PR and make sure the E2E tests passed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
