### PR TITLE
Fix fatal when OrdersTableMetaQuery::generate_where_for_clause_value() didn't return a string

### DIFF
--- a/plugins/woocommerce/changelog/fix-52064-orderstablemetaquery-generate_where_for_clause_value-fatal
+++ b/plugins/woocommerce/changelog/fix-52064-orderstablemetaquery-generate_where_for_clause_value-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal when OrdersTableMetaQuery::generate_where_for_clause_value() didn't return a string

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -657,6 +657,7 @@ class OrdersTableMetaQuery {
 				return "CAST({$clause['alias']}.meta_value AS {$clause['cast']}) {$meta_compare} {$where}";
 			}
 		}
-	}
 
+		return '';
+	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -350,7 +350,6 @@ class OrdersTableMetaQuery {
 		$queries     = $this->queries;
 		$sql_where   = $this->process( $queries );
 		$this->where = $sql_where;
-
 	}
 
 	/**
@@ -381,7 +380,7 @@ class OrdersTableMetaQuery {
 			$i               = 1;
 			while ( isset( $this->flattened_clauses[ $unique_flat_key ] ) ) {
 				$unique_flat_key = $flat_clause_key . '-' . $i;
-				$i++;
+				++$i;
 			}
 
 			$this->flattened_clauses[ $unique_flat_key ] =& $arg;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/52064.

This PR makes sure that `OrdersTableMetaQuery::generate_where_for_clause_value()` always returns a string, to avoid fatal errors occurring on certain occasions.

### How to test the changes in this Pull Request:

1. In a PHP 7.4 site, install [WooCommerce Print Invoices and Packing Lists](https://woocommerce.com/products/print-invoices-packing-lists/).
2. Go to WooCommerce > Orders (assuming your store has at least one order).
3. Filter by _Invoice not printed_.

![Image](https://github.com/user-attachments/assets/2873f96b-6cc4-4053-a6fb-2ccaf5bcd29d)

4. Ensure there is no fatal.