### PR TITLE
Product Collection: Hide preview label when specific product is selected

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/utils.tsx
@@ -207,16 +207,16 @@ export const useProductCollectionUIState = ( {
 } ) => {
 	// Fetch product to check if it's deleted.
 	// `product` will be undefined if it doesn't exist.
-	const productId = attributes.query?.productReference;
+	const productReference = attributes.query?.productReference;
 	const { product, hasResolved } = useSelect(
 		( selectFunc ) => {
-			if ( ! productId ) {
+			if ( ! productReference ) {
 				return { product: null, hasResolved: true };
 			}
 
 			const { getEntityRecord, hasFinishedResolution } =
 				selectFunc( coreDataStore );
-			const selectorArgs = [ 'postType', 'product', productId ];
+			const selectorArgs = [ 'postType', 'product', productReference ];
 			return {
 				product: getEntityRecord( ...selectorArgs ),
 				hasResolved: hasFinishedResolution(
@@ -225,7 +225,7 @@ export const useProductCollectionUIState = ( {
 				),
 			};
 		},
-		[ productId ]
+		[ productReference ]
 	);
 
 	const productCollectionUIStateInEditor = useMemo( () => {
@@ -255,7 +255,7 @@ export const useProductCollectionUIState = ( {
 			isProductContextSelected
 		) {
 			const isProductDeleted =
-				productId &&
+				productReference &&
 				( product === undefined || product?.status === 'trash' );
 			if ( isProductDeleted ) {
 				return ProductCollectionUIStatesInEditor.DELETED_PRODUCT_REFERENCE;
@@ -282,7 +282,9 @@ export const useProductCollectionUIState = ( {
 
 			if (
 				! isArchiveLocationWithTermId &&
-				! isProductLocationWithProductId
+				! isProductLocationWithProductId &&
+				// If there's a user-selected product reference, don't show the preview label
+				! productReference
 			) {
 				return ProductCollectionUIStatesInEditor.VALID_WITH_PREVIEW;
 			}
@@ -302,7 +304,7 @@ export const useProductCollectionUIState = ( {
 		location.sourceData?.productId,
 		usesReference,
 		attributes.collection,
-		productId,
+		productReference,
 		product,
 		hasInnerBlocks,
 		attributes.query?.productReference,

--- a/plugins/woocommerce/changelog/52150-add-51601-product-collection-hide-preview-label-when-from-a-specific-product-is-selected
+++ b/plugins/woocommerce/changelog/52150-add-51601-product-collection-hide-preview-label-when-from-a-specific-product-is-selected
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Product Collection: Hide preview label when specific product is selected


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51601

This PR modifies the Product Collection block to hide the preview label when a specific product is selected by the user. It addresses the issue of the preview label still showing even when a product reference was available. Also, when a specific product is selected, products should change according to the selected product on Editor.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add a Product Collection block in Single Product template
2. Choose "Related Products" collection
3. Select "Related Products" collection and verify that the preview label is visible
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/f2b9bde4-9528-4e08-88f4-4364f5ff4fed">

4. Change "products to show" option from "From the current product" to "From a specific product"
5. Select a specific product
6. Verify that the preview label is hidden after product is selected
	- Sidenote: While verifying this, make sure that "Related Products" collection is selected, as preview label is only visible when collection is selected in list view.
7. Verify that Related Products for the selected product are displayed correctly in Editor.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Collection: Hide preview label when specific product is selected

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
