### PR TITLE
Add tool to reset "Launch your store" and coming soon mode changes

### DIFF
--- a/plugins/woocommerce-beta-tester/api/api.php
+++ b/plugins/woocommerce-beta-tester/api/api.php
@@ -67,3 +67,4 @@ require 'remote-inbox-notifications/class-wca-test-helper-remote-inbox-notificat
 require 'remote-logging/remote-logging.php';
 require 'tools/wccom-request-errors.php';
 require 'tools/set-wccom-base-url.php';
+require 'tools/reset-launch-your-store.php';

--- a/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
@@ -1,0 +1,58 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+register_woocommerce_admin_test_helper_rest_route(
+	'/tools/reset-launch-your-store',
+	'tools_reset_launch_your_store'
+);
+
+/**
+ * Reset Launch Your Store settings.
+ *
+ * This function resets various options and settings related to the Launch Your Store feature.
+ * It is intended to be used during development or testing to reset the state of the feature.
+ *
+ * @return bool True if the reset was successful, false otherwise.
+ */
+function tools_reset_launch_your_store() {
+	global $wpdb;
+
+	// Reset site visibility settings.
+	delete_option( 'woocommerce_coming_soon' );
+	delete_option( 'woocommerce_store_pages_only' );
+	delete_option( 'woocommerce_private_link' );
+	delete_option( 'woocommerce_share_key' );
+
+	$result = ( new \Automattic\WooCommerce\Admin\API\LaunchYourStore() )->initialize_coming_soon();
+	if ( ! $result ) {
+		return new WP_Error( 'initialization_failed', 'Failed to initialize coming soon mode.' );
+	}
+
+	// Remove template changes.
+	$template = get_block_template( 'woocommerce/woocommerce//coming-soon', 'wp_template' );
+	if ( $template && isset( $template->wp_id ) ) {
+		$delete_result = wp_delete_post( $template->wp_id, true );
+		if ( false === $delete_result ) {
+			return new WP_Error( 'template_deletion_failed', 'Failed to delete the coming soon template.' );
+		}
+	}
+
+	// Reset survey completion state.
+	delete_option( 'woocommerce_admin_launch_your_store_survey_completed' );
+
+	// Reset essential task list completion tracking.
+	$tasks_completed = get_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task::COMPLETED_OPTION, array() );
+	$tasks_completed = array_filter(
+		$tasks_completed,
+		function( $task ) {
+			return 'launch-your-store' !== $task;
+		}
+	);
+	update_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task::COMPLETED_OPTION, $tasks_completed );
+
+	// Reset task list completion tracking.
+	delete_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList::COMPLETED_OPTION );
+
+	return true;
+}

--- a/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
@@ -54,8 +54,15 @@ function tools_reset_launch_your_store() {
 	);
 	update_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task::COMPLETED_OPTION, $tasks_completed );
 
-	// Reset task list completion tracking.
-	delete_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList::COMPLETED_OPTION );
+	// Reset setup task list completion tracking.
+	$task_lists_completed = get_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList::COMPLETED_OPTION, array() );
+	$task_lists_completed = array_filter(
+		$task_lists_completed,
+		function( $task_list ) {
+			return 'setup' !== $task_list;
+		}
+	);
+	update_option( \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList::COMPLETED_OPTION, $task_lists_completed );
 
 	return true;
 }

--- a/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
@@ -15,7 +15,6 @@ register_woocommerce_admin_test_helper_rest_route(
  * - Template changes
  * - Survey completion state
  * - Essential task list completion tracking
- * - Task list completion tracking
  *
  * @return bool True if the reset was successful, false otherwise.
  */

--- a/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-launch-your-store.php
@@ -10,8 +10,12 @@ register_woocommerce_admin_test_helper_rest_route(
 /**
  * Reset Launch Your Store settings.
  *
- * This function resets various options and settings related to the Launch Your Store feature.
- * It is intended to be used during development or testing to reset the state of the feature.
+ * This function resets the following:
+ * - Site visibility settings
+ * - Template changes
+ * - Survey completion state
+ * - Essential task list completion tracking
+ * - Task list completion tracking
  *
  * @return bool True if the reset was successful, false otherwise.
  */

--- a/plugins/woocommerce-beta-tester/changelog/add-reset-lys-tool
+++ b/plugins/woocommerce-beta-tester/changelog/add-reset-lys-tool
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tool to reset "Launch your store" and coming soon mode changes

--- a/plugins/woocommerce-beta-tester/src/tools/commands/index.js
+++ b/plugins/woocommerce-beta-tester/src/tools/commands/index.js
@@ -115,4 +115,9 @@ export default [
 		description: <SetWccomBaseUrl />,
 		action: UPDATE_WCCOM_BASE_URL_ACTION_NAME,
 	},
+	{
+		command: 'Reset Launch Your Store',
+		description: 'Resets Launch Your Store and coming soon mode changes.',
+		action: 'resetLaunchYourStore',
+	},
 ];

--- a/plugins/woocommerce-beta-tester/src/tools/data/actions.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/actions.js
@@ -317,3 +317,12 @@ export function* updateWccomBaseUrl( { url } ) {
 		} );
 	} );
 }
+
+export function* resetLaunchYourStore() {
+	yield runCommand( 'Reset Launch Your Store', function* () {
+		yield apiFetch( {
+			path: API_NAMESPACE + '/tools/reset-launch-your-store',
+			method: 'POST',
+		} );
+	} );
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49900

This PR adds a new tool to the WooCommerce Beta Tester plugin that allows developers and testers to reset the "Launch Your Store" feature and coming soon mode changes. This functionality is crucial for testing and development purposes, ensuring a clean slate for the Launch Your Store feature.

This new tool resets the following:

- Site visibility settings
- Template changes
- Survey completion state
- Essential task list completion tracking

<img width="1147" alt="Screenshot 2024-10-18 at 10 30 45" src="https://github.com/user-attachments/assets/3cd0bd77-4e47-4934-b4d7-a442f23a3c97">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally.
2. `cd to plugins/woocommerce-beta-tester` and run `pnpm run build:zip` to create a zip file.
3. Create a fresh site
4. Skip or complete the setup wizard
5. Customize the coming soon page
6. Launch the store
7. Complete the launch survey
8. GO to Go to wp-admin/tools.php?page=woocommerce-admin-test-helper > Tools
9. Click on the "Reset Launch Your Store" button
10. Verify that the site visibility settings, template changes, survey completion state, essential task list completion tracking, and other related options are reset.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
