### PR TITLE
Checkout: validate empty cart state before placing an order.

### DIFF
--- a/plugins/woocommerce/changelog/51810-bugfix-47967
+++ b/plugins/woocommerce/changelog/51810-bugfix-47967
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix #47967 where user's could place empty orders with the Checkout block.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -246,6 +246,11 @@ class Checkout extends AbstractCartRoute {
 		$this->cart_controller->calculate_totals();
 
 		/**
+		 * Validate that the cart is not empty.
+		 */
+		$this->cart_controller->validate_cart_not_empty();
+
+		/**
 		 * Validate items and fix violations before the order is processed.
 		 */
 		$this->cart_controller->validate_cart();

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -487,6 +487,23 @@ class CartController {
 	}
 
 	/**
+	 * When placing an order, validate that the cart is not empty.
+	 *
+	 * @throws InvalidCartException Exception if the cart is empty.
+	 */
+	public function validate_cart_not_empty() {
+		$cart_items = $this->get_cart_items();
+
+		if ( empty( $cart_items ) ) {
+			throw new InvalidCartException(
+				'woocommerce_cart_error',
+				new WP_Error( 'woocommerce_rest_cart_empty', __( 'Cannot place an order, your cart is empty.', 'woocommerce' ), 400 ),
+				400
+			);
+		}
+	}
+
+	/**
 	 * Validate all items in the cart and check for errors.
 	 *
 	 * @throws InvalidCartException Exception if invalid data is detected due to insufficient stock levels.
@@ -499,10 +516,6 @@ class CartController {
 		$too_many_in_cart_products     = [];
 		$partial_out_of_stock_products = [];
 		$not_purchasable_products      = [];
-
-		if ( empty( $cart_items ) ) {
-			$errors[] = new WP_Error( 'woocommerce_rest_cart_empty', __( 'Cannot place an order, your cart is empty.', 'woocommerce' ), 400 );
-		}
 
 		foreach ( $cart_items as $cart_item ) {
 			try {

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -492,7 +492,6 @@ class CartController {
 	 * @throws InvalidCartException Exception if invalid data is detected due to insufficient stock levels.
 	 */
 	public function validate_cart_items() {
-		$cart       = $this->get_cart_instance();
 		$cart_items = $this->get_cart_items();
 
 		$errors                        = [];
@@ -501,7 +500,11 @@ class CartController {
 		$partial_out_of_stock_products = [];
 		$not_purchasable_products      = [];
 
-		foreach ( $cart_items as $cart_item_key => $cart_item ) {
+		if ( empty( $cart_items ) ) {
+			$errors[] = new WP_Error( 'woocommerce_rest_cart_empty', __( 'Cannot place an order, your cart is empty.', 'woocommerce' ), 400 );
+		}
+
+		foreach ( $cart_items as $cart_item ) {
 			try {
 				$this->validate_cart_item( $cart_item );
 			} catch ( RouteException $error ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -497,6 +497,7 @@ class CartController {
 		if ( empty( $cart_items ) ) {
 			throw new InvalidCartException(
 				'woocommerce_cart_error',
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Errors are converted to response objects later.
 				new WP_Error( 'woocommerce_rest_cart_empty', __( 'Cannot place an order, your cart is empty.', 'woocommerce' ), 400 ),
 				400
 			);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #47967 

This adds an extra validation of the cart server-side to check if it's empty before trying to place an order. This solves an issue we have where on the front-end you could manipulate your cart and remove all items in another window or tab and the Checkout block currently cannot handle updating to reflect that state.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

0. This assumes you're using a block theme (ie Twenty Twenty-Four).

You can try reproduce the bug as listed in the original issue: #47967 
1. Go to a product page
2. Add it to cart
3. Open Cart page in a new tab
4. Open checkout page in a new tab
5. Fill in all the checkout fields but do not place the order
6. Go to the Cart tab and remove the cart item
7. Go to the Checkout page and place the order

Before this used to place an empty order, but now we display an error on the empty checkout page:

<img width="1909" alt="Screenshot 2024-10-01 at 9 01 58 PM" src="https://github.com/user-attachments/assets/f51727f3-9858-47d9-a822-390e62a3a419">

I think the look and behaviourUX could be improved in future iterations, but, at least this fixes the bug.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix #47967 where user's could place empty orders with the Checkout block.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
