### PR TITLE
Implement WC reset during e2e setup on external environments

### DIFF
--- a/plugins/woocommerce/changelog/e2e-dev-implement-wc-cleanup-for-tests
+++ b/plugins/woocommerce/changelog/e2e-dev-implement-wc-cleanup-for-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a site reset plugin for e2e testing with externally hosted sites


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This makes a couple of changes to the WC Cleanup plugin:
- Clean up all media files, not just images
- Change REST endpoint to GET instead of POST

This PR also implements the REST call during test setup (`global-setup`) for external environments (non-localhost environments)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure CI passes (will test running against `wp-env` to ensure nothing is broken there)
2. Running locally, run `pnpm test:e2e:with-env default-wpcom` and `pnpm test:e2e:with-env default-pressable`
3. Ensure that you see `Resetting site...`, `Reset successful: { message: 'Site reset successfully` }` before the tests run

<!-- End testing instructions -->
