### PR TITLE
Fix product count display on mini cart first render

### DIFF
--- a/plugins/woocommerce/changelog/fix-mini-cart-button-setting
+++ b/plugins/woocommerce/changelog/fix-mini-cart-button-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set server-side render of Mini-Cart icon to correctly show/hide the count based on block setting

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -422,10 +422,17 @@ class MiniCart extends AbstractBlock {
 		$product_count_color = array_key_exists( 'productCountColor', $attributes ) ? esc_attr( $attributes['productCountColor']['color'] ) : '';
 		$icon                = MiniCartUtils::get_svg_icon( $attributes['miniCartIcon'] ?? '', $icon_color );
 
+		$product_count_visibility = isset( $attributes['productCountVisibility'] ) ? $attributes['productCountVisibility'] : 'greater_than_zero';
+		$show_product_count       = 'always' === $product_count_visibility;
+		if ( 'greater_than_zero' === $product_count_visibility ) {
+			$cart               = $this->get_cart_instance();
+			$show_product_count = $cart && $cart->get_cart_contents_count() > 0;
+		}
+
 		$button_html = $this->get_cart_price_markup( $attributes ) . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
-			<span class="wc-block-mini-cart__badge" style="background:' . $product_count_color . '"></span>
+			' . ( $show_product_count ? '<span class="wc-block-mini-cart__badge" style="background:' . $product_count_color . '"></span>' : '' ) . '
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -3,14 +3,13 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * Tests for the Checkout block type
  *
  * @since $VID:$
  */
-class MiniCart extends MockeryTestCase {
+class MiniCart extends \WP_UnitTestCase {
 
 	/**
 	 * Setup test product data. Called before every test.
@@ -30,7 +29,7 @@ class MiniCart extends MockeryTestCase {
 			),
 		);
 		wc_empty_cart();
-		add_filter( 'woocommerce_is_rest_api_request', '__return_false' );
+		add_filter( 'woocommerce_is_rest_api_request', '__return_false', 1 );
 	}
 
 	/**
@@ -38,7 +37,8 @@ class MiniCart extends MockeryTestCase {
 	 * @return void
 	 */
 	protected function tearDown(): void {
-		remove_filter( 'woocommerce_is_rest_api_request', '__return_false' );
+		parent::tearDown();
+		remove_filter( 'woocommerce_is_rest_api_request', '__return_false', 1 );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -1,0 +1,79 @@
+<?php
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * Tests for the Checkout block type
+ *
+ * @since $VID:$
+ */
+class MiniCart extends MockeryTestCase {
+
+	/**
+	 * Setup test product data. Called before every test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$fixtures       = new FixtureData();
+		$this->products = array(
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 1',
+					'stock_status'  => 'instock',
+					'regular_price' => 10,
+					'weight'        => 10,
+				)
+			),
+		);
+		wc_empty_cart();
+	}
+
+	/**
+	 * Checks the output of the MiniCart block is correct based on the productCountVisibility attribute when cart is empty.
+	 * @return void
+	 */
+	public function test_product_count_visibility_with_empty_cart() {
+
+		// Test badge is shown when "always" is selected.
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"always"} /-->' );
+		$output = render_block( $block[0] );
+		$this->assertStringContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+
+		// Tests badge is not shown, because product count is not greater than zero when "greater_than_zero" is selected.
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"greater_than_zero"} /-->' );
+		$output = render_block( $block[0] );
+		$this->assertStringNotContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+
+		// Tests badge is not shown when "never" is selected.
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"never"} /-->' );
+		$output = render_block( $block[0] );
+		$this->assertStringNotContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+	}
+
+	/**
+	 * Checks the output of the MiniCart block is correct based on the productCountVisibility attribute when cart has products.
+	 * @return void
+	 */
+	public function test_product_count_visibility_with_products_in_cart() {
+		WC()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
+
+		// Tests badge is shown with items in cart when "always" is selected.
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"always"} /-->' );
+		$output = render_block( $block[0] );
+		$this->assertStringContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+
+		// Tests badge *is* shown, because product count is greater than zero when "greater_than_zero" is selected.
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"greater_than_zero"} /-->' );
+		$output = render_block( $block[0] );
+		$this->assertStringContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+
+		// Tests badge is not shown with items in cart when "never" is selected.
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"always"} /-->' );
+		$output = render_block( $block[0] );
+		$this->assertStringContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -81,8 +81,8 @@ class MiniCart extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<span class="wc-block-mini-cart__badge"', $output );
 
 		// Tests badge is not shown with items in cart when "never" is selected.
-		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"always"} /-->' );
+		$block  = parse_blocks( '<!-- wp:woocommerce/mini-cart {"productCountVisibility":"never"} /-->' );
 		$output = render_block( $block[0] );
-		$this->assertStringContainsString( '<span class="wc-block-mini-cart__badge"', $output );
+		$this->assertStringNotContainsString( '<span class="wc-block-mini-cart__badge"', $output );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -30,6 +30,15 @@ class MiniCart extends MockeryTestCase {
 			),
 		);
 		wc_empty_cart();
+		add_filter( 'woocommerce_is_rest_api_request', '__return_false' );
+	}
+
+	/**
+	 * Tear down test. Called after every test.
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'woocommerce_is_rest_api_request', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the PHP render of the Mini-Cart block so that the setting for displaying the product count is reflected on first render. In the block settings the count can be shown: always (`always`), never (`never`), or if cart is not empty (`greater_than_zero`).

The bug manifests because the initial HTML for the block is written to the page as plain HTML and hydrated only when the user interacts with the mini cart, this led to an incorrect state being shown where the setting was not respected.

In the case that the attribute is set to `never`, or `greater_than_zero` and product count is 0, the HTML for the badge will not be output in PHP.

If `always` or `greater_than_zero` and product count is >0 the HTML for the badge _will_ be output in PHP.

Also, PHP Unit tests have been added

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #52114

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the Mini-Cart block to your site (or find it in the site editor, usually in the header)
2. Select the Mini-Cart block in the editor and go to the `Show Cart Item Count:` setting
3. Set this to `Never`.
4. Ensure the preview on the editor updates, and the badge is hidden.
5. Load the block on the front end and ensure there is no count badge on the Mini-Cart block. Test this with an item in the cart, and no items in the cart. Ensure the badge never shows.
6. Go back to the Mini-Cart block in the editor and go to the `Show Cart Item Count:` setting
7. Set this to `Always (Even if empty)`.
8. Ensure the preview on the editor updates, and the badge is shown.
9. Load the block on the front end and ensure there is a count badge on the Mini-Cart block. Test this with an item in the cart, and no items in the cart. It should show 0 when the cart is empty, and the number of products when it is not. Ensure the number updates as you add/remove items from your cart.
10. Go back to the Mini-Cart block in the editor and go to the `Show Cart Item Count:` setting
11. Set this to `Only if cart has items`.
12. Ensure the preview on the editor updates, and the badge is shown.
13. Load the block on the front end and empty your cart. Ensure there is no count badge on the Mini-Cart block.
14. Add an item to your cart and ensure the count is shown.
15. Remove the item from your cart and ensure the count is no longer shown.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
