### PR TITLE
Hide platform selector text cursor

### DIFF
--- a/plugins/woocommerce/changelog/fix-hide-platform-selector-text-cursor
+++ b/plugins/woocommerce/changelog/fix-hide-platform-selector-text-cursor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide text cursor for platform selector

--- a/plugins/woocommerce/client/admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
@@ -123,3 +123,10 @@
 		}
 	}
 }
+
+.woocommerce-profiler-platform-selector {
+	.woocommerce-experimental-select-control__input {
+		// hide the caret since typing is disabled and search is not supported.
+		caret-color: transparent;
+	}
+}

--- a/plugins/woocommerce/client/admin/client/core-profiler/components/multiple-selector/multiple-selector.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/components/multiple-selector/multiple-selector.tsx
@@ -32,6 +32,7 @@ export const MultipleSelector = ( {
 }: Props ) => {
 	return (
 		<SelectControl
+			className="woocommerce-profiler-platform-selector"
 			label=""
 			multiple
 			__experimentalOpenMenuOnFocus


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51766

The platform selector shows a text cursor when the dropdown is open, but it's impossible to type in it. This is confusing for users as it looks like they can type in the dropdown. Alternatively, we can enable typing and support the search functionality but it requires additional work to implement and it doesn't seem required as NUX platform selector is also not supporting search/filtering.

Before:

https://github.com/user-attachments/assets/0daa2c02-3aaa-417a-b004-bac37c9508fb

After:

https://github.com/user-attachments/assets/5bd4f4f7-5d57-4b53-976b-7eba9ebc56e2


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Core Profiler
2. Continue to the Which one of these best describes you? step
3. Select `I’m already selling and I'm selling both online and offline`
4. Open the platform selector dropdown
5. Confirm that the text cursor is not visible when the dropdown is open

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
