### PR TITLE
[ci] Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -17,7 +17,7 @@ jobs:
             contents: read
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
                   fetch-depth: 0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `Changelogger use` job in pr-lint-monorepo.yml workflow [is logging a warning about using deprecated Node.js version](https://github.com/woocommerce/woocommerce/actions/runs/11050477734?pr=51707).

`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`

Bumping to actions/checkout@v4 should fix that.

### How to test the changes in this Pull Request:

Check the `pr-lint-monorepo.yml` workflow run for this PR. No warnings should be displayed in the Summary.
See: https://github.com/woocommerce/woocommerce/actions/runs/11050911760