### PR TITLE
Remove "banner" layout option from inbox note

### DIFF
--- a/packages/js/experimental/changelog/update-remove-banner-layout-from-inbox-note
+++ b/packages/js/experimental/changelog/update-remove-banner-layout-from-inbox-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove "banner" layout test case

--- a/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
@@ -76,15 +76,6 @@ describe( 'InboxNoteCard', () => {
 		expect( queryByText( 'Dismiss' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should render a notification type banner', () => {
-		const bannerNote = { ...note, layout: 'banner' };
-		const { container } = render(
-			<InboxNoteCard key={ bannerNote.id } note={ bannerNote } />
-		);
-		const listNoteWithBanner = container.querySelector( '.banner' );
-		expect( listNoteWithBanner ).not.toBeNull();
-	} );
-
 	it( 'should render a notification type thumbnail', () => {
 		const thumbnailNote = { ...note, layout: 'thumbnail' };
 		const { container } = render(

--- a/plugins/woocommerce-beta-tester/changelog/update-remove-banner-layout-from-inbox-note
+++ b/plugins/woocommerce-beta-tester/changelog/update-remove-banner-layout-from-inbox-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove "banner" layout option from inbox note

--- a/plugins/woocommerce-beta-tester/src/admin-notes/add-note.js
+++ b/plugins/woocommerce-beta-tester/src/admin-notes/add-note.js
@@ -115,7 +115,6 @@ export const AddNote = () => {
 						labelPosition="side"
 						options={ [
 							{ label: 'Plain', value: 'plain' },
-							{ label: 'Banner', value: 'banner' },
 							{ label: 'Thumbnail', value: 'thumbnail' },
 						] }
 						disabled={ noteType !== 'info' }

--- a/plugins/woocommerce/changelog/update-remove-banner-layout-from-inbox-note
+++ b/plugins/woocommerce/changelog/update-remove-banner-layout-from-inbox-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove deprecated "banner" layout option from inbox note

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -578,11 +578,7 @@ class Note extends \WC_Data {
 		if ( empty( $layout ) ) {
 			$layout = 'plain';
 		}
-		$valid_layouts = array( 'banner', 'plain', 'thumbnail' );
-
-		if ( 'banner' === $layout ) {
-			wc_deprecated_argument( 'Note::set_layout', '9.4.0', 'The "banner" layout is deprecated. Please use "thumbnail" instead to display a image.' );
-		}
+		$valid_layouts = array( 'plain', 'thumbnail' );
 
 		if ( in_array( $layout, $valid_layouts, true ) ) {
 			$this->set_prop( 'layout', $layout );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51560

We've deprecated the unsupported Inbox note banner layout in https://github.com/woocommerce/woocommerce/pull/51275. This PR is to remove it in 9.5.

This should be safe to remove since the `banner` layout option was never officially supported in frontend. Besides, we've deprecated the layout option in 9.4.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a fresh site
2. Go to `WooCommerce > Home`
3. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` > Remote Inbox Notifications
4. Click on Import from URL and use the following URL: https://gist.githubusercontent.com/chihsuan/8fbe10bd506461069e104db9734dd34c/raw/2b127b29fe0d6279834f403604b30f1b2cee0f5f/Banner%2520Layout%2520Note
5. Confirm that the note is imported successfully and it doesn't block user from other actions such as navigating to other pages
6. Confirm that ` PHP Fatal error:  Uncaught WC_Data_Exception: The admin note layout has a wrong prop value. in...` is displayed in debug.log 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
