### PR TITLE
Fix products base incorrectly matching pages with the same prefix

### DIFF
--- a/plugins/woocommerce/changelog/fix-51535-products-base-incorrectly-matching-pages
+++ b/plugins/woocommerce/changelog/fix-51535-products-base-incorrectly-matching-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product base incorrectly flagging as store pages on pages with same prefix

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -228,10 +228,10 @@ class WCAdminHelper {
 				// Check if the URL path starts with the matching base.
 				if ( 0 === strncmp( $url_path, trim( $permalink_structure[ $key ], '/' ), strlen( trim( $permalink_structure[ $key ], '/' ) ) ) ) {
 					$base_length = strlen( trim( $permalink_structure[ $key ], '/' ) );
-					$next_char = substr( $url_path, $base_length, 1 );
+					$next_char   = substr( $url_path, $base_length, 1 );
 
 					// If the next character is a slash, we're confident we're on a valid product page.
-					if ( $next_char === '/' ) {
+					if ( '/' === $next_char ) {
 						return true;
 					}
 				}

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -209,23 +209,35 @@ class WCAdminHelper {
 			}
 		}
 
-		// Check product, category and tag pages.
-		$permalink_structure = wc_get_permalink_structure();
-		$permalink_keys      = array(
-			'category_base',
-			'tag_base',
-			'product_base',
-		);
-
 		$url_path = wp_parse_url( $normalized_path, PHP_URL_PATH );
 
+		// Check if the URL matches any of the WooCommerce permalink structures.
 		if ( $url_path ) {
+			$permalink_structure = wc_get_permalink_structure();
+			$permalink_keys      = array(
+				'category_base',
+				'tag_base',
+				'product_base',
+			);
+
 			foreach ( $permalink_keys as $key ) {
 				if ( ! isset( $permalink_structure[ $key ] ) || ! is_string( $permalink_structure[ $key ] ) ) {
 					continue;
 				}
 
-				// Check if the URL path starts with the matching base.
+				/**
+				 * Check if the URL path starts with a URL segment matching the permalink base.
+				 *
+				 * Match examples:
+				 *    1. product_base = 'product'
+				 *       $url_path: '/product/blue-t-shirt'
+				 *    2. category_base = 'product-category'
+				 *       $url_path: '/product-category/clothing/'
+				 *
+				 * Non-match examples:
+				 *    1. product_base = 'product'
+				 *       $url_path: '/products' (URL segment partial match)
+				 */
 				if ( 0 === strncmp( $url_path, trim( $permalink_structure[ $key ], '/' ), strlen( trim( $permalink_structure[ $key ], '/' ) ) ) ) {
 					$base_length = strlen( trim( $permalink_structure[ $key ], '/' ) );
 					$next_char   = substr( $url_path, $base_length, 1 );
@@ -236,7 +248,25 @@ class WCAdminHelper {
 					}
 				}
 
-				// If the permalink structure contains placeholders, we need to check if the URL matches the structure using regex.
+				/**
+				 * If the permalink structure contains placeholders, we need to check if the URL matches the structure using regex.
+				 *
+				 * Match examples:
+				 *    1. product_base = 'product/%product_cat%'
+				 *       $url_path: '/product/t-shirts/blue-t-shirt'
+				 *       $url_path: '/product/electronics/smartphones/iphone-12'
+				 *    2. product_base = 'shop/%product_cat%/%product%'
+				 *       $url_path: '/shop/clothing/mens/summer-shirt'
+				 *    3. product_base = '%product_cat%'
+				 *       $url_path: '/electronics/laptops/macbook-pro'
+				 *
+				 * Non-match examples:
+				 *    1. product_base = 'product/%product_cat%'
+				 *       $url_path: '/blog/top-10-products'
+				 *       $url_path: '/product-reviews/best-sellers'
+				 *    2. product_base = 'shop/%product_cat%/%product%'
+				 *       $url_path: '/shop/new-arrivals'
+				 */
 				if ( strpos( $permalink_structure[ $key ], '%' ) !== false ) {
 					global $wp_rewrite;
 					$rules = $wp_rewrite->generate_rewrite_rule( $permalink_structure[ $key ] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -241,7 +241,6 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 		$permalink_structure = array(
 			'category_base' => 'product-category',
 			'tag_base'      => 'product-tag',
-			'product_base'  => 'product',
 		);
 
 		$wp_rewrite->expects( $this->any() )
@@ -255,6 +254,18 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 			$result                        = WCAdminHelper::is_store_page( $url );
 			$this->assertEquals( $expected_result, $result );
 		}
+
+		$callback = function($value) {
+			$value['product_base'] = 'product/';
+			return $value;
+		};
+
+		add_filter('pre_option_woocommerce_permalinks', $callback, 10, 1);
+
+		// Pages with name "products-demo" shouldn't be considered as a store page when product_base is set to "product/".
+		$this->assertEquals( false, WCAdminHelper::is_store_page( 'https://example.com/products-demo/' ) );
+
+		remove_filter('pre_option_woocommerce_permalinks', $callback);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -238,11 +238,6 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 
 		$wp_rewrite = $this->getMockBuilder( 'WP_Rewrite' )->getMock(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$permalink_structure = array(
-			'category_base' => 'product-category',
-			'tag_base'      => 'product-tag',
-		);
-
 		$wp_rewrite->expects( $this->any() )
 			->method( 'generate_rewrite_rule' )
 			->willReturn( array( 'shop/(.+?)/?$' => 'index.php?product_cat=$matches[1]&year=$matches[2]' ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -250,17 +250,17 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 			$this->assertEquals( $expected_result, $result );
 		}
 
-		$callback = function($value) {
+		$callback = function ( $value ) {
 			$value['product_base'] = 'product/';
 			return $value;
 		};
 
-		add_filter('pre_option_woocommerce_permalinks', $callback, 10, 1);
+		add_filter( 'pre_option_woocommerce_permalinks', $callback, 10, 1 );
 
 		// Pages with name "products-demo" shouldn't be considered as a store page when product_base is set to "product/".
 		$this->assertEquals( false, WCAdminHelper::is_store_page( 'https://example.com/products-demo/' ) );
 
-		remove_filter('pre_option_woocommerce_permalinks', $callback);
+		remove_filter( 'pre_option_woocommerce_permalinks', $callback );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #51535.

Fixes store page detection incorrectly flagging core pages where its URL has certain prefix.

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/c96f6b4b-106a-465f-948f-bcaad03f535e">

### How to test the changes in this Pull Request:

1. In a fresh site, go to `Pages > Add new page`
2. Set page title and content to anything
3. In site editor's `Page` tab, click `link`
4. Set the link to `products-demo` and publish the page
5. Go to `WooCommerce > Settings > Site visibility`
6. Enable `Coming soon` and `Apply to store pages only` and save
1. In an incognito window, navigate to the site's frontend
2. Click on the link to the new page
3. Observe coming soon page is **NOT shown**

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
