### PR TITLE
Fix ExtendStore Task Not Marked as Completed Upon Navigating Back to Home

### DIFF
--- a/plugins/woocommerce/changelog/fix-extend-store-task-is-not-marked-completed
+++ b/plugins/woocommerce/changelog/fix-extend-store-task-is-not-marked-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Invalidate the task list completion when a task is clicked

--- a/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list-item.test.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/components/test/task-list-item.test.tsx
@@ -42,6 +42,7 @@ const mockDispatch = {
 	undoDismissTask: jest.fn(),
 	undoSnoozeTask: jest.fn(),
 	visitedTask: jest.fn(),
+	invalidateResolutionForStoreSelector: jest.fn(),
 };
 ( useDispatch as jest.Mock ).mockReturnValue( mockDispatch );
 

--- a/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/setup-task-list.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/setup-task-list.tsx
@@ -67,6 +67,7 @@ export const SetupTaskList: React.FC< TaskListProps > = ( {
 		hideTaskList,
 		visitedTask,
 		keepCompletedTaskList: keepCompletedTasks,
+		invalidateResolutionForStoreSelector,
 	} = useDispatch( ONBOARDING_STORE_NAME );
 	const userPreferences = useUserPreferences();
 	const [ headerData, setHeaderData ] = useState< {
@@ -182,13 +183,13 @@ export const SetupTaskList: React.FC< TaskListProps > = ( {
 	};
 
 	// @todo This would be better as a task endpoint that handles updating the count.
-	const updateTrackStartedCount = ( taskId: string ) => {
+	const updateTrackStartedCount = async ( taskId: string ) => {
 		const newCount = getTaskStartedCount( taskId ) + 1;
 		const trackedStartedTasks =
 			userPreferences.task_list_tracked_started_tasks || {};
 
 		visitedTask( taskId );
-		userPreferences.updateUserPreferences( {
+		await userPreferences.updateUserPreferences( {
 			task_list_tracked_started_tasks: {
 				...( trackedStartedTasks || {} ),
 				[ taskId ]: newCount,
@@ -196,7 +197,7 @@ export const SetupTaskList: React.FC< TaskListProps > = ( {
 		} );
 	};
 
-	const trackClick = ( task: TaskType ) => {
+	const trackClick = async ( task: TaskType ) => {
 		recordEvent( `${ listEventPrefix }click`, {
 			task_name: task.id,
 			context: layoutString,
@@ -205,13 +206,20 @@ export const SetupTaskList: React.FC< TaskListProps > = ( {
 					task.additionalData.wooPaymentsIncentiveId,
 			} ),
 		} );
+
+		if ( ! task.isComplete ) {
+			await updateTrackStartedCount( task.id );
+		}
 	};
 
 	const goToTask = ( task: TaskType ) => {
-		trackClick( task );
-		if ( ! task.isComplete ) {
-			updateTrackStartedCount( task.id );
-		}
+		trackClick( task ).then( () => {
+			if ( ! isComplete ) {
+				// Invalidate the task list selector cache to force a re-fetch.
+				// This ensures the task completion status is up-to-date after visiting a task.
+				invalidateResolutionForStoreSelector( 'getTaskLists' );
+			}
+		} );
 
 		if ( task.actionUrl ) {
 			navigateTo( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49221

This PR addresses the issue where the `ExtendStore` task in the task list does not reflect its completion status after visiting the "Enhance your store with extensions" task unless the Home page is fully reloaded. 

Originally, the fix proposed re-fetching the task list status when returning to the Home page to ensure an accurate task completion display. However, based on feedback, a better solution is to invalidate the task list completion status immediately when a task is navigated. 

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Navigate to `WooCommerce > Home.`
3. Click on the `Enhance your store with extensions` task
4. Click the Home link to return to the Home page.
5. Confirm that the ExtendStore task is now marked as completed without requiring a page reload.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
