### PR TITLE
Cache block asset resource hints

### DIFF
--- a/plugins/woocommerce/changelog/update-49230
+++ b/plugins/woocommerce/changelog/update-49230
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Cache block asset resource hints

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -243,9 +243,10 @@ final class AssetsController {
 	 * @return array
 	 */
 	private function get_block_asset_resource_hints( $filename = '' ) {
-		$cached    = $this->get_block_asset_resource_hints_cache();
-		if ( isset( $cached['files'][ $filename ] ) ) {
-			return $cached['files'][ $filename ];
+		$cached = $this->get_block_asset_resource_hints_cache();
+
+		if ( isset( $cached[ $filename ] ) ) {
+			return $cached[ $filename ];
 		}
 
 		if ( ! $filename ) {

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -33,7 +33,7 @@ final class AssetsController {
 	/**
 	 * Initialize class features.
 	 */
-	public function init() {
+	protected function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingPublic
 		add_action( 'init', array( $this, 'register_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_and_enqueue_site_editor_assets' ) );
 		add_filter( 'wp_resource_hints', array( $this, 'add_resource_hints' ), 10, 2 );

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -202,6 +202,10 @@ final class AssetsController {
 	 * @return array|null Array of resource hints.
 	 */
 	private function get_block_asset_resource_hints_cache() {
+		if ( wp_is_development_mode( 'plugin' ) ) {
+			return null;
+		}
+
 		$cache = get_site_transient( 'woocommerce_block_asset_resource_hints' );
 
 		$current_version = array(
@@ -243,15 +247,16 @@ final class AssetsController {
 	 * @return array
 	 */
 	private function get_block_asset_resource_hints( $filename = '' ) {
+		if ( ! $filename ) {
+			return array();
+		}
+
 		$cached = $this->get_block_asset_resource_hints_cache();
 
 		if ( isset( $cached[ $filename ] ) ) {
 			return $cached[ $filename ];
 		}
 
-		if ( ! $filename ) {
-			return array();
-		}
 		$script_data = $this->api->get_script_data(
 			$this->api->get_block_asset_build_path( $filename )
 		);

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -203,6 +203,13 @@ final class AssetsController {
 	 * @return array
 	 */
 	private function get_block_asset_resource_hints( $filename = '' ) {
+		$cache_key = 'woocommerce_block_asset_resource_hints';
+		$cached    = get_site_transient( $cache_key );
+		$cached    = $cached ? $cached : array();
+		if ( isset( $cached[ $filename ] ) ) {
+			return $cached[ $filename ];
+		}
+
 		if ( ! $filename ) {
 			return array();
 		}
@@ -213,7 +220,8 @@ final class AssetsController {
 			array( esc_url( add_query_arg( 'ver', $script_data['version'], $script_data['src'] ) ) ),
 			$this->get_script_dependency_src_array( $script_data['dependencies'] )
 		);
-		return array_map(
+
+		$result = array_map(
 			function ( $src ) {
 				return array(
 					'href' => $src,
@@ -222,6 +230,11 @@ final class AssetsController {
 			},
 			array_unique( array_filter( $resources ) )
 		);
+
+		$cached[ $filename ] = $result;
+		set_site_transient( $cache_key, $cached, WEEK_IN_SECONDS );
+
+		return $result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
@@ -31,7 +33,7 @@ final class AssetsController {
 	/**
 	 * Initialize class features.
 	 */
-	protected function init() {
+	public function init() {
 		add_action( 'init', array( $this, 'register_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_and_enqueue_site_editor_assets' ) );
 		add_filter( 'wp_resource_hints', array( $this, 'add_resource_hints' ), 10, 2 );

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -18,7 +18,7 @@ class AssetsController extends \WP_UnitTestCase {
 	 */
 	private $api;
 
-    /**
+	/**
 	 * Holds the AssetsController under test.
 	 *
 	 * @var TestedAssetsController The AssetsController under test.
@@ -32,38 +32,38 @@ class AssetsController extends \WP_UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-        $this->api               = $this->createMock( Api::class );
+		$this->api               = $this->createMock( Api::class );
 		$this->assets_controller = new TestedAssetsController( $this->api );
 
-        // A block checkout or cart page must exist in order to have resource hints.
-        $page    = array(
+		// A block checkout or cart page must exist in order to have resource hints.
+		$page    = array(
 			'name'    => 'block-checkout',
 			'title'   => 'Block Checkout',
 			'content' => '<!-- wp:woocommerce/checkout -->',
 		);
 		$page_id = wc_create_page( $page['name'], 'woocommerce_checkout_page_id', $page['title'], $page['content'] );
 
-        // Ensure a product exists in the cart unless the test specifies otherwise.
-        $product = \WC_Helper_Product::create_simple_product();
-        wc()->cart->add_to_cart( $product->get_id() );
+		// Ensure a product exists in the cart unless the test specifies otherwise.
+		$product = \WC_Helper_Product::create_simple_product();
+		wc()->cart->add_to_cart( $product->get_id() );
 
-        // Set up some mock dependencies.
-        global $wp_scripts;
-        $wp_scripts->registered[ 'mock-dependency' ] = (object) array(
-            'ver'  => '1.2.3',
-            'src'  => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-dependency.js',
-            'deps' => array(
-                'mock-sub-dependency'
-            )
-        );
-        $wp_scripts->registered[ 'mock-sub-dependency' ] = (object) array(
-            'ver'  => '1.2.3',
-            'src'  => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-sub-dependency.js',
-            'deps' => array()
-        );
+		// Set up some mock dependencies.
+		global $wp_scripts;
+		$wp_scripts->registered['mock-dependency']     = (object) array(
+			'ver'  => '1.2.3',
+			'src'  => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-dependency.js',
+			'deps' => array(
+				'mock-sub-dependency',
+			),
+		);
+		$wp_scripts->registered['mock-sub-dependency'] = (object) array(
+			'ver'  => '1.2.3',
+			'src'  => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-sub-dependency.js',
+			'deps' => array(),
+		);
 	}
 
-    /**
+	/**
 	 * Clean up mock dependencies and pages after each test.
 	 *
 	 * @return void
@@ -71,14 +71,14 @@ class AssetsController extends \WP_UnitTestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
-        wp_delete_post( get_option( 'woocommerce_checkout_page_id' ), true );
+		wp_delete_post( get_option( 'woocommerce_checkout_page_id' ), true );
 		delete_option( 'woocommerce_checkout_page_id' );
 
-        wc()->cart->empty_cart();
+		wc()->cart->empty_cart();
 
-        global $wp_scripts;
-        unset( $wp_scripts->registered[ 'mock-dependency' ] );
-        unset( $wp_scripts->registered[ 'mock-sub-dependency' ] );
+		global $wp_scripts;
+		unset( $wp_scripts->registered['mock-dependency'] );
+		unset( $wp_scripts->registered['mock-sub-dependency'] );
 	}
 
 	/**
@@ -87,169 +87,168 @@ class AssetsController extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_no_additional_resource_hints_added() {
-        $mock_urls = array(
-            array(
-                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
-                'as' => 'script'
-            )
-        );
-        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'mock_relation' );
+		$mock_urls = array(
+			array(
+				'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+				'as'   => 'script',
+			),
+		);
+		$urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'mock_relation' );
 
-        $this->assertEquals( $mock_urls, $urls );
+		$this->assertEquals( $mock_urls, $urls );
 	}
 
-    /**
+	/**
 	 * Tests that no additional resource hints are added on non-prefetch, non-prerender relations.
 	 *
 	 * @return void
 	 */
 	public function test_no_additional_resource_hints_added_on_non_prefetch_prerender_relation() {
-        $mock_urls = array(
-            array(
-                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
-                'as' => 'script'
-            )
-        );
-        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'mock_relation' );
+		$mock_urls = array(
+			array(
+				'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+				'as'   => 'script',
+			),
+		);
+		$urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'mock_relation' );
 
-        $this->assertEquals( $mock_urls, $urls );
+		$this->assertEquals( $mock_urls, $urls );
 	}
 
-    /**
+	/**
 	 * Tests that no additional resource hints are added on empty carts.
 	 *
 	 * @return void
 	 */
 	public function test_no_additional_resource_hints_added_on_empty_cart() {
-        wc()->cart->empty_cart();
-        $mock_urls = array(
-            array(
-                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
-                'as' => 'script'
-            )
-        );
-        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'prefetch' );
+		wc()->cart->empty_cart();
+		$mock_urls = array(
+			array(
+				'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+				'as'   => 'script',
+			),
+		);
+		$urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'prefetch' );
 
-        $this->assertEquals( $mock_urls, $urls );
+		$this->assertEquals( $mock_urls, $urls );
 	}
 
-    /**
+	/**
 	 * Tests that no additional resource hints are added on empty carts.
 	 *
 	 * @return void
 	 */
 	public function test_additional_resource_hints_added_when_block_cart_exists() {
-        $this->api->expects( $this->once() )
-            ->method( 'get_script_data' )
-            ->willReturn(
-                array(
-                    'version' => '1.2.3',
-                    'src'     => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js',
-                    'dependencies' => array(
-                        'mock-dependency'
-                    )
-                )
-            );
+		$this->api->expects( $this->once() )
+			->method( 'get_script_data' )
+			->willReturn(
+				array(
+					'version'      => '1.2.3',
+					'src'          => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js',
+					'dependencies' => array(
+						'mock-dependency',
+					),
+				)
+			);
 
-        $mock_urls = array(
-            array(
-                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
-                'as' => 'script'
-            )
-        );
-        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'prefetch' );
+		$mock_urls = array(
+			array(
+				'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+				'as'   => 'script',
+			),
+		);
+		$urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'prefetch' );
 
-        $this->assertEquals(
-            array_merge(
-                $mock_urls,
-                array(
-                    array(
-                        'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js?ver=1.2.3',
-                        'as' => 'script'
-                    ),
-                    array(
-                        'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-dependency.js?ver=1.2.3',
-                        'as' => 'script'
-                    ),
-                    array(
-                        'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-sub-dependency.js?ver=1.2.3',
-                        'as' => 'script'
-                    ),
-                )
-            ),
-            $urls,
-        );
+		$this->assertEquals(
+			array_merge(
+				$mock_urls,
+				array(
+					array(
+						'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js?ver=1.2.3',
+						'as'   => 'script',
+					),
+					array(
+						'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-dependency.js?ver=1.2.3',
+						'as'   => 'script',
+					),
+					array(
+						'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-sub-dependency.js?ver=1.2.3',
+						'as'   => 'script',
+					),
+				)
+			),
+			$urls,
+		);
 	}
 
-    /**
+	/**
 	 * Tests that the additional resource hints uses the cache when available.
 	 *
 	 * @return void
 	 */
 	public function test_additional_resource_hints_cache() {
-        $mock_cache = array(
-            'files'   => array(
-                'checkout-frontend' =>array(
-                    'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-cached.js?ver=1.2.3',
-                    'as' => 'script'
-                )
-            ),
-            'version' => array(
-                'woocommerce' => WOOCOMMERCE_VERSION,
-                'wordpress'   => get_bloginfo( 'version' ),
-            )
-        );
-        set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
+		$mock_cache = array(
+			'files'   => array(
+				'checkout-frontend' => array(
+					'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-cached.js?ver=1.2.3',
+					'as'   => 'script',
+				),
+			),
+			'version' => array(
+				'woocommerce' => WOOCOMMERCE_VERSION,
+				'wordpress'   => get_bloginfo( 'version' ),
+			),
+		);
+		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
 
-        $urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
+		$urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
 
-        $this->assertEquals(
-            $mock_cache['files']['checkout-frontend'],
-            $urls,
-        );
+		$this->assertEquals(
+			$mock_cache['files']['checkout-frontend'],
+			$urls,
+		);
 	}
 
-    /**
+	/**
 	 * Tests that the additional resource hints don't use the cache when the version is invalid.
 	 *
 	 * @return void
 	 */
 	public function test_additional_resource_hints_invalid_cache() {
-        $this->api->expects( $this->once() )
-            ->method( 'get_script_data' )
-            ->willReturn(
-                array(
-                    'version'      => '1.2.3',
-                    'src'          => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js',
-                    'dependencies' => array(),
-                )
-            );
+		$this->api->expects( $this->once() )
+			->method( 'get_script_data' )
+			->willReturn(
+				array(
+					'version'      => '1.2.3',
+					'src'          => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js',
+					'dependencies' => array(),
+				)
+			);
 
-        $mock_cache = array(
-            'files'   => array(
-                'checkout-frontend' =>array(
-                    'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-cached.js?ver=1.2.3',
-                    'as' => 'script'
-                )
-            ),
-            'version' => array(
-                'woocommerce' => WOOCOMMERCE_VERSION,
-                'wordpress'   => '0.1.0-old',
-            )
-        );
-        set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
+		$mock_cache = array(
+			'files'   => array(
+				'checkout-frontend' => array(
+					'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-cached.js?ver=1.2.3',
+					'as'   => 'script',
+				),
+			),
+			'version' => array(
+				'woocommerce' => WOOCOMMERCE_VERSION,
+				'wordpress'   => '0.1.0-old',
+			),
+		);
+		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
 
-        $urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
+		$urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
 
-        $this->assertEquals(
-            array(
-                array(
-                    'href'     => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js?ver=1.2.3',
-                    'as' => 'script',
-                ),
-            ),
-            $urls,
-        );
+		$this->assertEquals(
+			array(
+				array(
+					'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js?ver=1.2.3',
+					'as'   => 'script',
+				),
+			),
+			$urls,
+		);
 	}
-
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -1,0 +1,255 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\AssetsController as TestedAssetsController;
+
+/**
+ * Unit tests for the PatternRegistry class.
+ */
+class AssetsController extends \WP_UnitTestCase {
+
+	/**
+	 * Holds the mock Api instance.
+	 *
+	 * @var Api The mock API.
+	 */
+	private $api;
+
+    /**
+	 * Holds the AssetsController under test.
+	 *
+	 * @var TestedAssetsController The AssetsController under test.
+	 */
+	private $block_types_controller;
+
+	/**
+	 * Sets up a new TestedAssetsController so it can be tested.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+        $this->api               = $this->createMock( Api::class );
+		$this->assets_controller = new TestedAssetsController( $this->api );
+
+        // A block checkout or cart page must exist in order to have resource hints.
+        $page    = array(
+			'name'    => 'block-checkout',
+			'title'   => 'Block Checkout',
+			'content' => '<!-- wp:woocommerce/checkout -->',
+		);
+		$page_id = wc_create_page( $page['name'], 'woocommerce_checkout_page_id', $page['title'], $page['content'] );
+
+        // Ensure a product exists in the cart unless the test specifies otherwise.
+        $product = \WC_Helper_Product::create_simple_product();
+        wc()->cart->add_to_cart( $product->get_id() );
+
+        // Set up some mock dependencies.
+        global $wp_scripts;
+        $wp_scripts->registered[ 'mock-dependency' ] = (object) array(
+            'ver'  => '1.2.3',
+            'src'  => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-dependency.js',
+            'deps' => array(
+                'mock-sub-dependency'
+            )
+        );
+        $wp_scripts->registered[ 'mock-sub-dependency' ] = (object) array(
+            'ver'  => '1.2.3',
+            'src'  => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-sub-dependency.js',
+            'deps' => array()
+        );
+	}
+
+    /**
+	 * Clean up mock dependencies and pages after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+        wp_delete_post( get_option( 'woocommerce_checkout_page_id' ), true );
+		delete_option( 'woocommerce_checkout_page_id' );
+
+        wc()->cart->empty_cart();
+
+        global $wp_scripts;
+        unset( $wp_scripts->registered[ 'mock-dependency' ] );
+        unset( $wp_scripts->registered[ 'mock-sub-dependency' ] );
+	}
+
+	/**
+	 * Tests that no additional resource hints are added on non-prefetch, non-prerender relations.
+	 *
+	 * @return void
+	 */
+	public function test_no_additional_resource_hints_added() {
+        $mock_urls = array(
+            array(
+                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+                'as' => 'script'
+            )
+        );
+        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'mock_relation' );
+
+        $this->assertEquals( $mock_urls, $urls );
+	}
+
+    /**
+	 * Tests that no additional resource hints are added on non-prefetch, non-prerender relations.
+	 *
+	 * @return void
+	 */
+	public function test_no_additional_resource_hints_added_on_non_prefetch_prerender_relation() {
+        $mock_urls = array(
+            array(
+                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+                'as' => 'script'
+            )
+        );
+        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'mock_relation' );
+
+        $this->assertEquals( $mock_urls, $urls );
+	}
+
+    /**
+	 * Tests that no additional resource hints are added on empty carts.
+	 *
+	 * @return void
+	 */
+	public function test_no_additional_resource_hints_added_on_empty_cart() {
+        wc()->cart->empty_cart();
+        $mock_urls = array(
+            array(
+                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+                'as' => 'script'
+            )
+        );
+        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'prefetch' );
+
+        $this->assertEquals( $mock_urls, $urls );
+	}
+
+    /**
+	 * Tests that no additional resource hints are added on empty carts.
+	 *
+	 * @return void
+	 */
+	public function test_additional_resource_hints_added_when_block_cart_exists() {
+        $this->api->expects( $this->once() )
+            ->method( 'get_script_data' )
+            ->willReturn(
+                array(
+                    'version' => '1.2.3',
+                    'src'     => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js',
+                    'dependencies' => array(
+                        'mock-dependency'
+                    )
+                )
+            );
+
+        $mock_urls = array(
+            array(
+                'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/blocks/mock.js?ver=1.1.0',
+                'as' => 'script'
+            )
+        );
+        $urls      = $this->assets_controller->add_resource_hints( $mock_urls, 'prefetch' );
+
+        $this->assertEquals(
+            array_merge(
+                $mock_urls,
+                array(
+                    array(
+                        'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js?ver=1.2.3',
+                        'as' => 'script'
+                    ),
+                    array(
+                        'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-dependency.js?ver=1.2.3',
+                        'as' => 'script'
+                    ),
+                    array(
+                        'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-sub-dependency.js?ver=1.2.3',
+                        'as' => 'script'
+                    ),
+                )
+            ),
+            $urls,
+        );
+	}
+
+    /**
+	 * Tests that the additional resource hints uses the cache when available.
+	 *
+	 * @return void
+	 */
+	public function test_additional_resource_hints_cache() {
+        $mock_cache = array(
+            'files'   => array(
+                'checkout-frontend' =>array(
+                    'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-cached.js?ver=1.2.3',
+                    'as' => 'script'
+                )
+            ),
+            'version' => array(
+                'woocommerce' => WOOCOMMERCE_VERSION,
+                'wordpress'   => get_bloginfo( 'version' ),
+            )
+        );
+        set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
+
+        $urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
+
+        $this->assertEquals(
+            $mock_cache['files']['checkout-frontend'],
+            $urls,
+        );
+	}
+
+    /**
+	 * Tests that the additional resource hints don't use the cache when the version is invalid.
+	 *
+	 * @return void
+	 */
+	public function test_additional_resource_hints_invalid_cache() {
+        $this->api->expects( $this->once() )
+            ->method( 'get_script_data' )
+            ->willReturn(
+                array(
+                    'version'      => '1.2.3',
+                    'src'          => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js',
+                    'dependencies' => array(),
+                )
+            );
+
+        $mock_cache = array(
+            'files'   => array(
+                'checkout-frontend' =>array(
+                    'href' => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/mock-cached.js?ver=1.2.3',
+                    'as' => 'script'
+                )
+            ),
+            'version' => array(
+                'woocommerce' => WOOCOMMERCE_VERSION,
+                'wordpress'   => '0.1.0-old',
+            )
+        );
+        set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
+
+        $urls = $this->assets_controller->add_resource_hints( array(), 'prefetch' );
+
+        $this->assertEquals(
+            array(
+                array(
+                    'href'     => 'http://test.local/wp-content/plugins/woocommerce/assets/client/block/checkout.js?ver=1.2.3',
+                    'as' => 'script',
+                ),
+            ),
+            $urls,
+        );
+	}
+
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR caches the block asset resource hints.  The `get_script_dependency_src_array` calls are recursive and result in about 10ms load on the page when items exist in the cart.  Caching the resource hints (and dependencies) lessens this load.

**Before:** 78.249ms
**After:** 67.691ms

This gives us a reduction of 36% over baseline when cart items are present when compared to a baseline local site without WooCommerce as measured in https://github.com/woocommerce/woocommerce/issues/50714.

Closes #49230  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Regression testing

1. Clear website cache.
2. Go to the homepage with nothing in your cart.
3. View source. Look for rel='prefetch' rules. Cart and checkout will not be there.
4. Go to the shop page and add something to the cart.
5. Go back to the homepage.
6. View source. Look for rel='prefetch' rules:

![149147708-009cf5fa-46fa-4cbb-80c6-6fe7f0cd5607](https://github.com/user-attachments/assets/70d32489-56fa-4d9c-8147-15e7697b7027)

#### Performance testing

1. Add the following snippet to your site to ensure a product always exists in the cart, replacing `PRODUCT_ID` with a real product id from your site:
```php
add_action( 'wp_loaded', function() {
	if ( wc()->cart && wc()->cart->is_empty() ) {
		wc()->cart->add_to_cart( PRODUCT_ID );
	}
} );
```
2. In a terminal, check the TTFB: `curl -o /dev/null -w "Connect: %{time_connect} TTFB: %{time_starttransfer} Total time: %{time_total} \n" testsite.local`, replacing `testsite.local` with your site.
3. Switch to `trunk` and run the above command again.
4. Note the drop in TTFB on this branch compared to `trunk`
5. This command can be repeated multiple times or you can use a script like [TTFB](https://github.com/jaygooby/ttfb.sh) to generate a larger sample size

#### Development testing

1. Modify some dependencies for the cached resource hints (e.g., remove the array of dependencies in `assets/client/blocks/cart-frontend.asset.php`)
2. In your `wp-config.php` set the development mode to `plugin`.  `define( 'WP_DEVELOPMENT_MODE', 'plugin' );`
3. Also add `define( 'SCRIPT_DEBUG', true );` to your `wp-config.php` (this is for cache busting the script dependency API)
4. Add something to your cart
5. Check the source for the page
7. Make sure that the cache is not used and the cart `prefetch` resources are no longer listed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
