### PR TITLE
Add sizes attribute to Product gallery thumbnail images to better load the appropriate resolution

### DIFF
--- a/plugins/woocommerce/changelog/fix-52071-thumbnail-images-sizes
+++ b/plugins/woocommerce/changelog/fix-52071-thumbnail-images-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Add sizes attribute to Product gallery thumbnail images to better load the appropriate resolution

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -256,6 +256,7 @@
                   onload: 'this.width = this.naturalWidth; this.height = this.naturalHeight',
                   src: slide.attr('data-thumb'),
                   srcset: slide.attr('data-thumb-srcset'),
+                  sizes: slide.attr('data-thumb-sizes'),
                   alt: slide.attr('alt')
                 })
               }

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1659,6 +1659,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 	$thumbnail_srcset  = wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size );
+	$thumbnail_sizes   = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
 
@@ -1696,7 +1697,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 		$image_params
 	);
 
-	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" data-thumb-srcset="' . esc_attr( $thumbnail_srcset ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" data-thumb-srcset="' . esc_attr( $thumbnail_srcset ) . '"  data-thumb-sizes="' . esc_attr( $thumbnail_sizes ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }
 
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/52071.

This PR adds the `sizes` attribute to the Product gallery thumbnail images. In https://github.com/woocommerce/woocommerce/pull/49112 we added the `srcset` attribute, but without the `sizes` attribute it was loading bigger images than necessary.

### How to test the changes in this Pull Request:

0. While not necessary, to better see the bug, go to `/wp-admin/customize.php` and make your product images to be cropped to 1:1.
1. Create a big square image on your device or use this one:
![Image](https://github.com/user-attachments/assets/64d36823-a93d-458e-917d-c30731c54e1b)
2. Create a product or edit an existing one and add the big image to the Product gallery.
![Image](https://github.com/user-attachments/assets/b08a2da4-7481-4509-8ab5-905e32ccb8df)
3. Go to the frontend. Make the window very big. In Firefox, you can fake it with <kbd>F12</kbd> > <kbd>Ctrl</kbd>+<kbd>M</kbd> and setting the width to something absurdly wide (ie: 5000px). Keep the pixel density to 1.
![Image](https://github.com/user-attachments/assets/b6c6310d-42f1-4c29-98db-29c17ac02d7e)
4. Notice that a small image is loaded:

Before | After
--- | ---
![Image](https://github.com/user-attachments/assets/87b546e8-ee46-467d-8a8b-041b569db8ae) | ![imatge](https://github.com/user-attachments/assets/d72f2cfa-8fb6-4007-8204-5de5316e4f32)

5. Try playing around with the pixel density, try with different resolutions and with different browsers and make sure we are always loading images with an appropriate resolution.