### PR TITLE
Product Collection: Remove best selling filter option

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
@@ -54,10 +54,6 @@ const orderOptions = [
 		value: 'sales/asc',
 	},
 	{
-		value: 'popularity/desc',
-		label: __( 'Best Selling', 'woocommerce' ),
-	},
-	{
 		value: 'rating/desc',
 		label: __( 'Top Rated', 'woocommerce' ),
 	},
@@ -73,6 +69,13 @@ const OrderByControl = ( props: QueryControlProps ) => {
 		trackInteraction( CoreFilterNames.ORDER );
 	};
 
+	let orderValue = `${ orderBy }/${ order }`;
+
+	// This is to provide backward compatibility as we removed the 'popularity' (Best Selling) option from the order options.
+	if ( orderBy === 'popularity' ) {
+		orderValue = `sales/${ order }`;
+	}
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Order by', 'woocommerce' ) }
@@ -85,7 +88,7 @@ const OrderByControl = ( props: QueryControlProps ) => {
 			resetAllFilter={ deselectCallback }
 		>
 			<SelectControl
-				value={ `${ orderBy }/${ order }` }
+				value={ orderValue }
 				options={ orderOptions }
 				label={ __( 'Order by', 'woocommerce' ) }
 				onChange={ ( value ) => {

--- a/plugins/woocommerce/changelog/51865-product-collections-remove-best-selling-filter
+++ b/plugins/woocommerce/changelog/51865-product-collections-remove-best-selling-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove "Best Selling" filters option in favor of "Sales, high to low" for Product Collection block

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -1064,7 +1064,8 @@ class ProductCollection extends AbstractBlock {
 			);
 		}
 
-		if ( 'sales' === $orderby ) {
+		// The popularity orderby value here is for backwards compatibility as we have since removed the filter option.
+		if ( 'sales' === $orderby || 'popularity' === $orderby ) {
 			add_filter( 'posts_clauses', array( $this, 'add_sales_sorting_posts_clauses' ), 10, 2 );
 			return array(
 				'isProductCollection' => true,
@@ -1073,8 +1074,7 @@ class ProductCollection extends AbstractBlock {
 		}
 
 		$meta_keys = array(
-			'popularity' => 'total_sales',
-			'rating'     => '_wc_average_rating',
+			'rating' => '_wc_average_rating',
 		);
 
 		return array(
@@ -1791,7 +1791,9 @@ class ProductCollection extends AbstractBlock {
 		}
 
 		$orderby = $query_vars['orderby'] ?? null;
-		if ( 'sales' !== $orderby ) {
+
+		// The popularity orderby value here is for backwards compatibility as we have since removed the filter option.
+		if ( 'sales' !== $orderby && 'popularity' !== $orderby ) {
 			return $clauses;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -1801,8 +1801,8 @@ class ProductCollection extends AbstractBlock {
 		$is_ascending_order = 'asc' === strtolower( $query_vars['order'] ?? 'desc' );
 
 		$clauses['orderby'] = $is_ascending_order ?
-			'wc_product_meta_lookup.total_sales ASC' :
-			'wc_product_meta_lookup.total_sales DESC';
+			'wc_product_meta_lookup.total_sales ASC, wc_product_meta_lookup.product_id ASC' :
+			'wc_product_meta_lookup.total_sales DESC, wc_product_meta_lookup.product_id DESC';
 
 		return $clauses;
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
@@ -253,19 +253,6 @@ class ProductCollection extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test merging order by popularity queries.
-	 */
-	public function test_merging_order_by_popularity_queries() {
-		$parsed_block                              = $this->get_base_parsed_block();
-		$parsed_block['attrs']['query']['orderBy'] = 'popularity';
-
-		$merged_query = $this->initialize_merged_query( $parsed_block );
-
-		$this->assertEquals( 'meta_value_num', $merged_query['orderby'] );
-		$this->assertEquals( 'total_sales', $merged_query['meta_key'] );
-	}
-
-	/**
 	 * Test product visibility query exist in merged query.
 	 */
 	public function test_product_visibility_query_exist_in_merged_query() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Reference original PR https://github.com/woocommerce/woocommerce/commit/31c675f93d45563b7bcb9111943099f2a19a0969

This is a follow-up PR to remove the Best Selling filter option as it functions the same as the newly added "Sales, high to low" option. The following has been done.

- Remove the Best Selling filter option from the dropdown menu
- Preserve backwards compatibility where if merchant had previous used this filter option, the dropdown will now show "Sales, high to low".

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]
> Before checking out this PR/branch
> - Add a post and add the Product Collection block.
> - Go to the inspector controls and in the ORDER BY filter options select "Best Selling" and save the post.

1. Checkout this PR/branch
2. Reload the post you created above
3. In the inspector controls ORDER BY filter options, you should now see "Sales, high to low" selected.
4. Ensure you indeed see the correct order in the editor.
5. Go to the frontend of this post and ensure it looks identical as the editor.
6. In the inspector controls ORDER BY filter options, select "Sales, low to high".
7. Ensure the editor updates and the order is expected. Save the post.
8. Go to the frontend of this post and ensure it looks identical as the editor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Remove "Best Selling" filters option in favor of "Sales, high to low" for Product Collection block
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
