### PR TITLE
CYS: color swatches are not accessible

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/color-palettes.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/color-palettes.tsx
@@ -1,7 +1,15 @@
 /**
+ * External dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { ColorPalette } from './types';
+
+const MAX_COLOR_PALETTES = 4;
 
 export const ColorPalettes = ( {
 	colorPalettes,
@@ -10,33 +18,71 @@ export const ColorPalettes = ( {
 	colorPalettes: ColorPalette[];
 	totalPalettes: number;
 } ) => {
-	let extra = null;
+	const canFit = totalPalettes <= MAX_COLOR_PALETTES;
 
-	if ( totalPalettes > 4 ) {
-		extra = <li className="more_palettes">+{ totalPalettes - 4 }</li>;
+	const descriptionId = useInstanceId(
+		ColorPalettes,
+		'color-palettes-description'
+	) as string;
+
+	function renderMore() {
+		if ( canFit ) return null;
+		return (
+			<li aria-hidden="true" className="more_palettes">
+				+{ totalPalettes - 4 }
+			</li>
+		);
+	}
+
+	function renderDescription() {
+		if ( canFit ) return null;
+		return (
+			<p
+				id={ descriptionId }
+				className="theme-card__color-palettes-description"
+			>
+				{ sprintf(
+					/* translators: $d is the total amount of color palettes */
+					__(
+						'There are a total of %d color palettes',
+						'woocommerce'
+					),
+					totalPalettes
+				) }
+			</p>
+		);
 	}
 
 	return (
-		<ul className="theme-card__color-palettes">
-			{ colorPalettes.map( ( colorPalette ) => (
-				<li
-					key={ colorPalette.title }
-					style={ {
-						background:
-							'linear-gradient(to right, ' +
-							colorPalette.primary +
-							' 0px, ' +
-							colorPalette.primary +
-							' 50%, ' +
-							colorPalette.secondary +
-							' 50%, ' +
-							colorPalette.secondary +
-							' 100%' +
-							')',
-					} }
-				></li>
-			) ) }
-			{ extra }
-		</ul>
+		<>
+			<ul
+				className="theme-card__color-palettes"
+				aria-label={ __( 'Color palettes', 'woocommerce' ) }
+				aria-describedby={ descriptionId }
+			>
+				{ colorPalettes.map( ( colorPalette ) => (
+					<li
+						key={ colorPalette.title }
+						aria-label={ colorPalette.title }
+						style={ {
+							background:
+								'linear-gradient(to right, ' +
+								colorPalette.primary +
+								' 0px, ' +
+								colorPalette.primary +
+								' 50%, ' +
+								colorPalette.secondary +
+								' 50%, ' +
+								colorPalette.secondary +
+								' 100%' +
+								')',
+						} }
+					/>
+				) ) }
+				{ renderMore() }
+			</ul>
+
+			{ renderDescription() }
+		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -314,6 +314,10 @@
 					text-align: center;
 				}
 			}
+
+			&-description {
+				@include visually-hidden();
+			}
 		}
 
 		.theme-card__free {

--- a/plugins/woocommerce/changelog/add-51574
+++ b/plugins/woocommerce/changelog/add-51574
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a11y to the color swatches


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51574

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to `Reset Customize Your Store` under `/wp-admin/tools.php?page=woocommerce-admin-test-helper`. The `WooCommerce Admin Test Helper` plugin is required.
2. Go to `/wp-admin/admin.php?page=wc-admin&path=/customize-store`
3. Right click over the color swatches and then click inspect element of any theme, for example TT4:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/7aec0597-4b46-4c4c-9652-f65c48d34c4e">

4. From the `Elements` tab of the DevTools select the `<ul class="theme-card__color-palettes" />` element. 
<img width="575" alt="image" src="https://github.com/user-attachments/assets/865481a3-97e7-47c1-8be0-d039a4f3439b">

5. Then from the bottom tabs select the `Accessibility` one 
<img width="575" alt="image" src="https://github.com/user-attachments/assets/d72e7f28-4b44-4ae4-b929-c89ca14d131a">

6. Notice that the `list` element has the label `Color palettes` and each `listitem` has the label corresponding to the name of each palette. Also notice that the `list` element has a description specifying the total amount of color palettes it has: `There are a total of 9 color palettes` . This only shows up when the total amount of color palettes are more than 4.
7. Make sure to activate VoiceOver in your Mac and check that the Screen Reader does the right speech.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
