### PR TITLE
Change aspect ratio of images in theme cards in in-app marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
@@ -260,7 +260,7 @@
 			.woocommerce-marketplace__product-card__image {
 				border-bottom: 1px solid $gray-200;
 				overflow: hidden;
-				padding-top: 75%;
+				padding-top: 56.25%;
 				position: relative;
 			}
 			.woocommerce-marketplace__product-card__image-inner {

--- a/plugins/woocommerce/changelog/51705-update-wccom-21726-theme-card-aspect-ratio
+++ b/plugins/woocommerce/changelog/51705-update-wccom-21726-theme-card-aspect-ratio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Changed aspect ratio of images in theme cards in the in-app marketplace to 16:9.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We are now using 16:9 images for themes in the in-app marketplace, so we need to change the image ratio. I've not tried to change the method we're using to use `aspect-ratio` and `object-fit` – that creates a small space below the image, and the change doesn't feel necessary at this point.

Closes 21726-gh-Automattic/woocommerce.com.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch on your local environment.
2. Open WooCommerce > Extensions and view the Themes tab, for example http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions.
3. Note that the images on the cards have the 16:9 aspect ratio. Try the page on various viewport sizes.
4. Please check that other marketplace pages are unaffected.

<!-- End testing instructions -->

### Screenshots

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e39a71e0-9a78-4320-af30-5a707555fd0c">

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changed aspect ratio of images in theme cards in the in-app marketplace to 16:9.

</details>