### PR TITLE
[dev] CI: drop baseline caching in perfromance metrics job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,14 +183,6 @@ jobs:
         with:
           pattern: 'last-run__${{ strategy.job-index }}'
 
-      - name: 'Download Performance metrics baseline'
-        if: ${{ matrix.report.resultsPath != '' && matrix.testType == 'performance'}}
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319
-        with:
-          path: 'tools/compare-perf/artifacts/*_55f855a2e6d769b5ae44305b2772eb30d3e721df_*'
-          key: "${{ runner.os }}-woocommerce-performance-metrics-55f855a2e6d769b5ae44305b2772eb30d3e721df-${{ hashFiles( 'plugins/woocommerce/tests/performance/**/*.js' ) }}"
-          restore-keys: '${{ runner.os }}-woocommerce-performance-metrics-55f855a2e6d769b5ae44305b2772eb30d3e721df-'
-
       - name: 'Run tests (${{ matrix.testType }})'
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}

--- a/.github/workflows/scripts/run-metrics.sh
+++ b/.github/workflows/scripts/run-metrics.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-# The commented variables are for troubleshooting locally.
+# The commented variables are for troubleshooting locally. The commented commands below are also for local troubleshooting.
 # GITHUB_EVENT_NAME='pull_request'
 # GITHUB_SHA=$(git rev-parse HEAD)
 # ARTIFACTS_PATH="$(realpath $(dirname -- ${BASH_SOURCE[0]})/../../../tools/compare-perf)/artifacts"
@@ -34,20 +34,16 @@ if [ "$GITHUB_EVENT_NAME" == "push" ] || [ "$GITHUB_EVENT_NAME" == "pull_request
 	if test -n "$(find $ARTIFACTS_PATH -maxdepth 1 -name "*_${GITHUB_SHA}_*" -print -quit)"; then
 		title "Skipping benchmarking head as benchmarking results already available under $ARTIFACTS_PATH"
 	else
-		title "##[group]Building head"
-		git -c core.hooksPath=/dev/null checkout --quiet $HEAD_BRANCH > /dev/null && echo 'On' $(git rev-parse HEAD)
-		pnpm run --if-present clean:build
-		pnpm install --filter='@woocommerce/plugin-woocommerce...' --frozen-lockfile --config.dedupe-peer-dependents=false
-		pnpm --filter='@woocommerce/plugin-woocommerce' build
-		echo '##[endgroup]'
+		# title "##[group]Building head"
+		# git -c core.hooksPath=/dev/null checkout --quiet $HEAD_BRANCH > /dev/null && echo 'On' $(git rev-parse HEAD)
+		# pnpm run --if-present clean:build
+		# pnpm install --filter='@woocommerce/plugin-woocommerce...' --frozen-lockfile --config.dedupe-peer-dependents=false
+		# pnpm --filter='@woocommerce/plugin-woocommerce' build
+		# echo '##[endgroup]'
 
 		title "##[group]Benchmarking head"
-		for ROUND in {1..2}; do
-			# We can afford only 2 rounds, each one takes ~2 minutes.
-			echo "$(date +"%T"): Round $ROUND of 2"
-			RESULTS_ID="editor_${GITHUB_SHA}_round-$ROUND" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics editor
-			RESULTS_ID="product-editor_${GITHUB_SHA}_round-$ROUND" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics product-editor
-        done
+		RESULTS_ID="editor_${GITHUB_SHA}_round-1" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics editor
+		RESULTS_ID="product-editor_${GITHUB_SHA}_round-1" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics product-editor
 		echo '##[endgroup]'
 	fi
 
@@ -60,26 +56,21 @@ if [ "$GITHUB_EVENT_NAME" == "push" ] || [ "$GITHUB_EVENT_NAME" == "pull_request
 
 		title "##[group]Building baseline"
 		git -c core.hooksPath=/dev/null checkout --quiet $BASE_SHA > /dev/null && echo 'On' $(git rev-parse HEAD)
-		pnpm run --if-present clean:build
+		pnpm run --if-present clean:build &
 		pnpm install --filter='@woocommerce/plugin-woocommerce...' --frozen-lockfile --config.dedupe-peer-dependents=false
 		pnpm --filter='@woocommerce/plugin-woocommerce' build
 		echo '##[endgroup]'
 
 		title "##[group]Benchmarking baseline"
-		for ROUND in {1..3}; do
-			# Each round takes ~2 minutes, running for ~6 minutes presumable generates good enough baseline (cached for 1 week in CI).
-			echo "$(date +"%T"): Round $ROUND of 3"
-			RESULTS_ID="editor_${BASE_SHA}_round-$ROUND" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics editor
-			RESULTS_ID="product-editor_${BASE_SHA}_round-$ROUND" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics product-editor
-        done
+		RESULTS_ID="editor_${BASE_SHA}_round-1" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics editor
+		RESULTS_ID="product-editor_${BASE_SHA}_round-1" pnpm --filter="@woocommerce/plugin-woocommerce" test:metrics product-editor
 		echo '##[endgroup]'
 
-		# This step is intended for running the script locally.
-		title "##[group]Restoring codebase state back to head"
-		git -c core.hooksPath=/dev/null checkout --quiet $HEAD_BRANCH > /dev/null && echo 'On' $(git rev-parse HEAD)
-		pnpm install --frozen-lockfile > /dev/null &
-		pnpm run --if-present clean:build
-		echo '##[endgroup]'
+		# title "##[group]Restoring codebase state back to head"
+		# git -c core.hooksPath=/dev/null checkout --quiet $HEAD_BRANCH > /dev/null && echo 'On' $(git rev-parse HEAD)
+		# pnpm install --frozen-lockfile > /dev/null &
+		# pnpm run --if-present clean:build
+		# echo '##[endgroup]'
 	fi
 
   	title "##[group]Processing reports under $ARTIFACTS_PATH"

--- a/plugins/woocommerce/changelog/update-49550-perfromance-job-no-caching
+++ b/plugins/woocommerce/changelog/update-49550-perfromance-job-no-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: omit caching baseline results in perfromance metrics job.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -483,7 +483,6 @@
 						"start": "test:perf:ci-setup"
 					},
 					"events": [
-						"pull_request",
 						"push"
 					]
 				},
@@ -508,6 +507,7 @@
 						"start": "env:test"
 					},
 					"events": [
+						"pull_request",
 						"push"
 					],
 					"report": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -507,7 +507,6 @@
 						"start": "env:test"
 					},
 					"events": [
-						"pull_request",
 						"push"
 					],
 					"report": {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follows up to p1727444589041479-slack-C03CPM3UXDJ and drops caching of baseline metrics.
Additionally, we'll run the K6 performance job on trunk merge only, as PRs CI checks waiting still surfaces in surveys.

Update:

### How to test the changes in this Pull Request:

- All CI checks shall pass