### PR TITLE
[ci-jobs] Add new unit tests to validate the prerelease WP offer flow in jobs matrix

### DIFF
--- a/tools/monorepo-utils/src/ci-jobs/lib/__tests__/test-environment.spec.ts
+++ b/tools/monorepo-utils/src/ci-jobs/lib/__tests__/test-environment.spec.ts
@@ -11,6 +11,31 @@ import { parseTestEnvConfig } from '../test-environment';
 
 jest.mock( 'node:http' );
 
+function mockWordPressAPI(
+	stableCheckResponse: any,
+	versionCheckResponse: any
+) {
+	jest.mocked( get ).mockImplementation( ( url, callback: any ) => {
+		const getStream = new Stream();
+		callback( getStream as IncomingMessage );
+
+		if ( url === 'http://api.wordpress.org/core/stable-check/1.0/' ) {
+			getStream.emit( 'data', JSON.stringify( stableCheckResponse ) );
+		} else if (
+			url
+				.toString()
+				.includes( 'http://api.wordpress.org/core/version-check/1.7' )
+		) {
+			getStream.emit( 'data', JSON.stringify( versionCheckResponse ) );
+		} else {
+			throw new Error( 'Invalid URL' );
+		}
+
+		getStream.emit( 'end' );
+		return jest.fn() as any;
+	} );
+}
+
 describe( 'Test Environment', () => {
 	describe( 'parseTestEnvConfig', () => {
 		it( 'should parse empty configs', async () => {
@@ -22,54 +47,27 @@ describe( 'Test Environment', () => {
 		describe( 'wpVersion', () => {
 			// We're going to mock an implementation of the request to the WordPress.org API.
 			// This simulates what happens when we call https.get() for it.
-			jest.mocked( get ).mockImplementation( ( url, callback: any ) => {
-				let response = {};
-				const getStream = new Stream();
-
-				if (
-					url === 'http://api.wordpress.org/core/stable-check/1.0/'
-				) {
-					// Let the consumer set up listeners for the stream.
-					callback( getStream as IncomingMessage );
-
-					response = {
-						'5.9': 'insecure',
-						'6.0': 'insecure',
-						'6.0.1': 'insecure',
-						'6.1': 'insecure',
-						'6.1.1': 'insecure',
-						'6.1.2': 'outdated',
-						'6.2': 'latest',
-					};
-				} else if (
-					url
-						.toString()
-						.includes(
-							'http://api.wordpress.org/core/version-check/1.7'
-						)
-				) {
-					response = {
-						offers: [
-							{
-								response: 'development',
-								version: '6.3-beta1',
-								download:
-									'https://wordpress.org/wordpress-6.3-beta1.zip',
-							},
-						],
-					};
-
-					callback( getStream as IncomingMessage );
-				} else {
-					throw new Error( 'Invalid URL' );
+			mockWordPressAPI(
+				{
+					'5.9': 'insecure',
+					'6.0': 'insecure',
+					'6.0.1': 'insecure',
+					'6.1': 'insecure',
+					'6.1.1': 'insecure',
+					'6.1.2': 'outdated',
+					'6.2': 'latest',
+				},
+				{
+					offers: [
+						{
+							response: 'development',
+							version: '6.3-beta1',
+							download:
+								'https://wordpress.org/wordpress-6.3-beta1.zip',
+						},
+					],
 				}
-
-				getStream.emit( 'data', JSON.stringify( response ) );
-
-				getStream.emit( 'end' ); // this will trigger the promise resolve
-
-				return jest.fn() as any;
-			} );
+			);
 
 			it( 'should parse "master" and "trunk" branches', async () => {
 				let envVars = await parseTestEnvConfig( {
@@ -179,6 +177,32 @@ describe( 'Test Environment', () => {
 						'https://wordpress.org/wordpress-6.3-beta1.zip',
 					WP_VERSION: '6.3-beta1',
 				} );
+			} );
+
+			it( 'should not create env vars if no prerelease is offered', async () => {
+				mockWordPressAPI(
+					{
+						'6.1.1': 'insecure',
+						'6.1.2': 'outdated',
+						'6.2': 'latest',
+					},
+					{
+						offers: [
+							{
+								response: 'latest',
+								version: '6.2',
+								download:
+									'https://wordpress.org/wordpress-6.2.zip',
+							},
+						],
+					}
+				);
+
+				const envVars = await parseTestEnvConfig( {
+					wpVersion: 'prerelease',
+				} );
+
+				expect( envVars ).toEqual( {} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/51814.
Added unit tests to validate the updated job matrix flows.

### How to test the changes in this Pull Request:

Check CI. The monorepo-utils unit tests should pass.
