### PR TITLE
Remove options to re-enable setup task list after completion

### DIFF
--- a/plugins/woocommerce/changelog/update-remove-reenable-setup-tasklist-option
+++ b/plugins/woocommerce/changelog/update-remove-reenable-setup-tasklist-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove re-eanble setup tasklist option

--- a/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/components/task-list-completed-header.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/components/task-list-completed-header.tsx
@@ -26,7 +26,6 @@ import HeaderImage from '../assets/completed-celebration-header.svg';
 
 type TaskListCompletedHeaderProps = {
 	hideTasks: () => void;
-	keepTasks: () => void;
 	customerEffortScore: boolean;
 };
 
@@ -47,7 +46,7 @@ function getStoreAgeInWeeks( adminInstallTimestamp: number ) {
 
 export const TaskListCompletedHeader: React.FC<
 	TaskListCompletedHeaderProps
-> = ( { hideTasks, keepTasks, customerEffortScore } ) => {
+> = ( { hideTasks, customerEffortScore } ) => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const [ showCesModal, setShowCesModal ] = useState( false );
 	const [ hasSubmittedScore, setHasSubmittedScore ] = useState( false );
@@ -190,14 +189,6 @@ export const TaskListCompletedHeader: React.FC<
 									) }
 									renderContent={ () => (
 										<div className="woocommerce-task-card__section-controls">
-											<Button
-												onClick={ () => keepTasks() }
-											>
-												{ __(
-													'Show setup task list',
-													'woocommerce'
-												) }
-											</Button>
 											<Button
 												onClick={ () => hideTasks() }
 											>

--- a/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/components/task-list-completed.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/components/task-list-completed.tsx
@@ -12,10 +12,8 @@ import HeaderImage from '../assets/task-list-completed.svg';
 
 export const TaskListCompleted = ( {
 	hideTasks,
-	keepTasks,
 }: {
 	hideTasks: () => void;
-	keepTasks: () => void;
 } ) => {
 	return (
 		<>
@@ -37,10 +35,7 @@ export const TaskListCompleted = ( {
 									'woocommerce'
 								) }
 							</h2>
-							<Button isSecondary onClick={ keepTasks }>
-								{ __( 'Keep list', 'woocommerce' ) }
-							</Button>
-							<Button isPrimary onClick={ hideTasks }>
+							<Button variant="primary" onClick={ hideTasks }>
 								{ __( 'Hide this list', 'woocommerce' ) }
 							</Button>
 						</div>

--- a/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/setup-task-list.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/setup-task-list.tsx
@@ -265,14 +265,10 @@ export const SetupTaskList: React.FC< TaskListProps > = ( {
 				{ cesHeader ? (
 					<TaskListCompletedHeader
 						hideTasks={ hideTasks }
-						keepTasks={ keepTasks }
 						customerEffortScore={ true }
 					/>
 				) : (
-					<TaskListCompleted
-						hideTasks={ hideTasks }
-						keepTasks={ keepTasks }
-					/>
+					<TaskListCompleted hideTasks={ hideTasks } />
 				) }
 			</>
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingHelper.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingHelper.php
@@ -83,12 +83,14 @@ class OnboardingHelper {
 			$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce' ) . '</p>' .
 				'<p><a href="' . wc_admin_url( '&path=/setup-wizard' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce' ) . '</a></p>';
 
-			$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce' ) . '</h3>';
-			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task lists, please click on the button below.', 'woocommerce' ) . '</p>' .
-			( $setup_list->is_hidden()
+			if ( ! $setup_list->has_previously_completed() ) {
+				$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce' ) . '</h3>';
+				$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task lists, please click on the button below.', 'woocommerce' ) . '</p>' .
+				( $setup_list->is_hidden()
 				? '<p><a href="' . wc_admin_url( '&reset_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce' ) . '</a></p>'
 				: '<p><a href="' . wc_admin_url( '&reset_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce' ) . '</a></p>'
-			);
+				);
+			}
 		}
 
 		if ( $extended_list ) {

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingHelper.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingHelper.php
@@ -83,7 +83,7 @@ class OnboardingHelper {
 			$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce' ) . '</p>' .
 				'<p><a href="' . wc_admin_url( '&path=/setup-wizard' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce' ) . '</a></p>';
 
-			if ( ! $setup_list->has_previously_completed() ) {
+			if ( ! $setup_list->is_complete() ) {
 				$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce' ) . '</h3>';
 				$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task lists, please click on the button below.', 'woocommerce' ) . '</p>' .
 				( $setup_list->is_hidden()


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49227

This PR addresses the misleading message `"Your store is ready for launch!" ` in the task list header when the setup task list is re-enabled after the store has been launched. To fix this issue, the re-enable options have been removed from both the Congrats menu and the Settings page when the task list is completed. (See https://github.com/woocommerce/woocommerce/issues/49227#issuecomment-2412674065).


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site.
2. Go to `WooCommerce > Home`
3. Complete the setup task list
4. Check that the "Show setup task list" option is no longer available in the Congrats menu.
5. Go to `/wp-admin/admin.php?page=wc-settings&tab=general` and click on `Help` menu > `Setup wizard`
6. Verify that the "Enable" button to re-enable the task list has been removed from the Settings page.

![Screenshot 2024-10-18 at 08 57 22](https://github.com/user-attachments/assets/93f9c027-2a65-4719-bea8-ac929aa7b0d0)
![Screenshot 2024-10-18 at 09 10 36](https://github.com/user-attachments/assets/ddf5e706-4c74-41e4-b900-39654eb31098)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
