### PR TITLE
Cherry-pick PR#51630 to 9.4

### DIFF
--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -201,6 +201,7 @@ class Checkout extends AbstractCartRoute {
 
 		$address_fields = $this->additional_fields_controller->get_fields_for_location( 'address' );
 		if ( ! empty( $address_fields ) ) {
+			$needs_shipping = WC()->cart->needs_shipping();
 			foreach ( $address_fields as $field_key => $address_field ) {
 				if ( $address_field['required'] && ! isset( $request['billing_address'][ $field_key ] ) ) {
 					throw new RouteException(
@@ -210,7 +211,7 @@ class Checkout extends AbstractCartRoute {
 						400
 					);
 				}
-				if ( $address_field['required'] && ! isset( $request['shipping_address'][ $field_key ] ) ) {
+				if ( $needs_shipping && $address_field['required'] && ! isset( $request['shipping_address'][ $field_key ] ) ) {
 					throw new RouteException(
 						'woocommerce_rest_checkout_missing_required_field',
 						/* translators: %s: is the field label */

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -72,6 +72,15 @@ class AdditionalFields extends MockeryTestCase {
 					'weight'        => 10,
 				)
 			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Virtual Test Product 3',
+					'stock_status'  => 'instock',
+					'regular_price' => 10,
+					'weight'        => 10,
+					'virtual'       => true,
+				)
+			),
 		);
 		$this->reset_session();
 	}
@@ -1680,6 +1689,54 @@ class AdditionalFields extends MockeryTestCase {
 
 		// Ensures the field isn't registered.
 		$this->assertFalse( $this->controller->is_field( $id ), \sprintf( '%s is still registered', $id ) );
+	}
+
+	/**
+	 * Ensures an order for a virtual product can be placed without a shipping address.
+	 */
+	public function test_place_virtual_product_order() {
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $this->products[2]->get_id(), 2 );
+		$id    = 'plugin-namespace/my-required-field';
+		$label = 'My Required Field';
+		\woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => $id,
+				'label'    => $label,
+				'location' => 'address',
+				'type'     => 'text',
+				'required' => true,
+			)
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'   => (object) array(
+					'first_name'                         => 'test',
+					'last_name'                          => 'test',
+					'company'                            => '',
+					'address_1'                          => 'test',
+					'address_2'                          => '',
+					'city'                               => 'test',
+					'state'                              => '',
+					'postcode'                           => 'cb241ab',
+					'country'                            => 'GB',
+					'phone'                              => '',
+					'email'                              => 'testaccount@test.com',
+					'plugin-namespace/gov-id'            => 'gov id',
+					'plugin-namespace/my-required-field' => 'req. field',
+				),
+				'payment_method'    => 'bacs',
+				'additional_fields' => array(
+					'plugin-namespace/job-function' => 'engineering',
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
 	}
 
 	/**


### PR DESCRIPTION
- See https://github.com/woocommerce/woocommerce/pull/51630.
- The above was merged to `trunk` and then cherry-picked to `release/9.3` in https://github.com/woocommerce/woocommerce/pull/51655.
- Since `release/9.4` was cut before that, we also need to perform this final cherry-pick.
- We don't need the changelog here, so I didn't cherry-pick d7288fa316b9580b62eb132114539af90a79cad1.
