### PR TITLE
Update block checkout tests and product creation tests for WP 6.7 compatibility

### DIFF
--- a/plugins/woocommerce/changelog/e2e-test-updates-for-wp67-compatibility
+++ b/plugins/woocommerce/changelog/e2e-test-updates-for-wp67-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updates to core e2e tests for WP 6.7 compatibility

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -35,8 +35,6 @@ const productData = {
 	},
 };
 
-const categoryName = `cat_${ Date.now() }`;
-
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
 	product: async ( { api }, use ) => {
@@ -50,7 +48,7 @@ const test = baseTest.extend( {
 
 		await api
 			.post( 'products/categories', {
-				name: categoryName,
+				name: `cat_${ Date.now() }`,
 			} )
 			.then( ( response ) => {
 				category = response.data;
@@ -147,10 +145,12 @@ for ( const productType of Object.keys( productData ) ) {
 			} );
 
 			await test.step( 'add product categories', async () => {
-				await page.getByText( categoryName ).first().check();
+				await page.getByText( category.name ).first().check();
 
 				await expect(
-					page.locator( '#product_cat-all' ).getByText( categoryName )
+					page
+						.locator( '#product_cat-all' )
+						.getByText( category.name )
 				).toBeVisible();
 			} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -35,6 +35,8 @@ const productData = {
 	},
 };
 
+const categoryName = `cat_${ Date.now() }`;
+
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
 	product: async ( { api }, use ) => {
@@ -48,7 +50,7 @@ const test = baseTest.extend( {
 
 		await api
 			.post( 'products/categories', {
-				name: `cat_${ Date.now() }`,
+				name: categoryName,
 			} )
 			.then( ( response ) => {
 				category = response.data;
@@ -145,17 +147,10 @@ for ( const productType of Object.keys( productData ) ) {
 			} );
 
 			await test.step( 'add product categories', async () => {
-				// Using getByRole here is unreliable
-				const categoryCheckbox = page.locator(
-					`#in-product_cat-${ category.id }`
-				);
-				await categoryCheckbox.check();
-				await expect( categoryCheckbox ).toBeChecked();
+				await page.getByText( categoryName ).first().check();
 
 				await expect(
-					page
-						.locator( '#product_cat-all' )
-						.getByText( category.name )
+					page.locator( '#product_cat-all' ).getByText( categoryName )
 				).toBeVisible();
 			} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -9,6 +9,7 @@ const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
 
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin, customer } = require( '../../test-data/data' );
+const { logIn } = require( '../../utils/login' );
 const { setFilterValue, clearFilters } = require( '../../utils/filters' );
 
 const {
@@ -721,9 +722,7 @@ test.describe(
 			).toBeVisible();
 
 			await page.goto( 'wp-login.php' );
-			await page.locator( 'input[name="log"]' ).fill( admin.username );
-			await page.locator( 'input[name="pwd"]' ).fill( admin.password );
-			await page.locator( 'text=Log In' ).click();
+			await logIn( page, admin.username, admin.password, false );
 
 			// load the order placed as a guest
 			await page.goto(
@@ -820,9 +819,7 @@ test.describe(
 
 			// Switch to admin user.
 			await page.goto( 'wp-login.php?loggedout=true' );
-			await page.locator( 'input[name="log"]' ).fill( admin.username );
-			await page.locator( 'input[name="pwd"]' ).fill( admin.password );
-			await page.locator( 'text=Log In' ).click();
+			await logIn( page, admin.username, admin.password, false );
 
 			// load the order placed as a customer
 			await page.goto(
@@ -913,9 +910,7 @@ test.describe(
 
 			// sign in as admin to confirm account creation
 			await page.goto( 'wp-admin/users.php' );
-			await page.locator( 'input[name="log"]' ).fill( admin.username );
-			await page.locator( 'input[name="pwd"]' ).fill( admin.password );
-			await page.locator( 'text=Log in' ).click();
+			await logIn( page, admin.username, admin.password, false );
 			await expect( page.locator( 'tbody#the-list' ) ).toContainText(
 				newAccountEmail
 			);
@@ -1014,11 +1009,12 @@ test.describe(
 
 			// Log in again.
 			await page.goto( '/my-account/' );
-			await page
-				.locator( '#username' )
-				.fill( newAccountEmailWithCustomPassword );
-			await page.locator( '#password' ).fill( newAccountCustomPassword );
-			await page.locator( 'text=Log in' ).click();
+			await logIn(
+				page,
+				newAccountEmailWithCustomPassword,
+				newAccountCustomPassword,
+				false
+			);
 			await expect(
 				page.getByRole( 'heading', { name: 'My account' } )
 			).toBeVisible();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As we've started running our test suites against pre-release WordPress versions, we discovered a couple of test failures in the upcoming WordPress 6.7 release.  These failures were due to changes in locators, and not in bugs introduced by WP 6.7

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `pnpm env:start`
2. `pnpm test:e2e merchant/product-create-simple shopper/checkout-block` to ensure that we haven't broken the tests in the current version of WP.
3. Update your environment to WP 6.7 beta (beta 2 is what I used for testing).  I used the WordPress Beta Tester plugin.
4. `pnpm test:e2e merchant/product-create-simple shopper/checkout-block`

<!-- End testing instructions -->

