### PR TITLE
Fix notices caused by legacy fee dynamic properties

### DIFF
--- a/plugins/woocommerce/changelog/fix-52024-legacy-fees
+++ b/plugins/woocommerce/changelog/fix-52024-legacy-fees
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Define legacy fee properties to prevent PHP notice

--- a/plugins/woocommerce/includes/class-wc-order-item-fee.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-fee.php
@@ -18,6 +18,21 @@ defined( 'ABSPATH' ) || exit;
  * Order item fee.
  */
 class WC_Order_Item_Fee extends WC_Order_Item {
+	/**
+	 * Legacy fee data.
+	 *
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var object
+	 */
+	public $legacy_fee = '';
+
+	/**
+	 * Legacy fee key.
+	 *
+	 * @deprecated 4.4.0 For legacy actions.
+	 * @var string
+	 */
+	public $legacy_fee_key = '';
 
 	/**
 	 * Order Data array. This is the core order data exposed in APIs since 3.0.0.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fees use 2 dynamic properties that cause notices in later versions of PHP. This defines both to mitigate.

Closes #52024

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Use this snippet to add a 100 fee to your carts.

```
add_action(
	'woocommerce_cart_calculate_fees',
	function () {
		WC()->cart->add_fee( 'Test fee', 100, false, 'standard' );
	}
);
```

Regular testers should simply place an order and ensure it works (no regressions).

Developers should check the PHP debug log. There should be no `Creation of dynamic property WC_Order_Item_Fee::$legacy_fee` notices present.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
