### PR TITLE
[Accessibility] Add headings to the main setions of the Cart page with block variation

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -76,6 +76,9 @@ const CartLineItemsTable = ( {
 			ref={ tableRef }
 			tabIndex={ -1 }
 		>
+			<caption className="screen-reader-text">
+				<h2>{ __( 'Products in cart', 'woocommerce' ) }</h2>
+			</caption>
 			<thead>
 				<tr className="wc-block-cart-items__header">
 					<th className="wc-block-cart-items__header-image">

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/block.tsx
@@ -11,9 +11,9 @@ const Block = ( {
 	content: string;
 } ): JSX.Element => {
 	return (
-		<span className={ clsx( className, 'wc-block-cart__totals-title' ) }>
+		<h2 className={ clsx( className, 'wc-block-cart__totals-title' ) }>
 			{ content }
-		</span>
+		</h2>
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/edit.tsx
@@ -23,9 +23,7 @@ export const Edit = ( {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
-			<span
-				className={ clsx( className, 'wc-block-cart__totals-title' ) }
-			>
+			<h2 className={ clsx( className, 'wc-block-cart__totals-title' ) }>
 				<PlainText
 					className={ '' }
 					value={ content }
@@ -34,7 +32,7 @@ export const Edit = ( {
 					}
 					style={ { backgroundColor: 'transparent' } }
 				/>
-			</span>
+			</h2>
 		</div>
 	);
 };

--- a/plugins/woocommerce/changelog/fix-51892
+++ b/plugins/woocommerce/changelog/fix-51892
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add headings to the main section of the Cart page with the block variation

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -883,6 +883,10 @@ table.variations {
 	}
 }
 
+.is-large.wc-block-cart .wc-block-cart__totals-title::before {
+	content: none;
+}
+
 /**
  * Checkout
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51892 .
Closes #51893 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the Cart page uses the block variation.
2. Add a product to the cart.
3. Go to the Cart page.
4. Turn on the screen reader.
5. When the focus enters the products table, verify the screen reader announces the table heading "Products in cart".
6. Turn on the Rotor functionality of the screen reader. In VoiceOver, this can be done by pressing Control + Option + U. [Use the VoiceOver rotor on Mac](https://support.apple.com/en-gw/guide/voiceover/mchlp2719/mac)
7. Go to the Headings section in the rotor.
8. Verify both the "Product in cart" and the "Cart totals" headings have level 2 (`<h2>`). 
9. Perform the test with the default WP themes and Storefront.
10. Verify the style of the "Cart totals" title remains the same.
11. The "Products in cart" heading is only visible to screen readers, so verifying its style is unnecessary.

**Testing the Cart totals section heading**


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
