### PR TITLE
Revert #51598

### DIFF
--- a/plugins/woocommerce/changelog/fix-41579
+++ b/plugins/woocommerce/changelog/fix-41579
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes possible TypeError in orders edit page where wrong parameter type is passed to `add_meta_boxes` action.

--- a/plugins/woocommerce/changelog/revert-51598-meta-box-hooks
+++ b/plugins/woocommerce/changelog/revert-51598-meta-box-hooks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: We are removing a change previously milestoned for 9.5.0 (as yet unreleased). Therefore, no changelog needed and the original changelog is removed as part of this PR.
+
+

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -160,6 +160,11 @@ class Edit {
 		 *
 		 * Fires after all built-in meta boxes have been added. Custom metaboxes may be enqueued here.
 		 *
+		 * Note that the documentation for this hook (and for the corresponding 'add_meta_boxes_<SCREEN_ID>' hook)
+		 * suggest that a post type will be supplied for the first parameter, and and an instance of WP_Post will be
+		 * supplied as the second parameter. We are not doing that here, however WordPress itself also deviates from
+		 * this in respect of comments and (though now less relevant) links.
+		 *
 		 * @since 3.8.0.
 		 */
 		do_action( 'add_meta_boxes', $this->screen_id, $this->order );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
-use WP_Post;
 
 /**
  * Class Edit.
@@ -156,37 +155,24 @@ class Edit {
 		$this->add_order_specific_meta_box();
 		$this->add_order_taxonomies_meta_box();
 
-		$order_post = get_post( $this->order->get_id() );
-
-		if ( $order_post instanceof WP_Post ) {
-			/**
-			 * From wp-admin/includes/meta-boxes.php.
-			 *
-			 * Fires after all built-in meta boxes have been added. Custom metaboxes may be enqueued here.
-			 *
-			 * @since 3.8.0.
-			 */
-			do_action( 'add_meta_boxes', $this->screen_id, $order_post );
-
-			/**
-			 * Provides an opportunity to inject custom meta boxes into the order editor screen. This
-			 * hook is an analog of `add_meta_boxes_<POST_TYPE>` as provided by WordPress core.
-			 *
-			 * @since 7.4.0
-			 *
-			 * @param WP_Post $order_post The order being edited.
-			 */
-			do_action( 'add_meta_boxes_' . $this->screen_id, $order_post );
-		}
+		/**
+		 * From wp-admin/includes/meta-boxes.php.
+		 *
+		 * Fires after all built-in meta boxes have been added. Custom metaboxes may be enqueued here.
+		 *
+		 * @since 3.8.0.
+		 */
+		do_action( 'add_meta_boxes', $this->screen_id, $this->order );
 
 		/**
-		 * Provides an opportunity to inject custom meta boxes into the order editor screen.
+		 * Provides an opportunity to inject custom meta boxes into the order editor screen. This
+		 * hook is an analog of `add_meta_boxes_<POST_TYPE>` as provided by WordPress core.
 		 *
-		 * @since 9.5.0
+		 * @since 7.4.0
 		 *
 		 * @param WC_Order $order The order being edited.
 		 */
-		do_action( 'woocommerce_order_editor_add_meta_boxes', $this->order );
+		do_action( 'add_meta_boxes_' . $this->screen_id, $this->order );
 
 		$this->enqueue_scripts();
 	}
@@ -194,7 +180,6 @@ class Edit {
 	/**
 	 * Set the current action for the form.
 	 *
-	 * @param string $action Action name.
 	 */
 	public function set_current_action( string $action ) {
 		$this->current_action = $action;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -180,6 +180,7 @@ class Edit {
 	/**
 	 * Set the current action for the form.
 	 *
+	 * @param string $action Action name.
 	 */
 	public function set_current_action( string $action ) {
 		$this->current_action = $action;


### PR DESCRIPTION
We are reverting #51598, which was milestoned for 9.5.0.

The reason for the revert is that, after some discussion, we decided the reasoning in https://github.com/woocommerce/woocommerce/issues/41579 was incorrect. WordPress Core *does* document the `add_meta_boxes` | `add_meta_boxes_<SCREEN_ID>` hooks as supply an instance of `WP_Post` but, in practice, it does not strictly adhere to this itself. For example, these same hooks are fired in relation to comments, and a `WP_Comment` rather than a `WP_Post` is supplied there.

Additionally, besides #41579 itself, there isn't much evidence of this presenting widespread problems since HPOS became the default order store.

Going forward, we recommend developers using these specific hooks avoid strict typing unless they have taken other appropriate measures to limit when their callbacks will be invoked.

**Testing**

This change restores how things worked before that earlier PR was merged. The code in question executes when the (HPOS) order editor is loaded, therefore please perform some testing in this area:

1. Ensure HPOS is enabled (it will be by default, if this is a new testing site).
2. Create some orders.
3. Edit some of those orders, ensure you can interact with the order editor as previously.