### PR TITLE
Checkout: Add loading placeholder and payment method toggle

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js
@@ -33,17 +33,19 @@ export const useCheckoutSubmit = () => {
 			hasError: store.hasError(),
 		};
 	} );
-	const { activePaymentMethod, isExpressPaymentMethodActive } = useSelect(
-		( select ) => {
-			const store = select( PAYMENT_STORE_KEY );
+	const {
+		activePaymentMethod,
+		isExpressPaymentMethodActive,
+		isPaymentMethodsInitialized,
+	} = useSelect( ( select ) => {
+		const store = select( PAYMENT_STORE_KEY );
 
-			return {
-				activePaymentMethod: store.getActivePaymentMethod(),
-				isExpressPaymentMethodActive:
-					store.isExpressPaymentMethodActive(),
-			};
-		}
-	);
+		return {
+			activePaymentMethod: store.getActivePaymentMethod(),
+			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
+			isPaymentMethodsInitialized: store.paymentMethodsInitialized(),
+		};
+	} );
 
 	const { onSubmit } = useCheckoutEventsContext();
 
@@ -58,7 +60,10 @@ export const useCheckoutSubmit = () => {
 		paymentMethodButtonLabel,
 		onSubmit,
 		isCalculating,
-		isDisabled: isProcessing || isExpressPaymentMethodActive,
+		isDisabled:
+			isProcessing ||
+			isExpressPaymentMethodActive ||
+			! isPaymentMethodsInitialized,
 		waitingForProcessing,
 		waitingForRedirect,
 	};

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -11,6 +11,7 @@ import clsx from 'clsx';
 import { RadioControlAccordion } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -28,7 +29,6 @@ const PaymentMethodOptions = () => {
 	const {
 		activeSavedToken,
 		activePaymentMethod,
-		isExpressPaymentMethodActive,
 		savedPaymentMethods,
 		availablePaymentMethods,
 	} = useSelect( ( select ) => {
@@ -36,7 +36,6 @@ const PaymentMethodOptions = () => {
 		return {
 			activeSavedToken: store.getActiveSavedToken(),
 			activePaymentMethod: store.getActivePaymentMethod(),
-			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
 			savedPaymentMethods: store.getSavedPaymentMethods(),
 			availablePaymentMethods: store.getAvailablePaymentMethods(),
 		};
@@ -94,7 +93,22 @@ const PaymentMethodOptions = () => {
 	const singleOptionClass = clsx( {
 		'disable-radio-control': isSinglePaymentMethod,
 	} );
-	return isExpressPaymentMethodActive ? null : (
+
+	const globalPaymentMethods = getSetting( 'globalPaymentMethods' );
+
+	if ( Object.keys( options ).length === 0 ) {
+		return (
+			<div
+				className="wc-payment-method-options-placeholder"
+				style={ {
+					minHeight:
+						Object.keys( globalPaymentMethods ).length * 3 + 'em',
+				} }
+			></div>
+		);
+	}
+
+	return (
 		<RadioControlAccordion
 			highlightChecked={ true }
 			id={ 'wc-payment-method-options' }

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -61,7 +61,9 @@ const PaymentMethodOptions = () => {
 					  } ),
 			name: `wc-saved-payment-method-token-${ name }`,
 			content: (
-				<PaymentMethodCard showSaveOption={ supports.showSaveOption }>
+				<PaymentMethodCard
+					showSaveOption={ !! supports.showSaveOption }
+				>
 					{ cloneElement( component, {
 						__internalSetActivePaymentMethod,
 						...paymentMethodInterface,

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js
@@ -24,14 +24,21 @@ const PaymentMethods = () => {
 		paymentMethodsInitialized,
 		availablePaymentMethods,
 		savedPaymentMethods,
+		isExpressPaymentMethodActive,
 	} = useSelect( ( select ) => {
 		const store = select( PAYMENT_STORE_KEY );
 		return {
 			paymentMethodsInitialized: store.paymentMethodsInitialized(),
 			availablePaymentMethods: store.getAvailablePaymentMethods(),
 			savedPaymentMethods: store.getSavedPaymentMethods(),
+			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
 		};
 	} );
+
+	// If using an express payment method, don't show the regular payment methods.
+	if ( isExpressPaymentMethodActive ) {
+		return null;
+	}
 
 	if (
 		paymentMethodsInitialized &&

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Label } from '@woocommerce/blocks-components';
+import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import { Button } from '@ariakit/react';
 
 /**
  * Internal dependencies
@@ -20,17 +21,22 @@ import './style.scss';
  * @return {*} The rendered component.
  */
 const PaymentMethods = () => {
+	const [ showPaymentMethodsToggle, setShowPaymentMethodsToggle ] =
+		useState( false );
 	const {
 		paymentMethodsInitialized,
 		availablePaymentMethods,
-		savedPaymentMethods,
+		hasSavedPaymentMethods,
 		isExpressPaymentMethodActive,
+		activeSavedToken,
 	} = useSelect( ( select ) => {
 		const store = select( PAYMENT_STORE_KEY );
 		return {
 			paymentMethodsInitialized: store.paymentMethodsInitialized(),
+			activeSavedToken: store.getActiveSavedToken(),
 			availablePaymentMethods: store.getAvailablePaymentMethods(),
-			savedPaymentMethods: store.getSavedPaymentMethods(),
+			hasSavedPaymentMethods:
+				Object.keys( store.getSavedPaymentMethods() || {} ).length > 0,
 			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
 		};
 	} );
@@ -47,25 +53,43 @@ const PaymentMethods = () => {
 		return <NoPaymentMethods />;
 	}
 
+	// Show payment methods if the toggle is on or if there are no saved payment methods, or if the active saved token is not set.
+	const showPaymentMethods =
+		showPaymentMethodsToggle ||
+		! hasSavedPaymentMethods ||
+		( paymentMethodsInitialized && ! activeSavedToken );
+
 	return (
 		<>
-			<SavedPaymentMethodOptions />
-			{ Object.keys( savedPaymentMethods ).length > 0 && (
-				<Label
-					label={ __( 'Use another payment method.', 'woocommerce' ) }
-					screenReaderLabel={ __(
-						'Other available payment methods',
-						'woocommerce'
-					) }
-					wrapperElement="p"
-					wrapperProps={ {
-						className: [
-							'wc-block-components-checkout-step__description wc-block-components-checkout-step__description-payments-aligned',
-						],
-					} }
-				/>
+			{ hasSavedPaymentMethods && (
+				<>
+					<SavedPaymentMethodOptions />
+					<p className="wc-block-components-checkout-step__description wc-block-components-checkout-step__description-payments-aligned">
+						<Button
+							render={ <span /> }
+							type="button"
+							className="wc-block-components-show-payment-methods__link"
+							onClick={ ( e ) => {
+								e.preventDefault();
+								setShowPaymentMethodsToggle(
+									! showPaymentMethodsToggle
+								);
+							} }
+							aria-label={ __(
+								'Use another payment method',
+								'woocommerce'
+							) }
+							aria-expanded={ showPaymentMethodsToggle }
+						>
+							{ __(
+								'Use another payment method',
+								'woocommerce'
+							) }
+						</Button>
+					</p>
+				</>
 			) }
-			<PaymentMethodOptions />
+			{ showPaymentMethods && <PaymentMethodOptions /> }
 		</>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.tsx
@@ -69,15 +69,20 @@ const getDefaultLabel = ( {
 };
 
 const SavedPaymentMethodOptions = () => {
-	const { activeSavedToken, activePaymentMethod, savedPaymentMethods } =
-		useSelect( ( select ) => {
-			const store = select( PAYMENT_STORE_KEY );
-			return {
-				activeSavedToken: store.getActiveSavedToken(),
-				activePaymentMethod: store.getActivePaymentMethod(),
-				savedPaymentMethods: store.getSavedPaymentMethods(),
-			};
-		} );
+	const {
+		activeSavedToken,
+		activePaymentMethod,
+		savedPaymentMethods,
+		paymentMethodsInitialized,
+	} = useSelect( ( select ) => {
+		const store = select( PAYMENT_STORE_KEY );
+		return {
+			activeSavedToken: store.getActiveSavedToken(),
+			activePaymentMethod: store.getActivePaymentMethod(),
+			savedPaymentMethods: store.getSavedPaymentMethods(),
+			paymentMethodsInitialized: store.paymentMethodsInitialized(),
+		};
+	} );
 	const { __internalSetActivePaymentMethod } =
 		useDispatch( PAYMENT_STORE_KEY );
 	const canMakePaymentArg = getCanMakePaymentArg();
@@ -153,6 +158,7 @@ const SavedPaymentMethodOptions = () => {
 		dispatchCheckoutEvent,
 		canMakePaymentArg,
 	] );
+
 	const savedPaymentMethodHandler =
 		!! activeSavedToken &&
 		paymentMethods[ activePaymentMethod ] &&
@@ -167,12 +173,16 @@ const SavedPaymentMethodOptions = () => {
 			  )
 			: null;
 
+	const selected = paymentMethodsInitialized
+		? activeSavedToken
+		: options[ 0 ].value;
+
 	return options.length > 0 ? (
 		<>
 			<RadioControl
 				highlightChecked={ true }
 				id={ 'wc-payment-method-saved-tokens' }
-				selected={ activeSavedToken }
+				selected={ selected }
 				options={ options }
 				onChange={ () => void 0 }
 			/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -149,6 +149,13 @@
 	pointer-events: all; // Overrides parent disabled component in editor context
 }
 
+.wc-payment-method-options-placeholder {
+	display: block;
+	height: 100px;
+	width: 100%;
+	@include placeholder();
+}
+
 .is-mobile,
 .is-small {
 	.wc-block-card-elements {

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -156,6 +156,20 @@
 	@include placeholder();
 }
 
+.wc-block-components-show-payment-methods__link {
+	font-weight: normal;
+	background: none;
+	border: none;
+	padding: 0;
+	text-decoration: underline;
+	cursor: pointer;
+	text-align: left;
+
+	&[aria-expanded="true"] {
+		text-decoration: none;
+	}
+}
+
 .is-mobile,
 .is-small {
 	.wc-block-card-elements {

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -174,13 +174,6 @@ describe( 'PaymentMethods', () => {
 		);
 
 		await waitFor( () => {
-			const savedPaymentMethodOptions = screen.queryByText(
-				/Saved payment method options/
-			);
-			expect( savedPaymentMethodOptions ).not.toBeNull();
-		} );
-
-		await waitFor( () => {
 			const paymentMethodOptions = screen.queryByText(
 				/Payment method options/
 			);

--- a/plugins/woocommerce-blocks/assets/js/types/type-defs/payments.ts
+++ b/plugins/woocommerce-blocks/assets/js/types/type-defs/payments.ts
@@ -150,7 +150,12 @@ export type PaymentMethods =
 /**
  * Used to represent payment methods in a context where storing objects is not allowed, i.e. in data stores.
  */
-export type PlainPaymentMethods = Record<
+export type PlainPaymentMethods = Record< string, { name: string } >;
+
+/**
+ * Used to represent payment methods in a context where storing objects is not allowed, i.e. in data stores.
+ */
+export type PlainExpressPaymentMethods = Record<
 	string,
 	{
 		name: string;
@@ -160,11 +165,6 @@ export type PlainPaymentMethods = Record<
 		supportsStyle: string[];
 	}
 >;
-
-/**
- * Used to represent payment methods in a context where storing objects is not allowed, i.e. in data stores.
- */
-export type PlainExpressPaymentMethods = PlainPaymentMethods;
 
 export type ExpressPaymentMethods =
 	| Record< string, ExpressPaymentMethodConfigInstance >

--- a/plugins/woocommerce/changelog/update-46086-payment-methods-placeholder-state
+++ b/plugins/woocommerce/changelog/update-46086-payment-methods-placeholder-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add loading placeholder and payment method toggle to block checkout

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -410,7 +410,7 @@ class Checkout extends AbstractBlock {
 			$this->asset_data_registry->add( 'activeShippingZones', CartCheckoutUtils::get_shipping_zones() );
 		}
 
-		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'globalPaymentMethods' ) ) {
+		if ( ! $this->asset_data_registry->exists( 'globalPaymentMethods' ) ) {
 			// These are used to show options in the sidebar. We want to get the full list of enabled payment methods,
 			// not just the ones that are available for the current cart (which may not exist yet).
 			$payment_methods           = $this->get_enabled_payment_gateways();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes improvements to the payment method area on checkout based on the designs in #46086. It's not possible to change how saved payment methods rely on payment methods being initialised, but this PR makes the loading delay less noticeable and fixes some edge cases issues. Notably:

1. During init, a loading placeholder is shown in place of the payment methods. The height of this area is based on the number of installed payment methods to make this a best guess.

![Screenshot 2024-10-15 at 16 38 41](https://github.com/user-attachments/assets/f089a4cb-e51b-48c3-8ce5-4e9df2cee980)

2. During init, the Place Order button is disabled to prevent placing an order before a payment method is selected.
3. During init, the first saved method is selected (forced). This prevents the radio options being blank and then toggling on much later.

4. If saved methods are present, payment methods are toggled hidden by default. The `Use another payment method` link will toggle these open. 

![Screenshot 2024-10-15 at 16 35 52](https://github.com/user-attachments/assets/10b7944a-53ee-4f38-9ddb-95a210903969)

Closes #46086

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You will need Stripe extension installed and configured to test fully.

1. Add something to your cart, go to checkout, and place the order to check for payment method regressions.
2. Add something to your cart, go to cart, and place an order using an express payment method to test for regressions.
3. With Stripe enable and no saved methods, check that the payment area shows a loading indicator before payment methods are loaded. See screenshot above.
4. As a logged in user, place an order using Stripe Credit card and save it to your account.
5. Checkout again. The saved method is selected by default. Check you can toggle the visibility of payment methods and place the order using any of the methods or tokens.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
