### PR TITLE
[Experimental] Refact Rating filter block for the new Product Filters block structure

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/edit.tsx
@@ -22,6 +22,7 @@ const TEMPLATE: InnerBlockTemplate[] = [
 	],
 	[ 'woocommerce/product-filter-active' ],
 	[ 'woocommerce/product-filter-price' ],
+	[ 'woocommerce/product-filter-rating' ],
 	[ 'woocommerce/product-filter-attribute' ],
 	[ 'woocommerce/product-filter-status' ],
 	[

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -26,7 +26,7 @@ import './editor.scss';
 import { EditProps } from './types';
 import { getColorClasses, getColorVars } from './utils';
 
-const Edit = ( props: EditProps ): JSX.Element => {
+const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 	const {
 		clientId,
 		context,
@@ -205,4 +205,4 @@ export default withColors( {
 	optionElementBorder: 'option-element-border',
 	optionElementSelected: 'option-element-border',
 	optionElement: 'option-element',
-} )( Edit );
+} )( CheckboxListEdit );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -30,7 +30,7 @@
 		},
 		"displayStyle": {
 			"type": "string",
-			"default": "woocommerce/product-filter-checkbox-list"
+			"default": "list"
 		},
 		"selectType": {
 			"type": "string",

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -30,7 +30,7 @@
 		},
 		"displayStyle": {
 			"type": "string",
-			"default": "list"
+			"default": "woocommerce/product-filter-checkbox-list"
 		},
 		"selectType": {
 			"type": "string",

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -7,7 +7,6 @@
 	"keywords": [],
 	"supports": {
 		"interactivity": true,
-		"inserter": false,
 		"color": {
 			"background": false,
 			"text": true

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -1,12 +1,10 @@
 {
 	"name": "woocommerce/product-filter-rating",
 	"version": "1.0.0",
-	"title": "Filter Options",
+	"title": "Rating (Experimental)",
 	"description": "Enable customers to filter the product collection by rating.",
 	"category": "woocommerce",
-	"keywords": [
-		"WooCommerce"
-	],
+	"keywords": [],
 	"supports": {
 		"interactivity": true,
 		"inserter": false,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -13,7 +13,7 @@
 		}
 	},
 	"ancestor": [
-		"woocommerce/product-filter"
+		"woocommerce/product-filters"
 	],
 	"usesContext": [
 		"query",

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/components/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/components/inspector.tsx
@@ -23,7 +23,7 @@ import { Attributes } from '../types';
 export const Inspector = ( {
 	attributes,
 	setAttributes,
-}: BlockEditProps< Attributes > ) => {
+}: Pick< BlockEditProps< Attributes >, 'attributes' | 'setAttributes' > ) => {
 	const { showCounts, displayStyle, selectType } = attributes;
 	return (
 		<InspectorControls key="inspector">

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -17,7 +17,7 @@ import {
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
 import { useState, useMemo, useEffect } from '@wordpress/element';
-import { Notice, withSpokenMessages } from '@wordpress/components';
+import { withSpokenMessages } from '@wordpress/components';
 import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
@@ -31,19 +31,9 @@ import { InitialDisabled } from '../../components/initial-disabled';
 import { PreviewDropdown } from '../components/preview-dropdown';
 import { getAllowedBlocks } from '../../utils';
 import { EXCLUDED_BLOCKS } from '../../constants';
-import './style.scss';
+import { Notice } from '../../components/notice';
 import type { Attributes } from './types';
-
-const NoRatings = () => (
-	<Notice status="warning" isDismissible={ false }>
-		<p>
-			{ __(
-				"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
-				'woocommerce'
-			) }
-		</p>
-	</Notice>
-);
+import './style.scss';
 
 const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { attributes, setAttributes } = props;
@@ -215,7 +205,14 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 
 			<div { ...innerBlocksProps }>
 				<InitialDisabled>
-					{ displayNoProductRatingsNotice && <NoRatings /> }
+					{ displayNoProductRatingsNotice && (
+						<Notice>
+							{ __(
+								"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
+								'woocommerce'
+							) }
+						</Notice>
+					) }
 					<div
 						className={ clsx( `style-${ displayStyle }`, {
 							'is-loading': isLoading,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -19,6 +19,7 @@ import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { Notice, withSpokenMessages } from '@wordpress/components';
 import type { BlockEditProps } from '@wordpress/blocks';
+import { productFilterRating as icon } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -95,9 +96,6 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 					{
 						lock: {
 							remove: true,
-						},
-						metadata: {
-							name: __( 'Stars', 'woocommerce' ),
 						},
 					},
 				],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -19,7 +19,6 @@ import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { Notice, withSpokenMessages } from '@wordpress/components';
 import type { BlockEditProps } from '@wordpress/blocks';
-import { productFilterRating as icon } from '@woocommerce/icons';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -44,8 +44,6 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 
 	const blockProps = useBlockProps();
 
-	const isEditor = true;
-
 	const setWrapperVisibility = useSetWraperVisibility();
 	const [ queryState ] = useQueryStateByContext();
 
@@ -53,7 +51,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 		useCollectionData( {
 			queryRating: true,
 			queryState,
-			isEditor,
+			isEditor: true,
 		} );
 
 	const [ displayedOptions, setDisplayedOptions ] = useState(

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -96,6 +96,9 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 						lock: {
 							remove: true,
 						},
+						metadata: {
+							name: __( 'Stars', 'woocommerce' ),
+						},
 					},
 				],
 			],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -42,6 +42,8 @@ const NoRatings = () => (
 const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { attributes, setAttributes } = props;
 
+	const { displayStyle, isPreview, showCounts, selectType } = attributes;
+
 	const blockProps = useBlockProps();
 
 	const setWrapperVisibility = useSetWraperVisibility();
@@ -55,15 +57,13 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 		} );
 
 	const [ displayedOptions, setDisplayedOptions ] = useState(
-		attributes.isPreview ? previewOptions : []
+		isPreview ? previewOptions : []
 	);
 
 	const isLoading =
-		! attributes.isPreview &&
-		filteredCountsLoading &&
-		displayedOptions.length === 0;
+		! isPreview && filteredCountsLoading && displayedOptions.length === 0;
 
-	const isDisabled = ! attributes.isPreview && filteredCountsLoading;
+	const isDisabled = ! isPreview && filteredCountsLoading;
 
 	const initialFilters = useMemo(
 		() => getActiveFilters( 'rating_filter' ),
@@ -91,7 +91,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 		 * @param {string} queryStatus The status slug to check.
 		 */
 
-		if ( filteredCountsLoading || attributes.isPreview ) {
+		if ( filteredCountsLoading || isPreview ) {
 			return;
 		}
 
@@ -119,7 +119,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 							key={ item?.rating }
 							rating={ item?.rating }
 							ratedProductsCount={
-								attributes.showCounts ? item?.count : null
+								showCounts ? item?.count : null
 							}
 						/>
 					),
@@ -129,8 +129,8 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 
 		setDisplayedOptions( newOptions );
 	}, [
-		attributes.showCounts,
-		attributes.isPreview,
+		showCounts,
+		isPreview,
 		filteredCounts,
 		filteredCountsLoading,
 		productRatingsQuery,
@@ -165,17 +165,14 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 				<Disabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }
 					<div
-						className={ clsx(
-							`style-${ attributes.displayStyle }`,
-							{
-								'is-loading': isLoading,
-							}
-						) }
+						className={ clsx( `style-${ displayStyle }`, {
+							'is-loading': isLoading,
+						} ) }
 					>
-						{ attributes.displayStyle === 'dropdown' ? (
+						{ displayStyle === 'dropdown' ? (
 							<PreviewDropdown
 								placeholder={
-									attributes.selectType === 'single'
+									selectType === 'single'
 										? __( 'Select a rating', 'woocommerce' )
 										: __( 'Select ratings', 'woocommerce' )
 								}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -39,7 +39,7 @@ const NoRatings = () => (
 	</Notice>
 );
 
-const Edit = ( props: BlockEditProps< Attributes > ) => {
+const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { attributes, setAttributes } = props;
 
 	const blockProps = useBlockProps();
@@ -198,4 +198,4 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	);
 };
 
-export default withSpokenMessages( Edit );
+export default withSpokenMessages( RatingFilterEdit );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useBlockProps } from '@wordpress/block-editor';
-import type { BlockEditProps } from '@wordpress/blocks';
 import Rating from '@woocommerce/base-components/product-rating';
 import {
 	useQueryStateByKey,
@@ -16,6 +15,7 @@ import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { CheckboxList } from '@woocommerce/blocks-components';
 import { Disabled, Notice, withSpokenMessages } from '@wordpress/components';
+import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -17,7 +17,7 @@ import {
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
 import { useState, useMemo, useEffect } from '@wordpress/element';
-import { Disabled, Notice, withSpokenMessages } from '@wordpress/components';
+import { Notice, withSpokenMessages } from '@wordpress/components';
 import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
@@ -27,11 +27,12 @@ import { previewOptions } from './preview';
 import { getActiveFilters } from './utils';
 import { useSetWraperVisibility } from '../../../filter-wrapper/context';
 import { Inspector } from './components/inspector';
+import { InitialDisabled } from '../../components/initial-disabled';
 import { PreviewDropdown } from '../components/preview-dropdown';
-import type { Attributes } from './types';
-import './style.scss';
 import { getAllowedBlocks } from '../../utils';
 import { EXCLUDED_BLOCKS } from '../../constants';
+import './style.scss';
+import type { Attributes } from './types';
 
 const NoRatings = () => (
 	<Notice status="warning" isDismissible={ false }>
@@ -213,7 +214,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 
 			<div { ...innerBlocksProps }>
-				<Disabled>
+				<InitialDisabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }
 					<div
 						className={ clsx( `style-${ displayStyle }`, {
@@ -241,7 +242,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 							</BlockContextProvider>
 						) }
 					</div>
-				</Disabled>
+				</InitialDisabled>
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -40,7 +40,7 @@ const NoRatings = () => (
 );
 
 const Edit = ( props: BlockEditProps< Attributes > ) => {
-	const blockAttributes = props.attributes;
+	const { attributes, setAttributes } = props;
 
 	const blockProps = useBlockProps();
 
@@ -57,15 +57,15 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 		} );
 
 	const [ displayedOptions, setDisplayedOptions ] = useState(
-		blockAttributes.isPreview ? previewOptions : []
+		attributes.isPreview ? previewOptions : []
 	);
 
 	const isLoading =
-		! blockAttributes.isPreview &&
+		! attributes.isPreview &&
 		filteredCountsLoading &&
 		displayedOptions.length === 0;
 
-	const isDisabled = ! blockAttributes.isPreview && filteredCountsLoading;
+	const isDisabled = ! attributes.isPreview && filteredCountsLoading;
 
 	const initialFilters = useMemo(
 		() => getActiveFilters( 'rating_filter' ),
@@ -93,7 +93,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 		 * @param {string} queryStatus The status slug to check.
 		 */
 
-		if ( filteredCountsLoading || blockAttributes.isPreview ) {
+		if ( filteredCountsLoading || attributes.isPreview ) {
 			return;
 		}
 
@@ -121,7 +121,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 							key={ item?.rating }
 							rating={ item?.rating }
 							ratedProductsCount={
-								blockAttributes.showCounts ? item?.count : null
+								attributes.showCounts ? item?.count : null
 							}
 						/>
 					),
@@ -131,8 +131,8 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 
 		setDisplayedOptions( newOptions );
 	}, [
-		blockAttributes.showCounts,
-		blockAttributes.isPreview,
+		attributes.showCounts,
+		attributes.isPreview,
 		filteredCounts,
 		filteredCountsLoading,
 		productRatingsQuery,
@@ -158,35 +158,30 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 
 	return (
 		<>
-			<Inspector { ...props } />
+			<Inspector
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
 
 			<div { ...blockProps }>
 				<Disabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }
 					<div
 						className={ clsx(
-							`style-${ blockAttributes.displayStyle }`,
+							`style-${ attributes.displayStyle }`,
 							{
 								'is-loading': isLoading,
 							}
 						) }
 					>
-						{ blockAttributes.displayStyle === 'dropdown' ? (
-							<>
-								<PreviewDropdown
-									placeholder={
-										blockAttributes.selectType === 'single'
-											? __(
-													'Select a rating',
-													'woocommerce'
-											  )
-											: __(
-													'Select ratings',
-													'woocommerce'
-											  )
-									}
-								/>
-							</>
+						{ attributes.displayStyle === 'dropdown' ? (
+							<PreviewDropdown
+								placeholder={
+									attributes.selectType === 'single'
+										? __( 'Select a rating', 'woocommerce' )
+										: __( 'Select ratings', 'woocommerce' )
+								}
+							/>
 						) : (
 							<CheckboxList
 								options={ displayedOptions }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -21,11 +21,11 @@ import { Disabled, Notice, withSpokenMessages } from '@wordpress/components';
  * Internal dependencies
  */
 import { previewOptions } from './preview';
-import { Attributes } from './types';
 import { getActiveFilters } from './utils';
 import { useSetWraperVisibility } from '../../../filter-wrapper/context';
 import { Inspector } from './components/inspector';
 import { PreviewDropdown } from '../components/preview-dropdown';
+import type { Attributes } from './types';
 import './style.scss';
 
 const NoRatings = () => (
@@ -83,7 +83,8 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 		useState( false );
 
 	/**
-	 * Compare intersection of all ratings and filtered counts to get a list of options to display.
+	 * Compare intersection of all ratings
+	 * and filtered counts to get a list of options to display.
 	 */
 	useEffect( () => {
 		/**
@@ -158,6 +159,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	return (
 		<>
 			<Inspector { ...props } />
+
 			<div { ...blockProps }>
 				<Disabled>
 					{ displayNoProductRatingsNotice && <NoRatings /> }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -91,7 +91,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 					],
 				],
 				[
-					displayStyle,
+					'woocommerce/product-filter-checkbox-list',
 					{
 						lock: {
 							remove: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -25,7 +25,6 @@ import type { BlockEditProps } from '@wordpress/blocks';
  */
 import { previewOptions } from './preview';
 import { getActiveFilters } from './utils';
-import { useSetWraperVisibility } from '../../../filter-wrapper/context';
 import { Inspector } from './components/inspector';
 import { PreviewDropdown } from '../components/preview-dropdown';
 import { getAllowedBlocks } from '../../utils';
@@ -91,7 +90,6 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 		}
 	);
 
-	const setWrapperVisibility = useSetWraperVisibility();
 	const [ queryState ] = useQueryStateByContext();
 
 	const { results: filteredCounts, isLoading: filteredCountsLoading } =
@@ -178,7 +176,6 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	] );
 
 	if ( ! filteredCountsLoading && displayedOptions.length === 0 ) {
-		setWrapperVisibility( false );
 		return null;
 	}
 
@@ -189,11 +186,8 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	);
 
 	if ( ! hasFilterableProducts ) {
-		setWrapperVisibility( false );
 		return null;
 	}
-
-	setWrapperVisibility( true );
 
 	return (
 		<>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -27,7 +27,6 @@ import { previewOptions } from './preview';
 import { getActiveFilters } from './utils';
 import { useSetWraperVisibility } from '../../../filter-wrapper/context';
 import { Inspector } from './components/inspector';
-import { InitialDisabled } from '../../components/initial-disabled';
 import { PreviewDropdown } from '../components/preview-dropdown';
 import { getAllowedBlocks } from '../../utils';
 import { EXCLUDED_BLOCKS } from '../../constants';
@@ -204,42 +203,40 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 
 			<div { ...innerBlocksProps }>
-				<InitialDisabled>
-					{ displayNoProductRatingsNotice && (
-						<Notice>
-							{ __(
-								"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
-								'woocommerce'
-							) }
-						</Notice>
-					) }
-					<div
-						className={ clsx( `style-${ displayStyle }`, {
-							'is-loading': isLoading,
-						} ) }
-					>
-						{ displayStyle === 'dropdown' ? (
-							<PreviewDropdown
-								placeholder={
-									selectType === 'single'
-										? __( 'Select a rating', 'woocommerce' )
-										: __( 'Select ratings', 'woocommerce' )
-								}
-							/>
-						) : (
-							<BlockContextProvider
-								value={ {
-									filterData: {
-										items: displayedOptions,
-										isLoading,
-									},
-								} }
-							>
-								{ children }
-							</BlockContextProvider>
+				{ displayNoProductRatingsNotice && (
+					<Notice>
+						{ __(
+							"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
+							'woocommerce'
 						) }
-					</div>
-				</InitialDisabled>
+					</Notice>
+				) }
+				<div
+					className={ clsx( `style-${ displayStyle }`, {
+						'is-loading': isLoading,
+					} ) }
+				>
+					{ displayStyle === 'dropdown' ? (
+						<PreviewDropdown
+							placeholder={
+								selectType === 'single'
+									? __( 'Select a rating', 'woocommerce' )
+									: __( 'Select ratings', 'woocommerce' )
+							}
+						/>
+					) : (
+						<BlockContextProvider
+							value={ {
+								filterData: {
+									items: displayedOptions,
+									isLoading,
+								},
+							} }
+						>
+							{ children }
+						</BlockContextProvider>
+					) }
+				</div>
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -116,9 +116,6 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 		initialFilters
 	);
 
-	const [ displayNoProductRatingsNotice, setDisplayNoProductRatingsNotice ] =
-		useState( false );
-
 	/**
 	 * Compare intersection of all ratings
 	 * and filtered counts to get a list of options to display.
@@ -143,7 +140,6 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 
 		if ( orderedRatings.length === 0 ) {
 			setDisplayedOptions( previewOptions );
-			setDisplayNoProductRatingsNotice( true );
 			return;
 		}
 
@@ -189,6 +185,8 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 		return null;
 	}
 
+	const showNoProductsNotice = ! filteredCountsLoading && ! filteredCounts;
+
 	return (
 		<>
 			<Inspector
@@ -197,7 +195,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 
 			<div { ...innerBlocksProps }>
-				{ displayNoProductRatingsNotice && (
+				{ showNoProductsNotice && (
 					<Notice>
 						{ __(
 							"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/frontend.ts
@@ -28,12 +28,13 @@ function getUrl( filters: Array< string | null > ) {
 }
 
 /**
- * Get the rating filters from the context
+ * Get the rating list (an array of strings)
+ * from the product filters context.
  *
  * @param {ProductFiltersContext} context The context
  * @return {Array} The rating filters
  */
-function getRatingFilters( context: ProductFiltersContext ) {
+function getRatingFilters( context: ProductFiltersContext ): Array< string > {
 	if ( ! context.params[ filterRatingKey ] ) {
 		return [];
 	}
@@ -81,6 +82,19 @@ store( 'woocommerce/product-filter-rating', {
 			const filters = items.map( ( i ) => i.value );
 
 			navigate( getUrl( filters ) );
+		},
+
+		clearFilters: () => {
+			const context = getContext< ProductFiltersContext >(
+				'woocommerce/product-filters'
+			);
+			const updatedParams = context.params;
+
+			delete updatedParams[ filterRatingKey ];
+
+			context.params = {
+				...updatedParams,
+			};
 		},
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/frontend.ts
@@ -72,17 +72,6 @@ store( 'woocommerce/product-filter-rating', {
 				[ filterRatingKey ]: updatedFiltersList.join( ',' ),
 			};
 		},
-		onDropdownChange: () => {
-			const dropdownContext = getContext< DropdownContext >(
-				'woocommerce/interactivity-dropdown'
-			);
-
-			const selectedItems = dropdownContext.selectedItems;
-			const items = selectedItems || [];
-			const filters = items.map( ( i ) => i.value );
-
-			navigate( getUrl( filters ) );
-		},
 
 		clearFilters: () => {
 			const context = getContext< ProductFiltersContext >(

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/frontend.ts
@@ -2,30 +2,13 @@
  * External dependencies
  */
 import { getContext, store, getElement } from '@woocommerce/interactivity';
-import { DropdownContext } from '@woocommerce/interactivity-components/dropdown';
 
 /**
  * Internal dependencies
  */
-import { navigate } from '../../frontend';
 import type { ProductFiltersContext } from '../../frontend';
 
 const filterRatingKey = 'rating_filter';
-
-function getUrl( filters: Array< string | null > ) {
-	filters = filters.filter( Boolean );
-	const url = new URL( window.location.href );
-
-	if ( filters.length ) {
-		// add filters to url
-		url.searchParams.set( 'rating_filter', filters.join( ',' ) );
-	} else {
-		// remove filters from url
-		url.searchParams.delete( 'rating_filter' );
-	}
-
-	return url.href;
-}
 
 /**
  * Get the rating list (an array of strings)

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/index.tsx
@@ -9,6 +9,7 @@ import { productFilterRating as icon } from '@woocommerce/icons';
  * Internal dependencies
  */
 import edit from './edit';
+import save from './save';
 import metadata from './block.json';
 
 if ( isExperimentalBlocksEnabled() ) {
@@ -18,5 +19,6 @@ if ( isExperimentalBlocksEnabled() ) {
 			...metadata.attributes,
 		},
 		edit,
+		save,
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
-import { productFilterOptions } from '@woocommerce/icons';
+import { productFilterRating as icon } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import metadata from './block.json';
 
 if ( isExperimentalBlocksEnabled() ) {
 	registerBlockType( metadata, {
-		icon: productFilterOptions,
+		icon,
 		attributes: {
 			...metadata.attributes,
 		},

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/save.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/save.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const Save = () => {
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <div { ...innerBlocksProps } />;
+};
+
+export default Save;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/types.ts
@@ -3,6 +3,5 @@ export interface Attributes {
 	displayStyle: string;
 	selectType: string;
 	showCounts: boolean;
-	showFilterButton: boolean;
 	isPreview?: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/utils.ts
@@ -4,11 +4,6 @@
 import { isString } from '@woocommerce/types';
 import { getUrlParameter } from '@woocommerce/utils';
 
-/**
- * Internal dependencies
- */
-import metadata from './block.json';
-
 export const getActiveFilters = ( queryParamKey = 'filter_rating' ) => {
 	const params = getUrlParameter( queryParamKey );
 
@@ -21,30 +16,4 @@ export const getActiveFilters = ( queryParamKey = 'filter_rating' ) => {
 		: ( params as string[] );
 
 	return parsedParams;
-};
-
-export function generateUniqueId() {
-	return Math.floor( Math.random() * Date.now() );
-}
-
-export const formatSlug = ( slug: string ) =>
-	slug
-		.trim()
-		.replace( /\s/g, '-' )
-		.replace( /_/g, '-' )
-		.replace( /-+/g, '-' )
-		.replace( /[^a-zA-Z0-9-]/g, '' );
-
-export const parseAttributes = ( data: Record< string, unknown > ) => {
-	return {
-		showFilterButton: data?.showFilterButton === 'true',
-		showCounts: data?.showCounts === 'true',
-		isPreview: false,
-		displayStyle:
-			( isString( data?.displayStyle ) && data.displayStyle ) ||
-			metadata.attributes.displayStyle.default,
-		selectType:
-			( isString( data?.selectType ) && data.selectType ) ||
-			metadata.attributes.selectType.default,
-	};
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/frontend.ts
@@ -6,7 +6,7 @@ import { getContext, getElement, store } from '@woocommerce/interactivity';
 /**
  * Internal dependencies
  */
-import { ProductFiltersContext } from '../../frontend';
+import type { ProductFiltersContext } from '../../frontend';
 
 const filterStockStatusKey = 'filter_stock_status';
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/edit.tsx
@@ -21,7 +21,7 @@ import {
  * Internal dependencies
  */
 import Block from './block';
-import { Attributes } from './types';
+import type { Attributes } from './types';
 import './editor.scss';
 
 const noRatingsNotice = (

--- a/plugins/woocommerce/changelog/update-woo-blocks-refact-rating-block
+++ b/plugins/woocommerce/changelog/update-woo-blocks-refact-rating-block
@@ -1,4 +1,3 @@
 Significance: patch
 Type: update
-
-Rating Filter block: refact block according to the new Product Filters block structure
+Comment: Rating Filter block: refact block according to the new Product Filters block structure

--- a/plugins/woocommerce/changelog/update-woo-blocks-refact-rating-block
+++ b/plugins/woocommerce/changelog/update-woo-blocks-refact-rating-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Rating Filter block: refact block according to the new Product Filters block structure

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -196,9 +196,9 @@ final class ProductFilterRating extends AbstractBlock {
 	/**
 	 * Get the Rating list items.
 	 *
-	 * @param array  $rating_counts          - The rating counts.
-	 * @param string $selected_ratings_query - The url query param for selected ratings.
-	 * @param bool   $show_counts            - Whether to show the counts.
+	 * @param array $rating_counts          - The rating counts.
+	 * @param mixed $selected_ratings_query - The url query param for selected ratings.
+	 * @param bool  $show_counts            - Whether to show the counts.
 	 * @return array
 	 */
 	private function get_rating_items( $rating_counts, $selected_ratings_query, $show_counts ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -122,7 +122,7 @@ final class ProductFilterRating extends AbstractBlock {
 		 * Get the rating items
 		 * based on the selected ratings and the rating counts.
 		 */
-		$items = $this->get_checkbox_list_items( $rating_counts, $selected_rating, $attributes['showCounts'] ?? false );
+		$items = $this->get_rating_items( $rating_counts, $selected_rating, $attributes['showCounts'] ?? false );
 
 		$filter_context = array(
 			'filterData' => array(
@@ -194,14 +194,14 @@ final class ProductFilterRating extends AbstractBlock {
 	}
 
 	/**
-	 * Get the checkbox list items.
+	 * Get the Rating list items.
 	 *
-	 * @param array  $rating_counts    The rating counts.
-	 * @param string $selected_ratings_query The url query param for selected ratings.
-	 * @param bool   $show_counts      Whether to show the counts.
+	 * @param array  $rating_counts          - The rating counts.
+	 * @param string $selected_ratings_query - The url query param for selected ratings.
+	 * @param bool   $show_counts            - Whether to show the counts.
 	 * @return array
 	 */
-	private function get_checkbox_list_items( $rating_counts, $selected_ratings_query, $show_counts ) {
+	private function get_rating_items( $rating_counts, $selected_ratings_query, $show_counts ) {
 		return array_map(
 			function( $rating ) use ( $selected_ratings_query, $show_counts ) {
 				$rating_str  = (string) $rating['rating'];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -293,6 +293,19 @@ final class ProductFilterRating extends AbstractBlock {
 		}
 
 		$counts = $filters->get_rating_counts( $query_vars );
+
+		/*
+		 * Sort the counts by rating value in descending order.
+		 * Todo: Consider to implement this consistently in the query.
+		 * @see https://github.com/woocommerce/woocommerce/pull/52152#issuecomment-2437598323
+		 */
+		uksort(
+			$counts,
+			function( $a, $b ) {
+				return $b - $a;
+			}
+		);
+
 		$data   = array();
 
 		foreach ( $counts as $key => $value ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\InteractivityComponents\CheckboxList;
-use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
 use Automattic\WooCommerce\Blocks\Utils\ProductCollectionUtils;
 use Automattic\WooCommerce\Blocks\QueryFilters;
 use Automattic\WooCommerce\Blocks\Package;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -133,8 +133,6 @@ final class ProductFilterRating extends AbstractBlock {
 			),
 			'hasSelectedFilters' => count( $selected_rating ) > 0,
 		);
-		$display_style  = $attributes['displayStyle'] ?? 'list';
-		$show_counts    = $attributes['showCounts'] ?? false;
 
 		$wrapper_attributes = array(
 			'data-wc-interactive'  => wp_json_encode( array( 'namespace' => $this->get_full_block_name() ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -195,29 +195,29 @@ final class ProductFilterRating extends AbstractBlock {
 	 * Get the Rating list items.
 	 *
 	 * @param array $rating_counts          - The rating counts.
-	 * @param mixed $selected_ratings_query - The url query param for selected ratings.
+	 * @param array $selected_ratings_query - The url query param for selected ratings.
 	 * @param bool  $show_counts            - Whether to show the counts.
 	 * @return array
 	 */
 	private function get_rating_items( $rating_counts, $selected_ratings_query, $show_counts ) {
 		return array_map(
 			function ( $rating ) use ( $selected_ratings_query, $show_counts ) {
-				$rating_str  = (string) $rating['rating'];
+				$rating      = (string) $rating['rating'];
 				$count       = $rating['count'];
 				$count_label = $show_counts ? "($count)" : '';
 
 				$aria_label = sprintf(
 					/* translators: %1$d is referring to rating value. Example: Rated 4 out of 5. */
 					__( 'Rated %s out of 5', 'woocommerce' ),
-					$rating_str,
+					$rating,
 				);
 
 				return array(
-					'id'         => 'rating-' . $rating_str,
-					'selected'   => in_array( $rating_str, $selected_ratings_query, true ),
-					'label'      => $this->render_rating_label( (int) $rating_str, $count_label ),
+					'id'         => 'rating-' . $rating,
+					'selected'   => in_array( $rating, $selected_ratings_query, true ),
+					'label'      => $this->render_rating_label( (int) $rating, $count_label ),
 					'aria_label' => $aria_label,
-					'value'      => $rating_str,
+					'value'      => $rating,
 				);
 			},
 			$rating_counts

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -194,33 +194,32 @@ final class ProductFilterRating extends AbstractBlock {
 	/**
 	 * Get the Rating list items.
 	 *
-	 * @param array $rating_counts          - The rating counts.
-	 * @param array $selected_ratings_query - The url query param for selected ratings.
-	 * @param bool  $show_counts            - Whether to show the counts.
-	 * @return array
+	 * @param array $ratings     - The rating counts.
+	 * @param array $selected    - an array of selected ratings.
+	 * @param bool  $with_counts - Whether to show the counts.
+	 * @return array The rating items.
 	 */
-	private function get_rating_items( $rating_counts, $selected_ratings_query, $show_counts ) {
+	private function get_rating_items( $ratings, $selected, $with_counts ) {
 		return array_map(
-			function ( $rating ) use ( $selected_ratings_query, $show_counts ) {
-				$rating      = (string) $rating['rating'];
-				$count       = $rating['count'];
-				$count_label = $show_counts ? "($count)" : '';
+			function ( $rating ) use ( $selected, $with_counts ) {
+				$value       = (string) $rating['rating'];
+				$count_label = $with_counts ? "({$rating['count']})" : '';
 
 				$aria_label = sprintf(
 					/* translators: %1$d is referring to rating value. Example: Rated 4 out of 5. */
 					__( 'Rated %s out of 5', 'woocommerce' ),
-					$rating,
+					$value,
 				);
 
 				return array(
-					'id'         => 'rating-' . $rating,
-					'selected'   => in_array( $rating, $selected_ratings_query, true ),
-					'label'      => $this->render_rating_label( (int) $rating, $count_label ),
+					'id'         => 'rating-' . $value,
+					'selected'   => in_array( $value, $selected, true ),
+					'label'      => $this->render_rating_label( (int) $value, $count_label ),
 					'aria_label' => $aria_label,
-					'value'      => $rating,
+					'value'      => $value,
 				);
 			},
-			$rating_counts
+			$ratings
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -290,20 +290,7 @@ final class ProductFilterRating extends AbstractBlock {
 		}
 
 		$counts = $filters->get_rating_counts( $query_vars );
-
-		/*
-		 * Sort the counts by rating value in descending order.
-		 * Todo: Consider to implement this consistently in the query.
-		 * @see https://github.com/woocommerce/woocommerce/pull/52152#issuecomment-2437598323
-		 */
-		uksort(
-			$counts,
-			function ( $a, $b ) {
-				return $b - $a;
-			}
-		);
-
-		$data = array();
+		$data   = array();
 
 		foreach ( $counts as $key => $value ) {
 			$data[] = array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -112,7 +112,7 @@ final class ProductFilterRating extends AbstractBlock {
 			return '';
 		}
 
-		$rating_counts   = $this->get_rating_counts( $block );
+		$rating_counts = $this->get_rating_counts( $block );
 
 		// Pick the selected ratings from the query string.
 		$query           = isset( $_GET[ self::RATING_FILTER_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::RATING_FILTER_QUERY_VAR ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -125,7 +125,7 @@ final class ProductFilterRating extends AbstractBlock {
 		$items = $this->get_rating_items( $rating_counts, $selected_rating, $attributes['showCounts'] ?? false );
 
 		$filter_context = array(
-			'filterData' => array(
+			'filterData'         => array(
 				'items'   => $items,
 				'actions' => array(
 					'toggleFilter' => "{$this->get_full_block_name()}::actions.toggleFilter",
@@ -141,7 +141,7 @@ final class ProductFilterRating extends AbstractBlock {
 			'data-wc-context'      => wp_json_encode(
 				array(
 					'hasSelectedFilters' => $filter_context['hasSelectedFilters'],
-					'hasFilterOptions'   => ! empty( $items),
+					'hasFilterOptions'   => ! empty( $items ),
 				),
 				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 			),
@@ -203,7 +203,7 @@ final class ProductFilterRating extends AbstractBlock {
 	 */
 	private function get_rating_items( $rating_counts, $selected_ratings_query, $show_counts ) {
 		return array_map(
-			function( $rating ) use ( $selected_ratings_query, $show_counts ) {
+			function ( $rating ) use ( $selected_ratings_query, $show_counts ) {
 				$rating_str  = (string) $rating['rating'];
 				$count       = $rating['count'];
 				$count_label = $show_counts ? "($count)" : '';
@@ -301,12 +301,12 @@ final class ProductFilterRating extends AbstractBlock {
 		 */
 		uksort(
 			$counts,
-			function( $a, $b ) {
+			function ( $a, $b ) {
 				return $b - $a;
 			}
 		);
 
-		$data   = array();
+		$data = array();
 
 		foreach ( $counts as $key => $value ) {
 			$data[] = array(

--- a/plugins/woocommerce/src/Blocks/QueryFilters.php
+++ b/plugins/woocommerce/src/Blocks/QueryFilters.php
@@ -148,7 +148,7 @@ final class QueryFilters {
 			WHERE product_id IN ( {$product_query_sql} )
 			AND average_rating > 0
 			GROUP BY rounded_average_rating
-			ORDER BY rounded_average_rating ASC
+			ORDER BY rounded_average_rating DESC
 		";
 
 		$results = $wpdb->get_results( $rating_count_sql ); // phpcs:ignore


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR updates the **Rating Filter** block to work correctly with the new structure of the **Products Filter**.

### Disclaimer

This RP does not handle the Dropdown mode of the filter. I suggest to table it in a follow-up PR

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51639

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' build` command to have experimental blocks available.
1. Add the **Product Filters (Experimental)** block to the Product Catalog template.
2. Save and go to the shop page.
4. Select some filters, see filter blocks react, and update the filter options accordingly.
5. Interact with the **Rating** filter slider, see the filter updated accordingly.

https://github.com/user-attachments/assets/5d42339a-130d-4274-b9ad-7953943a7d1d

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
