### PR TITLE
Fix/51435 product collection flaky e2e test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -47,6 +47,10 @@ test.describe( 'Product Collection registration', () => {
 			name: 'My Custom Collection with Advanced Preview',
 			label: 'Block: My Custom Collection with Advanced Preview',
 		},
+		myCustomCollectionWithProductContext: {
+			name: 'My Custom Collection - Product Context',
+			label: 'Block: My Custom Collection - Product Context',
+		},
 	};
 
 	// Activate plugin which registers custom product collections
@@ -372,7 +376,7 @@ test.describe( 'Product Collection registration', () => {
 		} );
 	} );
 
-	test.skip( 'Product picker should be shown when selected product is deleted', async ( {
+	test( 'Product picker should be shown when selected product is deleted', async ( {
 		pageObject,
 		admin,
 		editor,
@@ -396,6 +400,9 @@ test.describe( 'Product Collection registration', () => {
 		await pageObject.chooseCollectionInPost(
 			'myCustomCollectionWithProductContext'
 		);
+		const block = editor.canvas.getByLabel(
+			MY_REGISTERED_COLLECTIONS.myCustomCollectionWithProductContext.label
+		);
 
 		// Verify that product picker is shown in Editor
 		const editorProductPicker = editor.canvas.locator(
@@ -408,6 +415,12 @@ test.describe( 'Product Collection registration', () => {
 			editor.canvas,
 			'A Test Product'
 		);
+		await expect(
+			block
+				.getByLabel( BLOCK_LABELS.productImage )
+				.locator( 'visible=true' )
+				.first()
+		).toBeVisible();
 		await expect( editorProductPicker ).toBeHidden();
 
 		await editor.saveDraft();
@@ -436,6 +449,12 @@ test.describe( 'Product Collection registration', () => {
 
 		// Product Picker shouldn't be shown as product is available now
 		await page.reload();
+		await expect(
+			block
+				.getByLabel( BLOCK_LABELS.productImage )
+				.locator( 'visible=true' )
+				.first()
+		).toBeVisible();
 		await expect( editorProductPicker ).toBeHidden();
 
 		// Delete the product from database, instead of trashing it
@@ -449,6 +468,7 @@ test.describe( 'Product Collection registration', () => {
 		} );
 
 		// Product picker should be shown in Editor
+		await page.reload();
 		await expect( deletedProductPicker ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection-tester.block_theme.spec.ts
@@ -416,10 +416,7 @@ test.describe( 'Product Collection registration', () => {
 			'A Test Product'
 		);
 		await expect(
-			block
-				.getByLabel( BLOCK_LABELS.productImage )
-				.locator( 'visible=true' )
-				.first()
+			block.getByLabel( BLOCK_LABELS.productImage ).first()
 		).toBeVisible();
 		await expect( editorProductPicker ).toBeHidden();
 
@@ -450,10 +447,7 @@ test.describe( 'Product Collection registration', () => {
 		// Product Picker shouldn't be shown as product is available now
 		await page.reload();
 		await expect(
-			block
-				.getByLabel( BLOCK_LABELS.productImage )
-				.locator( 'visible=true' )
-				.first()
+			block.getByLabel( BLOCK_LABELS.productImage ).first()
 		).toBeVisible();
 		await expect( editorProductPicker ).toBeHidden();
 

--- a/plugins/woocommerce/changelog/fix-51435_product_collection_flaky_e2e_test
+++ b/plugins/woocommerce/changelog/fix-51435_product_collection_flaky_e2e_test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update product collection E2E test to be more reliable when testing the collection block with product context.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This should fix a flaky E2E tests, where I believe the test cases where satisfied to early during loading states causing the checks to move ahead to quickly.
I added some additional checks to validate each step.

Closes #51435 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run E2E tests following these steps: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/tests/e2e/README.md#preparing-the-environment. and make sure they all pass.
2. Run the E2E tests also with the `--ui` flag to make sure they pass.
3. Check the GH actions of this PR and make sure the E2E tests passed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
