### PR TITLE
Revert packages initialization timeline change

### DIFF
--- a/plugins/woocommerce/changelog/51728-fix-issue-51711
+++ b/plugins/woocommerce/changelog/51728-fix-issue-51711
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This PR reverts a change that hasn't yet been released, so no changelog is required.
+

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -26,7 +26,7 @@ class WC_Brands {
 	public function __construct() {
 		$this->template_url = apply_filters( 'woocommerce_template_url', 'woocommerce/' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
-		add_action( 'plugins_loaded', array( $this, 'register_hooks' ), 2 );
+		add_action( 'plugins_loaded', array( $this, 'register_hooks' ), 11 );
 
 		$this->register_shortcodes();
 	}

--- a/plugins/woocommerce/src/Internal/Brands.php
+++ b/plugins/woocommerce/src/Internal/Brands.php
@@ -54,7 +54,7 @@ class Brands {
 		return ( $assignment <= 6 ); // Considering 5% of the 0-120 range.
 	}
 
-	/*
+	/**
 	 * If WooCommerce Brands gets activated forcibly, without WooCommerce active (e.g. via '--skip-plugins'),
 	 * remove WooCommerce Brands initialization functions early on in the 'plugins_loaded' timeline.
 	 */

--- a/plugins/woocommerce/src/Internal/Brands.php
+++ b/plugins/woocommerce/src/Internal/Brands.php
@@ -25,11 +25,6 @@ class Brands {
 			return;
 		}
 
-		// If the WooCommerce Brands plugin is activated via the WP CLI using the '--skip-plugins' flag, deactivate it here.
-		if ( function_exists( 'wc_brands_init' ) ) {
-			remove_action( 'plugins_loaded', 'wc_brands_init', 1 );
-		}
-
 		include_once WC_ABSPATH . 'includes/class-wc-brands.php';
 		include_once WC_ABSPATH . 'includes/class-wc-brands-coupons.php';
 		include_once WC_ABSPATH . 'includes/class-wc-brands-brand-settings-manager.php';
@@ -57,5 +52,20 @@ class Brands {
 			return false;
 		}
 		return ( $assignment <= 6 ); // Considering 5% of the 0-120 range.
+	}
+
+	/*
+	 * If WooCommerce Brands gets activated forcibly, without WooCommerce active (e.g. via '--skip-plugins'),
+	 * remove WooCommerce Brands initialization functions early on in the 'plugins_loaded' timeline.
+	 */
+	public static function prepare() {
+
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		if ( function_exists( 'wc_brands_init' ) ) {
+			remove_action( 'plugins_loaded', 'wc_brands_init', 1 );
+		}
 	}
 }

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -153,7 +153,6 @@ class Packages {
 	/**
 	 * Prepare merged packages for initialization.
 	 * Especially useful when running actions early in the 'plugins_loaded' timeline.
-	 *
 	 */
 	public static function prepare_packages() {
 		foreach ( self::get_enabled_packages() as $package_name => $package_class ) {

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -66,7 +66,8 @@ class Packages {
 	 * @since 3.7.0
 	 */
 	public static function init() {
-		add_action( 'plugins_loaded', array( __CLASS__, 'on_init' ), 0 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'prepare_packages' ), -100 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'on_init' ), 10 );
 
 		// Prevent plugins already merged into WooCommerce core from getting activated as standalone plugins.
 		add_action( 'activate_plugin', array( __CLASS__, 'deactivate_merged_plugins' ) );
@@ -147,6 +148,19 @@ class Packages {
 	 */
 	public static function is_package_enabled( $package ) {
 		return array_key_exists( $package, self::get_enabled_packages() );
+	}
+
+	/**
+	 * Prepare merged packages for initialization.
+	 * Especially useful when running actions early in the 'plugins_loaded' timeline.
+	 *
+	 */
+	public static function prepare_packages() {
+		foreach ( self::get_enabled_packages() as $package_name => $package_class ) {
+			if ( method_exists( $package_class, 'prepare' ) ) {
+				call_user_func( array( $package_class, 'prepare' ) );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reverts a change that made all merged packages, included Blocks and WC Admin, to be initialized in `plugins_loaded` with priority `0`, instead of with priority `10`. The initial change was made to accommodate for the fact that the WooCommerce Brands plugin, that is now merged in core, was initialized in `plugins_loaded` with priority `1` and this caused a conflict during the initialization process. To avoid this conflict, I created a new `prepare` step before the initialization that runs in `plugins_loaded` with priority `-100`.

Closes #51711 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that the reported issue has been resolved: https://github.com/woocommerce/woocommerce/issues/51711 by following the steps to reproduce.
2. Ensure that Brands can be activated without issues, following the Activation flow tests from: https://github.com/woocommerce/woocommerce/discussions/51678

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR reverts a change that hasn't yet been released, so no changelog is required. 

</details>
