### PR TITLE
Early translation mitigation

### DIFF
--- a/plugins/woocommerce/changelog/fix-early-translation-mitigation
+++ b/plugins/woocommerce/changelog/fix-early-translation-mitigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support situations in which (WooCommerce) translations are inadvertently loaded too early.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -871,7 +871,7 @@ final class WooCommerce {
 		 */
 		$locale = apply_filters( 'plugin_locale', $locale, 'woocommerce' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
-		unload_textdomain( 'woocommerce' );
+		unload_textdomain( 'woocommerce', true );
 		load_textdomain( 'woocommerce', WP_LANG_DIR . '/woocommerce/woocommerce-' . $locale . '.mo' );
 		load_plugin_textdomain( 'woocommerce', false, plugin_basename( dirname( WC_PLUGIN_FILE ) ) . '/i18n/languages' );
 	}


### PR DESCRIPTION
Under WordPress 6.7, we may encounter problems if translations are initialized prematurely. 

Most of these problems within WooCommerce Core have already been addressed (see [here](https://github.com/woocommerce/woocommerce/pull/52055) and [here](https://github.com/woocommerce/woocommerce/pull/47113)), but it is possible for other plugins to trigger this problem when interacting with WooCommerce, even if they are technically waiting until `init` before doing anything and even if they don't directly reference our textdomain. 

For example, consider this code (noting that this is a pretty common pattern that we've been actively recommending):

```php
use Automattic\WooCommerce\Utilities\FeaturesUtil;

add_action(
	'before_woocommerce_init',
	function () {
		if ( class_exists( FeaturesUtil::class ) ) {
			FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
		}
	}
);
```

This leads to the `FeaturesController` checking if the referenced feature exists. To do this, it must first build a list of known features, and it happens that the feature definitions contain [pieces of translatable text](https://github.com/woocommerce/woocommerce/blob/9.3.3/plugins/woocommerce/src/Internal/Features/FeaturesController.php#L168-L169), such as `'Analytics'`. That's sort of fine, except that *almost* immediately afterwards, WooCommerce [unloads its translations](https://github.com/woocommerce/woocommerce/blob/9.3.3/plugins/woocommerce/includes/class-woocommerce.php#L874) before loading them again.

💡 _When we unload our translations, we implicitly tell WordPress that they are not reloadable. That's because making them reloadable is a 'new' thing (introduced in WP 6.1) that wasn't possible when this code was first written._

Since WordPress has been told the translations should not be reloaded again ... they aren't. This change fixes that by making them reloadable. It's also the smallest/least intrusive change I could think of.

Final note. We seem to live in a world of many edge cases, so I guess a question that might arise is, what if making the translation just-in-time reloadable causes a problem of some kind for some deployments that we don't anticipate early enough? If so, I guess we could provide a custom snippet that effectively unwinds this PR:

<details>
<summary> Custom snippet to restore the previous behavior </summary>

```php
function unload_woocommerce_translations_make_non_reloadable( $value, $domain, $reloadable ) {
	if ( $domain === 'woocommerce' && $reloadable ) {
		remove_filter( 'override_unload_textdomain', 'unload_woocommerce_translations_make_non_reloadable' );
		unload_textdomain( 'woocommerce', false );
		return true;
	}

	return $value;
}

add_filter( 'override_unload_textdomain', 'unload_woocommerce_translations_make_non_reloadable', 10, 3 );
```

</details>

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a single file custom plugin as follows, give it a name like `test.php`:

```php
/**
 * Plugin name: Test
 * Description: Test translation issues.
 */

use Automattic\WooCommerce\Utilities\FeaturesUtil;

add_action(
	'before_woocommerce_init',
	function () {
		if ( class_exists( FeaturesUtil::class ) ) {
			FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
		}
	}
);
```

2. Start with WP 6.6.x. Install and activate Storefront for this test.
3. Install and activate a non-`en_US` translation. I recommend `fr_FR` or `de_DE` as pretty complete translations.
4. Ensure you see the translations take effect in **WooCommerce ‣ Settings ‣ General** and in the storefront.
5. Activate our test plugin. Confirm the above is still true.
6. Update to WP 6.7 Beta [(instructions here)](https://wordpress.org/news/2024/10/wordpress-6-7-beta-3/). Confirm the above is still true.
7. Deactivate our test plugin. Confirm the above is still true.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
