### PR TITLE
Disable turning the current Analytics feature off

### DIFF
--- a/plugins/woocommerce/changelog/update-disable-reports-setting
+++ b/plugins/woocommerce/changelog/update-disable-reports-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disable turning the current Analytics feature off.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -166,11 +166,27 @@ class FeaturesController {
 			$legacy_features = array(
 				'analytics'            => array(
 					'name'               => __( 'Analytics', 'woocommerce' ),
-					'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
+					'description'        => sprintf(
+						// translators: 1: line break tag.
+						__(
+							'Enable WooCommerce Analytics%1$s
+							The legacy Reports code will soon get removed.
+							If you enable the currently maintained Analytics now, you will not be able to turn it back off.',
+							'woocommerce'
+						),
+						'<br/>'
+					),
 					'option_key'         => Analytics::TOGGLE_OPTION_NAME,
 					'is_experimental'    => false,
 					'enabled_by_default' => true,
-					'disable_ui'         => false,
+					// Do not show the setting at all, if that's completely fresh install.
+					'disable_ui'         => get_option( Analytics::TOGGLE_OPTION_NAME, null ) === null,
+					'setting'            => array(
+						// Disable turning the feature off.
+						'disabled'        => function () {
+							return get_option( Analytics::TOGGLE_OPTION_NAME ) === 'yes';
+						},
+					),
 					'is_legacy'          => true,
 				),
 				'product_block_editor' => array(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -183,7 +183,7 @@ class FeaturesController {
 					'disable_ui'         => get_option( Analytics::TOGGLE_OPTION_NAME, null ) === null,
 					'setting'            => array(
 						// Disable turning the feature off.
-						'disabled'       => function () {
+						'disabled' => function () {
 							return get_option( Analytics::TOGGLE_OPTION_NAME ) === 'yes';
 						},
 					),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -183,7 +183,7 @@ class FeaturesController {
 					'disable_ui'         => get_option( Analytics::TOGGLE_OPTION_NAME, null ) === null,
 					'setting'            => array(
 						// Disable turning the feature off.
-						'disabled'        => function () {
+						'disabled'       => function () {
 							return get_option( Analytics::TOGGLE_OPTION_NAME ) === 'yes';
 						},
 					),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -169,8 +169,8 @@ class FeaturesController {
 					'description'        => sprintf(
 						// translators: 1: line break tag.
 						__(
-							'Enable WooCommerce Analytics%1$s
-							The legacy Reports code will soon get removed.
+							'Enable WooCommerce Analytics.%1$s
+							The legacy Reports code will soon be removed.
 							If you enable the currently maintained Analytics now, you will not be able to turn it back off.',
 							'woocommerce'
 						),

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1898,7 +1898,9 @@ test.describe.serial( 'Settings API tests: CRUD', () => {
 						expect.objectContaining( {
 							id: 'woocommerce_analytics_enabled',
 							label: 'Analytics',
-							description: 'Enable WooCommerce Analytics',
+							description: expect.stringContaining(
+								'Enable WooCommerce Analytics'
+							),
 							type: 'checkbox',
 							default: 'yes',
 							value: 'yes',

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1893,19 +1893,11 @@ test.describe.serial( 'Settings API tests: CRUD', () => {
 						} ),
 					] )
 				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_analytics_enabled',
-							label: 'Analytics',
-							description: expect.stringContaining(
-								'Enable WooCommerce Analytics'
-							),
-							type: 'checkbox',
-							default: 'yes',
-							value: 'yes',
-						} ),
-					] )
+				// New installs should not have Analytics settings available.
+				expect( responseJSON ).not.toContainEqual(
+					expect.objectContaining( {
+						id: 'woocommerce_analytics_enabled',
+					} )
 				);
 			} );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
@@ -8,14 +8,14 @@ test.describe(
 		test.use( { storageState: process.env.ADMINSTATE } );
 
 		test.beforeAll( async ( { baseURL } ) => {
-			// make sure the analytics connection is disabled
+			// Make sure the usage tracking is disabled.
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,
 				consumerSecret: process.env.CONSUMER_SECRET,
 				version: 'wc/v3',
 			} );
-			await api.put( 'settings/advanced/woocommerce_analytics_enabled', {
+			await api.put( 'settings/advanced/woocommerce_allow_tracking', {
 				value: 'no',
 			} );
 			await api.put(
@@ -26,12 +26,12 @@ test.describe(
 			);
 		} );
 
-		test( 'can enable analytics tracking', async ( { page } ) => {
+		test( 'can enable usage tracking', async ( { page } ) => {
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com'
 			);
 
-			// enable analytics tracking
+			// Enable usage tracking.
 			await page
 				.getByLabel( 'Allow usage of WooCommerce to be tracked' )
 				.check();


### PR DESCRIPTION
_This is a part of the entire Reports deprecation branch https://github.com/woocommerce/woocommerce/pull/51665_

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- This PR hides the "Enable WooCommerce Analytics" setting completely for the fresh installs. 
@eason9487 I'd appreciate your comment on this one, as it was not mentioned your plan. But IMHO, such an approach would make the experience cleaner for merchants who install it fresh and don't necessarily know what the legacy reports are and why should they disable the new ones. Plus it will make it a smoother transition to remove the setting completely in the future.

- Adds a note for legacy reports users that once they enable it, there is no turning back. Makes the setting disabled once turned on.
- + extra, Fix tests for usage tracking setting, as those were disabling the wrong setting key in the test setup - https://github.com/woocommerce/woocommerce/pull/51757/commits/8cd2d6ceba1dd991b6105b0a2156779f01df89ec

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before checking out this branch, go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Disable `Enable WooCommerce Analytics` and save
3. Checkout this branch & build
4. Refresh `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
5. You should see a note saying that once enabled there is no turning back. Check the copy.
   ![image](https://github.com/user-attachments/assets/3065dcd0-d1ef-4146-9d41-9d284d169dcf)
6. Enable and save
7. Check that the Setting is disabled
   ![image](https://github.com/user-attachments/assets/eeda8bd0-3ce8-41ba-a19a-f3729bd5d111)
9. Add a snippet to check if this can still be tweaked
	```php
	add_filter( 'woocommerce_feature_setting', function ( $settings, $feature ) {
	    if( $feature === 'analytics' ) {
	        $settings[ 'disabled' ] = false;
	    }
	    return $settings;
	}, null, 2 );
	```
10. Reload and check that the setting is enabled.
11. Remove the snippet.
12. Start a fresh install or remove the `woocommerce_analytics_enabled` option
	```sh
	wp option delete woocommerce_analytics_enabled
	```
13. Refresh `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
14. Check that there is no setting for Analytics
   ![image](https://github.com/user-attachments/assets/a4b7e4f6-45ab-4c58-a01f-39e903c550fe)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
