### PR TITLE
 Fix LYS Whats Next actions

### DIFF
--- a/plugins/woocommerce/changelog/fix-not-show-mailchimp-if-already-installed
+++ b/plugins/woocommerce/changelog/fix-not-show-mailchimp-if-already-installed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix lys whats next actions and add unit tests

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/WhatsNext.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/WhatsNext.tsx
@@ -56,7 +56,8 @@ export const getActionsList = ( {
 			{}
 		);
 
-	const isMarketingTaskCompleted = setupTasksCompletion?.marketing || false;
+	const isMarketingTaskCompleted =
+		extendedTasksCompletion?.marketing || false;
 	const isPaymentsTaskCompleted = setupTasksCompletion?.payments || false;
 	const isMobileTaskCompleted =
 		extendedTasksCompletion?.[ 'get-mobile-app' ] || false;

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/WhatsNext.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/WhatsNext.tsx
@@ -12,7 +12,7 @@ import type { TaskListType } from '@woocommerce/data';
  */
 import { ADMIN_URL } from '~/utils/admin-settings';
 
-type WhatsNextProps = {
+export type WhatsNextProps = {
 	activePlugins: string[];
 	allTasklists: TaskListType[];
 };
@@ -25,7 +25,10 @@ type Action = {
 	trackEvent: string;
 };
 
-const getActionsList = ( { activePlugins, allTasklists }: WhatsNextProps ) => {
+export const getActionsList = ( {
+	activePlugins,
+	allTasklists,
+}: WhatsNextProps ) => {
 	const actions: Action[] = [];
 	const pick = ( action: Action, condition: boolean ) => {
 		if ( actions.length < 3 && condition ) {
@@ -137,8 +140,8 @@ const getActionsList = ( { activePlugins, allTasklists }: WhatsNextProps ) => {
 	pick( extensions, true ); // No condition yet
 
 	// Pick second three
-	pick( mobileApp, isMobileTaskCompleted );
-	pick( mailchimp, true ); // No condition yet
+	pick( mobileApp, ! isMobileTaskCompleted );
+	pick( mailchimp, ! isMailChimpActivated );
 	pick( externalDocumentation, true ); // No condition yet
 
 	// Pick last three

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/test/WahtsNext.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/test/WahtsNext.tsx
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { getActionsList, WhatsNextProps } from '../WhatsNext';
-import { ADMIN_URL } from '~/utils/admin-settings';
 
 describe( 'getActionsList', () => {
 	const defaultProps: WhatsNextProps = {

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/test/WahtsNext.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/test/WahtsNext.tsx
@@ -1,0 +1,202 @@
+/**
+ * Internal dependencies
+ */
+import { getActionsList, WhatsNextProps } from '../WhatsNext';
+import { ADMIN_URL } from '~/utils/admin-settings';
+
+describe( 'getActionsList', () => {
+	const defaultProps: WhatsNextProps = {
+		allTasklists: [
+			{
+				id: 'setup',
+				title: 'Setup',
+				isHidden: false,
+				isVisible: true,
+				isComplete: false,
+				eventPrefix: 'tasklist_setup',
+				displayProgressHeader: true,
+				keepCompletedTaskList: 'yes',
+				tasks: [
+					{
+						id: 'marketing',
+						isComplete: false,
+						content: '',
+						parentId: 'setup',
+						isDismissable: false,
+						isDismissed: false,
+						time: '',
+						title: '',
+						actionLabel: '',
+						additionalInfo: '',
+						canView: true,
+						isActioned: false,
+						isDisabled: false,
+						isSnoozed: false,
+						isSnoozeable: false,
+						snoozedUntil: 0,
+						isVisible: true,
+						isVisited: false,
+						recordViewEvent: false,
+						eventPrefix: '',
+						level: 3,
+					},
+					{
+						id: 'payments',
+						isComplete: false,
+						content: '',
+						parentId: 'setup',
+						isDismissable: false,
+						isDismissed: false,
+						time: '',
+						title: '',
+						actionLabel: '',
+						additionalInfo: '',
+						canView: true,
+						isActioned: false,
+						isDisabled: false,
+						isSnoozed: false,
+						isSnoozeable: false,
+						snoozedUntil: 0,
+						isVisible: true,
+						isVisited: false,
+						recordViewEvent: false,
+						eventPrefix: '',
+						level: 3,
+					},
+				],
+			},
+		],
+		activePlugins: [],
+	};
+
+	it( 'should return 3 actions', () => {
+		const actions = getActionsList( defaultProps );
+		expect( actions ).toHaveLength( 3 );
+	} );
+
+	it( 'should include marketing, payment and extensions actions', () => {
+		const actions = getActionsList( defaultProps );
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { title: 'Promote your products' } )
+		);
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { title: 'Provide more ways to pay' } )
+		);
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { title: 'Power up your store' } )
+		);
+	} );
+
+	it( 'should not include marketing action when marketing task is completed', () => {
+		const props = {
+			...defaultProps,
+			allTasklists: [
+				{
+					id: 'setup',
+					tasks: [
+						{ id: 'marketing', isComplete: true },
+						{ id: 'payments', isComplete: false },
+					],
+				},
+			],
+		};
+		const actions = getActionsList( props as WhatsNextProps );
+		const marketingAction = actions.find(
+			( action ) => action.title === 'Promote your products'
+		);
+		expect( marketingAction ).toBeUndefined();
+	} );
+
+	it( 'should not include payments action when payments task is completed', () => {
+		const props = {
+			...defaultProps,
+			allTasklists: [
+				{
+					id: 'setup',
+					tasks: [
+						{ id: 'marketing', isComplete: true },
+						{ id: 'payments', isComplete: true },
+					],
+				},
+			],
+		};
+		const actions = getActionsList( props as WhatsNextProps );
+		const paymentsAction = actions.find(
+			( action ) => action.title === 'Provide more ways to pay'
+		);
+		expect( paymentsAction ).toBeUndefined();
+	} );
+
+	it( 'should include mobileApp, mailchimp actions when first three actions are completed', () => {
+		const props = {
+			...defaultProps,
+			allTasklists: [
+				{
+					id: 'setup',
+					tasks: [
+						{ id: 'marketing', isComplete: true },
+						{ id: 'payments', isComplete: true },
+					],
+				},
+			],
+		};
+		const actions = getActionsList( props as WhatsNextProps );
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { linkText: 'Get the app' } )
+		);
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { title: 'Build customer relationships' } )
+		);
+	} );
+
+	it( 'should not include Mailchimp action when Mailchimp is activated', () => {
+		const props = {
+			...defaultProps,
+			allTasklists: [
+				{
+					id: 'setup',
+					tasks: [
+						{ id: 'marketing', isComplete: true },
+						{ id: 'payments', isComplete: true },
+					],
+				},
+			],
+			activePlugins: [ 'mailchimp-for-woocommerce' ],
+		};
+		const actions = getActionsList( props as WhatsNextProps );
+		const mailchimpAction = actions.find(
+			( action ) => action.title === 'Build customer relationships'
+		);
+		expect( mailchimpAction ).toBeUndefined();
+	} );
+
+	it( 'should include payments, extensions and externalDocumentation actions', () => {
+		const props = {
+			...defaultProps,
+			allTasklists: [
+				{
+					id: 'setup',
+					tasks: [
+						{ id: 'marketing', isComplete: true },
+						{ id: 'payments', isComplete: true },
+					],
+				},
+				{
+					id: 'extended',
+					tasks: [ { id: 'get-mobile-app', isComplete: true } ],
+				},
+			],
+			activePlugins: [ 'mailchimp-for-woocommerce' ],
+		};
+		const actions = getActionsList( props as WhatsNextProps );
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { title: 'Provide more ways to pay' } )
+		);
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { title: 'Power up your store' } )
+		);
+		expect( actions ).toContainEqual(
+			expect.objectContaining( { linkText: 'Explore support resources' } )
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/test/WahtsNext.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/test/WahtsNext.tsx
@@ -17,7 +17,7 @@ describe( 'getActionsList', () => {
 				keepCompletedTaskList: 'yes',
 				tasks: [
 					{
-						id: 'marketing',
+						id: 'payments',
 						isComplete: false,
 						content: '',
 						parentId: 'setup',
@@ -39,11 +39,23 @@ describe( 'getActionsList', () => {
 						eventPrefix: '',
 						level: 3,
 					},
+				],
+			},
+			{
+				id: 'extended',
+				title: 'Extended',
+				isHidden: false,
+				isVisible: true,
+				isComplete: false,
+				eventPrefix: 'tasklist_extended',
+				displayProgressHeader: true,
+				keepCompletedTaskList: 'yes',
+				tasks: [
 					{
-						id: 'payments',
+						id: 'marketing',
 						isComplete: false,
 						content: '',
-						parentId: 'setup',
+						parentId: 'extended',
 						isDismissable: false,
 						isDismissed: false,
 						time: '',
@@ -92,10 +104,11 @@ describe( 'getActionsList', () => {
 			allTasklists: [
 				{
 					id: 'setup',
-					tasks: [
-						{ id: 'marketing', isComplete: true },
-						{ id: 'payments', isComplete: false },
-					],
+					tasks: [ { id: 'payments', isComplete: false } ],
+				},
+				{
+					id: 'extended',
+					tasks: [ { id: 'marketing', isComplete: true } ],
 				},
 			],
 		};
@@ -112,10 +125,11 @@ describe( 'getActionsList', () => {
 			allTasklists: [
 				{
 					id: 'setup',
-					tasks: [
-						{ id: 'marketing', isComplete: true },
-						{ id: 'payments', isComplete: true },
-					],
+					tasks: [ { id: 'payments', isComplete: true } ],
+				},
+				{
+					id: 'extended',
+					tasks: [ { id: 'marketing', isComplete: false } ],
 				},
 			],
 		};
@@ -132,10 +146,11 @@ describe( 'getActionsList', () => {
 			allTasklists: [
 				{
 					id: 'setup',
-					tasks: [
-						{ id: 'marketing', isComplete: true },
-						{ id: 'payments', isComplete: true },
-					],
+					tasks: [ { id: 'payments', isComplete: true } ],
+				},
+				{
+					id: 'extended',
+					tasks: [ { id: 'marketing', isComplete: true } ],
 				},
 			],
 		};
@@ -175,14 +190,14 @@ describe( 'getActionsList', () => {
 			allTasklists: [
 				{
 					id: 'setup',
-					tasks: [
-						{ id: 'marketing', isComplete: true },
-						{ id: 'payments', isComplete: true },
-					],
+					tasks: [ { id: 'payments', isComplete: true } ],
 				},
 				{
 					id: 'extended',
-					tasks: [ { id: 'get-mobile-app', isComplete: true } ],
+					tasks: [
+						{ id: 'marketing', isComplete: true },
+						{ id: 'get-mobile-app', isComplete: true },
+					],
 				},
 			],
 			activePlugins: [ 'mailchimp-for-woocommerce' ],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49225.

Currently, Mailchimp and Mobile App actions are shown even if the user already has completed actions. They should only be shown when the user doesn't complete the tasks/hasn't installed the plugins. (0BWMerqRR1f468EwC7g5tg-fi-925_15371)

Additionally, we've moved the marketing task to Next thing To Do task list but didn't update the logic to retrieve the task. This PR also fixes the logic to get the marketing task.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site.
2. Skip setup wizard.
3. Complete all setup tasks except for Launch your store.
4. Complete the marketing task.
5. Complete Launch your store, stay on the page and check if mobile app and mailchimp actions are shown.


<img width="940" alt="Screenshot 2024-10-21 at 16 09 58" src="https://github.com/user-attachments/assets/62ff5c97-28a5-4c41-bc8e-5e0740c1df93">

6. Open a new tab and install and activate [Mailchimp for WooCommerce](https://wordpress.org/plugins/mailchimp-for-woocommerce/).
7. Go to `WooCoomerce > Home` and complete the `Get the free WooCommerce mobile App` task.
8. Refresh the Launch your store success page and confirm that the mobile app and mailchimp actions are not shown.

<img width="946" alt="Screenshot 2024-10-21 at 16 11 10" src="https://github.com/user-attachments/assets/75021b27-fbf7-4e20-99e9-395ee63bc3b4">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>