### PR TITLE
[dev] Monorepo: improve changelogger prompts in CI.

### DIFF
--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -223,7 +223,7 @@ foreach ( $touched_projects as $slug => $files ) {
 				"::error::Project %s is being changed, but no change file in %s is touched!\n\nUse `pnpm --filter=./%s changelog add` to add a change file.\n",
 				$slug,
 				"$slug/{$changelogger_projects[ $slug ]['changes-dir']}/",
-				$slug
+				json_decode( file_get_contents( sprintf( './%s/package.json', $slug ) ), true )['name'] ?? $slug
 			);
 			printf( "---\n" );
 			$exit = 1;

--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -220,10 +220,10 @@ foreach ( $touched_projects as $slug => $files ) {
 		} elseif ( getenv( 'CI' ) ) {
 			printf( "---\n" ); // Bracket message containing newlines for better visibility in GH's logs.
 			printf(
-				"::error::Project %s is being changed, but no change file in %s is touched!\n\nUse `pnpm --filter=./%s changelog add` to add a change file.\n",
+				"::error::Project %s is being changed, but no change file in %s is touched!\n\nUse `pnpm --filter='%s' changelog add` to add a change file.\n",
 				$slug,
 				"$slug/{$changelogger_projects[ $slug ]['changes-dir']}/",
-				json_decode( file_get_contents( sprintf( './%s/package.json', $slug ) ), true )['name'] ?? $slug
+				json_decode( file_get_contents( sprintf( './%s/package.json', $slug ) ), true )['name'] ?? ( './' . $slug )
 			);
 			printf( "---\n" );
 			$exit = 1;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes missing changelog entry prompt from e.g. `Use 'pnpm --filter=./plugins/woocommerce changelog add' to add a change file.` to `Use 'pnpm --filter='@woocommerce/plugin-woocommerce' changelog add' to add a change file.`

### How to test the changes in this Pull Request:

- TBD
