### PR TITLE
Store API: Normalize cart items on load to ensure quantity limits are respected

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/notify-quantity-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/notify-quantity-changes.ts
@@ -31,105 +31,6 @@ const isWithinQuantityLimits = ( cartItem: CartItem ) => {
 const stripAndDecode = ( text: string ) => {
 	return stripHTML( decodeEntities( text ) );
 };
-const notifyIfQuantityLimitsChanged = ( oldCart: Cart, newCart: Cart ) => {
-	newCart.items.forEach( ( cartItem ) => {
-		const oldCartItem = oldCart.items.find( ( item ) => {
-			return item && item.key === cartItem.key;
-		} );
-
-		// If getCartData has not finished resolving, then this is the first load.
-		const isFirstLoad = oldCart.items.length === 0;
-
-		// Item has been removed, we don't need to do any more checks.
-		if ( ! oldCartItem && ! isFirstLoad ) {
-			return;
-		}
-
-		if ( isWithinQuantityLimits( cartItem ) ) {
-			return;
-		}
-
-		const quantityAboveMax =
-			cartItem.quantity > cartItem.quantity_limits.maximum;
-		const quantityBelowMin =
-			cartItem.quantity < cartItem.quantity_limits.minimum;
-		const quantityOutOfStep =
-			cartItem.quantity % cartItem.quantity_limits.multiple_of !== 0;
-
-		// If the quantity is still within the constraints, then we don't need to show any notice, this is because
-		// QuantitySelector will not automatically update the value.
-		if ( ! quantityAboveMax && ! quantityBelowMin && ! quantityOutOfStep ) {
-			return;
-		}
-
-		if ( quantityOutOfStep ) {
-			dispatch( 'core/notices' ).createInfoNotice(
-				sprintf(
-					/* translators: %1$s is the name of the item, %2$d is the quantity of the item. %3$d is a number that the quantity must be a multiple of. */
-					__(
-						'The quantity of "%1$s" was changed to %2$d. You must purchase this product in groups of %3$d.',
-						'woocommerce'
-					),
-					stripAndDecode( cartItem.name ),
-					// We round down to the nearest step value here. We need to do it this way because at this point we
-					// don't know the next quantity. That only gets set once the HTML Input field applies its min/max
-					// constraints.
-					Math.floor(
-						cartItem.quantity / cartItem.quantity_limits.multiple_of
-					) * cartItem.quantity_limits.multiple_of,
-					cartItem.quantity_limits.multiple_of
-				),
-				{
-					context: 'wc/cart',
-					speak: true,
-					type: 'snackbar',
-					id: `${ cartItem.key }-quantity-update`,
-				}
-			);
-			return;
-		}
-
-		if ( quantityBelowMin ) {
-			dispatch( 'core/notices' ).createInfoNotice(
-				sprintf(
-					/* translators: %1$s is the name of the item, %2$d is the quantity of the item. */
-					__(
-						'The quantity of "%1$s" was increased to %2$d. This is the minimum required quantity.',
-						'woocommerce'
-					),
-					stripAndDecode( cartItem.name ),
-					cartItem.quantity_limits.minimum
-				),
-				{
-					context: 'wc/cart',
-					speak: true,
-					type: 'snackbar',
-					id: `${ cartItem.key }-quantity-update`,
-				}
-			);
-			return;
-		}
-
-		// Quantity is above max, so has been reduced.
-		dispatch( 'core/notices' ).createInfoNotice(
-			sprintf(
-				/* translators: %1$s is the name of the item, %2$d is the quantity of the item. */
-				__(
-					'The quantity of "%1$s" was decreased to %2$d. This is the maximum allowed quantity.',
-					'woocommerce'
-				),
-				stripAndDecode( cartItem.name ),
-				cartItem.quantity_limits.maximum
-			),
-			{
-				context: 'wc/cart',
-				speak: true,
-				type: 'snackbar',
-				id: `${ cartItem.key }-quantity-update`,
-			}
-		);
-	} );
-};
 
 const notifyIfQuantityChanged = (
 	oldCart: Cart,
@@ -230,6 +131,5 @@ export const notifyQuantityChanges = ( {
 		return;
 	}
 	notifyIfRemoved( oldCart, newCart, cartItemsPendingDelete );
-	notifyIfQuantityLimitsChanged( oldCart, newCart );
 	notifyIfQuantityChanged( oldCart, newCart, cartItemsPendingQuantity );
 };

--- a/plugins/woocommerce-blocks/assets/js/data/cart/test/notify-quantity-changes.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/test/notify-quantity-changes.ts
@@ -46,60 +46,6 @@ describe( 'notifyQuantityChanges', () => {
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
-	it( 'shows notices when the quantity limits of an item change', () => {
-		const { oldCart, newCart } = getFreshCarts();
-		newCart.items[ 0 ].quantity_limits.minimum = 50;
-		notifyQuantityChanges( {
-			oldCart,
-			newCart,
-			cartItemsPendingQuantity: [],
-		} );
-		expect( mockedCreateInfoNotice ).toHaveBeenLastCalledWith(
-			'The quantity of "Beanie" was increased to 50. This is the minimum required quantity.',
-			{
-				context: 'wc/cart',
-				speak: true,
-				type: 'snackbar',
-				id: '1-quantity-update',
-			}
-		);
-
-		newCart.items[ 0 ].quantity_limits.minimum = 1;
-		newCart.items[ 0 ].quantity_limits.maximum = 10;
-		// Quantity needs to be outside the limits for the notice to show.
-		newCart.items[ 0 ].quantity = 11;
-		notifyQuantityChanges( {
-			oldCart,
-			newCart,
-			cartItemsPendingQuantity: [],
-		} );
-		expect( mockedCreateInfoNotice ).toHaveBeenLastCalledWith(
-			'The quantity of "Beanie" was decreased to 10. This is the maximum allowed quantity.',
-			{
-				context: 'wc/cart',
-				speak: true,
-				type: 'snackbar',
-				id: '1-quantity-update',
-			}
-		);
-		newCart.items[ 0 ].quantity = 10;
-		oldCart.items[ 0 ].quantity = 10;
-		newCart.items[ 0 ].quantity_limits.multiple_of = 6;
-		notifyQuantityChanges( {
-			oldCart,
-			newCart,
-			cartItemsPendingQuantity: [],
-		} );
-		expect( mockedCreateInfoNotice ).toHaveBeenLastCalledWith(
-			'The quantity of "Beanie" was changed to 6. You must purchase this product in groups of 6.',
-			{
-				context: 'wc/cart',
-				speak: true,
-				type: 'snackbar',
-				id: '1-quantity-update',
-			}
-		);
-	} );
 	it( 'does not show notices if the quantity limit changes, and the quantity is within limits', () => {
 		const { oldCart, newCart } = getFreshCarts();
 		newCart.items[ 0 ].quantity = 5;

--- a/plugins/woocommerce/changelog/fix-52109-item-qty-normalization
+++ b/plugins/woocommerce/changelog/fix-52109-item-qty-normalization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Store API will ensure the cart response has valid quantities for items if setting limits via filters

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -1,5 +1,5 @@
 <?php
-
+declare( strict_types=1 );
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 use Automattic\WooCommerce\Blocks\Package;
@@ -177,6 +177,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 			);
 		}
 		$this->cart_controller->load_cart();
+		$this->cart_controller->normalize_cart();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -31,7 +31,11 @@ class CartItemSchema extends ItemSchema {
 	 * @return array
 	 */
 	public function get_item_response( $cart_item ) {
-		$product = $cart_item['data'];
+		$product = $cart_item['data'] ?? false;
+
+		if ( ! $product instanceof \WC_Product ) {
+			return [];
+		}
 
 		/**
 		 * Filter the product permalink.

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -226,7 +226,7 @@ class CartController {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', esc_html__( 'Cart item does not exist.', 'woocommerce' ), 409 );
 		}
 
-		$product = $cart_item['data'];
+		$product = $cart_item['data'] ?? false;
 
 		if ( ! $product instanceof \WC_Product ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_product', esc_html__( 'Cart item is invalid.', 'woocommerce' ), 404 );
@@ -643,7 +643,7 @@ class CartController {
 	 * @param array $cart_item Cart item array.
 	 */
 	public function validate_cart_item( $cart_item ) {
-		$product = $cart_item['data'];
+		$product = $cart_item['data'] ?? false;
 
 		if ( ! $product instanceof \WC_Product ) {
 			return;

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -39,6 +39,22 @@ class CartController {
 	}
 
 	/**
+	 * Normalizes the cart by fixing any quantity violations.
+	 */
+	public function normalize_cart() {
+		$quantity_limits = new QuantityLimits();
+		$cart_items      = $this->get_cart_items();
+
+		foreach ( $cart_items as $cart_item ) {
+			$normalized_qty = $quantity_limits->normalize_cart_item_quantity( $cart_item['quantity'], $cart_item );
+
+			if ( $normalized_qty !== $cart_item['quantity'] ) {
+				$this->set_cart_item_quantity( $cart_item['key'], $normalized_qty );
+			}
+		}
+	}
+
+	/**
 	 * Gets the latest cart instance, and ensures totals have been calculated before returning.
 	 *
 	 * @return \WC_Cart

--- a/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
@@ -83,7 +83,7 @@ final class QuantityLimits {
 	 * @return int
 	 */
 	public function normalize_cart_item_quantity( int $quantity, array $cart_item ) {
-		$product = $cart_item['data'];
+		$product = $cart_item['data'] ?? false;
 
 		if ( ! $product instanceof \WC_Product ) {
 			return $quantity;
@@ -132,7 +132,11 @@ final class QuantityLimits {
 	 */
 	public function validate_cart_item_quantity( $quantity, $cart_item ) {
 		$limits  = $this->get_cart_item_quantity_limits( $cart_item );
-		$product = $cart_item['data'];
+		$product = $cart_item['data'] ?? false;
+
+		if ( ! $product instanceof \WC_Product ) {
+			return true;
+		}
 
 		if ( ! $limits['editable'] ) {
 			/* translators: 1: product name */

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
@@ -12,6 +12,66 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 class CartControllerTests extends TestCase {
 	/**
+	 * Test the normalize_cart method.
+	 */
+	public function test_normalize_cart() {
+		$class    = new CartController();
+		$fixtures = new FixtureData();
+
+		$product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product 1',
+				'regular_price' => 10,
+			)
+		);
+
+		// Test maximum quantity after normalizing.
+		$product_key = wc()->cart->add_to_cart( $product->get_id(), 5 );
+		add_filter(
+			'woocommerce_store_api_product_quantity_maximum',
+			function ( $value, $product, $cart_item ) {
+				return 2;
+			},
+			10,
+			3
+		);
+		$class->normalize_cart();
+		$this->assertEquals( 2, wc()->cart->get_cart_item( $product_key )['quantity'] );
+		remove_all_filters( 'woocommerce_store_api_product_quantity_maximum' );
+		wc()->cart->empty_cart();
+
+		// Test minimum quantity after normalizing.
+		$product_key = wc()->cart->add_to_cart( $product->get_id(), 1 );
+		add_filter(
+			'woocommerce_store_api_product_quantity_minimum',
+			function ( $value, $product, $cart_item ) {
+				return 5;
+			},
+			10,
+			3
+		);
+		$class->normalize_cart();
+		$this->assertEquals( 5, wc()->cart->get_cart_item( $product_key )['quantity'] );
+		remove_all_filters( 'woocommerce_store_api_product_quantity_minimum' );
+		wc()->cart->empty_cart();
+
+		// Test multiple of after normalizing.
+		$product_key = wc()->cart->add_to_cart( $product->get_id(), 7 );
+		add_filter(
+			'woocommerce_store_api_product_quantity_multiple_of',
+			function ( $value, $product, $cart_item ) {
+				return 3;
+			},
+			10,
+			3
+		);
+		$class->normalize_cart();
+		$this->assertEquals( 6, wc()->cart->get_cart_item( $product_key )['quantity'] );
+		remove_all_filters( 'woocommerce_store_api_product_quantity_multiple_of' );
+		wc()->cart->empty_cart();
+	}
+
+	/**
 	 * Test cart error code is getting exposed.
 	 */
 	public function test_get_cart_errors() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
@@ -29,11 +29,10 @@ class CartControllerTests extends TestCase {
 		$product_key = wc()->cart->add_to_cart( $product->get_id(), 5 );
 		add_filter(
 			'woocommerce_store_api_product_quantity_maximum',
-			function ( $value, $product, $cart_item ) {
+			function () {
 				return 2;
 			},
-			10,
-			3
+			10
 		);
 		$class->normalize_cart();
 		$this->assertEquals( 2, wc()->cart->get_cart_item( $product_key )['quantity'] );
@@ -44,11 +43,10 @@ class CartControllerTests extends TestCase {
 		$product_key = wc()->cart->add_to_cart( $product->get_id(), 1 );
 		add_filter(
 			'woocommerce_store_api_product_quantity_minimum',
-			function ( $value, $product, $cart_item ) {
+			function () {
 				return 5;
 			},
-			10,
-			3
+			10
 		);
 		$class->normalize_cart();
 		$this->assertEquals( 5, wc()->cart->get_cart_item( $product_key )['quantity'] );
@@ -59,11 +57,10 @@ class CartControllerTests extends TestCase {
 		$product_key = wc()->cart->add_to_cart( $product->get_id(), 7 );
 		add_filter(
 			'woocommerce_store_api_product_quantity_multiple_of',
-			function ( $value, $product, $cart_item ) {
+			function () {
 				return 3;
 			},
-			10,
-			3
+			10
 		);
 		$class->normalize_cart();
 		$this->assertEquals( 6, wc()->cart->get_cart_item( $product_key )['quantity'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Quantity limits can be set using filters. Minimum, maximum, multiple. This was respected on add to cart endpoints, but not general cart responses and checkout.

This PR adds a normalisation method to ensure cart item quantities fit within the limits. Because this is done on the API side, `notifyIfQuantityLimitsChanged` is not needed because the client will only see valid amounts.

This is an alternative to allowing invalid amounts and surfacing errors in the cart for manual resolution.

Closes #52109

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Testers should check for regressions by going through the full add to cart, cart, checkout flow.

Developers can use snippets to test the normalization. 

1. Go to a single product page and add 6 of the same item to the cart.
2. Implement this snippet:

```php
add_filter( 'woocommerce_store_api_product_quantity_maximum', 'filter_max_cart_item_qty', 10, 3 );

function filter_max_cart_item_qty( $value, $product, $cart_item ) {
	return 2;
}
```

3. Visit the cart page
4. Item quantity will be reduced to 2

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
