### PR TITLE
Add order by sales filter option to product collection

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
@@ -46,6 +46,14 @@ const orderOptions = [
 		value: 'price/asc',
 	},
 	{
+		label: __( 'Sales, high to low', 'woocommerce' ),
+		value: 'sales/desc',
+	},
+	{
+		label: __( 'Sales, low to high', 'woocommerce' ),
+		value: 'sales/asc',
+	},
+	{
 		value: 'popularity/desc',
 		label: __( 'Best Selling', 'woocommerce' ),
 	},

--- a/plugins/woocommerce/changelog/51790-product-collection-add-sales-ordering
+++ b/plugins/woocommerce/changelog/51790-product-collection-add-sales-ordering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add sales low to high and sales high to low filter options for product collection block

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -53,7 +53,7 @@ class ProductCollection extends AbstractBlock {
 	 *
 	 * @var array
 	 */
-	protected $custom_order_opts = array( 'popularity', 'rating', 'post__in', 'price' );
+	protected $custom_order_opts = array( 'popularity', 'rating', 'post__in', 'price', 'sales' );
 
 
 	/**
@@ -1064,6 +1064,14 @@ class ProductCollection extends AbstractBlock {
 			);
 		}
 
+		if ( 'sales' === $orderby ) {
+			add_filter( 'posts_clauses', array( $this, 'add_sales_sorting_posts_clauses' ), 10, 2 );
+			return array(
+				'isProductCollection' => true,
+				'orderby'             => $orderby,
+			);
+		}
+
 		$meta_keys = array(
 			'popularity' => 'total_sales',
 			'rating'     => '_wc_average_rating',
@@ -1763,6 +1771,36 @@ class ProductCollection extends AbstractBlock {
 		$clauses['orderby'] = $is_ascending_order ?
 			'wc_product_meta_lookup.min_price ASC, wc_product_meta_lookup.product_id ASC' :
 			'wc_product_meta_lookup.max_price DESC, wc_product_meta_lookup.product_id DESC';
+
+		return $clauses;
+	}
+
+	/**
+	 * Add the `posts_clauses` filter to add sales-based sorting
+	 *
+	 * @param array    $clauses The list of clauses for the query.
+	 * @param WP_Query $query   The WP_Query instance.
+	 * @return array   Modified list of clauses.
+	 */
+	public function add_sales_sorting_posts_clauses( $clauses, $query ) {
+		$query_vars                  = $query->query_vars;
+		$is_product_collection_block = $query_vars['isProductCollection'] ?? false;
+
+		if ( ! $is_product_collection_block ) {
+			return $clauses;
+		}
+
+		$orderby = $query_vars['orderby'] ?? null;
+		if ( 'sales' !== $orderby ) {
+			return $clauses;
+		}
+
+		$clauses['join']    = $this->append_product_sorting_table_join( $clauses['join'] );
+		$is_ascending_order = 'asc' === strtolower( $query_vars['order'] ?? 'desc' );
+
+		$clauses['orderby'] = $is_ascending_order ?
+			'wc_product_meta_lookup.total_sales ASC' :
+			'wc_product_meta_lookup.total_sales DESC';
 
 		return $clauses;
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
@@ -1240,4 +1240,24 @@ class ProductCollection extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wc_product_meta_lookup.max_price DESC', $query->request );
 	}
+
+	/**
+	 * Test the add_sales_sorting_posts_clauses method.
+	 */
+	public function test_add_sales_sorting_posts_clauses() {
+		$parsed_block                              = $this->get_base_parsed_block();
+		$parsed_block['attrs']['query']['orderBy'] = 'sales';
+
+		$parsed_block['attrs']['query']['order'] = 'asc';
+		$merged_query                            = $this->initialize_merged_query( $parsed_block );
+		$query                                   = new WP_Query( $merged_query );
+
+		$this->assertStringContainsString( 'wc_product_meta_lookup.total_sales ASC', $query->request );
+
+		$parsed_block['attrs']['query']['order'] = 'desc';
+		$merged_query                            = $this->initialize_merged_query( $parsed_block );
+		$query                                   = new WP_Query( $merged_query );
+
+		$this->assertStringContainsString( 'wc_product_meta_lookup.total_sales DESC', $query->request );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49528

This PR adds the filter option "Sales, high to low" and "Sales, low to high".

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a new page or a post.
2. Add the Product Collection block.
3. Choose "create your own" collection.
4. In the inspector Controls find "ORDER BY" option.
5. Click on it and you should see a dropdown with many options. Newly added is the "Sales, high to low" and "Sales, low to high".
6. Choose each one of the two and ensure you see the products update in the editor to match the filter option you choose.
7. Save and view the post/page in the frontend. Ensure it matches what you saved in the editor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add sales low to high and sales high to low filter options for product collection block
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
