### PR TITLE
Update makepot-audit include path: Replace 'client' with 'assets

### DIFF
--- a/plugins/woocommerce/changelog/52096-dev-fix-makepot-include-path
+++ b/plugins/woocommerce/changelog/52096-dev-fix-makepot-include-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update makepot-audit include path: Replace 'client' with 'assets

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -120,7 +120,7 @@
 			"phpcbf -p"
 		],
 		"makepot-audit": [
-			"wp --allow-root i18n make-pot . --include=\"woocommerce.php,client,i18n,includes,lib,packages,patterns,src,templates\" --slug=woocommerce"
+			"wp --allow-root i18n make-pot . --include=\"woocommerce.php,assets,i18n,includes,lib,packages,patterns,src,templates\" --slug=woocommerce"
 		],
 		"makepot": [
 			"@makepot-audit --skip-audit"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I found that building zip process is extremely slow, specifically when the `makepot-audit` command is executed. 

After some investigation, I believe it's because we've merged the `woocommerce-admin` into the `./client` directory.

![Screenshot 2024-10-17 at 11 29 29](https://github.com/user-attachments/assets/1cdb3afb-acb0-4337-918a-cb1ec24ca6aa)

The existing `make pot-audit` command includes the `client` pattern, ~which is weird because the `client` directory in the zip file doesn't contain any files that need to be included in the pot file~, which matches both `client` and `assets/client` directories.

Since we don't need to include the `client` directory in the pot file, I've updated the `makepot-audit` command to include the `assets` directory instead of the `client` directory.

This change should make the `makepot-audit` command faster and more efficient.

I was trying to use `--exclude` option in the `makepot-audit` command, but it seems that the `--exclude` option doesn't work as expected when `--include` option is used. So I just updated the `makepot-audit` command to include the `assets` directory instead of the `client` directory.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Testing the `makepot-audit` command**

1. Checkout this branch
2. Run `cd plugins/woocommerce`
3. Run `pnpm makepot`
4. It should finish successfully without any errors within a reasonable time frame
5. It should not include `client/admin` files in the `i18n/languages/woocommerce.pot` file

**Comfiring that woocommerce.pot file still includes the files in `assets/client`**

1. Download the latest [WooCommerce](https://downloads.wordpress.org/plugin/woocommerce.9.3.3.zip) plugin from the WordPress.org repository 
2. Unzip the downloaded WooCommerce plugin
3. Compare `i18n/languages/woocommerce.pot` file in the unzipped WooCommerce plugin with the `i18n/languages/woocommerce.pot` file in your local WooCommerce plugin directory
4. Confirm that files in `assets/client` are still included in the `i18n/languages/woocommerce.pot` file  (Current nightly build includes `client/admin` files in the `i18n/languages/woocommerce.pot` file)



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update makepot-audit include path: Replace 'client' with 'assets

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
