### PR TITLE
Cherry pick #51465 into release/9.3 to fix recently failing PHP unit tests on WP Nightly

### DIFF
--- a/plugins/woocommerce/changelog/fix-unit-test-trac-61739
+++ b/plugins/woocommerce/changelog/fix-unit-test-trac-61739
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update unit test to account for WordPress nightly change. See core trac ticket 61739
+
+

--- a/plugins/woocommerce/changelog/fix-unit-test-trac-61739
+++ b/plugins/woocommerce/changelog/fix-unit-test-trac-61739
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Update unit test to account for WordPress nightly change. See core trac ticket 61739
-
-

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/product-reviews.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/product-reviews.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * Tests for the product reviews REST API.
  *
@@ -50,40 +53,42 @@ class WC_Tests_API_Product_Reviews_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 10, count( $product_reviews ) );
-		$this->assertContains(
-			array(
-				'id'                   => $review_id,
-				'date_created'         => $product_reviews[0]['date_created'],
-				'date_created_gmt'     => $product_reviews[0]['date_created_gmt'],
-				'product_id'           => $product->get_id(),
-				'product_name'         => $product->get_name(),
-				'product_permalink'    => $product->get_permalink(),
-				'status'               => 'approved',
-				'reviewer'             => 'admin',
-				'reviewer_email'       => 'woo@woo.local',
-				'review'               => "<p>Review content here</p>\n",
-				'rating'               => 0,
-				'verified'             => false,
-				'reviewer_avatar_urls' => $product_reviews[0]['reviewer_avatar_urls'],
-				'_links'               => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v3/products/reviews/' . $review_id ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'                   => $review_id,
+					'date_created'         => $product_reviews[0]['date_created'],
+					'date_created_gmt'     => $product_reviews[0]['date_created_gmt'],
+					'product_id'           => $product->get_id(),
+					'product_name'         => $product->get_name(),
+					'product_permalink'    => $product->get_permalink(),
+					'status'               => 'approved',
+					'reviewer'             => 'admin',
+					'reviewer_email'       => 'woo@woo.local',
+					'review'               => "<p>Review content here</p>\n",
+					'rating'               => 0,
+					'verified'             => false,
+					'reviewer_avatar_urls' => $product_reviews[0]['reviewer_avatar_urls'],
+					'_links'               => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v3/products/reviews/' . $review_id ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v3/products/reviews' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v3/products/reviews' ),
+							),
 						),
-					),
-					'up'         => array(
-						array(
-							'href' => rest_url( '/wc/v3/products/' . $product->get_id() ),
+						'up'         => array(
+							array(
+								'href' => rest_url( '/wc/v3/products/' . $product->get_id() ),
+							),
 						),
 					),
 				),
-			),
-			$product_reviews
+				$product_reviews[0]
+			)
 		);
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/settings.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/settings.php
@@ -6,6 +6,7 @@
  * @since 3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
@@ -482,29 +483,39 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/products' ) );
 		$data     = $response->get_data();
 		$this->assertTrue( is_array( $data ) );
-		$this->assertContains(
-			array(
-				'id'          => 'woocommerce_downloads_require_login',
-				'label'       => 'Access restriction',
-				'description' => 'Downloads require login',
-				'type'        => 'checkbox',
-				'default'     => 'no',
-				'tip'         => 'This setting does not apply to guest purchases.',
-				'value'       => 'no',
-				'_links'      => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v2/settings/products/woocommerce_downloads_require_login' ),
+		$data_download_required_login = null;
+		foreach ( $data as $setting ) {
+			if ( 'woocommerce_downloads_require_login' === $setting['id'] ) {
+				$data_download_required_login = $setting;
+				break;
+			}
+		}
+		$this->assertNotEmpty( $data_download_required_login );
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'          => 'woocommerce_downloads_require_login',
+					'label'       => 'Access restriction',
+					'description' => 'Downloads require login',
+					'type'        => 'checkbox',
+					'default'     => 'no',
+					'tip'         => 'This setting does not apply to guest purchases.',
+					'value'       => 'no',
+					'_links'      => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v2/settings/products/woocommerce_downloads_require_login' ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/settings/products' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/settings/products' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data_download_required_login
+			)
 		);
 
 		// test get single.
@@ -540,29 +551,41 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertContains(
-			array(
-				'id'          => 'recipient',
-				'label'       => 'Recipient(s)',
-				'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-				'type'        => 'text',
-				'default'     => '',
-				'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-				'value'       => '',
-				'_links'      => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v2/settings/email_new_order/recipient' ),
+		$recipient_setting = null;
+		foreach ( $settings as $setting ) {
+			if ( 'recipient' === $setting['id'] ) {
+				$recipient_setting = $setting;
+				break;
+			}
+		}
+
+		$this->assertNotEmpty( $recipient_setting );
+
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'          => 'recipient',
+					'label'       => 'Recipient(s)',
+					'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+					'type'        => 'text',
+					'default'     => '',
+					'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+					'value'       => '',
+					'_links'      => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v2/settings/email_new_order/recipient' ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/settings/email_new_order' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/settings/email_new_order' ),
+							),
 						),
 					),
 				),
-			),
-			$settings
+				$recipient_setting
+			)
 		);
 
 		// test get single.

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-methods.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-methods.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * Tests for the Shipping Methods REST API.
  *
@@ -44,25 +47,37 @@ class Shipping_Methods_V2 extends WC_REST_Unit_Test_Case {
 		$methods  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains(
-			array(
-				'id'          => 'free_shipping',
-				'title'       => 'Free shipping',
-				'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
-				'_links'      => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping_methods/free_shipping' ),
+
+		$free_shipping_method = null;
+		foreach ( $methods as $method ) {
+			if ( 'free_shipping' === $method['id'] ) {
+				$free_shipping_method = $method;
+				break;
+			}
+		}
+		$this->assertNotEmpty( $free_shipping_method );
+
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'          => 'free_shipping',
+					'title'       => 'Free shipping',
+					'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
+					'_links'      => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping_methods/free_shipping' ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping_methods' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping_methods' ),
+							),
 						),
 					),
 				),
-			),
-			$methods
+				$free_shipping_method
+			)
 		);
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-zones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-zones.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * Shipping Zones API Tests
  * @package WooCommerce\Tests\API
@@ -74,30 +76,32 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 1 );
-		$this->assertContains(
-			array(
-				'id'     => $data[0]['id'],
-				'name'   => 'Locations not covered by your other zones',
-				'order'  => 0,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $data[0]['id'] ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $data[0]['id'],
+					'name'   => 'Locations not covered by your other zones',
+					'order'  => 0,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $data[0]['id'] ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $data[0]['id'] . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $data[0]['id'] . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data[0]
+			)
 		);
 
 		// Create a zone and make sure it's in the response
@@ -108,30 +112,32 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 2 );
-		$this->assertContains(
-			array(
-				'id'     => $data[1]['id'],
-				'name'   => 'Zone 1',
-				'order'  => 0,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $data[1]['id'] ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $data[1]['id'],
+					'name'   => 'Zone 1',
+					'order'  => 0,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $data[1]['id'] ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $data[1]['id'] . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $data[1]['id'] . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data[1]
+			)
 		);
 	}
 
@@ -195,30 +201,32 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals(
-			array(
-				'id'     => $data['id'],
-				'name'   => 'Test Zone',
-				'order'  => 1,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $data['id'],
+					'name'   => 'Test Zone',
+					'order'  => 1,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data
+			)
 		);
 	}
 
@@ -260,30 +268,32 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
-			array(
-				'id'     => $zone->get_id(),
-				'name'   => 'Zone Test',
-				'order'  => 2,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $zone->get_id(),
+					'name'   => 'Zone Test',
+					'order'  => 2,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data
+			)
 		);
 	}
 
@@ -359,30 +369,32 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
-			array(
-				'id'     => $zone->get_id(),
-				'name'   => 'Test Zone',
-				'order'  => 0,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $zone->get_id(),
+					'name'   => 'Test Zone',
+					'order'  => 0,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data
+			)
 		);
 	}
 
@@ -624,13 +636,13 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 1 );
-		$this->assertContains( $expected, $data );
+		$this->assertEmpty( ArrayUtil::deep_assoc_array_diff( $expected, $data[0] ) );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id ) );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( $expected, $data );
+		$this->assertEmpty( ArrayUtil::deep_assoc_array_diff( $expected, $data ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/product-reviews.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/product-reviews.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * Tests for the product reviews REST API.
  *
@@ -50,40 +53,42 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 10, count( $product_reviews ) );
-		$this->assertContains(
-			array(
-				'id'                   => $review_id,
-				'date_created'         => $product_reviews[0]['date_created'],
-				'date_created_gmt'     => $product_reviews[0]['date_created_gmt'],
-				'product_id'           => $product->get_id(),
-				'product_name'         => $product->get_name(),
-				'product_permalink'    => $product->get_permalink(),
-				'status'               => 'approved',
-				'reviewer'             => 'admin',
-				'reviewer_email'       => 'woo@woo.local',
-				'review'               => "<p>Review content here</p>\n",
-				'rating'               => 0,
-				'verified'             => false,
-				'reviewer_avatar_urls' => $product_reviews[0]['reviewer_avatar_urls'],
-				'_links'               => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v3/products/reviews/' . $review_id ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'                   => $review_id,
+					'date_created'         => $product_reviews[0]['date_created'],
+					'date_created_gmt'     => $product_reviews[0]['date_created_gmt'],
+					'product_id'           => $product->get_id(),
+					'product_name'         => $product->get_name(),
+					'product_permalink'    => $product->get_permalink(),
+					'status'               => 'approved',
+					'reviewer'             => 'admin',
+					'reviewer_email'       => 'woo@woo.local',
+					'review'               => "<p>Review content here</p>\n",
+					'rating'               => 0,
+					'verified'             => false,
+					'reviewer_avatar_urls' => $product_reviews[0]['reviewer_avatar_urls'],
+					'_links'               => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v3/products/reviews/' . $review_id ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v3/products/reviews' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v3/products/reviews' ),
+							),
 						),
-					),
-					'up'         => array(
-						array(
-							'href' => rest_url( '/wc/v3/products/' . $product->get_id() ),
+						'up'         => array(
+							array(
+								'href' => rest_url( '/wc/v3/products/' . $product->get_id() ),
+							),
 						),
 					),
 				),
-			),
-			$product_reviews
+				$product_reviews[0]
+			)
 		);
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/settings.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/settings.php
@@ -6,6 +6,7 @@
  * @since 3.5.0
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
@@ -481,29 +482,42 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/products' ) );
 		$data     = $response->get_data();
 		$this->assertTrue( is_array( $data ) );
-		$this->assertContains(
-			array(
-				'id'          => 'woocommerce_downloads_require_login',
-				'label'       => 'Access restriction',
-				'description' => 'Downloads require login',
-				'type'        => 'checkbox',
-				'default'     => 'no',
-				'tip'         => 'This setting does not apply to guest purchases.',
-				'value'       => 'no',
-				'_links'      => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v3/settings/products/woocommerce_downloads_require_login' ),
+
+		$setting_downloads_required = null;
+		foreach ( $data as $setting ) {
+			if ( 'woocommerce_downloads_require_login' === $setting['id'] ) {
+				$setting_downloads_required = $setting;
+				break;
+			}
+		}
+
+		$this->assertNotEmpty( $setting_downloads_required );
+
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'          => 'woocommerce_downloads_require_login',
+					'label'       => 'Access restriction',
+					'description' => 'Downloads require login',
+					'type'        => 'checkbox',
+					'default'     => 'no',
+					'tip'         => 'This setting does not apply to guest purchases.',
+					'value'       => 'no',
+					'_links'      => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v3/settings/products/woocommerce_downloads_require_login' ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v3/settings/products' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v3/settings/products' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$setting_downloads_required
+			)
 		);
 
 		// test get single.
@@ -539,29 +553,41 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertContains(
-			array(
-				'id'          => 'recipient',
-				'label'       => 'Recipient(s)',
-				'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-				'type'        => 'text',
-				'default'     => '',
-				'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-				'value'       => '',
-				'_links'      => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v3/settings/email_new_order/recipient' ),
+		$recipient_setting = null;
+		foreach ( $settings as $setting ) {
+			if ( 'recipient' === $setting['id'] ) {
+				$recipient_setting = $setting;
+				break;
+			}
+		}
+
+		$this->assertNotEmpty( $recipient_setting );
+
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'          => 'recipient',
+					'label'       => 'Recipient(s)',
+					'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+					'type'        => 'text',
+					'default'     => '',
+					'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+					'value'       => '',
+					'_links'      => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v3/settings/email_new_order/recipient' ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v3/settings/email_new_order' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v3/settings/email_new_order' ),
+							),
 						),
 					),
 				),
-			),
-			$settings
+				$recipient_setting
+			)
 		);
 
 		// test get single.

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-methods.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-methods.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * Tests for the Shipping Methods REST API.
  *
@@ -44,25 +47,37 @@ class Shipping_Methods extends WC_REST_Unit_Test_Case {
 		$methods  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains(
-			array(
-				'id'          => 'free_shipping',
-				'title'       => 'Free shipping',
-				'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
-				'_links'      => array(
-					'self'       => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping_methods/free_shipping' ),
+
+		$free_shipping = null;
+		foreach ( $methods as $method ) {
+			if ( 'free_shipping' === $method['id'] ) {
+				$free_shipping = $method;
+				break;
+			}
+		}
+		$this->assertNotEmpty( $free_shipping );
+
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'          => 'free_shipping',
+					'title'       => 'Free shipping',
+					'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
+					'_links'      => array(
+						'self'       => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping_methods/free_shipping' ),
+							),
 						),
-					),
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping_methods' ),
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping_methods' ),
+							),
 						),
 					),
 				),
-			),
-			$methods
+				$free_shipping
+			)
 		);
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-zones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-zones.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * Shipping Zones API Tests
  *
@@ -77,30 +79,32 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 1 );
-		$this->assertContains(
-			array(
-				'id'     => $data[0]['id'],
-				'name'   => 'Locations not covered by your other zones',
-				'order'  => 0,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $data[0]['id'] ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $data[0]['id'],
+					'name'   => 'Locations not covered by your other zones',
+					'order'  => 0,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $data[0]['id'] ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $data[0]['id'] . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $data[0]['id'] . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data[0]
+			)
 		);
 
 		// Create a zone and make sure it's in the response
@@ -111,30 +115,32 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 2 );
-		$this->assertContains(
-			array(
-				'id'     => $data[1]['id'],
-				'name'   => 'Zone 1',
-				'order'  => 0,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $data[1]['id'] ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $data[1]['id'],
+					'name'   => 'Zone 1',
+					'order'  => 0,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $data[1]['id'] ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $data[1]['id'] . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $data[1]['id'] . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data[1]
+			)
 		);
 	}
 
@@ -202,30 +208,32 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals(
-			array(
-				'id'     => $data['id'],
-				'name'   => 'Test Zone',
-				'order'  => 1,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $data['id'] ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $data['id'],
+					'name'   => 'Test Zone',
+					'order'  => 1,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $data['id'] ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $data['id'] . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $data['id'] . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data
+			)
 		);
 	}
 
@@ -269,30 +277,32 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
-			array(
-				'id'     => $zone->get_id(),
-				'name'   => 'Zone Test',
-				'order'  => 2,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $zone->get_id(),
+					'name'   => 'Zone Test',
+					'order'  => 2,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data
+			)
 		);
 	}
 
@@ -373,30 +383,32 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
-			array(
-				'id'     => $zone->get_id(),
-				'name'   => 'Test Zone',
-				'order'  => 0,
-				'_links' => array(
-					'self'        => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() ),
+		$this->assertEmpty(
+			ArrayUtil::deep_assoc_array_diff(
+				array(
+					'id'     => $zone->get_id(),
+					'name'   => 'Test Zone',
+					'order'  => 0,
+					'_links' => array(
+						'self'        => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() ),
+							),
 						),
-					),
-					'collection'  => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones' ),
+						'collection'  => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones' ),
+							),
 						),
-					),
-					'describedby' => array(
-						array(
-							'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() . '/locations' ),
+						'describedby' => array(
+							array(
+								'href' => rest_url( '/wc/v3/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
 					),
 				),
-			),
-			$data
+				$data
+			)
 		);
 	}
 
@@ -644,13 +656,12 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 1 );
-		$this->assertContains( $expected, $data );
-
+		$this->assertEmpty( ArrayUtil::deep_assoc_array_diff( $expected, $data[0] ) );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id ) );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( $expected, $data );
+		$this->assertEmpty( ArrayUtil::deep_assoc_array_diff( $expected, $data ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR cherry-picks https://github.com/woocommerce/woocommerce/pull/51465 into the 9.3 release branch in order to fix the PHP unit tests against WP nightly that had been failing recently.