### PR TITLE
Fix: potential React error in filter blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/utils/filters.ts
+++ b/plugins/woocommerce-blocks/assets/js/utils/filters.ts
@@ -55,7 +55,22 @@ export function changeUrl( newUrl: string ) {
 			}
 		} );
 
-		window.location.href = url.href;
+		/**
+		 * Submit the filter URL through a hidden form to bypass the browser cache.
+		 */
+		const form = document.createElement( 'form' );
+		form.method = 'GET';
+		form.action = url.pathname;
+		form.style.display = 'none';
+		url.searchParams.forEach( ( value, key ) => {
+			const input = document.createElement( 'input' );
+			input.type = 'hidden';
+			input.name = key;
+			input.value = value;
+			form.appendChild( input );
+		} );
+		document.body.appendChild( form );
+		form.submit();
 	} else {
 		window.history.replaceState( {}, '', newUrl );
 	}

--- a/plugins/woocommerce/changelog/fix-49637-react-error-product-filters
+++ b/plugins/woocommerce/changelog/fix-49637-react-error-product-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Filter blocks: fix potential React error when users interact with filter blocks.


### PR DESCRIPTION
…r cache### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49637.

This PR fixes the potential React render error when shoppers interact with the filter block. We use `window.location` to navigate shoppers to new pages when they add or remove a filter, which involves the cache from the browser's session history, and it messes up the React rendering. This PR fixes that issue by using a workaround to navigate the filter URL through a hidden form, which always requests a page from the server.

Note that: We're working on new filter blocks that don't have this issue in #46142.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Shop page and click on Edit site
4. Add the following blocks to the Shop page: (Make sure browser cache is enabled)
   - Filter by Attribute (e.g. size)
   - Filter by Attribute (e.g. color)
   - Active filters
5. Go to the shop page and try to filter by size or color
6. Click on reset filters
7. Repeat steps 5 and 6 many times to verify there aren't any errors and the filter blocks work as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
