### PR TITLE
Product Collection: Fix JS error when client-side nav is disabled

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/frontend.tsx
@@ -170,7 +170,7 @@ const productCollectionStore = {
 			}
 		},
 		*viewProduct() {
-			const ctx = getContext< ProductCollectionStoreContext >() || {};
+			const ctx = getContext< ProductCollectionStoreContext >();
 			const collection = ctx?.collection;
 			const productId = ctx?.productId;
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/frontend.tsx
@@ -170,8 +170,9 @@ const productCollectionStore = {
 			}
 		},
 		*viewProduct() {
-			const { collection, productId } =
-				getContext< ProductCollectionStoreContext >();
+			const ctx = getContext< ProductCollectionStoreContext >() || {};
+			const collection = ctx?.collection;
+			const productId = ctx?.productId;
 
 			if ( productId ) {
 				triggerViewedProductEvent( { collection, productId } );
@@ -200,8 +201,8 @@ const productCollectionStore = {
 			}
 		},
 		*onRender() {
-			const { collection } =
-				getContext< ProductCollectionStoreContext >();
+			const ctx = getContext< ProductCollectionStoreContext >();
+			const collection = ctx?.collection;
 
 			triggerProductListRenderedEvent( { collection } );
 		},

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/frontend.tsx
@@ -170,9 +170,8 @@ const productCollectionStore = {
 			}
 		},
 		*viewProduct() {
-			const ctx = getContext< ProductCollectionStoreContext >();
-			const collection = ctx?.collection;
-			const productId = ctx?.productId;
+			const { collection, productId } =
+				getContext< ProductCollectionStoreContext >();
 
 			if ( productId ) {
 				triggerViewedProductEvent( { collection, productId } );
@@ -201,8 +200,8 @@ const productCollectionStore = {
 			}
 		},
 		*onRender() {
-			const ctx = getContext< ProductCollectionStoreContext >();
-			const collection = ctx?.collection;
+			const { collection } =
+				getContext< ProductCollectionStoreContext >();
 
 			triggerProductListRenderedEvent( { collection } );
 		},

--- a/plugins/woocommerce/changelog/fix-52038
+++ b/plugins/woocommerce/changelog/fix-52038
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: fix JS error when client-side nav is disabled

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -321,12 +321,10 @@ class ProductCollection extends AbstractBlock {
 			);
 			$p->set_attribute(
 				'data-wc-context',
-				wp_json_encode(
-					$collection ? array(
-						'collection' => $collection,
-					) : '{}',
+				$collection ? wp_json_encode(
+					array( 'collection' => $collection ),
 					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-				)
+				) : '{}'
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -319,17 +319,15 @@ class ProductCollection extends AbstractBlock {
 				'data-wc-init',
 				'callbacks.onRender'
 			);
-			if ( $collection ) {
-				$p->set_attribute(
-					'data-wc-context',
-					wp_json_encode(
-						array(
-							'collection' => $collection,
-						),
-						JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-					)
-				);
-			}
+			$p->set_attribute(
+				'data-wc-context',
+				wp_json_encode(
+					$collection ? array(
+						'collection' => $collection,
+					) : '{}',
+					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+				)
+			);
 		}
 
 		return $p->get_updated_html();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was a JS error coming on Product Collection render when client-side navigation was disabled and default collection was used. In those circumstances, the Interactivity context was never initiated and caused error when accessing it in frontend.
This PR adds more defensive approach to accessing it.

Closes https://github.com/woocommerce/woocommerce/issues/52038

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Collection in Product Catalog template
2. Go to Inspector Controls > Advanced > enable Force Page Reload
3. Save
4. Open console
5. Go to frontend
6. Make sure there's no error like this (or similar)
```
Cannot destructure property 'collection' of '(0 , _woocommerce_interactivity__WEBPACK_IMPORTED_MODULE_0__.getContext)(...)' as it is undefined.
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
