### PR TITLE
Ensure Product Collection filter names are consistently capitalized

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -151,7 +151,7 @@ export const HandPickedProductsControlField = ( {
 	return (
 		<FormTokenField
 			displayTransform={ transformTokenIntoProductName }
-			label={ __( 'Hand-Picked Products', 'woocommerce' ) }
+			label={ __( 'Hand-Picked', 'woocommerce' ) }
 			onChange={ onTokenChange }
 			onInputChange={ isLargeCatalog ? handleSearch : undefined }
 			suggestions={ suggestions }
@@ -186,7 +186,7 @@ const HandPickedProductsControl = ( {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Hand-Picked Products', 'woocommerce' ) }
+			label={ __( 'Hand-Picked', 'woocommerce' ) }
 			hasValue={ () => !! selectedProductIds?.length }
 			onDeselect={ deselectCallback }
 			resetAllFilter={ deselectCallback }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/stock-status-control.tsx
@@ -49,7 +49,7 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 
 	return (
 		<ToolsPanelItem
-			label={ __( 'Stock status', 'woocommerce' ) }
+			label={ __( 'Stock Status', 'woocommerce' ) }
 			hasValue={ () =>
 				! fastDeepEqual(
 					query.woocommerceStockStatus,
@@ -61,7 +61,7 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 			isShownByDefault
 		>
 			<FormTokenField
-				label={ __( 'Stock status', 'woocommerce' ) }
+				label={ __( 'Stock Status', 'woocommerce' ) }
 				onChange={ ( statusLabels ) => {
 					const woocommerceStockStatus = statusLabels
 						.map( getStockStatusIdByLabel )

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
@@ -48,6 +48,20 @@ function TaxonomyControls( {
 		return null;
 	}
 
+	/**
+	 * Normalize the name so first letter of every word is capitalized.
+	 */
+	const normalizeName = ( name: string ) => {
+		if ( ! name ) {
+			return name;
+		}
+
+		return name
+			.split( ' ' )
+			.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+			.join( ' ' );
+	};
+
 	return (
 		<>
 			{ taxonomies.map( ( taxonomy: Taxonomy ) => {
@@ -75,7 +89,7 @@ function TaxonomyControls( {
 				return (
 					<ToolsPanelItem
 						key={ slug }
-						label={ name }
+						label={ normalizeName( name ) }
 						hasValue={ () => termIds.length }
 						onDeselect={ deselectCallback }
 						resetAllFilter={ deselectCallback }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/taxonomy-controls/index.tsx
@@ -51,9 +51,9 @@ function TaxonomyControls( {
 	/**
 	 * Normalize the name so first letter of every word is capitalized.
 	 */
-	const normalizeName = ( name: string ) => {
+	const normalizeName = ( name: string | undefined | null ) => {
 		if ( ! name ) {
-			return name;
+			return '';
 		}
 
 		return name

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -97,9 +97,9 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock();
 
-		await pageObject.addFilter( 'Show Hand-picked Products' );
+		await pageObject.addFilter( 'Show Hand-picked' );
 
-		const filterName = 'Hand-picked Products';
+		const filterName = 'Hand-picked';
 		await pageObject.setFilterComboboxValue( filterName, [ 'Album' ] );
 		await expect( pageObject.products ).toHaveCount( 1 );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -396,7 +396,7 @@ class ProductCollectionPage {
 
 	async addFilter(
 		name:
-			| 'Show Hand-picked Products'
+			| 'Show Hand-picked'
 			| 'Keyword'
 			| 'Show product categories'
 			| 'Show product tags'

--- a/plugins/woocommerce/changelog/51779-product-collection-standardize-names
+++ b/plugins/woocommerce/changelog/51779-product-collection-standardize-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Ensure Product Collection filter names are consistently capitalized.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51233

This PR standardizes the Filters label/names so that the first letter of the words are capitalized. It also removes the trailing name "Product" from the name.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]
> Make sure you're using a block theme i.e. Twenty Twenty Four

1. Go to Appearance > Editor > Templates > WooCommerce > Product Catalog (make sure you reset the template)
2. If it isn't already there, add the Product Collection block.
3. Change the collection so that it can be filtered such as the "Top Rated" collection.
4. In the inspector controls, go to the Filters section and click on the three dots icon to the right of the section name.
5. In the dropdown menu you should see each filter name is in the format of capitalized first letter of every word.
6. You should also see that "Hand-Picked" no longer has "Products" at the end of it.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Ensure Product Collection filter names are consistently capitalized.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
