### PR TITLE
One approach to improve the truncation in Product Summary

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
@@ -139,6 +139,7 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 				maxLength={ maxLength }
 				countType={ blocksConfig.wordCountType || 'words' }
 				style={ styleProps.style }
+				truncateToFirstParagraph={ isDescendantOfAllProducts }
 			/>
 			{ isDescendantOfAllProducts && showLink && linkText ? (
 				<a href={ `${ product.permalink }#tab-description` }>

--- a/plugins/woocommerce-blocks/assets/js/base/components/summary/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/summary/index.tsx
@@ -16,16 +16,18 @@ interface SummaryProps {
 	maxLength?: number;
 	countType?: WordCountType;
 	style?: CSSProperties;
+	truncateToFirstParagraph?: boolean;
 }
 /**
  * Summary component.
  *
- * @param {Object}        props           Component props.
- * @param {string}        props.source    Source text.
- * @param {number}        props.maxLength Max length of the summary, using countType.
- * @param {string}        props.countType One of words, characters_excluding_spaces, or characters_including_spaces.
- * @param {string}        props.className Class name for rendered component.
- * @param {CSSProperties} props.style     Style Object for rendered component.
+ * @param {Object}        props                          Component props.
+ * @param {string}        props.source                   Source text.
+ * @param {number}        props.maxLength                Max length of the summary, using countType.
+ * @param {string}        props.countType                One of words, characters_excluding_spaces, or characters_including_spaces.
+ * @param {string}        props.className                Class name for rendered component.
+ * @param {CSSProperties} props.style                    Style Object for rendered component.
+ * @param {boolean}       props.truncateToFirstParagraph Whether source should be truncated to first paragraph or exact word count.
  *
  */
 export const Summary = ( {
@@ -34,10 +36,16 @@ export const Summary = ( {
 	countType = 'words',
 	className = '',
 	style = {},
+	truncateToFirstParagraph = true,
 }: SummaryProps ): JSX.Element => {
 	const summaryText = useMemo( () => {
-		return generateSummary( source, maxLength, countType );
-	}, [ source, maxLength, countType ] );
+		return generateSummary(
+			source,
+			maxLength,
+			countType,
+			truncateToFirstParagraph
+		);
+	}, [ source, maxLength, countType, truncateToFirstParagraph ] );
 
 	return (
 		<RawHTML style={ style } className={ className }>

--- a/plugins/woocommerce-blocks/assets/js/base/components/summary/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/summary/utils.ts
@@ -32,7 +32,8 @@ const getFirstParagraph = ( source: string ) => {
 export const generateSummary = (
 	source: string,
 	maxLength = 15,
-	countType: CountType = 'words'
+	countType: CountType = 'words',
+	truncateToFirstParagraph = true
 ) => {
 	const sourceWithParagraphs = autop( source );
 	const sourceWordCount = count( sourceWithParagraphs, countType );
@@ -44,16 +45,20 @@ export const generateSummary = (
 	const firstParagraph = getFirstParagraph( sourceWithParagraphs );
 	const firstParagraphWordCount = count( firstParagraph, countType );
 
-	if ( firstParagraphWordCount <= maxLength ) {
+	if ( truncateToFirstParagraph && firstParagraphWordCount <= maxLength ) {
 		return firstParagraph;
 	}
 
+	const sourceToTruncate = truncateToFirstParagraph
+		? firstParagraph
+		: sourceWithParagraphs;
+
 	if ( countType === 'words' ) {
-		return trimWords( firstParagraph, maxLength );
+		return trimWords( sourceToTruncate, maxLength );
 	}
 
 	return trimCharacters(
-		firstParagraph,
+		sourceToTruncate,
 		maxLength,
 		countType === 'characters_including_spaces'
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is one approach to fix a problem raised in https://github.com/woocommerce/woocommerce/pull/48984#pullrequestreview-2260208233 by @gigitux about Product Summary block improvements.

There's inconsistency between truncation happening in Editor vs frontend. This approach is super easy and uses existing utilities and functions. But has a downside that even though the truncation is synced between Editor and frontend, the styling is gone in the Editor when truncation is applied.

But even though it happens, I still think there's a bigger value in synced truncation than in synced styling. Keep in mind only tags are stripped out but paragraphs and new lines are kept in place which gives a merchant the idea of the summary volume to be displayed. I'll try to implement more advanced fix but I thought it's worth sharing there's some not perfect but supper cheap (effort-wise) alternative.

Editor - no truncation. Styling is preserved | Frontend - no truncation. 1:1 experience
-- | --
<img width="431" alt="image" src="https://github.com/user-attachments/assets/255f98dd-07ff-476b-9259-7921afc70bef"> | <img width="458" alt="image" src="https://github.com/user-attachments/assets/592121b8-a9e4-4bee-b992-41fe0e5b2c24">

Editor - truncation applied (20 words). Tags are removed impacting styling | Frontend - truncation applied. Styling respects tags
-- | --
<img width="434" alt="image" src="https://github.com/user-attachments/assets/21e7a93e-344d-4b19-b3a3-74935d60d5b5"> | <img width="451" alt="image" src="https://github.com/user-attachments/assets/dc0015c4-ae1d-430c-bf69-62267120490b">

As you can see the result is not 1:1. Not only due to the styling but also due to a bit different algorithm for counting words. The frontend one I think takes into account HTML tags hence the text is in reality shorter. In Editor we're using imperfect util which actually displays more words...
But I think it's acceptable. That's also why I think this solution would be overall acceptable at least as a temporary measure bringing lots of value and minimising downsides. I'm open for feedback!

cc: @sunyatasattva , @gigitux 🙏 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
