### PR TITLE
Add Products by Brand template label

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-brands-template-strings
+++ b/plugins/woocommerce/changelog/fix-product-brands-template-strings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add Products by Brand user-friendly title to the New template popup

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\Constants;
  *
  * Important: For internal use only by the Automattic\WooCommerce\Internal\Brands package.
  *
- * @version 9.4.0
+ * @version 9.5.0
  */
 class WC_Brands {
 

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -269,6 +269,7 @@ class WC_Brands {
 					'labels'                => array(
 						'name'              => __( 'Brands', 'woocommerce' ),
 						'singular_name'     => __( 'Brand', 'woocommerce' ),
+						'template_name'     => _x( 'Products by Brand', 'Template name', 'woocommerce' ),
 						'search_items'      => __( 'Search Brands', 'woocommerce' ),
 						'all_items'         => __( 'All Brands', 'woocommerce' ),
 						'parent_item'       => __( 'Parent Brand', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the `template_name` attribute to the Brands taxonomy.

### How to test the changes in this Pull Request:

0. Make sure you have Brands activate. You can activate it with this code snippet:
```
add_action( 'init', function() {
    update_option( 'wc_feature_woocommerce_brands_enabled', 'yes' );
    update_option( 'woocommerce_remote_variant_assignment', 2 );
} );
```
1. Go to Appearance > Editor > Templates > Add New Template.
2. Verify a _Products by Brand_ option appears, instead of _Brands Archives_

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/9c976fbf-2def-4e1a-b1b8-e63c0e2eb88f) | ![imatge](https://github.com/user-attachments/assets/28cf4ded-3254-4b2c-a452-a5b102d40669)