### PR TITLE
Fix clearing search input in In-App Marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/search/search.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/search/search.tsx
@@ -36,7 +36,7 @@ function Search(): JSX.Element {
 		}
 	}, [ query.term ] );
 
-	const runSearch = () => {
+	const runSearch = ( term?: string ) => {
 		const newQuery: { term?: string; tab?: string } = query;
 
 		// If we're on 'Discover' or 'My subscriptions' when a search is initiated, move to the extensions tab
@@ -44,7 +44,10 @@ function Search(): JSX.Element {
 			newQuery.tab = 'extensions';
 		}
 
-		newQuery.term = searchTerm.trim();
+		newQuery.term = typeof term !== 'undefined' ? term : searchTerm.trim();
+		if ( ! newQuery.term ) {
+			delete newQuery.term;
+		}
 
 		// When the search term changes, we reset the query string on purpose.
 		navigateTo( {
@@ -64,6 +67,11 @@ function Search(): JSX.Element {
 		}
 	};
 
+	const onClose = () => {
+		setSearchTerm( '' );
+		runSearch( '' );
+	};
+
 	return (
 		<SearchControl
 			label={ searchPlaceholder }
@@ -71,6 +79,7 @@ function Search(): JSX.Element {
 			value={ searchTerm }
 			onChange={ setSearchTerm }
 			onKeyUp={ handleKeyUp }
+			onClose={ onClose }
 			className="woocommerce-marketplace__search"
 		/>
 	);

--- a/plugins/woocommerce/changelog/51916-fix-marketplace-clear-search
+++ b/plugins/woocommerce/changelog/51916-fix-marketplace-clear-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix clearing search input in In-App Marketplace using close icon


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Fix clearing search input in In-App Marketplace. Currently, clicking on X icon clears the input but doesn't update displayed results. This PR should fix it.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 21868-gh-Automattic/woocommerce.com.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and get a new build
2. Visit the In-App Marketplace and visit[ the Extensions page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=extensions&path=%2Fextensions&category=_all).
3. Use search input to filter extensions
4. Once extensions are filtered, use 'X' (close) icon in the search control to clear the input
5. Confirm that using the icon clears the input, refreshes properly list of displayed products, and properly updates URL (removing `term` query parameter)
6. Try also clearing the input by removing all text and clicking Enter to submit it. It should work the same as when you would use the close icon.
7. Check that functionality works properly in other tabs too
8. Please test around this issue

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix clearing search input in In-App Marketplace using close icon

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

![image](https://github.com/user-attachments/assets/1079663b-cffa-4f19-89f1-45da787d9abf)
