### PR TITLE
Replace __experimentalGetGlobalBlocksByName with stable getBlocksByName

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -103,15 +103,10 @@ const isInProductArchive = () => {
 const isFirstBlockThatUsesPageContext = (
 	property: 'inherit' | 'filterable'
 ) => {
-	// We use experimental selector because it's been graduated as stable (`getBlocksByName`)
-	// in Gutenberg 17.6 (https://github.com/WordPress/gutenberg/pull/58156) and will be
-	// available in WordPress 6.5.
-	// Created issue for that: https://github.com/woocommerce/woocommerce/issues/44768.
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet, natively.
-	const { __experimentalGetGlobalBlocksByName, getBlock } =
-		select( blockEditorStore );
-	const productCollectionBlockIDs = __experimentalGetGlobalBlocksByName(
+	const { getBlocksByName, getBlock } = select( blockEditorStore );
+	const productCollectionBlockIDs = getBlocksByName(
 		'woocommerce/product-collection'
 	) as string[];
 

--- a/plugins/woocommerce/changelog/51773-product-collection-replace-experimental
+++ b/plugins/woocommerce/changelog/51773-product-collection-replace-experimental
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace __experimentalGetGlobalBlocksByName with stable getBlocksByName for Product Collection block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44768

This PR replaces __experimentalGetGlobalBlocksByName with stable getBlocksByName.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]
> Make sure you're using a block theme i.e. Twenty Twenty Four

1. Go to Appearance > Editor > Templates > WooCommerce > Product Catalog (make sure you reset the template)
2. If it isn't already there, add the Product Collection block.
3. Try choosing different collections and ensure you see them populate. Save.
4. Go to frontend Shop page and ensure you see the same collection as in the editor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Replace __experimentalGetGlobalBlocksByName with stable getBlocksByName for Product Collection block
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
