### PR TITLE
Stop using unknown option for rsync during build process

### DIFF
--- a/plugins/woocommerce/changelog/fix-delete-rsync-nocompression-option
+++ b/plugins/woocommerce/changelog/fix-delete-rsync-nocompression-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: It's update to building process removing one unused option. Not worth mentioning in the changelog
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -660,7 +660,7 @@
 	},
 	"wireit": {
 		"build:project:copy-assets:legacy": {
-			"command": "rsync -avhW --checksum --no-compress --delete --quiet client/legacy/build/css/ assets/css && rsync -avhW --checksum --no-compress --delete --quiet client/legacy/build/js/ assets/js",
+			"command": "rsync -avhW --checksum --delete --quiet client/legacy/build/css/ assets/css && rsync -avhW --checksum --delete --quiet client/legacy/build/js/ assets/js",
 			"files": [
 				"client/legacy/build/**/*.*"
 			],
@@ -670,7 +670,7 @@
 			]
 		},
 		"build:project:copy-assets:admin": {
-			"command": "rsync -avhW --checksum --no-compress --delete --quiet ../woocommerce-admin/build/ assets/client/admin",
+			"command": "rsync -avhW --checksum --delete --quiet ../woocommerce-admin/build/ assets/client/admin",
 			"files": [
 				"../woocommerce-admin/build/**/*.*"
 			],
@@ -679,7 +679,7 @@
 			]
 		},
 		"build:project:copy-assets:blocks": {
-			"command": "rsync -avhW --checksum --no-compress --delete --quiet ../woocommerce-blocks/build/ assets/client/blocks && rsync -avhW --checksum --no-compress --quiet ../woocommerce-blocks/blocks.ini blocks.ini",
+			"command": "rsync -avhW --checksum --delete --quiet ../woocommerce-blocks/build/ assets/client/blocks && rsync -avhW --checksum --quiet ../woocommerce-blocks/blocks.ini blocks.ini",
 			"files": [
 				"../woocommerce-blocks/build/**/*.*"
 			],
@@ -712,6 +712,7 @@
 				"node_modules/@woocommerce/e2e-core-tests/CHANGELOG.md",
 				"node_modules/@woocommerce/api/dist/",
 				"node_modules/@woocommerce/admin-e2e-tests/build",
+				"node_modules/@woocommerce/classic-assets/build",
 				"node_modules/@woocommerce/block-library/build",
 				"node_modules/@woocommerce/block-library/blocks.ini",
 				"node_modules/@woocommerce/admin-library/build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21722,7 +21722,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      react: ^17.0.2
+      react: 18.2.0
 
   react-number-format@4.9.3:
     resolution: {integrity: sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==}
@@ -21912,7 +21912,7 @@ packages:
   react-with-direction@1.4.0:
     resolution: {integrity: sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==}
     peerDependencies:
-      react: ^17.0.2
+      react: ^0.14 || ^15 || ^16
       react-dom: ^0.14 || ^15 || ^16
 
   react-with-styles-interface-css@4.0.3:
@@ -41020,7 +41020,7 @@ snapshots:
 
   '@wordpress/core-data@5.5.0(react@17.0.2)':
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.23.5
       '@wordpress/api-fetch': 6.21.0
       '@wordpress/blocks': 11.21.0(react@17.0.2)
       '@wordpress/compose': 5.20.0(react@17.0.2)
@@ -41028,7 +41028,7 @@ snapshots:
       '@wordpress/deprecated': 3.41.0
       '@wordpress/element': 4.20.0
       '@wordpress/html-entities': 3.24.0
-      '@wordpress/i18n': 4.57.0
+      '@wordpress/i18n': 4.47.0
       '@wordpress/is-shallow-equal': 4.24.0
       '@wordpress/url': 3.48.0
       change-case: 4.1.2


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I couldn't build a project after https://github.com/woocommerce/woocommerce/pull/51612.

According to [`rsync` docs](https://linux.die.net/man/1/rsync) there's no `--no-compress` option. Seems like you pass `--compress` if you want compression so it’s disabled by default. Removing this option allowed me to build the project successfully but it's not my area of expertise so I'd appreciate a confirmation if that's the way to go and why the option was there in a first place (potentially working for others).

Errors:

```
plugins/woocommerce build:project:copy-assets:legacy: rsync: --no-compress: unknown option
plugins/woocommerce build:project:copy-assets:blocks: rsync: --no-compress: unknown option
plugins/woocommerce build:project:copy-assets:legacy: rsync error: syntax or usage error (code 1) at 
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout to this branch locally
2. Run `pnpm build`
3. There shouldn't be any build errors and project should build correctly

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
