### PR TITLE
Fix media queries for iOS Simulator in in-app marketplace

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/header/header.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/header/header.scss
@@ -14,8 +14,8 @@
 	top: var(--wp-admin--admin-bar--height, 32px);
 	z-index: 1;
 
-	/* On narrow screens, "stack" header items and hide the bottom border */
-	@media (width <= $breakpoint-medium) {
+	// On narrow screens, "stack" header items and hide the bottom border
+	@media screen and (max-width: $breakpoint-medium) {
 		border-bottom: 0;
 		grid-template: "mktpl-title mktpl-meta" 60px
 			"mktpl-tabs mktpl-tabs" 48px
@@ -29,14 +29,14 @@
 		margin: 0;
 		padding: 10px 0 0;
 
-		@media (width <= $breakpoint-medium) {
+		@media screen and (max-width: $breakpoint-medium) {
 			padding-left: var(--large-gap);
 		}
 	}
 }
 
 .woocommerce-marketplace--my-subscriptions {
-	@media (width <= $breakpoint-medium) {
+	@media screen and (max-width: $breakpoint-medium) {
 		.woocommerce-marketplace__search {
 			display: none;
 		}
@@ -50,7 +50,7 @@
 	grid-area: mktpl-title;
 	line-height: 18px;
 
-	@media (width <= $breakpoint-medium) {
+	@media screen and (max-width: $breakpoint-medium) {
 		padding: 0 $content-spacing-small;
 	}
 }
@@ -60,7 +60,7 @@
 	justify-self: end;
 	padding-top: 10px;
 
-	@media (width <= $breakpoint-medium) {
+	@media screen and (max-width: $breakpoint-medium) {
 		margin-right: $content-spacing-small;
 		padding: 0;
 	}
@@ -70,7 +70,7 @@
 	align-self: end;
 	grid-area: mktpl-tabs;
 
-	@media (width <= $breakpoint-medium) {
+	@media screen and (max-width: $breakpoint-medium) {
 		padding: 0 $content-spacing-small;
 	}
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/search/search.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/search/search.scss
@@ -5,7 +5,7 @@
 	margin-top: 15px;
 	width: 320px;
 
-	@media (width <= $breakpoint-medium) {
+	@media screen and (max-width: $breakpoint-medium) {
 		margin: $grid-unit-20 $grid-unit-20 $grid-unit-10 $grid-unit-20;
 		width: calc(100% - $grid-unit-20 * 2);
 

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -59,7 +59,7 @@
 	}
 }
 
-@media (width <= $breakpoint-medium) {
+@media screen and (max-width: $breakpoint-medium) {
 	.woocommerce-marketplace__tabs {
 		border-bottom: 1px solid $gutenberg-gray-300;
 

--- a/plugins/woocommerce/changelog/51979-update-wccom-21880-marketplace-media-queries
+++ b/plugins/woocommerce/changelog/51979-update-wccom-21880-marketplace-media-queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Changes in-app marketplace media queries to use older `min-width` syntax.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Changes media queries in marketplace CSS from `@media (width <= n)` to `@media screen and (max-width: n)` for better cross-device support.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 21880-gh-Automattic/woocommerce.com.

Safari on iOS Simulator (for example on iPhone 14 Pro Max iOS 16.1) doesn't render the page correctly when we use the more modern media query. Real iPhones seem to be OK. To ensure iOS Simulator shows the right layout, I've changed them to the `min-width` syntax.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch.
2. Start an iPhone emulator in iOS Simulator, and view the in-app marketplace, for example http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions. Check that the header, category tabs and search input render as expected. The search input should be below the tabs.
3. View the same page in a desktop browser at different viewport sizes. Check that it renders as expected.
4. Ideally, view the changes in a real mobile phone, for example by checking out this branch on a JN site using WooCommerce Beta Tester.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Changes in-app marketplace media queries to use older `min-width` syntax.

</details>

### Screenshots

#### Bad layout

<img width="350" alt="image" src="https://github.com/user-attachments/assets/7aa3a3ff-58a3-49aa-9b69-9d798053c8ca">

#### Good layout

<img width="350" alt="image" src="https://github.com/user-attachments/assets/72146784-6ef8-4e29-96ab-5d39379f213a">
