### PR TITLE
Add core feature for site visibility badge

### DIFF
--- a/plugins/woocommerce/changelog/add-badge-feature
+++ b/plugins/woocommerce/changelog/add-badge-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add core feature for site visibility badge

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -3,6 +3,7 @@
 declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ComingSoon;
+
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 
@@ -117,4 +118,61 @@ class ComingSoonAdminBarBadge {
 			</style>';
 		}
 	}
+}
+
+add_action( 'show_user_profile', '\Automattic\WooCommerce\Internal\ComingSoon\custom_user_profile_field' );
+add_action( 'edit_user_profile', '\Automattic\WooCommerce\Internal\ComingSoon\custom_user_profile_field' );
+
+function custom_user_profile_field( $user ) {
+    ?>
+	<br />
+    <h3><?php _e('WooCommerce Options', 'textdomain'); ?></h3>
+    <table class="form-table">
+        <tr>
+            <th><label for="custom_option"><?php _e('Toolbar', 'textdomain'); ?></label></th>
+            <td>
+                <label><input type="checkbox" name="custom_option" id="custom_option" value="<?php echo esc_attr( get_user_meta( $user->ID, 'custom_option', true ) ); ?>" class="regular-text" /> Show the site visibility badge in toolbar.</label>
+            </td>
+        </tr>
+    </table>
+    <?php
+}
+
+add_action( 'personal_options_update', '\Automattic\WooCommerce\Internal\ComingSoon\save_custom_user_profile_field' );
+add_action( 'edit_user_profile_update', '\Automattic\WooCommerce\Internal\ComingSoon\save_custom_user_profile_field' );
+
+function save_custom_user_profile_field( $user_id ) {
+    if ( !current_user_can( 'edit_user', $user_id ) ) {
+        return false;
+    }
+    update_user_meta( $user_id, 'custom_option', sanitize_text_field( $_POST['custom_option'] ) );
+}
+
+
+add_action( 'personal_options', '\Automattic\WooCommerce\Internal\ComingSoon\custom_show_badge_option' );
+
+function custom_show_badge_option( $user ) {
+    ?>
+    <tr>
+        <th scope="row"><?php _e('Site Visibility Badge', 'textdomain'); ?></th>
+        <td>
+            <label for="show_badge">
+                <input type="checkbox" name="show_badge" id="show_badge" value="1" <?php checked( get_user_meta( $user->ID, 'show_badge', true ), 1 ); ?> />
+                <?php _e('Show WooCommerce site visibility badge in Toolbar', 'textdomain'); ?>
+            </label>
+        </td>
+    </tr>
+    <?php
+}
+
+add_action( 'personal_options_update', 'save_show_badge_option' );
+add_action( 'edit_user_profile_update', 'save_show_badge_option' );
+
+function save_show_badge_option( $user_id ) {
+    if ( ! current_user_can( 'edit_user', $user_id ) ) {
+        return false;
+    }
+
+    $show_badge = isset( $_POST['show_badge'] ) ? 1 : 0;
+    update_user_meta( $user_id, 'show_badge', $show_badge );
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -3,6 +3,7 @@
 declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ComingSoon;
+
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -3,7 +3,6 @@
 declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ComingSoon;
-
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 
@@ -118,61 +117,4 @@ class ComingSoonAdminBarBadge {
 			</style>';
 		}
 	}
-}
-
-add_action( 'show_user_profile', '\Automattic\WooCommerce\Internal\ComingSoon\custom_user_profile_field' );
-add_action( 'edit_user_profile', '\Automattic\WooCommerce\Internal\ComingSoon\custom_user_profile_field' );
-
-function custom_user_profile_field( $user ) {
-    ?>
-	<br />
-    <h3><?php _e('WooCommerce Options', 'textdomain'); ?></h3>
-    <table class="form-table">
-        <tr>
-            <th><label for="custom_option"><?php _e('Toolbar', 'textdomain'); ?></label></th>
-            <td>
-                <label><input type="checkbox" name="custom_option" id="custom_option" value="<?php echo esc_attr( get_user_meta( $user->ID, 'custom_option', true ) ); ?>" class="regular-text" /> Show the site visibility badge in toolbar.</label>
-            </td>
-        </tr>
-    </table>
-    <?php
-}
-
-add_action( 'personal_options_update', '\Automattic\WooCommerce\Internal\ComingSoon\save_custom_user_profile_field' );
-add_action( 'edit_user_profile_update', '\Automattic\WooCommerce\Internal\ComingSoon\save_custom_user_profile_field' );
-
-function save_custom_user_profile_field( $user_id ) {
-    if ( !current_user_can( 'edit_user', $user_id ) ) {
-        return false;
-    }
-    update_user_meta( $user_id, 'custom_option', sanitize_text_field( $_POST['custom_option'] ) );
-}
-
-
-add_action( 'personal_options', '\Automattic\WooCommerce\Internal\ComingSoon\custom_show_badge_option' );
-
-function custom_show_badge_option( $user ) {
-    ?>
-    <tr>
-        <th scope="row"><?php _e('Site Visibility Badge', 'textdomain'); ?></th>
-        <td>
-            <label for="show_badge">
-                <input type="checkbox" name="show_badge" id="show_badge" value="1" <?php checked( get_user_meta( $user->ID, 'show_badge', true ), 1 ); ?> />
-                <?php _e('Show WooCommerce site visibility badge in Toolbar', 'textdomain'); ?>
-            </label>
-        </td>
-    </tr>
-    <?php
-}
-
-add_action( 'personal_options_update', 'save_show_badge_option' );
-add_action( 'edit_user_profile_update', 'save_show_badge_option' );
-
-function save_show_badge_option( $user_id ) {
-    if ( ! current_user_can( 'edit_user', $user_id ) ) {
-        return false;
-    }
-
-    $show_badge = isset( $_POST['show_badge'] ) ? 1 : 0;
-    update_user_meta( $user_id, 'show_badge', $show_badge );
 }

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -3,8 +3,8 @@
 declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\ComingSoon;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
-use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * Adds hooks to add a badge to the WordPress admin bar showing site visibility.
@@ -30,7 +30,7 @@ class ComingSoonAdminBarBadge {
 	 */
 	public function site_visibility_badge( $wp_admin_bar ) {
 		// Early exit if LYS feature is disabled.
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+		if ( ! FeaturesUtil::feature_is_enabled( 'site_visibility_badge' ) ) {
 			return;
 		}
 
@@ -68,7 +68,7 @@ class ComingSoonAdminBarBadge {
 	 */
 	public function output_css() {
 		// Early exit if LYS feature is disabled.
-		if ( ! Features::is_enabled( 'launch-your-store' ) ) {
+		if ( ! FeaturesUtil::feature_is_enabled( 'site_visibility_badge' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -224,6 +224,18 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'is_experimental'    => false,
 				),
+				'site_visibility_badge' => array(
+					'name'               => __( 'Site visibility badge', 'woocommerce' ),
+					'description'        => __(
+						'Enable the site visibility badge in the WordPress admin bar',
+						'woocommerce'
+					),
+					'enabled_by_default' => true,
+					'disable_ui'         => false,
+					'is_legacy'          => true,
+					'is_experimental'    => false,
+					'disabled'           => false,
+				),
 				'hpos_fts_indexes'     => array(
 					'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
 					'description'        => __(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -164,7 +164,7 @@ class FeaturesController {
 	private function get_feature_definitions() {
 		if ( empty( $this->features ) ) {
 			$legacy_features = array(
-				'analytics'             => array(
+				'analytics'            => array(
 					'name'               => __( 'Analytics', 'woocommerce' ),
 					'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
 					'option_key'         => Analytics::TOGGLE_OPTION_NAME,
@@ -173,7 +173,7 @@ class FeaturesController {
 					'disable_ui'         => false,
 					'is_legacy'          => true,
 				),
-				'product_block_editor'  => array(
+				'product_block_editor' => array(
 					'name'            => __( 'New product editor', 'woocommerce' ),
 					'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 					'is_experimental' => true,
@@ -194,13 +194,13 @@ class FeaturesController {
 						return $string;
 					},
 				),
-				'cart_checkout_blocks'  => array(
+				'cart_checkout_blocks' => array(
 					'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 					'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
 					'is_experimental' => false,
 					'disable_ui'      => true,
 				),
-				'marketplace'           => array(
+				'marketplace'          => array(
 					'name'               => __( 'Marketplace', 'woocommerce' ),
 					'description'        => __(
 						'New, faster way to find extensions and themes for your WooCommerce store',
@@ -213,7 +213,7 @@ class FeaturesController {
 				),
 				// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 				// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
-				'order_attribution'     => array(
+				'order_attribution'    => array(
 					'name'               => __( 'Order Attribution', 'woocommerce' ),
 					'description'        => __(
 						'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
@@ -224,7 +224,7 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'is_experimental'    => false,
 				),
-				'site_visibility_badge'  => array(
+				'site_visibility_badge' => array(
 					'name'               => __( 'Site visibility badge', 'woocommerce' ),
 					'description'        => __(
 						'Enable the site visibility badge in the WordPress admin bar',
@@ -236,7 +236,7 @@ class FeaturesController {
 					'is_experimental'    => false,
 					'disabled'           => false,
 				),
-				'hpos_fts_indexes'      => array(
+				'hpos_fts_indexes'     => array(
 					'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
 					'description'        => __(
 						'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',
@@ -247,7 +247,7 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'option_key'         => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 				),
-				'remote_logging'        => array(
+				'remote_logging'       => array(
 					'name'               => __( 'Remote Logging', 'woocommerce' ),
 					'description'        => __(
 						'Enable this feature to log errors and related data to Automattic servers for debugging purposes and to improve WooCommerce',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -224,7 +224,7 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'is_experimental'    => false,
 				),
-				'site_visibility_badge'  => array(
+				'site_visibility_badge' => array(
 					'name'               => __( 'Site visibility badge', 'woocommerce' ),
 					'description'        => __(
 						'Enable the site visibility badge in the WordPress admin bar',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -164,7 +164,7 @@ class FeaturesController {
 	private function get_feature_definitions() {
 		if ( empty( $this->features ) ) {
 			$legacy_features = array(
-				'analytics'            => array(
+				'analytics'             => array(
 					'name'               => __( 'Analytics', 'woocommerce' ),
 					'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
 					'option_key'         => Analytics::TOGGLE_OPTION_NAME,
@@ -173,7 +173,7 @@ class FeaturesController {
 					'disable_ui'         => false,
 					'is_legacy'          => true,
 				),
-				'product_block_editor' => array(
+				'product_block_editor'  => array(
 					'name'            => __( 'New product editor', 'woocommerce' ),
 					'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 					'is_experimental' => true,
@@ -194,13 +194,13 @@ class FeaturesController {
 						return $string;
 					},
 				),
-				'cart_checkout_blocks' => array(
+				'cart_checkout_blocks'  => array(
 					'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 					'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
 					'is_experimental' => false,
 					'disable_ui'      => true,
 				),
-				'marketplace'          => array(
+				'marketplace'           => array(
 					'name'               => __( 'Marketplace', 'woocommerce' ),
 					'description'        => __(
 						'New, faster way to find extensions and themes for your WooCommerce store',
@@ -213,7 +213,7 @@ class FeaturesController {
 				),
 				// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 				// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
-				'order_attribution'    => array(
+				'order_attribution'     => array(
 					'name'               => __( 'Order Attribution', 'woocommerce' ),
 					'description'        => __(
 						'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
@@ -224,7 +224,7 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'is_experimental'    => false,
 				),
-				'site_visibility_badge' => array(
+				'site_visibility_badge'  => array(
 					'name'               => __( 'Site visibility badge', 'woocommerce' ),
 					'description'        => __(
 						'Enable the site visibility badge in the WordPress admin bar',
@@ -236,7 +236,7 @@ class FeaturesController {
 					'is_experimental'    => false,
 					'disabled'           => false,
 				),
-				'hpos_fts_indexes'     => array(
+				'hpos_fts_indexes'      => array(
 					'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
 					'description'        => __(
 						'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',
@@ -247,7 +247,7 @@ class FeaturesController {
 					'is_legacy'          => true,
 					'option_key'         => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 				),
-				'remote_logging'       => array(
+				'remote_logging'        => array(
 					'name'               => __( 'Remote Logging', 'woocommerce' ),
 					'description'        => __(
 						'Enable this feature to log errors and related data to Automattic servers for debugging purposes and to improve WooCommerce',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51389 .

As an alternative to https://github.com/woocommerce/woocommerce/pull/51398, this PR adds a core feature for the site visibility badge, allowing it to be disabled on sites that don't need it.

This places a checkbox amongst other features in the advanced settings screen. This is arguably more preferable to the "Site visibility" settings screen, where our newer users visit and may need to learn concepts like the admin bar.

https://github.com/user-attachments/assets/e1f444e6-67d6-4ccf-a17a-97b2c070cc11


The feature uses a WordPress option under the hood. As such, it may be controlled by code - e.g. in a provisioning script for new sites:

```
update_option( 'woocommerce_feature_site_visibility_badge_enabled', 'no' );
```

The feature defaults to enabled as we have signals that badge has utility for a large amount of sites. In the initial launch of the badge, we see 1000+ tracked sites using the live -> coming soon flow per day. For the sites that don't need the badge, we aim for the feature setting to be easy to disable either by the settings UI or deploying code to update the option.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Enabled by default
1. Delete the option `woocommerce_feature_site_visibility_badge_enabled` if it exists on the site
1. In Admin, visit WooCommerce > Settings > Advanced > Features
2. See that the "Enable the site visibility badge in the WordPress admin bar" setting is checked and the badge is present in the admin bar.

##### Check disabled functionality
1. Uncheck the "Enable the site visibility badge in the WordPress admin bar" setting and save settings.
2. See that the site visibility badge is **not** present in the WordPress admin bar.

##### Check re-enabled functionality
1. Uncheck the "Enable the site visibility badge in the WordPress admin bar" setting and save settings.
1. Check  the "Enable the site visibility badge in the WordPress admin bar" setting and save settings.
2. See that the site visibility badge is present in the WordPress admin bar.

##### Code
1. Delete the option `woocommerce_feature_site_visibility_badge_enabled` if it exists on the site
2. Run the following as a code snippet or WP shell command: `update_option( 'woocommerce_feature_site_visibility_badge_enabled', 'no' );`
3. Reload any screen showing the admin bar.
4. See that the site visibility badge is **not** present in the WordPress admin bar.




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
