### PR TITLE
[e2e tests] Fix broken gloabal-teardown with WP 6.7-beta1

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-global-teardown-wp6.7.beta1
+++ b/plugins/woocommerce/changelog/e2e-fix-global-teardown-wp6.7.beta1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix the global teardown failing with wp6.7-beta1

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -1,5 +1,6 @@
 const { chromium, expect } = require( '@playwright/test' );
 const { admin } = require( './test-data/data' );
+const { logIn } = require( './utils/login' );
 
 module.exports = async ( config ) => {
 	const { baseURL, userAgent } = config.projects[ 0 ].use;
@@ -19,16 +20,7 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < keysRetries; i++ ) {
 		try {
 			console.log( 'Trying to clear consumer token... Try:' + i );
-			await adminPage.goto( `/wp-admin` );
-			await adminPage
-				.locator( 'input[name="log"]' )
-				.fill( admin.username );
-			await adminPage
-				.locator( 'input[name="pwd"]' )
-				.fill( admin.password );
-			await adminPage.locator( 'text=Log In' ).click();
-			// eslint-disable-next-line playwright/no-networkidle
-			await adminPage.waitForLoadState( 'networkidle' );
+			await logIn( adminPage, admin.username, admin.password );
 			await adminPage.goto(
 				`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
 			);
@@ -92,6 +84,7 @@ module.exports = async ( config ) => {
 			break;
 		} catch ( e ) {
 			console.log( 'Failed to clear consumer token. Retrying...' );
+			console.log( e );
 		}
 	}
 

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -20,6 +20,7 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < keysRetries; i++ ) {
 		try {
 			console.log( 'Trying to clear consumer token... Try:' + i );
+			await adminPage.goto( `/wp-admin` );
 			await logIn( adminPage, admin.username, admin.password );
 			await adminPage.goto(
 				`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The global-teardown throws an error when running the tests with WP6.7-beta1.
The failure is in the login flow when attempting to clear the API token.

```
Error: locator.click: Error: strict mode violation: locator('text=Log In') resolved to 2 elements:
    1) <h1 class="screen-reader-text">Log In</h1> aka getByRole('heading', { name: 'Log In' })
    2) <input type="submit" id="wp-submit" value="Log In" name="wp-submit" class="button button-primary button-large"/> aka getByRole('button', { name: 'Log In' })
```

Fixed by using the login utility instead, which already has a unique locator for the log in button.

### How to test the changes in this Pull Request:

Locally, you'll need to run any test with both the current WP version and with WP 6.7-beta1.

Run a test with:
```
pnpm test:e2e -g "Load the home page" 
```

To use the WP beta version you can update the .wp-env.json config and set `"core": "https://downloads.wordpress.org/release/wordpress-6.7-beta1.zip"`
