### PR TITLE
Change cache control to max-age=60 for coming soon pages

### DIFF
--- a/plugins/woocommerce/changelog/update-change-cache-control-to-60s-for-coming-soon-pages
+++ b/plugins/woocommerce/changelog/update-change-cache-control-to-60s-for-coming-soon-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update cache control header to 60s for coming soon pages

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -48,8 +48,8 @@ class ComingSoonRequestHandler {
 			return $template;
 		}
 
-		// A coming soon page needs to be displayed. Don't cache this response.
-		nocache_headers();
+		// A coming soon page needs to be displayed. Set a short cache duration to prevents ddos attacks.
+		header( 'Cache-Control: max-age=60' );
 
 		$is_fse_theme         = wc_current_theme_is_fse_theme();
 		$is_store_coming_soon = $this->coming_soon_helper->is_store_coming_soon();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/364.

Coming-soon pages are currently set with `Cache-Control: no-cache`, requiring the server to process every request. This makes these pages vulnerable to DDoS attacks since bad actors can repeatedly hit the endpoints and consume server resources.

This PR set `Cache-Control: max-age=60` for coming-soon pages. This allows CDNs or other caching mechanisms to cache the page for 60 seconds while maintaining reasonable update times. The downside is that the coming soon page may not be updated for 60 seconds, but these are relatively minor since:

- 60 seconds is a short cache duration
- Coming-soon pages aren't typically dynamic content
- The security benefit outweighs the slight delay in updates

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Skip Core Profiler
3. Visit front page in incognito mode
4. Verify the page response headers: Cache-Control header is set to `max-age=60` in browser dev tools

![Screenshot 2024-10-22 at 10 12 19](https://github.com/user-attachments/assets/ba208477-53b1-431e-b50e-887cb739345c)
![Screenshot 2024-10-22 at 10 12 01](https://github.com/user-attachments/assets/b2bf2e13-96f3-467c-8117-15e4eb31166c)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
