### PR TITLE
[Accessibility] Associate the shipping calculator button to its form in Cart page

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx
@@ -13,8 +13,10 @@ import { removeNoticesWithContext } from '@woocommerce/base-utils';
  */
 import ShippingCalculatorAddress from './address';
 import './style.scss';
+import { CalculatorButtonProps } from '../totals/shipping/calculator-button';
 
-interface ShippingCalculatorProps {
+interface ShippingCalculatorProps
+	extends Pick< CalculatorButtonProps, 'shippingCalculatorID' > {
 	onUpdate?: ( newAddress: ShippingAddress ) => void;
 	onCancel?: () => void;
 	addressFields?: Partial< keyof ShippingAddress >[];
@@ -28,11 +30,15 @@ const ShippingCalculator = ( {
 		/* Do nothing */
 	},
 	addressFields = [ 'country', 'state', 'city', 'postcode' ],
+	shippingCalculatorID,
 }: ShippingCalculatorProps ): JSX.Element => {
 	const { shippingAddress } = useCustomerData();
 	const noticeContext = 'wc/cart/shipping-calculator';
 	return (
-		<div className="wc-block-components-shipping-calculator">
+		<div
+			className="wc-block-components-shipping-calculator"
+			id={ shippingCalculatorID }
+		>
 			<StoreNoticesContainer context={ noticeContext } />
 			<ShippingCalculatorAddress
 				address={ shippingAddress }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/calculator-button.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/calculator-button.tsx
@@ -8,12 +8,14 @@ export interface CalculatorButtonProps {
 	label?: string;
 	isShippingCalculatorOpen: boolean;
 	setIsShippingCalculatorOpen: ( isShippingCalculatorOpen: boolean ) => void;
+	shippingCalculatorID: string;
 }
 
 export const CalculatorButton = ( {
 	label = __( 'Calculate', 'woocommerce' ),
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
+	shippingCalculatorID,
 }: CalculatorButtonProps ): JSX.Element => {
 	return (
 		<Button
@@ -26,6 +28,7 @@ export const CalculatorButton = ( {
 			} }
 			aria-label={ label }
 			aria-expanded={ isShippingCalculatorOpen }
+			aria-controls={ shippingCalculatorID }
 		>
 			{ label }
 		</Button>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -96,6 +96,7 @@ export const TotalsShipping = ( {
 		) : (
 			totalShippingValue
 		);
+	const shippingCalculatorID = 'shipping-calculator-form-wrapper';
 
 	return (
 		<div
@@ -121,6 +122,9 @@ export const TotalsShipping = ( {
 									setIsShippingCalculatorOpen={
 										setIsShippingCalculatorOpen
 									}
+									shippingCalculatorID={
+										shippingCalculatorID
+									}
 								/>
 						  )
 				}
@@ -141,6 +145,7 @@ export const TotalsShipping = ( {
 								setIsShippingCalculatorOpen={
 									setIsShippingCalculatorOpen
 								}
+								shippingCalculatorID={ shippingCalculatorID }
 							/>
 						</>
 					) : null
@@ -155,6 +160,7 @@ export const TotalsShipping = ( {
 					onCancel={ () => {
 						setIsShippingCalculatorOpen( false );
 					} }
+					shippingCalculatorID={ shippingCalculatorID }
 				/>
 			) }
 			{ showRateSelector &&

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -14,10 +14,13 @@ import { useSelect } from '@wordpress/data';
 import ShippingLocation from '../../shipping-location';
 import { CalculatorButton, CalculatorButtonProps } from './calculator-button';
 
-export interface ShippingAddressProps {
+export interface ShippingAddressProps
+	extends Pick<
+		CalculatorButtonProps,
+		'shippingCalculatorID' | 'setIsShippingCalculatorOpen'
+	> {
 	showCalculator: boolean;
 	isShippingCalculatorOpen: boolean;
-	setIsShippingCalculatorOpen: CalculatorButtonProps[ 'setIsShippingCalculatorOpen' ];
 	shippingAddress: ShippingAddressType;
 }
 
@@ -26,6 +29,7 @@ export const ShippingAddress = ( {
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
 	shippingAddress,
+	shippingCalculatorID,
 }: ShippingAddressProps ): JSX.Element | null => {
 	const prefersCollection = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).prefersCollection()
@@ -49,6 +53,7 @@ export const ShippingAddress = ( {
 					label={ label }
 					isShippingCalculatorOpen={ isShippingCalculatorOpen }
 					setIsShippingCalculatorOpen={ setIsShippingCalculatorOpen }
+					shippingCalculatorID={ shippingCalculatorID }
 				/>
 			) }
 		</>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-placeholder.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-placeholder.tsx
@@ -8,12 +8,15 @@ import { __ } from '@wordpress/i18n';
  */
 import { CalculatorButton, CalculatorButtonProps } from './calculator-button';
 
-export interface ShippingPlaceholderProps {
+export interface ShippingPlaceholderProps
+	extends Pick<
+		CalculatorButtonProps,
+		'setIsShippingCalculatorOpen' | 'shippingCalculatorID'
+	> {
 	showCalculator: boolean;
 	isShippingCalculatorOpen: boolean;
 	isCheckout?: boolean;
 	addressProvided: boolean;
-	setIsShippingCalculatorOpen: CalculatorButtonProps[ 'setIsShippingCalculatorOpen' ];
 }
 
 export const ShippingPlaceholder = ( {
@@ -22,6 +25,7 @@ export const ShippingPlaceholder = ( {
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
 	isCheckout = false,
+	shippingCalculatorID,
 }: ShippingPlaceholderProps ): JSX.Element => {
 	if ( ! showCalculator ) {
 		const label = addressProvided
@@ -44,6 +48,7 @@ export const ShippingPlaceholder = ( {
 			) }
 			isShippingCalculatorOpen={ isShippingCalculatorOpen }
 			setIsShippingCalculatorOpen={ setIsShippingCalculatorOpen }
+			shippingCalculatorID={ shippingCalculatorID }
 		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-placeholder.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-placeholder.tsx
@@ -8,6 +8,8 @@ import { screen, render } from '@testing-library/react';
  */
 import ShippingPlaceholder from '../shipping-placeholder';
 
+const shippingCalculatorID = 'shipping-calculator-form-wrapper';
+
 describe( 'ShippingPlaceholder', () => {
 	it( 'should show correct text if showCalculator is false and addressProvided is false', () => {
 		const { rerender } = render(
@@ -17,6 +19,7 @@ describe( 'ShippingPlaceholder', () => {
 				isCheckout={ true }
 				isShippingCalculatorOpen={ false }
 				setIsShippingCalculatorOpen={ jest.fn() }
+				shippingCalculatorID={ shippingCalculatorID }
 			/>
 		);
 		expect(
@@ -29,6 +32,7 @@ describe( 'ShippingPlaceholder', () => {
 				addressProvided={ false }
 				isShippingCalculatorOpen={ false }
 				setIsShippingCalculatorOpen={ jest.fn() }
+				shippingCalculatorID={ shippingCalculatorID }
 			/>
 		);
 		expect(
@@ -44,6 +48,7 @@ describe( 'ShippingPlaceholder', () => {
 				isCheckout={ true }
 				isShippingCalculatorOpen={ false }
 				setIsShippingCalculatorOpen={ jest.fn() }
+				shippingCalculatorID={ shippingCalculatorID }
 			/>
 		);
 		expect(

--- a/plugins/woocommerce/changelog/fix-51898
+++ b/plugins/woocommerce/changelog/fix-51898
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Associate shipping calculator button to its form via aria-expanded/controls attribute

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -268,8 +268,19 @@ jQuery( function ( $ ) {
 		/**
 		 * Toggle Shipping Calculator panel
 		 */
-		toggle_shipping: function () {
-			$( '.shipping-calculator-form' ).slideToggle( 'slow' );
+		toggle_shipping: function ( event ) {
+			var $target = $( event.currentTarget );
+
+			$( '.shipping-calculator-form' ).slideToggle( 'slow', function () {
+				var self = this;
+
+				setTimeout( function () {
+					var $form = $( self );
+
+					$target.attr( 'aria-expanded', $form.is( ':visible' ) ? 'true' : 'false' );
+				}, 0 );
+			} );
+			
 			$( 'select.country_to_state, input.country_to_state' ).trigger(
 				'change'
 			);

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -21,9 +21,9 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 <form class="woocommerce-shipping-calculator" action="<?php echo esc_url( wc_get_cart_url() ); ?>" method="post">
 
-	<?php printf( '<a href="#" class="shipping-calculator-button">%s</a>', esc_html( ! empty( $button_text ) ? $button_text : __( 'Calculate shipping', 'woocommerce' ) ) ); ?>
+	<?php printf( '<a href="#" class="shipping-calculator-button" aria-expanded="false" aria-controls="shipping-calculator-form" role="button">%s</a>', esc_html( ! empty( $button_text ) ? $button_text : __( 'Calculate shipping', 'woocommerce' ) ) ); ?>
 
-	<section class="shipping-calculator-form" style="display:none;">
+	<section class="shipping-calculator-form" id="shipping-calculator-form" style="display:none;">
 
 		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_country', true ) ) : ?>
 			<p class="form-row form-row-wide" id="calc_shipping_country_field">

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 9.5.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51898 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On admin, go to WooCommerce > Settings > Shipping > Shipping settings.
2. Check the "Enable the shipping calculator on the cart page" if it's not checked yet.
3. Go to WooCommerce > Settings > Shipping > Shipping zones.
4. Add a new zone.
5. On the Shipping zones page, add a free Shipping method.
6. On the frontend, add a product to the cart and go to the Cart page.
7. Turn on the screen reader.
8. On the Cart totals section, click on the "Change address" button.
![Screenshot 2024-10-17 at 18 02 13](https://github.com/user-attachments/assets/f310ccef-3a22-4d24-bcb9-edd2de46a405)
10. Verify that the screen reader announces whether the form is expanded or collapsed.
11. Turn off the screen reader.
12. Go back to the Shipping zones page on the admin and disable the Free Shipping method.
![image](https://github.com/user-attachments/assets/5008f338-ae65-40e7-bfc3-93c1e3fe229d)
13. Save the changes.
14. Go back to the Cart page.
15. Turn on the screen reader.
16. Perform the same tests as before, the only difference is that the button should read something like "Enter address to check delivery options".
![Screenshot 2024-10-17 at 18 06 50](https://github.com/user-attachments/assets/a9548e11-6ffd-4a5b-95db-1c294195fa3a)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
