### PR TITLE
Fix core profiler extensions page from selecting activated plugins

### DIFF
--- a/plugins/woocommerce/changelog/fix-51764-activated-plugins-remove-click
+++ b/plugins/woocommerce/changelog/fix-51764-activated-plugins-remove-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Core profiler remove selecting activated plugins in extensions page

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins.tsx
@@ -62,6 +62,10 @@ export const Plugins = ( {
 	);
 
 	const setSelectedPlugin = ( plugin: Extension ) => {
+		// Don't allow selecting a plugin that is already activated.
+		if ( plugin.is_activated ) {
+			return;
+		}
 		setSelectedPlugins(
 			selectedPlugins.some( ( item ) => item.key === plugin.key )
 				? selectedPlugins.filter( ( item ) => item.key !== plugin.key )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #51764.

Fixes core profiler extensions page from being able to select activated plugins

### How to test the changes in this Pull Request:

1. Create a JN site with Jetpack plugin installed
2. Go to the core profiler installation step
3. Observe the Jetpack plugin has `Installed` label
4. Click on Jetpack plugin
5. Observe the terms text at the bottom does not change (should be `By installing WooCommerce Tax plugin for free you agree to our Terms of Service.` if you haven't unselected any other plugins) 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
