### PR TITLE
Give the "Change address" in classic cart the `role="button"`

### DIFF
--- a/plugins/woocommerce/changelog/51960-fix-51896-buttons-given-role-of-links
+++ b/plugins/woocommerce/changelog/51960-fix-51896-buttons-given-role-of-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix - Accessibility: Give "Change address" link in classic cart `role="button"`

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -135,8 +135,8 @@ jQuery( function ( $ ) {
 			if ( $( '.woocommerce-checkout' ).length ) {
 				$( document.body ).trigger( 'update_checkout' );
 			}
-			
-			// Store the old coupon error message and value before the 
+
+			// Store the old coupon error message and value before the
 			// .woocommerce-cart-form is replaced with the new form.
 			var $old_coupon_field_val = $( '#coupon_code' ).val();
 			var $old_coupon_error_msg = $( '#coupon_code' )
@@ -151,7 +151,7 @@ jQuery( function ( $ ) {
 			if ( preserve_notices && $old_coupon_error_msg.length > 0 ) {
 				var $new_coupon_field = $( '.woocommerce-cart-form' ).find( '#coupon_code' );
 				var $new_coupon_field_wrapper = $new_coupon_field.closest( '.coupon' );
-				
+
 				$new_coupon_field.val( $old_coupon_field_val );
 				// The coupon input with error needs to be focused before adding the live region
 				// with the error message, otherwise the screen reader won't read it.
@@ -210,11 +210,11 @@ jQuery( function ( $ ) {
 
 		if ( typeof html_element === 'string' ) {
 			var msg = $( $.parseHTML( html_element ) ).text().trim();
-			
+
 			if ( msg === '' ) {
 				return;
 			}
-			
+
 			$coupon_error_el = $( '<p class="coupon-error-notice" id="coupon-error-notice">' + msg + '</p>' );
 		} else {
 			$coupon_error_el = html_element;
@@ -223,13 +223,21 @@ jQuery( function ( $ ) {
 		if ( is_live_region ) {
 			$coupon_error_el.attr( 'role', 'alert' );
 		}
-		
+
 		$target.find( '#coupon_code' )
 			.addClass( 'has-error' )
 			.attr( 'aria-invalid', 'true' )
 			.attr( 'aria-describedby', 'coupon-error-notice' );
 		$target.append( $coupon_error_el );
-	};	
+	};
+
+	var toggle_shipping = function () {
+		$( '.shipping-calculator-form' ).slideToggle( 'slow' );
+		$( 'select.country_to_state, input.country_to_state' ).trigger(
+			'change'
+		);
+		$( document.body ).trigger( 'country_to_state_changed' ); // Trigger select2 to load.
+	};
 
 	/**
 	 * Object to handle AJAX calls for cart shipping changes.
@@ -252,6 +260,11 @@ jQuery( function ( $ ) {
 				this.toggle_shipping
 			);
 			$( document ).on(
+				'keydown',
+				'.shipping-calculator-button',
+				this.toggle_shipping_on_keydown
+			);
+			$( document ).on(
 				'change',
 				'select.shipping_method, :input[name^=shipping_method]',
 				this.shipping_method_selected
@@ -269,12 +282,18 @@ jQuery( function ( $ ) {
 		 * Toggle Shipping Calculator panel
 		 */
 		toggle_shipping: function () {
-			$( '.shipping-calculator-form' ).slideToggle( 'slow' );
-			$( 'select.country_to_state, input.country_to_state' ).trigger(
-				'change'
-			);
-			$( document.body ).trigger( 'country_to_state_changed' ); // Trigger select2 to load.
+			toggle_shipping();
 			return false;
+		},
+
+		/**
+		 * Toggle Shipping Calculator panel after pressing Space
+		 */
+		toggle_shipping_on_keydown: function ( event ) {
+			if ( 32 === event.which ) {
+				event.preventDefault();
+				toggle_shipping();
+			}
 		},
 
 		/**
@@ -304,7 +323,7 @@ jQuery( function ( $ ) {
 				dataType: 'html',
 				success: function ( response ) {
 					update_cart_totals_div( response );
-					
+
 					var newCurrentTarget = document.getElementById( event.currentTarget.id );
 
 					if ( newCurrentTarget ) {
@@ -589,17 +608,17 @@ jQuery( function ( $ ) {
 						'.woocommerce-error, .woocommerce-message, .woocommerce-info, ' +
 						'.is-error, .is-info, .is-success, .coupon-error-notice'
 					).remove();
-					
+
 					// We only want to show coupon notices if they are not errors.
 					// Coupon errors are shown under the input.
 					if ( response.indexOf( 'woocommerce-error' ) === -1 && response.indexOf( 'is-error' ) === -1 ) {
-						show_notice( response );						
+						show_notice( response );
 					} else {
 						var $coupon_wrapper = $text_field.closest( '.coupon' );
 
 						if ( $coupon_wrapper.length > 0 ) {
 							show_coupon_error( response, $coupon_wrapper, false );
-						}						
+						}
 					}
 
 					$( document.body ).trigger( 'applied_coupon', [

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 9.4.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -21,7 +21,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 <form class="woocommerce-shipping-calculator" action="<?php echo esc_url( wc_get_cart_url() ); ?>" method="post">
 
-	<?php printf( '<a href="#" class="shipping-calculator-button">%s</a>', esc_html( ! empty( $button_text ) ? $button_text : __( 'Calculate shipping', 'woocommerce' ) ) ); ?>
+	<?php printf( '<a href="#" role="button" class="shipping-calculator-button">%s</a>', esc_html( ! empty( $button_text ) ? $button_text : __( 'Calculate shipping', 'woocommerce' ) ) ); ?>
 
 	<section class="shipping-calculator-form" style="display:none;">
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51896.

This PR solves an issue with the accessibility of the "Change address" link on the classic cart page.

The issue is that the link functions as a button so it should either be a `<button>` HTML element (which is preferred) or have the attribute `role="button"` and handle both Enter and spacebar key presses.

I opted for the second approach not to disrupt existing themes that might rely on the current styling of the link in the classic cart, especially since the default experience is now the cart block.

The cart block already uses role="button" and handles spacebar key presses so no change was needed there.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add some products to your cart.
1. Ensure your cart page is displaying the classic cart.
2. Using the Tab key, focus the "Change address" link.
3. Press spacebar. Notice it opens the form to change the address but does not scroll the page down.
4. Press spacebar again. The form should hide.
5. Press another key that isn't spacebar or Enter. The native browser behavior should happen (so possibly nothing should happen if you press a letter key).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix - Accessibility: Give "Change address" link in classic cart `role="button"`

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
