### PR TITLE
[blocks e2e tests] Increase the shards number to 10

### DIFF
--- a/plugins/woocommerce/changelog/ci-update-shards-for-blocks-e2e
+++ b/plugins/woocommerce/changelog/ci-update-shards-for-blocks-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -526,15 +526,16 @@
 					"testType": "e2e",
 					"command": "test:e2e:blocks",
 					"shardingArguments": [
-						"--shard=1/9",
-						"--shard=2/9",
-						"--shard=3/9",
-						"--shard=4/9",
-						"--shard=5/9",
-						"--shard=6/9",
-						"--shard=7/9",
-						"--shard=8/9",
-						"--shard=9/9"
+						"--shard=1/10",
+						"--shard=2/10",
+						"--shard=3/10",
+						"--shard=4/10",
+						"--shard=5/10",
+						"--shard=6/10",
+						"--shard=7/10",
+						"--shard=8/10",
+						"--shard=9/10",
+						"--shard=10/10"
 					],
 					"changes": [
 						"src/Blocks/**",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

See p1727441336634309-slack-C03CPM3UXDJ for more context.

With https://github.com/woocommerce/woocommerce/pull/49148 we reduced the number of shards used in Blocks e2e tests from 10 to 9 because the split was unbalanced. In the meantime the tests were regrouped resulting in a more balanced spread. We can now return to 10 shards to speed things up.

### How to test the changes in this Pull Request:

Check the Blocks e2e tests jobs in CI. There should be 10 of them all passing.