### PR TITLE
Update the stalebot exempt label used for skipped tests issues

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,4 +1,4 @@
-name: 'Process stale needs-feedback issues'
+name: 'Process stale issues'
 on:
     schedule:
         - cron: '21 0 * * *'
@@ -14,7 +14,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - name: Scan issues
+            - name: Process stale issues
               uses: actions/stale@v9.0.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,12 +31,12 @@ jobs:
                   only-issue-labels: 'needs: author feedback'
                   close-issue-label: "status: can't reproduce"
                   ascending: true
-            - name: Process Stale Flaky Test Issues
+            - name: Process stale flaky tests issues
               uses: actions/stale@v9.0.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   only-issue-labels: 'metric: flaky e2e test'
-                  exempt-issue-labels: 'metric: skipped test'
+                  exempt-issue-labels: 'type: skipped test'
                   days-before-stale: -1
                   days-before-close: -1
                   days-before-issue-stale: 5


### PR DESCRIPTION
### Changes proposed in this Pull Request:

More context: p1726750018082939/1726747454.051529-slack-C01BWDDTGKX
Replace the exempt issue label `metric: skipped test` label with `type: skipped test` in the stale bot configuration. This is for consistency.
I also updated some titles to better describe the workflow and the steps.

### How to test the changes in this Pull Request:

Run the stalebot.yml workflow on this branch and check the logs. It should skip the issues labeled with `type: skipped test`.
[Here's a test run](https://github.com/woocommerce/woocommerce/actions/runs/11034266698/job/30647384445#step:3:22474) where issue 51435 was skipped because it contains an exempt label.