### PR TITLE
Checkout: Fix default customer location and geolocation so only allowed countries get selected

### DIFF
--- a/plugins/woocommerce/changelog/fix-51402-geolocation-validity
+++ b/plugins/woocommerce/changelog/fix-51402-geolocation-validity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed geolocation so if it geolocates to a non-allowed country, no country is selected in checkout.

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -142,7 +142,16 @@ class WC_Geolocation {
 	 * @return array
 	 */
 	public static function geolocate_ip( $ip_address = '', $fallback = false, $api_fallback = true ) {
-		// Filter to allow custom geolocation of the IP address.
+		/**
+		 * Filter to allow custom geolocation of the IP address.
+		 *
+		 * @since 3.9.0
+		 * @param string $geolocation Country code.
+		 * @param string $ip_address IP Address.
+		 * @param bool $fallback If true, fallbacks to alternative IP detection (can be slower).
+		 * @param bool $api_fallback If true, uses geolocation APIs if the database file doesn't exist (can be slower).
+		 * @return string
+		 */
 		$country_code = apply_filters( 'woocommerce_geolocate_ip', false, $ip_address, $fallback, $api_fallback );
 
 		if ( false !== $country_code ) {

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1310,6 +1310,7 @@ function wc_get_base_location() {
  * Uses geolocation to get the customer country and state only if they are valid values.
  *
  * @since 9.5.0
+ * @param array $fallback Fallback location.
  * @return array
  */
 function wc_get_customer_geolocation( $fallback = array(

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1307,6 +1307,49 @@ function wc_get_base_location() {
 }
 
 /**
+ * Uses geolocation to get the customer country and state only if they are valid values.
+ *
+ * @since 9.5.0
+ * @return array
+ */
+function wc_get_customer_geolocation( $fallback = array(
+	'country' => '',
+	'state'   => '',
+) ) {
+	$ua = wc_get_user_agent();
+
+	// Exclude common bots from geolocation by user agent.
+	if ( stristr( $ua, 'bot' ) || stristr( $ua, 'spider' ) || stristr( $ua, 'crawl' ) ) {
+		return $fallback;
+	}
+
+	$geolocation = WC_Geolocation::geolocate_ip( '', true, false );
+
+	if ( empty( $geolocation['country'] ) ) {
+		return $fallback;
+	}
+
+	// Ensure geolocation is valid.
+	$allowed_countries = WC()->countries->get_allowed_countries();
+
+	if ( ! in_array( $geolocation['country'], array_keys( $allowed_countries ), true ) ) {
+		return $fallback;
+	}
+
+	$allowed_states = WC()->countries->get_allowed_country_states();
+	$country_states = $allowed_states[ $geolocation['country'] ] ?? array();
+
+	if ( $country_states && ! in_array( $geolocation['state'], array_keys( $country_states ), true ) ) {
+		$geolocation['state'] = '';
+	}
+
+	return array(
+		'country' => $geolocation['country'],
+		'state'   => $geolocation['state'],
+	);
+}
+
+/**
  * Get the customer's default location.
  *
  * Filtered, and set to base location or left blank. If cache-busting,
@@ -1317,32 +1360,46 @@ function wc_get_base_location() {
  */
 function wc_get_customer_default_location() {
 	$set_default_location_to = get_option( 'woocommerce_default_customer_address', 'base' );
-	$default_location        = '' === $set_default_location_to ? '' : get_option( 'woocommerce_default_country', 'US:CA' );
-	$location                = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', $default_location ) );
 
-	// Geolocation takes priority if used and if geolocation is possible.
-	if ( 'geolocation' === $set_default_location_to || 'geolocation_ajax' === $set_default_location_to ) {
-		$ua = wc_get_user_agent();
-
-		// Exclude common bots from geolocation by user agent.
-		if ( ! stristr( $ua, 'bot' ) && ! stristr( $ua, 'spider' ) && ! stristr( $ua, 'crawl' ) ) {
-			$geolocation = WC_Geolocation::geolocate_ip( '', true, false );
-
-			if ( ! empty( $geolocation['country'] ) ) {
-				$location = $geolocation;
-			}
-		}
+	// Unless the location should be blank, use the base location as the default.
+	if ( '' !== $set_default_location_to ) {
+		$default_location_string = get_option( 'woocommerce_default_country', 'US:CA' );
 	}
 
-	// Once we have a location, ensure it's valid, otherwise fallback to a valid location.
-	$allowed_country_codes = WC()->countries->get_allowed_countries();
+	$default_location = wc_format_country_state_string(
+		/**
+		 * Filter the customer default location before geolocation.
+		 *
+		 * @since 2.3.0
+		 * @param string $default_location_string The default location.
+		 * @return string
+		 */
+		apply_filters( 'woocommerce_customer_default_location', $default_location_string ?? '' )
+	);
 
-	if ( ! empty( $location['country'] ) && ! array_key_exists( $location['country'], $allowed_country_codes ) ) {
-		$location['country'] = current( array_keys( $allowed_country_codes ) );
-		$location['state']   = '';
+	// Ensure defaults are valid.
+	$allowed_countries = WC()->countries->get_allowed_countries();
+
+	if ( ! in_array( $default_location['country'], array_keys( $allowed_countries ), true ) ) {
+		$default_location = array(
+			'country' => '',
+			'state'   => '',
+		);
 	}
 
-	return apply_filters( 'woocommerce_customer_default_location_array', $location );
+	// Geolocation takes priority if geolocation is possible.
+	if ( in_array( $set_default_location_to, array( 'geolocation', 'geolocation_ajax' ), true ) ) {
+		$default_location = wc_get_customer_geolocation( $default_location );
+	}
+
+	/**
+	 * Filter the customer default location after geolocation.
+	 *
+	 * @since 2.3.0
+	 * @param array $customer_location The customer location with keys 'country' and 'state'.
+	 * @return array
+	 */
+	return apply_filters( 'woocommerce_customer_default_location_array', $default_location );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1333,14 +1333,14 @@ function wc_get_customer_geolocation( $fallback = array(
 	// Ensure geolocation is valid.
 	$allowed_countries = WC()->countries->get_allowed_countries();
 
-	if ( ! in_array( $geolocation['country'], array_keys( $allowed_countries ), true ) ) {
+	if ( ! isset( $allowed_countries[ $geolocation['country'] ] ) ) {
 		return $fallback;
 	}
 
 	$allowed_states = WC()->countries->get_allowed_country_states();
 	$country_states = $allowed_states[ $geolocation['country'] ] ?? array();
 
-	if ( $country_states && ! in_array( $geolocation['state'], array_keys( $country_states ), true ) ) {
+	if ( $country_states && ! isset( $country_states[ $geolocation['state'] ] ) ) {
 		$geolocation['state'] = '';
 	}
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1320,7 +1320,7 @@ function wc_get_customer_geolocation( $fallback = array(
 	$ua = wc_get_user_agent();
 
 	// Exclude common bots from geolocation by user agent.
-	if ( stristr( $ua, 'bot' ) || stristr( $ua, 'spider' ) || stristr( $ua, 'crawl' ) ) {
+	if ( stripos( $ua, 'bot' ) !== false || stripos( $ua, 'spider' ) !== false || stripos( $ua, 'crawl' ) !== false ) {
 		return $fallback;
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
@@ -400,56 +400,6 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting the customer default location with different configurations of options set or unset.
-	 */
-	public function test_wc_get_customer_default_location() {
-		// Test with none of the options set.
-		delete_option( 'woocommerce_default_customer_address' );
-		delete_option( 'woocommerce_default_country' );
-		delete_option( 'woocommerce_allowed_countries' );
-		delete_option( 'woocommerce_specific_allowed_countries' );
-		$customer_default_location = wc_get_customer_default_location();
-		$this->assertEquals( 'US', $customer_default_location['country'] );
-		$this->assertEquals( 'CA', $customer_default_location['state'] );
-
-		// Test with default address set.
-		update_option( 'woocommerce_default_customer_address', 'base' );
-		update_option( 'woocommerce_default_country', 'DE:LS' );
-		delete_option( 'woocommerce_allowed_countries' );
-		delete_option( 'woocommerce_specific_allowed_countries' );
-		$customer_default_location = wc_get_customer_default_location();
-		$this->assertEquals( 'DE', $customer_default_location['country'] );
-		$this->assertEquals( 'LS', $customer_default_location['state'] );
-
-		// Test with default address, but specific countries set.
-		update_option( 'woocommerce_default_customer_address', 'base' );
-		update_option( 'woocommerce_default_country', 'DE:LS' );
-		update_option( 'woocommerce_allowed_countries', 'specific' );
-		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
-		$customer_default_location = wc_get_customer_default_location();
-		$this->assertEquals( 'DE', $customer_default_location['country'] );
-		$this->assertEquals( 'LS', $customer_default_location['state'] );
-
-		// Test with no default address, but specific countries set.
-		delete_option( 'woocommerce_default_customer_address' );
-		delete_option( 'woocommerce_default_country' );
-		update_option( 'woocommerce_allowed_countries', 'specific' );
-		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
-		$customer_default_location = wc_get_customer_default_location();
-		$this->assertEquals( 'DE', $customer_default_location['country'] );
-		$this->assertEquals( '', $customer_default_location['state'] );
-
-		// Test forgetting to set the allowed countries to specific.
-		delete_option( 'woocommerce_default_customer_address' );
-		delete_option( 'woocommerce_default_country' );
-		delete_option( 'woocommerce_allowed_countries', 'specific' );
-		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
-		$customer_default_location = wc_get_customer_default_location();
-		$this->assertEquals( 'US', $customer_default_location['country'] );
-		$this->assertEquals( 'CA', $customer_default_location['state'] );
-	}
-
-	/**
 	 * Test setting a customer's location (multiple address fields at once)
 	 * @since 3.0.0
 	 */

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
 /**
  * Core functions tests
  *
@@ -60,7 +60,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 	public function test_wc_get_rounding_precision( $decimals, $expected ) {
 		add_filter(
 			'wc_get_price_decimals',
-			function() use ( $decimals ) {
+			function () use ( $decimals ) {
 				return $decimals;
 			}
 		);
@@ -91,7 +91,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 	public function test_wc_add_number_precision( $decimals, $value, $round, $expected ) {
 		add_filter(
 			'wc_get_price_decimals',
-			function() use ( $decimals ) {
+			function () use ( $decimals ) {
 				return $decimals;
 			}
 		);
@@ -114,7 +114,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 	public function test_wc_remove_number_precision( $decimals, $value, $expected ) {
 		add_filter(
 			'wc_get_price_decimals',
-			function() use ( $decimals ) {
+			function () use ( $decimals ) {
 				return $decimals;
 			}
 		);
@@ -132,5 +132,102 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$expected = '<span class="woocommerce-help-tip" tabindex="0" aria-label="Strong text regular text" data-tip="&lt;strong&gt;Strong text&lt;/strong&gt; regular text"></span>';
 		$this->assertEquals( $expected, wc_help_tip( '<strong>Strong text</strong> regular text', false ) );
 		$this->assertEquals( $expected, wc_help_tip( '<strong>Strong text</strong> regular text', true ) );
+	}
+
+	/**
+	 * Test wc_get_customer_default_location() function.
+	 */
+	public function test_wc_get_customer_default_location() {
+		/**
+		 * Test with none of the options set. In this case the location should be empty.
+		 *
+		 * woocommerce_default_country is set to 'US:CA' by default unless it was defined during setup.
+		 */
+		delete_option( 'woocommerce_default_customer_address' );
+		delete_option( 'woocommerce_default_country' );
+		delete_option( 'woocommerce_allowed_countries' );
+		delete_option( 'woocommerce_specific_allowed_countries' );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( 'CA', $result['state'] );
+
+		// Test with a default address defined during setup. This country has states.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'DE', $result['country'] );
+		$this->assertEquals( 'LS', $result['state'] );
+
+		// Test with a default address defined during setup. This country has no states.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'GB' );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'GB', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+
+		// Test with default address, but specific countries set. Address is allowed.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'DE', 'AT', 'CH' ) );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'DE', $result['country'] );
+		$this->assertEquals( 'LS', $result['state'] );
+
+		// Test with default address, but specific countries set. Address is not allowed.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'GB' ) );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( '', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+
+		// Test with no default address.
+		update_option( 'woocommerce_default_customer_address', '' );
+		update_option( 'woocommerce_default_country', 'GB' );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( '', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+
+		// Test with geolocation.
+		update_option( 'woocommerce_default_customer_address', 'geolocation' );
+		update_option( 'woocommerce_default_country', 'GB' );
+		delete_option( 'woocommerce_allowed_countries' );
+		delete_option( 'woocommerce_specific_allowed_countries' );
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function () {
+				return array(
+					'country' => 'FR',
+					'state'   => '',
+				);
+			},
+			10
+		);
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'FR', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+		remove_all_filters( 'woocommerce_geolocate_ip' );
+
+		// Test with geolocation but geolocated country is not allowed.
+		update_option( 'woocommerce_default_customer_address', 'geolocation' );
+		update_option( 'woocommerce_default_country', 'GB' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'GB' ) );
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function () {
+				return array(
+					'country' => 'FR',
+					'state'   => '',
+				);
+			},
+			10
+		);
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'GB', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+		remove_all_filters( 'woocommerce_geolocate_ip' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -198,10 +198,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_geolocate_ip',
 			function () {
-				return array(
-					'country' => 'FR',
-					'state'   => '',
-				);
+				return 'FR';
 			},
 			10
 		);
@@ -218,10 +215,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		add_filter(
 			'woocommerce_geolocate_ip',
 			function () {
-				return array(
-					'country' => 'FR',
-					'state'   => '',
-				);
+				return 'FR';
 			},
 			10
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Refactor default location logic so that the default country is definitely allowed. This means if it geo-locates to a non-allowed country, the country will be the base country instead of selecting the first country in the dropdown.

Closes #51402

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To test this you either need to have setup MaxMind under WC > Settings > Integrations, or you can force a value with a small function:

```php
add_filter(
	'woocommerce_geolocate_ip',
	function ( $geolocation ) {
		return 'FR';
	},
	10
);
```

1. Implement snippet above.
2. WC > Settings > Set store address to the UK
3. WC > Settings > Selling Locations. Sell to all countries except France.
4. WC > Settings > Default customer location set to geolocate
5. Go to checkout in a new browser session as a guest. 
6. Confirm UK is selected by default
7. WC > Settings > Default customer location set to "no address"
8. Go to checkout in a new browser session as a guest. 
9. Confirm no country is selected

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
