### PR TITLE
fix: i18n shipping region settings placeholder text

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-region-settings-i18n
+++ b/plugins/woocommerce/changelog/fix-shipping-region-settings-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: i18n shipping region settings placeholder text

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -3,6 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { TreeSelectControl } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
 
 export const RegionPicker = ( { options, initialValues } ) => {
 	const [ selected, setSelected ] = useState( initialValues );
@@ -18,8 +19,8 @@ export const RegionPicker = ( { options, initialValues } ) => {
 			value={ selected }
 			onChange={ onChange }
 			options={ options }
-			placeholder="Start typing to filter zones"
-			selectAllLabel="Select all countries"
+			placeholder={ __( 'Start typing to filter zones', 'woocommerce' ) }
+			selectAllLabel={ __( 'Select all countries', 'woocommerce' ) }
 			individuallySelectParent
 			maxVisibleTags={ 5 }
 		/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51762

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that translated text won't appear until translations have been contributed, so you will probably see English until it has been. Inspection of the code should suffice, and also ensure that the label still renders - even if it's in English.

1. Create a fresh site
2. Change your site language to `Español` on Setting page
3. Go to `Escritorio > Actualizaciones` (/wp-admin/update-core.php)
4. Click on `Actualizar las traducciones` button to download woocommerce transalation
5. Go to Shipping settings (/wp-admin/admin.php?page=wc-settings&tab=shipping)
6. Confirm that `Región(es) de la zona` option input field placeholder is translated or visible
7. Click on input field and confirm that "Selector all countries" is translated or visible

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
