### PR TITLE
Prevent early translation loading

### DIFF
--- a/plugins/woocommerce/changelog/51843-fix-l10n-too-early
+++ b/plugins/woocommerce/changelog/51843-fix-l10n-too-early
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Removes several side effects in the code base that caused translations to be loaded too early.

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -95,7 +95,7 @@ class BlockPatterns {
 	 * @return array|WP_Error
 	 */
 	private function get_patterns_dictionary() {
-		if ( $this->dictionary === null ) {
+		if ( null === $this->dictionary ) {
 			$this->dictionary = PatternsHelper::get_patterns_dictionary();
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -82,13 +82,24 @@ class BlockPatterns {
 		$this->pattern_registry   = $pattern_registry;
 		$this->ptk_patterns_store = $ptk_patterns_store;
 
-		$this->dictionary = PatternsHelper::get_patterns_dictionary();
-
 		add_action( 'init', array( $this, 'register_block_patterns' ) );
 
 		if ( Features::is_enabled( 'pattern-toolkit-full-composability' ) ) {
 			add_action( 'init', array( $this, 'register_ptk_patterns' ) );
 		}
+	}
+
+	/**
+	 * Returns the Patterns dictionary.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function get_patterns_dictionary() {
+		if ( $this->dictionary === null ) {
+			$this->dictionary = PatternsHelper::get_patterns_dictionary();
+		}
+
+		return $this->dictionary;
 	}
 
 	/**
@@ -103,7 +114,7 @@ class BlockPatterns {
 
 		$patterns = $this->get_block_patterns();
 		foreach ( $patterns as $pattern ) {
-			$this->pattern_registry->register_block_pattern( $pattern['source'], $pattern, $this->dictionary );
+			$this->pattern_registry->register_block_pattern( $pattern['source'], $pattern, $this->get_patterns_dictionary() );
 		}
 	}
 
@@ -212,7 +223,7 @@ class BlockPatterns {
 			$pattern['slug']    = $pattern['name'];
 			$pattern['content'] = $pattern['html'];
 
-			$this->pattern_registry->register_block_pattern( $pattern['ID'], $pattern, $this->dictionary );
+			$this->pattern_registry->register_block_pattern( $pattern['ID'], $pattern, $this->get_patterns_dictionary() );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
@@ -12,20 +12,15 @@ class PatternRegistry {
 	const SLUG_REGEX            = '/^[A-z0-9\/_-]+$/';
 	const COMMA_SEPARATED_REGEX = '/[\s,]+/';
 
-
 	/**
-	 * Associates pattern slugs with their localized labels for categorization.
+	 * Returns pattern slugs with their localized labels for categorization.
+	 *
 	 * Each key represents a unique pattern slug, while the value is the localized label.
 	 *
-	 * @var array $category_labels
+	 * @return array<string, string>
 	 */
-	private $category_labels;
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->category_labels = [
+	private function get_category_labels() {
+		return [
 			'woo-commerce'     => __( 'WooCommerce', 'woocommerce' ),
 			'intro'            => __( 'Intro', 'woocommerce' ),
 			'featured-selling' => __( 'Featured Selling', 'woocommerce' ),
@@ -148,10 +143,10 @@ class PatternRegistry {
 			}
 		}
 
-        // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
+		// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
 		$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', 'woocommerce' );
 		if ( ! empty( $pattern_data['description'] ) ) {
-            // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
+			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
 			$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'woocommerce' );
 		}
 
@@ -186,13 +181,15 @@ class PatternRegistry {
 			}
 		}
 
+		$category_labels = $this->get_category_labels();
+
 		if ( ! empty( $pattern_data['categories'] ) ) {
 			foreach ( $pattern_data['categories'] as $key => $category ) {
 				$category_slug = _wp_to_kebab_case( $category );
 
 				$pattern_data['categories'][ $key ] = $category_slug;
 
-				$label = isset( $this->category_labels[ $category_slug ] ) ? $this->category_labels[ $category_slug ] : self::kebab_to_capital_case( $category_slug );
+				$label = $category_labels[ $category_slug ] ?? self::kebab_to_capital_case( $category_slug );
 
 				register_block_pattern_category(
 					$category_slug,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow-up to #47113, see that one for context.

Closes #51843.

There is a new change in WordPress 6.7 that prevents plugins from loading translations too early, without waiting for more parts of WordPress being loaded. A dev-note will be published soon with more details.

It also changes how `load_plugin_textdomain()` works, as it delays actual loading until the first `__()` call is encountered.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Without this PR**

1. Use WordPress 6.7
2. Set site language to something other than en_US
3. Ensure all translations are installed
4. See warning about WooCommerce causing translations to be loaded too early
5. See that none of the strings are actually translated

**With this PR**


1. Use WordPress 6.7
2. Set site language to something other than en_US
3. Ensure all translations are installed
4. See no warnings.
5. See that strings are actually translated

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
