### PR TITLE
New Product Editor: For Grouped Products, the pricing fields are displaying even though they shouldn't

### DIFF
--- a/plugins/woocommerce/changelog/fix-51308
+++ b/plugins/woocommerce/changelog/fix-51308
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable pricing fields when the product type is grouped

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -238,6 +238,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'disableConditions' => array(
 					array(
 						'expression' => 'editedProduct.type === "variable"',
+					),
+					array(
 						'expression' => 'editedProduct.type === "grouped"',
 					),
 				),
@@ -264,6 +266,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'disableConditions' => array(
 					array(
 						'expression' => 'editedProduct.type === "variable"',
+					),
+					array(
 						'expression' => 'editedProduct.type === "grouped"',
 					),
 				),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -238,6 +238,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'disableConditions' => array(
 					array(
 						'expression' => 'editedProduct.type === "variable"',
+						'expression' => 'editedProduct.type === "grouped"',
 					),
 				),
 			)
@@ -263,6 +264,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'disableConditions' => array(
 					array(
 						'expression' => 'editedProduct.type === "variable"',
+						'expression' => 'editedProduct.type === "grouped"',
 					),
 				),
 			)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51308

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Try the new product editor (Beta)` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Create a new Grouped Product or edit an existing one using the New Product Editor.
3. The regular and sale price fields should be disabled 
<img width="709" alt="image" src="https://github.com/user-attachments/assets/130aba21-1bdf-4b4a-b49b-a2b2725a5597">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
