### PR TITLE
Add theme type to System Status Report

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-theme-type-to-system-status
+++ b/plugins/woocommerce/changelog/fix-add-theme-type-to-system-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add theme type (block theme or classic theme) to System Status Report

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -983,6 +983,21 @@ if ( 0 < $mu_plugins_count ) :
 				<td><?php echo esc_html( $theme['parent_author_url'] ); ?></td>
 			</tr>
 		<?php endif ?>
+		<?php if ( isset( $theme['is_block_theme'] ) ) : ?>
+		<tr>
+			<td data-export-label="Theme type"><?php esc_html_e( 'Theme type', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether the current active theme is a block theme or a classic theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td>
+				<?php
+				if ( $theme['is_block_theme'] ) {
+					esc_html_e( 'Block theme', 'woocommerce' );
+				} else {
+					esc_html_e( 'Classic theme', 'woocommerce' );
+				}
+				?>
+			</td>
+		</tr>
+		<?php endif ?>
 		<tr>
 			<td data-export-label="WooCommerce Support"><?php esc_html_e( 'WooCommerce support', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether or not the current active theme declares WooCommerce support.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -499,6 +499,12 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
+						'is_block_theme'          => array(
+							'description' => __( 'Is this theme a block theme?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
 						'has_woocommerce_support' => array(
 							'description' => __( 'Does the theme declare WooCommerce support?', 'woocommerce' ),
 							'type'        => 'boolean',
@@ -1333,6 +1339,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				'version_latest'          => WC_Admin_Status::get_latest_theme_version( $active_theme ),
 				'author_url'              => esc_url_raw( $active_theme->{'Author URI'} ),
 				'is_child_theme'          => is_child_theme(),
+				'is_block_theme'          => wc_current_theme_is_fse_theme(),
 				'has_woocommerce_support' => current_theme_supports( 'woocommerce' ),
 				'has_woocommerce_file'    => ( file_exists( get_stylesheet_directory() . '/woocommerce.php' ) || file_exists( get_template_directory() . '/woocommerce.php' ) ),
 				'has_outdated_templates'  => $outdated_templates,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -51,7 +51,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		add_action( 'deactivate_plugin', array( __CLASS__, 'clean_plugin_cache' ) );
 		add_action(
 			'upgrader_process_complete',
-			function( $upgrader, $extra ) {
+			function ( $upgrader, $extra ) {
 				if ( ! $extra || ! $extra['type'] ) {
 					return;
 				}

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
@@ -444,6 +444,7 @@ test.describe( 'System Status API tests', () => {
 						version_latest: expect.any( String ),
 						author_url: expect.any( String ),
 						is_child_theme: expect.any( Boolean ),
+						is_block_theme: expect.any( Boolean ),
 						has_woocommerce_support: expect.any( Boolean ),
 						has_woocommerce_file: expect.any( Boolean ),
 						has_outdated_templates: expect.any( Boolean ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
@@ -190,7 +190,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$active_theme = wp_get_theme();
 		$theme        = (array) $this->fetch_or_get_system_status_data_for_user( self::$administrator_user )['theme'];
 
-		$this->assertEquals( 13, count( $theme ) );
+		$this->assertEquals( 14, count( $theme ) );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertEquals( $active_theme->Name, $theme['name'] );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
@@ -285,7 +285,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$matching_tool_data = current(
 			array_filter(
 				$data,
-				function( $tool ) {
+				function ( $tool ) {
 					return 'regenerate_thumbnails' === $tool['id'];
 				}
 			)

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
@@ -305,7 +305,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$matching_tool_data = current(
 			array_filter(
 				$data,
-				function( $tool ) {
+				function ( $tool ) {
 					return 'regenerate_thumbnails' === $tool['id'];
 				}
 			)
@@ -344,7 +344,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$matching_tool_data = current(
 			array_filter(
 				$data,
-				function( $tool ) {
+				function ( $tool ) {
 					return 'regenerate_thumbnails' === $tool['id'];
 				}
 			)

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
@@ -217,7 +217,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$active_theme = wp_get_theme();
 		$theme        = (array) $this->fetch_or_get_system_status_data_for_user( self::$administrator_user )['theme'];
 
-		$this->assertEquals( 13, count( $theme ) );
+		$this->assertEquals( 14, count( $theme ) );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertEquals( $active_theme->Name, $theme['name'] );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/51433.

This PR adds data about the theme type to the System Status Report, so we can easily know if it's a block or a classic theme.

### How to test the changes in this Pull Request:

1. Enable a block theme and go to WooCommerce > Status > System Status and search for _Theme type:_.
2. If it doesn't appear, that's probably because there is a previous transient with the data. Go to the `wp_options` table in the database, and delete the `_transient_wc_system_status_theme_info` entry.
3. Repeat step 1.
4. Try with a block theme and classic theme and verify the value displayed in the UI is correct.

![image](https://github.com/user-attachments/assets/e2daa816-c125-411b-b1dc-8c6e258cb45d)
