### PR TITLE
Add constant retrieving support to LegacyProxy

### DIFF
--- a/plugins/woocommerce/changelog/pr-51768
+++ b/plugins/woocommerce/changelog/pr-51768
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add constant retrieving support to LegacyProxy

--- a/plugins/woocommerce/src/Proxies/LegacyProxy.php
+++ b/plugins/woocommerce/src/Proxies/LegacyProxy.php
@@ -118,4 +118,25 @@ class LegacyProxy {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		exit( $status );
 	}
+
+	/**
+	 * Check if a constant is defined.
+	 *
+	 * @param string $constant_name The name of the constant.
+	 * @return bool True if the constant is defined, false otherwise.
+	 */
+	public function constant_is_defined( string $constant_name ) {
+		return defined( $constant_name );
+	}
+
+	/**
+	 * Get the value of a constant, or a default value.
+	 *
+	 * @param string     $constant_name The name of the constant.
+	 * @param mixed|null $default_value The default value to return if the constant is not defined.
+	 * @return mixed|null The value of the constant if it's defined, $default otherwise.
+	 */
+	public function get_constant_value( string $constant_name, $default_value = null ) {
+		return defined( $constant_name ) ? constant( $constant_name ) : $default_value;
+	}
 }

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
@@ -285,6 +285,17 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	}
 
 	/**
+	 * Register a value that will be returned when a constant is requested with "get_constant_value" (or "constant_is_defined").
+	 * A value of null will cause the constant to be considered as not defined.
+	 *
+	 * @param string     $constant_name The name of the constant to register the value for.
+	 * @param mixed|null $value The value to register, or null to register the constant as not defined.
+	 */
+	public function register_constant_mock( string $constant_name, $value ) {
+		wc_get_container()->get( LegacyProxy::class )->register_constant_mock( $constant_name, $value );
+	}
+
+	/**
 	 * Asserts that a certain callable output is equivalent to a given piece of HTML.
 	 *
 	 * "Equivalent" means that the string representations of the HTML pieces are equal


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds the `constant_is_defined( string $constant_name )` and `get_constant_value( string $constant_name, $default_value = null )` methods to the `LegacyProxy` class, and the `register_constant_mock( string $constant_name, $value )` and `unregister_constant_mock( string $constant_name )` methods to `MockableLegacyProxy`. This allows writing unit tests for code whose logic depends on the existence or the value of a given constant.

Worth noting that `register_constant_mock` can be used to alter the value that `get_constant_value` returns for an actually existing constant, and that passing a value of null to `register_constant_mock` will force the constant to be considered as undefined. This can be used to test "constant not defined" scenarios, even for constants that are already defined.

### How to test the changes in this Pull Request:

Run the unit tests introduced in the pull request. Command line testing (in `wp shell`) is possible too:

```
wp> $p=wc_get_container()->get( Automattic\WooCommerce\Proxies\LegacyProxy::class)
=> object(Automattic\WooCommerce\Proxies\LegacyProxy)#2172 (0) {
}
wp> $p->constant_is_defined('DB_USER')
=> bool(true)
wp> $p->constant_is_defined('NOT_EXISTING')
=> bool(false)
wp> $p->get_constant_value('DB_USER')
=> string(4) "root"
wp> $p->get_constant_value('DB_USER', 1234)
=> string(4) "root"
wp> $p->get_constant_value('NOT_EXISTING')
=> NULL
wp> $p->get_constant_value('NOT_EXISTING', 1234)
=> int(1234)
```

...and for the mockable version:

```
wp> $p = new Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProxy()
=> object(Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProxy)#7376 (6) {
...
}
wp> $p->register_constant_mock('FOOBAR',1234)
=> NULL
wp> $p->get_constant_value('FOOBAR')
=> int(1234)
wp> $p->register_constant_mock('DB_USER',1234)
=> NULL
wp> $p->get_constant_value('DB_USER')
=> int(1234)
wp> $p->register_constant_mock('DB_USER',null)
=> NULL
wp> $p->constant_is_defined('DB_USER')
=> bool(false)
wp> $p->get_constant_value('DB_USER',5678)
=> int(5678)
wp> $p->unregister_constant_mock('DB_USER')
=> NULL
wp> $p->get_constant_value('DB_USER')
=> string(4) "root"
wp> DB_USER
=> string(4) "root"
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
