### PR TITLE
[dev] Monorepo: codeowners file update for Flux.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,4 @@
 # Files in root of repository
 /.* @woocommerce/flux
 /*.* @woocommerce/flux
+/changelog.txt


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Spotted i nhttps://github.com/woocommerce/woocommerce/pull/51693: top-level changelog should not be owned by Flux. In this PR we are addressing this, while other top-level files ownership is unchanged

### How to test the changes in this Pull Request:

n/a
