### PR TITLE
Resolve type expectations when invoking meta box callbacks from the order editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-52119-meta-box-data-type
+++ b/plugins/woocommerce/changelog/fix-52119-meta-box-data-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: A changelog entry was supplied in #51598, this is further enhancement/correction for that work.
+
+

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -506,14 +506,24 @@ class Edit {
 	 * Helper function to render meta boxes.
 	 */
 	private function render_meta_boxes() {
+		$order_post = get_post( $this->order->get_id() );
+
+		// We need to supply WP_Post objects since, for compatibility reasons, we are also supplying objects of that
+		// type when we trigger 'add_meta_boxes` from within the setup() method. Meta box callbacks can reasonably
+		// assume they will receive data objects of that same type.
+		if ( ! $order_post instanceof WP_Post ) {
+			wc_get_logger()->warning( 'Unable to render order editor meta boxes, as it was not possible to acquire a post object.' );
+			return;
+		}
+
 		?>
 		<div id="postbox-container-1" class="postbox-container">
-			<?php do_meta_boxes( $this->screen_id, 'side', $this->order ); ?>
+			<?php do_meta_boxes( $this->screen_id, 'side', $order_post ); ?>
 		</div>
 		<div id="postbox-container-2" class="postbox-container">
 			<?php
-			do_meta_boxes( $this->screen_id, 'normal', $this->order );
-			do_meta_boxes( $this->screen_id, 'advanced', $this->order );
+			do_meta_boxes( $this->screen_id, 'normal', $order_post );
+			do_meta_boxes( $this->screen_id, 'advanced', $order_post );
 			?>
 		</div>
 		<?php


### PR DESCRIPTION
This is a further correction for the work merged via https://github.com/woocommerce/woocommerce/pull/51598. Summary:

- As detailed in https://github.com/woocommerce/woocommerce/pull/51598, when we trigger `add_meta_boxes` within the (HPOS) order editor we should supply a `WP_Post`, not a `WC_Order`, as we are repurposing a widely-used core WP hook that is documented as supplying a regular post object.
- When we then invoke `do_meta_boxes()`, we perhaps should also supply the same type (that is, an instance of `WP_Post`), as this is similarly what the callbacks may reasonably expect.

Note that this was effectively included in the first draft of the original PR, but we elected to remove it because `do_meta_boxes()` does not require the data object to be a `WP_Post`. The situation is therefore a little ambiguous ... keeping this PR as a draft until we decide how we want to proceed.

Closes #52119.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

TBD, but you can refer to the notes in #52119 in the meantime.

