### PR TITLE
[dev] CI: refine pr-lint-monorepo workflow filters (take 2)

### DIFF
--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,10 +1,11 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on:
     pull_request:
-        paths-ignore:
-            - '**/changelog/**'
-            - '.github/**'
-            - '!.github/workflows/pr-lint-monorepo.yml'
+        paths:
+            - '.github/workflows/pr-lint-monorepo.yml'
+            - 'packages/**'
+            - 'plugins/**'
+            - '!**/changelog/**'
         branches:
             - 'trunk'
 

--- a/changelog/39948-patch-4
+++ b/changelog/39948-patch-4
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Do not remove sale date from when the sale is still active

--- a/changelog/43571-migrated-template-structure-documentation
+++ b/changelog/43571-migrated-template-structure-documentation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-comment: Migrated Template structure & Overriding templates via a theme into /docs

--- a/changelog/e2e-fix-allure-upload-input
+++ b/changelog/e2e-fix-allure-upload-input
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix the incorrect workflow input for uploading Allure reports.

--- a/changelog/e2e-update-locator-in-allows-customer-to-place-order-test
+++ b/changelog/e2e-update-locator-in-allows-customer-to-place-order-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update locator to reduce flakiness when running tests against a JN site

--- a/changelog/pr-36705
+++ b/changelog/pr-36705
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Added `woocommerce_widget_layered_nav_filters_start/end` hooks around layered nav filters widget


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In this PR we refine filters for running `Changelogger use` job to aim changes in packages and plugins directories.
This also invalidates the need for a top-level changelog directory, which we are removing as well.

### How to test the changes in this Pull Request:

- CI checks shall pass
