### PR TITLE
[Accessibility] Use product name as fallback alt text in product gallery

### DIFF
--- a/plugins/woocommerce/changelog/feature-48388
+++ b/plugins/woocommerce/changelog/feature-48388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use product name as fallback alt text in product gallery

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1651,7 +1651,9 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  * @param bool $main_image Is this the main image or a thumbnail?.
  * @return string
  */
-function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
+function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_index = -1 ) {
+	global $product;
+
 	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
 	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
 	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
@@ -1662,6 +1664,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$thumbnail_sizes   = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+	$alt_text          = empty( $alt_text ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index  ) : $alt_text;
 
 	/**
 	 * Filters the attributes for the image markup.
@@ -1680,6 +1683,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 			'data-large_image_width'  => esc_attr( $full_src[1] ),
 			'data-large_image_height' => esc_attr( $full_src[2] ),
 			'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
+			'alt'                     => $alt_text
 		),
 		$attachment_id,
 		$image_size,
@@ -1700,6 +1704,27 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" data-thumb-srcset="' . esc_attr( $thumbnail_srcset ) . '"  data-thumb-sizes="' . esc_attr( $thumbnail_sizes ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }
 
+if ( ! function_exists( 'woocommerce_get_alt_from_product_title_and_position' ) ) {
+
+	/**
+	 * Get alt text based on product name and image position in gallery.
+	 *
+	 * @since 9.3.3
+	 * @param string  $product_name Product name.
+	 * @param bool    $main_image Is this the main image or a thumbnail?.
+	 * @param int     $image_index Image position in gallery.
+	 * @return string Alt text.
+	 */
+	function woocommerce_get_alt_from_product_title_and_position( $product_name, $main_image, $image_index ) {
+		if ( $image_index === -1 ) {
+			return $product_name;
+		}
+
+		$adder = $main_image ? 1 : 2;
+
+		return sprintf( __( '%s - Image %s', 'woocommerce' ), $product_name, ( $image_index + $adder ) );
+	}
+}
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {
 
 	/**

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1649,6 +1649,7 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  * @since 3.3.2
  * @param int  $attachment_id Attachment ID.
  * @param bool $main_image Is this the main image or a thumbnail?.
+ * @param int  $image_index The image index in the gallery.
  * @return string
  */
 function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_index = -1 ) {
@@ -1683,7 +1684,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 			'data-large_image_width'  => esc_attr( $full_src[1] ),
 			'data-large_image_height' => esc_attr( $full_src[2] ),
 			'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
-			'alt'                     => $alt_text
+			'alt'                     => $alt_text,
 		),
 		$attachment_id,
 		$image_size,
@@ -1710,19 +1711,19 @@ if ( ! function_exists( 'woocommerce_get_alt_from_product_title_and_position' ) 
 	 * Get alt text based on product name and image position in gallery.
 	 *
 	 * @since 9.3.3
-	 * @param string  $product_name Product name.
-	 * @param bool    $main_image Is this the main image or a thumbnail?.
-	 * @param int     $image_index Image position in gallery.
+	 * @param string $product_name Product name.
+	 * @param bool   $main_image Is this the main image or a thumbnail?.
+	 * @param int    $image_index Image position in gallery.
 	 * @return string Alt text.
 	 */
 	function woocommerce_get_alt_from_product_title_and_position( $product_name, $main_image, $image_index ) {
-		if ( $image_index === -1 ) {
+		if ( -1 === $image_index ) {
 			return $product_name;
 		}
 
 		$adder = $main_image ? 1 : 2;
-
-		return sprintf( __( '%s - Image %s', 'woocommerce' ), $product_name, ( $image_index + $adder ) );
+		/* translators: 1: product name 2: image position */
+		return sprintf( __( '%1$s - Image %2$s', 'woocommerce' ), $product_name, ( $image_index + $adder ) );
 	}
 }
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1665,7 +1665,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 	$thumbnail_sizes   = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-	$alt_text          = empty( $alt_text ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index  ) : $alt_text;
+	$alt_text          = empty( $alt_text ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
 
 	/**
 	 * Filters the attributes for the image markup.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1684,7 +1684,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 			'data-large_image_width'  => esc_attr( $full_src[1] ),
 			'data-large_image_height' => esc_attr( $full_src[2] ),
 			'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
-			'alt'                     => $alt_text,
+			'alt'                     => esc_attr( $alt_text ),
 		),
 		$attachment_id,
 		$image_size,

--- a/plugins/woocommerce/templates/single-product/product-thumbnails.php
+++ b/plugins/woocommerce/templates/single-product/product-thumbnails.php
@@ -12,7 +12,7 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     3.5.1
+ * @version     9.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/product-thumbnails.php
+++ b/plugins/woocommerce/templates/single-product/product-thumbnails.php
@@ -27,7 +27,7 @@ global $product;
 $attachment_ids = $product->get_gallery_image_ids();
 
 if ( $attachment_ids && $product->get_image_id() ) {
-	foreach ( $attachment_ids as $attachment_id ) {
-		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
+	foreach ( $attachment_ids as $key => $attachment_id ) {
+		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id, false, $key ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/plugins/woocommerce/templates/single-product/product-thumbnails.php
+++ b/plugins/woocommerce/templates/single-product/product-thumbnails.php
@@ -28,6 +28,14 @@ $attachment_ids = $product->get_gallery_image_ids();
 
 if ( $attachment_ids && $product->get_image_id() ) {
 	foreach ( $attachment_ids as $key => $attachment_id ) {
-		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id, false, $key ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
+		/**
+		 * Filter product image thumbnail HTML string.
+		 *
+		 * @since 1.6.4
+		 *
+		 * @param string $html          Product image thumbnail HTML string.
+		 * @param int    $attachment_id Attachment ID.
+		 */
+		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id, false, $key ), $attachment_id ); // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2919,7 +2919,7 @@ importers:
         version: 6.3.19(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/edit-site':
         specifier: 6.11.0
-        version: 6.11.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
+        version: 6.11.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/editor':
         specifier: wp-6.0
         version: 12.5.11(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
@@ -22564,7 +22564,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      react: ^17.0.2
+      react: 18.2.0
 
   react-number-format@4.9.3:
     resolution: {integrity: sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==}
@@ -22754,7 +22754,7 @@ packages:
   react-with-direction@1.4.0:
     resolution: {integrity: sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==}
     peerDependencies:
-      react: ^17.0.2
+      react: ^0.14 || ^15 || ^16
       react-dom: ^0.14 || ^15 || ^16
 
   react-with-styles-interface-css@4.0.3:
@@ -33129,19 +33129,19 @@ snapshots:
       '@types/react': 17.0.71
       '@types/react-dom': 18.0.10
 
-  '@radix-ui/react-dialog@1.0.5(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@radix-ui/react-dialog@1.0.5(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.71)(react@17.0.2)
       '@radix-ui/react-context': 1.0.1(@types/react@17.0.71)(react@17.0.2)
-      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@radix-ui/react-focus-guards': 1.0.1(@types/react@17.0.71)(react@17.0.2)
-      '@radix-ui/react-focus-scope': 1.0.4(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@radix-ui/react-id': 1.0.1(@types/react@17.0.71)(react@17.0.2)
-      '@radix-ui/react-portal': 1.0.4(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@radix-ui/react-presence': 1.0.1(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@radix-ui/react-slot': 1.0.2(@types/react@17.0.71)(react@17.0.2)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@17.0.71)(react@17.0.2)
       aria-hidden: 1.2.3
@@ -33150,6 +33150,7 @@ snapshots:
       react-remove-scroll: 2.5.5(@types/react@17.0.71)(react@17.0.2)
     optionalDependencies:
       '@types/react': 17.0.71
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-direction@1.0.1(@types/react@17.0.71)(react@17.0.2)':
     dependencies:
@@ -33243,18 +33244,19 @@ snapshots:
       '@types/react': 17.0.71
       '@types/react-dom': 18.0.10
 
-  '@radix-ui/react-dismissable-layer@1.0.5(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.71)(react@17.0.2)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.71)(react@17.0.2)
       '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@17.0.71)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 17.0.71
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-focus-guards@1.0.0(react@17.0.2)':
     dependencies:
@@ -33346,16 +33348,17 @@ snapshots:
       '@types/react': 17.0.71
       '@types/react-dom': 18.0.10
 
-  '@radix-ui/react-focus-scope@1.0.4(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.71)(react@17.0.2)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.71)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 17.0.71
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-id@1.0.0(react@17.0.2)':
     dependencies:
@@ -33496,14 +33499,15 @@ snapshots:
       '@types/react': 17.0.71
       '@types/react-dom': 18.0.10
 
-  '@radix-ui/react-portal@1.0.4(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@radix-ui/react-portal@1.0.4(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 17.0.71
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-presence@1.0.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -33532,7 +33536,7 @@ snapshots:
       '@types/react': 17.0.71
       '@types/react-dom': 18.0.10
 
-  '@radix-ui/react-presence@1.0.1(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@radix-ui/react-presence@1.0.1(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.71)(react@17.0.2)
@@ -33541,6 +33545,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 17.0.71
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-primitive@1.0.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -33575,6 +33580,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 17.0.71
       '@types/react-dom': 18.0.10
+
+  '@radix-ui/react-primitive@1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@radix-ui/react-slot': 1.0.2(@types/react@17.0.71)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 17.0.71
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-primitive@1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -40048,7 +40063,7 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@wordpress/block-editor@14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/block-editor@14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@emotion/react': 11.11.1(@types/react@17.0.71)(react@17.0.2)
@@ -40059,7 +40074,7 @@ snapshots:
       '@wordpress/blob': 4.10.0
       '@wordpress/block-serialization-default-parser': 5.10.0
       '@wordpress/blocks': 13.10.0(react@17.0.2)
-      '@wordpress/commands': 1.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/commands': 1.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/compose': 7.10.0(react@17.0.2)
       '@wordpress/data': 10.10.0(react@17.0.2)
@@ -40715,7 +40730,7 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@wordpress/commands@1.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/commands@1.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -40726,7 +40741,7 @@ snapshots:
       '@wordpress/keyboard-shortcuts': 5.10.0(react@17.0.2)
       '@wordpress/private-apis': 1.10.0
       clsx: 2.1.1
-      cmdk: 1.0.0(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      cmdk: 1.0.0(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
@@ -41922,31 +41937,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@wordpress/core-commands@0.7.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@wordpress/commands': 0.9.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/core-data': 6.24.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/data': 9.27.0(react@17.0.2)
-      '@wordpress/element': 5.22.0
-      '@wordpress/i18n': 4.57.0
-      '@wordpress/icons': 9.36.0
-      '@wordpress/private-apis': 0.20.0
-      '@wordpress/router': 0.7.0(react@17.0.2)
-      '@wordpress/url': 3.48.0
-      react: 17.0.2
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - '@types/react'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - bufferutil
-      - react-dom
-      - supports-color
-      - utf-8-validate
-      - vite
-
   '@wordpress/core-data@4.4.5(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.23.5
@@ -42167,11 +42157,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/core-data@7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/core-data@7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/api-fetch': 7.10.0
-      '@wordpress/block-editor': 14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/block-editor': 14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/blocks': 13.10.0(react@17.0.2)
       '@wordpress/compose': 7.10.0(react@17.0.2)
       '@wordpress/data': 10.10.0(react@17.0.2)
@@ -43100,7 +43090,7 @@ snapshots:
       '@wordpress/commands': 0.9.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/components': 25.16.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/compose': 6.34.0(react@17.0.2)
-      '@wordpress/core-commands': 0.7.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/core-commands': 0.7.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/core-data': 6.24.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/data': 9.27.0(react@17.0.2)
       '@wordpress/date': 4.44.0
@@ -43127,7 +43117,7 @@ snapshots:
       '@wordpress/style-engine': 1.30.0
       '@wordpress/url': 3.48.0
       '@wordpress/viewport': 5.24.0(react@17.0.2)
-      '@wordpress/widgets': 3.24.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/widgets': 3.24.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/wordcount': 3.47.0
       change-case: 4.1.2
       classnames: 2.3.2
@@ -43156,7 +43146,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@wordpress/edit-site@6.11.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
+  '@wordpress/edit-site@6.11.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@react-spring/web': 9.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -43166,7 +43156,7 @@ snapshots:
       '@wordpress/block-editor': 9.8.0(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/block-library': 7.19.0(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/blocks': 12.35.0(react@17.0.2)
-      '@wordpress/commands': 1.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/commands': 1.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/components': 19.17.0(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/compose': 5.4.2(react@17.0.2)
       '@wordpress/core-commands': 0.7.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -43179,7 +43169,7 @@ snapshots:
       '@wordpress/editor': 12.5.11(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/element': 4.20.0
       '@wordpress/escape-html': 3.10.0
-      '@wordpress/fields': 0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/fields': 0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/hooks': 3.6.1
       '@wordpress/html-entities': 3.6.1
       '@wordpress/i18n': 4.58.0
@@ -43187,13 +43177,13 @@ snapshots:
       '@wordpress/keyboard-shortcuts': 3.4.2(react@17.0.2)
       '@wordpress/keycodes': 3.58.0
       '@wordpress/notices': 3.12.0(react@17.0.2)
-      '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/plugins': 4.4.4(react@17.0.2)
       '@wordpress/preferences': 1.2.6(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/primitives': 3.4.1
       '@wordpress/priority-queue': 3.10.0
       '@wordpress/private-apis': 1.10.0
-      '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/router': 0.7.0(react@17.0.2)
       '@wordpress/style-engine': 1.41.0
       '@wordpress/url': 3.7.1
@@ -43772,14 +43762,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/fields@0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/fields@0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/blob': 4.10.0
       '@wordpress/blocks': 13.10.0(react@17.0.2)
       '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/compose': 7.10.0(react@17.0.2)
-      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/data': 10.10.0(react@17.0.2)
       '@wordpress/dataviews': 4.6.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/element': 6.10.0
@@ -43788,8 +43778,8 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.10.0(react@17.0.2)
       '@wordpress/notices': 5.10.0(react@17.0.2)
-      '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/primitives': 4.10.0(react@17.0.2)
+      '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/primitives': 4.11.0(react@17.0.2)
       '@wordpress/private-apis': 1.10.0
       '@wordpress/url': 4.10.0
       '@wordpress/warning': 3.10.0
@@ -44592,15 +44582,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/patterns@2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/patterns@2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 4.10.0
-      '@wordpress/block-editor': 14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/block-editor': 14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/blocks': 13.10.0(react@17.0.2)
       '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/compose': 7.10.0(react@17.0.2)
-      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/data': 10.10.0(react@17.0.2)
       '@wordpress/element': 6.10.0
       '@wordpress/html-entities': 4.10.0
@@ -45155,13 +45145,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/reusable-blocks@5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/reusable-blocks@5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@wordpress/block-editor': 14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/block-editor': 14.5.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/blocks': 13.10.0(react@17.0.2)
       '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/data': 10.10.0(react@17.0.2)
       '@wordpress/element': 6.10.0
       '@wordpress/i18n': 5.10.0
@@ -46096,34 +46086,6 @@ snapshots:
       - '@babel/helper-module-imports'
       - '@babel/types'
       - '@emotion/is-prop-valid'
-      - '@types/react'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - vite
-
-  '@wordpress/widgets@3.24.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@wordpress/api-fetch': 6.44.0
-      '@wordpress/block-editor': 12.15.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/blocks': 12.24.0(react@17.0.2)
-      '@wordpress/components': 25.16.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/compose': 6.34.0(react@17.0.2)
-      '@wordpress/core-data': 6.24.0(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@wordpress/data': 9.27.0(react@17.0.2)
-      '@wordpress/element': 5.35.0
-      '@wordpress/i18n': 4.57.0
-      '@wordpress/icons': 9.48.0
-      '@wordpress/notices': 4.15.0(react@17.0.2)
-      classnames: 2.3.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
       - '@types/react'
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
@@ -48667,10 +48629,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  cmdk@1.0.0(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  cmdk@1.0.0(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
-      '@radix-ui/react-dialog': 1.0.5(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48388 .
Closes #51904 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In the frontend, go to a product page with a gallery. If you used the sample data to create the store, the Hoodie product can be used for testing.
2. Inspect the gallery and verify the images inside the anchor tag have alt texts. The parent of the anchor tag that wraps the image should also have the same alt text in the `data-thumb-alt` attribute.
![Screenshot 2024-10-05 at 16 28 37](https://github.com/user-attachments/assets/8b0fb8ef-caf9-42e2-8ec3-671e784e218c)

    - If the image already has an alt text defined in the Media Library, verify this is the image's alt text in the frontend.
![Screenshot 2024-10-05 at 16 23 07](https://github.com/user-attachments/assets/9abad09a-9804-45f0-a197-63addd3b09eb)
    - Otherwise, the alt text should follow this format: "{Product name} - Image {Image position in the gallery}"
![Screenshot 2024-10-05 at 16 32 25](https://github.com/user-attachments/assets/9f3f4c37-2059-4473-9f45-b5ca7aaa6ffc)
3. In the frontend, go to a product page with only feature image (without gallery)
4. Verify the image's alt text is either the text defined on the Media Library or the product name, but without the number of the image position, since there is no gallery.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
