### PR TITLE
CYS: remove GO_BACK_TO_HOME state

### DIFF
--- a/plugins/woocommerce/changelog/fix-51867
+++ b/plugins/woocommerce/changelog/fix-51867
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Remove GO_BACK_TO_HOME state from the Transitional screen

--- a/plugins/woocommerce/client/admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/index.tsx
@@ -537,9 +537,6 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 						component: AssemblerHub,
 					},
 					on: {
-						GO_BACK_TO_HOME: {
-							actions: 'redirectToWooHome',
-						},
 						COMPLETE_SURVEY: {
 							actions: 'completeSurvey',
 						},

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/index.tsx
@@ -31,7 +31,7 @@ import { isEntrepreneurFlow } from '~/customize-store/design-with-ai/entrepreneu
 export * as actions from './actions';
 export * as services from './services';
 
-export type events = { type: 'GO_BACK_TO_HOME' } | { type: 'COMPLETE_SURVEY' };
+export type events = { type: 'COMPLETE_SURVEY' };
 
 export const Transitional = ( {
 	sendEvent,
@@ -138,13 +138,11 @@ export const Transitional = ( {
 					{ isEntrepreneurFlow() && (
 						<Button
 							variant="primary"
+							href={ homeUrl }
 							onClick={ () => {
 								trackEvent(
 									'customize_your_store_entrepreneur_home_click'
 								);
-								sendEvent( {
-									type: 'GO_BACK_TO_HOME',
-								} );
 							} }
 						>
 							{ __( 'Back to Home', 'woocommerce' ) }
@@ -253,13 +251,11 @@ export const Transitional = ( {
 									</p>
 									<Button
 										variant="link"
+										href={ homeUrl }
 										onClick={ () => {
 											trackEvent(
 												'customize_your_store_transitional_home_click'
 											);
-											sendEvent( {
-												type: 'GO_BACK_TO_HOME',
-											} );
 										} }
 									>
 										{ __( 'Back to Home', 'woocommerce' ) }

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/index.tsx
@@ -6,6 +6,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import {
 	Button,
 	Modal,
@@ -49,6 +50,7 @@ export const Transitional = ( {
 	aiOnline: boolean;
 } ) => {
 	const homeUrl: string = getSetting( 'homeUrl', '' );
+	const adminUrl = getNewPath( getPersistedQuery(), '/', {} );
 	const closeSurvey = () => {
 		setSurveyOpen( false );
 	};
@@ -138,7 +140,7 @@ export const Transitional = ( {
 					{ isEntrepreneurFlow() && (
 						<Button
 							variant="primary"
-							href={ homeUrl }
+							href={ adminUrl }
 							onClick={ () => {
 								trackEvent(
 									'customize_your_store_entrepreneur_home_click'
@@ -251,7 +253,7 @@ export const Transitional = ( {
 									</p>
 									<Button
 										variant="link"
-										href={ homeUrl }
+										href={ adminUrl }
 										onClick={ () => {
 											trackEvent(
 												'customize_your_store_transitional_home_click'

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/test/index.test.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/test/index.test.tsx
@@ -107,7 +107,7 @@ describe( 'Transitional', () => {
 		);
 	} );
 
-	it( 'should send GO_BACK_TO_HOME event when clicking on "Back to Home" button', () => {
+	it( 'should track "customize_your_store_transitional_home_click" event when clicking on "Back to Home" button', () => {
 		// @ts-ignore
 		render( <Transitional { ...props } /> );
 
@@ -117,9 +117,6 @@ describe( 'Transitional', () => {
 			} )
 			.click();
 
-		expect( props.sendEvent ).toHaveBeenCalledWith( {
-			type: 'GO_BACK_TO_HOME',
-		} );
 		expect( trackEvent ).toHaveBeenCalledWith(
 			'customize_your_store_transitional_home_click'
 		);

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/test/index.test.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/test/index.test.tsx
@@ -63,7 +63,7 @@ describe( 'Transitional', () => {
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByRole( 'button', {
+			screen.getByRole( 'link', {
 				name: /Back to Home/i,
 			} )
 		).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe( 'Transitional', () => {
 		render( <Transitional { ...props } /> );
 
 		screen
-			.getByRole( 'button', {
+			.getByRole( 'link', {
 				name: /Back to Home/i,
 			} )
 			.click();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51867

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper > Tools > "Reset Customize Your Store"`.
2. In the admin, go to `WooCommerce > Customize Your Store > Create your own theme`.
3. Finish customizing and you will be redirected to the **Congratulations view**.
4. Try clicking on `Back to Home` with your mouse middle click or via Ctrl+Click to open the links in a new tab.
5. Notice the redirection is natively handled by the browser.
6. When doing the entrepreneur flow by visiting this url: `/wp-admin/admin.php?page=wc-admin&customizing=true&path=%2Fcustomize-store%2Ftransitional&ref=entrepreneur-signup` the `Back to Home` button should behave as in point 5.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
