### PR TITLE
Product Collection: fix price range posts clauses

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -289,7 +289,7 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 
 		await pageObject.addFilter( 'Price Range' );
 		await pageObject.setPriceRange( {
-			min: '18.33',
+			min: '25',
 		} );
 
 		await expect( pageObject.products ).toHaveCount( 7 );
@@ -299,17 +299,17 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 			max: '17.21',
 		} );
 
-		await expect( pageObject.products ).toHaveCount( 1 );
+		await expect( pageObject.products ).toHaveCount( 2 );
 
 		await pageObject.setPriceRange( {
 			max: '17.29',
 		} );
 
-		await expect( pageObject.products ).toHaveCount( 4 );
+		await expect( pageObject.products ).toHaveCount( 5 );
 
 		await pageObject.publishAndGoToFrontend();
 
-		await expect( pageObject.products ).toHaveCount( 4 );
+		await expect( pageObject.products ).toHaveCount( 5 );
 	} );
 
 	// See https://github.com/woocommerce/woocommerce/pull/49917

--- a/plugins/woocommerce/changelog/fix-product-collection-price-range-posts-clauses
+++ b/plugins/woocommerce/changelog/fix-product-collection-price-range-posts-clauses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: fix the price range posts clauses.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -1719,18 +1719,18 @@ class ProductCollection extends AbstractBlock {
 		$min_price = $price_range['min'] ?? null;
 		if ( $min_price ) {
 			if ( $adjust_for_taxes ) {
-				$clauses['where'] .= $this->get_price_filter_query_for_displayed_taxes( $min_price, 'min_price', '>=' );
+				$clauses['where'] .= $this->get_price_filter_query_for_displayed_taxes( $min_price, 'max_price', '>=' );
 			} else {
-				$clauses['where'] .= $wpdb->prepare( ' AND wc_product_meta_lookup.min_price >= %f ', $min_price );
+				$clauses['where'] .= $wpdb->prepare( ' AND wc_product_meta_lookup.max_price >= %f ', $min_price );
 			}
 		}
 
 		$max_price = $price_range['max'] ?? null;
 		if ( $max_price ) {
 			if ( $adjust_for_taxes ) {
-				$clauses['where'] .= $this->get_price_filter_query_for_displayed_taxes( $max_price, 'max_price', '<=' );
+				$clauses['where'] .= $this->get_price_filter_query_for_displayed_taxes( $max_price, 'min_price', '<=' );
 			} else {
-				$clauses['where'] .= $wpdb->prepare( ' AND wc_product_meta_lookup.max_price <= %f ', $max_price );
+				$clauses['where'] .= $wpdb->prepare( ' AND wc_product_meta_lookup.min_price <= %f ', $max_price );
 			}
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
@@ -831,7 +831,7 @@ class ProductCollection extends \WP_UnitTestCase {
 
 		$query = new WP_Query( $merged_query );
 
-		$this->assertStringContainsString( 'wc_product_meta_lookup.min_price >= 1.', $query->request );
+		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price >= 1.', $query->request );
 	}
 
 	/**
@@ -854,7 +854,7 @@ class ProductCollection extends \WP_UnitTestCase {
 
 		$query = new WP_Query( $merged_query );
 
-		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price <= 1.', $query->request );
+		$this->assertStringContainsString( 'wc_product_meta_lookup.min_price <= 1.', $query->request );
 	}
 
 	/**
@@ -879,8 +879,8 @@ class ProductCollection extends \WP_UnitTestCase {
 
 		$query = new WP_Query( $merged_query );
 
-		$this->assertStringContainsString( 'wc_product_meta_lookup.min_price >= 1.', $query->request );
-		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price <= 2.', $query->request );
+		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price >= 1.', $query->request );
+		$this->assertStringContainsString( 'wc_product_meta_lookup.min_price <= 2.', $query->request );
 	}
 
 	/**
@@ -911,8 +911,8 @@ class ProductCollection extends \WP_UnitTestCase {
 		delete_option( 'woocommerce_tax_display_shop' );
 		delete_option( 'woocommerce_prices_include_tax' );
 
-		$this->assertStringContainsString( 'wc_product_meta_lookup.min_price >= 1.', $query->request );
-		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price <= 2.', $query->request );
+		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price >= 1.', $query->request );
+		$this->assertStringContainsString( 'wc_product_meta_lookup.min_price <= 2.', $query->request );
 	}
 
 	/**
@@ -950,8 +950,8 @@ class ProductCollection extends \WP_UnitTestCase {
 		$product->delete();
 		WC_Tax::delete_tax_class_by( 'slug', 'collection-test' );
 
-		$this->assertStringContainsString( "( wc_product_meta_lookup.tax_class = 'collection-test' AND wc_product_meta_lookup.`min_price` >= 1.", $query->request );
-		$this->assertStringContainsString( "( wc_product_meta_lookup.tax_class = 'collection-test' AND wc_product_meta_lookup.`max_price` <= 2.", $query->request );
+		$this->assertStringContainsString( "( wc_product_meta_lookup.tax_class = 'collection-test' AND wc_product_meta_lookup.`max_price` >= 1.", $query->request );
+		$this->assertStringContainsString( "( wc_product_meta_lookup.tax_class = 'collection-test' AND wc_product_meta_lookup.`min_price` <= 2.", $query->request );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50019.

This PR fixes the issue with the posts clauses used for the price range filter of the Product Collection block, which makes the PC block return the incorrect set of products.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new post.
2. Add the Product Collection block.
3. Apply the merchant price range filter that should include at least one product with variations. For example a Hoodie with a price from `$10 to $30` price should be included in the results if the price range is `$10 to $50`, `$30 to $50`, or `$20 to $50`.
4. Notice that the matching product **is in** the results.
5. Publish the post and go to the front end.
6. See that the matching product **is in** the results.
7. Go back to the editor.
8. Remove the merchant price range filter.
9. Add the `Filter by Price` block.
10. Publish the post and go to front end.
11. Apply the same price range and see that the matching product with variations is included with the results.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
