### PR TITLE
Fix product form metabox issue on Safari 18.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-51684_product_form_metabox_issue_on_safari
+++ b/plugins/woocommerce/changelog/fix-51684_product_form_metabox_issue_on_safari
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CSS issue with Safari 18.0 on the product form page.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8795,3 +8795,8 @@ table.bar_chart {
 html:has(#status-table-templates){
 	scroll-padding-top: 80px;
 }
+
+// Fix for Safari bug: https://bugs.webkit.org/show_bug.cgi?id=280063.
+.woocommerce-admin-page #postbox-container-2 {
+	clear: left;
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds a fix for a metabox issue in Safari 18.0 that causes the main product metabox to show up underneath the metaboxes in the right column when you are in the 2 column mode.
Note that they are fixing this in Safari: https://bugs.webkit.org/show_bug.cgi?id=280063 ( but don't know yet when that patch release will be out ).

Closes #51684 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have Safari 18.0 installed
2. Load `trunk` and got to **Products > Add New**, notice the issue with the metaboxes showing in the right column.
3. Load this branch and build it. 
4. Refresh the **Products > Add New** page, the metaboxes should render correctly
5. Switch between single and two columns under screen options, everything should still look correctly.
6. Load the same page in Chrome/Chromium and Firefox and make sure things look correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
