### PR TITLE
Add composition path prefix to storybook to allow publishing to gh-pages

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -27,6 +27,8 @@ jobs:
 
             - name: Build Storybook
               run: pnpm --filter='@woocommerce/storybook' build-storybook --quiet
+              env:
+                  STORYBOOK_COMPOSITION_PATH_PREFIX: /woocommerce
 
             - name: Deploy
               uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/tools/storybook/.storybook/main.js
+++ b/tools/storybook/.storybook/main.js
@@ -28,11 +28,18 @@ module.exports = {
 		if ( configType === 'DEVELOPMENT' ) {
 			return {};
 		}
+
+		let pathPrefix = (
+			process.env.STORYBOOK_COMPOSITION_PATH_PREFIX ?? ''
+		).trim();
+		if ( pathPrefix && ! pathPrefix.startsWith( '/' ) ) {
+			pathPrefix = '/' + pathPrefix;
+		}
 		return {
 			'woocommerce-blocks': {
 				expanded: false,
 				title: 'WooCommerce Blocks',
-				url: '/assets/woocommerce-blocks',
+				url: pathPrefix + '/assets/woocommerce-blocks',
 			},
 		};
 	},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It appears the composition url for storybook relies on the root url, meaning that `/assets/woocommerce-blocks` went to `woocommerce.github.io/assets/woocommerce-blocks` instead of `woocommerce.github.io/woocommerce/assets/woocommerce-blocks`
See error in the current published version: https://woocommerce.github.io/woocommerce/

This PR adds a environment option to add a prefix which we can in turn add to our GH action.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build storybook using the env variable, like so: `STORYBOOK_COMPOSITION_PATH_PREFIX="storybook-static" pnpm --filter=@woocommerce/storybook run build-storybook`
2. Serve the `storybook` directory with `http-server` -> `npx http-server tools/storybook` ( that way we simulate the folder structure as storybook lives within `storybook-static`
3. Go to the url and click on the `storybook-static` folder, this should load storybook and load WooCommerce Blocks correctly as well.
4. Do the above steps ( 1 - 3 ) again with adding the `/` -> `STORYBOOK_COMPOSITION_PATH_PREFIX="/storybook-static"`, it should still work correctly.
5. Do the above steps ( 1 - 3 ) again without adding the environment variable -> `pnpm --filter=@woocommerce/storybook run build-storybook`, notice that this time you see the same error as in https://woocommerce.github.io/woocommerce/

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
