### PR TITLE
Update Mastercard branding (MasterCard -> Mastercard)

### DIFF
--- a/docs/payments/payment-token-api.md
+++ b/docs/payments/payment-token-api.md
@@ -322,7 +322,7 @@ Supported types/labels:
 
 ```php
 array(
-	'mastercard'       => __( 'MasterCard', 'woocommerce' ),
+	'mastercard'       => __( 'Mastercard', 'woocommerce' ),
 	'visa'             => __( 'Visa', 'woocommerce' ),
 	'discover'         => __( 'Discover', 'woocommerce' ),
 	'american express' => __( 'American Express', 'woocommerce' ),

--- a/plugins/woocommerce/changelog/52101-fix-mastercard-branding
+++ b/plugins/woocommerce/changelog/52101-fix-mastercard-branding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Updated instances of "MasterCard" to "Mastercard" to reflect the brand's new stylization.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1564,7 +1564,7 @@ function wc_get_credit_card_type_label( $type ) {
 	$labels = apply_filters(
 		'woocommerce_credit_card_type_labels',
 		array(
-			'mastercard'       => _x( 'MasterCard', 'Name of credit card', 'woocommerce' ),
+			'mastercard'       => _x( 'Mastercard', 'Name of credit card', 'woocommerce' ),
 			'visa'             => _x( 'Visa', 'Name of credit card', 'woocommerce' ),
 			'discover'         => _x( 'Discover', 'Name of credit card', 'woocommerce' ),
 			'american express' => _x( 'American Express', 'Name of credit card', 'woocommerce' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -958,7 +958,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_credit_card_type_label() {
 		$this->assertEquals( 'Visa', wc_get_credit_card_type_label( 'visa' ) );
 		$this->assertEquals( 'JCB', wc_get_credit_card_type_label( 'jCb' ) );
-		$this->assertEquals( 'MasterCard', wc_get_credit_card_type_label( 'Mastercard' ) );
+		$this->assertEquals( 'Mastercard', wc_get_credit_card_type_label( 'Mastercard' ) );
 		$this->assertEquals( 'American Express', wc_get_credit_card_type_label( 'american_express' ) );
 		$this->assertEquals( 'American Express', wc_get_credit_card_type_label( 'american-express' ) );
 		$this->assertEquals( 'Cartes Bancaires', wc_get_credit_card_type_label( 'cartes_bancaires' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In 2016 Mastercard did a slight rebranding and changed from **MasterCard** to **Mastercard** (lowercase c). See offical pages like https://www.mastercard.com/brandcenter/en/brand-history. 

This PR updates the core WC function which uses and references the old brand stylization.  

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install a payment extension like Stripe (any gateway that uses the base WC_Payment_Token_CC class will work). 
2. Setup the payment extension. 
3. Add an item to the card and using a Mastercard card.
    - If you're using Stripe, use `5555555555554444` 
4. On the checkout check the box to save the payment method. 
5. Complete the purchase
6. Add another product to your cart. 
7. Go to the checkout page and note the saved tokens section.
8. On `trunk` the brand will be displayed as **MasterCard** on this branch it is the newer **Mastercard**. 

| Before | After |
|--------|--------|
| <img width="528" alt="Screenshot 2024-10-17 at 5 24 55 pm" src="https://github.com/user-attachments/assets/aee0fac9-a4b6-4919-8872-7d5e67424fb0"> | <img width="636" alt="Screenshot 2024-10-17 at 5 24 05 pm" src="https://github.com/user-attachments/assets/1c426a9f-0b97-431a-bc6a-6a1bfb43f2b9"> |

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Updated instances of "MasterCard" to "Mastercard" to reflect the brand's new stylization.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
