### PR TITLE
Fix mobile app modal UI

### DIFF
--- a/plugins/woocommerce/changelog/fix-mobile-app-modal-ui
+++ b/plugins/woocommerce/changelog/fix-mobile-app-modal-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix mobile app modal UI

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/index.tsx
@@ -115,7 +115,20 @@ export const MobileAppModal = () => {
 		state,
 		isRetryingMagicLinkSend,
 		magicLinkRequestStatus,
+		completeAppInstallationStep,
 	] );
+
+	const clearQueryString = useCallback( () => {
+		// clear the search params that we use so that the URL is clean
+		updateQueryString(
+			{
+				jetpackState: undefined,
+				mobileAppModal: undefined,
+			},
+			undefined,
+			Object.fromEntries( searchParams.entries() )
+		);
+	}, [ searchParams ] );
 
 	return (
 		<>
@@ -125,21 +138,19 @@ export const MobileAppModal = () => {
 						updateOptions( {
 							woocommerce_admin_dismissed_mobile_app_modal: 'yes',
 						} );
-						// clear the search params that we use so that the URL is clean
-						updateQueryString(
-							{
-								jetpackState: undefined,
-								mobileAppModal: undefined,
-							},
-							undefined,
-							Object.fromEntries( searchParams.entries() )
-						);
+						clearQueryString();
 					} }
 					className={ 'woocommerce__mobile-app-welcome-modal' }
 					pages={ [
 						{
 							content: (
-								<ModalIllustrationLayout body={ pageContent } />
+								<ModalIllustrationLayout
+									body={ pageContent }
+									onDismiss={ () => {
+										clearQueryString();
+										setGuideIsOpen( false );
+									} }
+								/>
 							),
 						},
 					] }

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/layouts/ModalIllustrationLayout.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/layouts/ModalIllustrationLayout.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button, Icon } from '@wordpress/components';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -10,8 +12,10 @@ import Illustration from '../illustrations/intro-devices-desktop.png';
 
 export const ModalIllustrationLayout = ( {
 	body,
+	onDismiss,
 }: {
 	body: React.ReactNode;
+	onDismiss: () => void;
 } ) => {
 	return (
 		<div className="mobile-app-modal-layout">
@@ -25,6 +29,15 @@ export const ModalIllustrationLayout = ( {
 					) }
 				/>
 			</div>
+			<Button
+				variant="tertiary"
+				className="woocommerce__mobile-app-welcome-modal__close-button"
+				label={ __( 'Close', 'woocommerce' ) }
+				icon={ <Icon icon={ closeSmall } viewBox="6 4 12 14" /> }
+				iconSize={ 16 }
+				size={ 16 }
+				onClick={ onDismiss }
+			></Button>
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
@@ -16,6 +16,11 @@
 	// Overrides the default modal max-height.
 	max-height: unset;
 
+	@media only screen and (max-width: $break-mobile) {
+		min-width: 100%;
+		max-height: 575px;
+	}
+
 	.components-modal__header {
 		height: 0;
 
@@ -35,6 +40,10 @@
 			grid-template-columns: 3fr 2fr;
 			min-height: 575px;
 
+			@media only screen and (max-width: $break-mobile) {
+				grid-template-columns: 1fr;
+			}
+
 			.mobile-app-modal-content {
 				display: flex;
 
@@ -47,10 +56,13 @@
 					.modal-layout-header {
 						.modal-header > h1 {
 							line-height: normal;
+							margin: 24px 0 0;
 						}
 					}
 					.modal-layout-body {
 						flex-grow: 1;
+						margin-bottom: 16px;
+
 						.modal-subheader {
 							margin-top: 16px;
 							margin-bottom: 24px;
@@ -58,6 +70,7 @@
 								font-weight: 400;
 								color: #757575;
 								line-height: 1.6rem;
+								margin: 0;
 							}
 						}
 					}
@@ -95,12 +108,16 @@
 				background-repeat: no-repeat;
 				background-image: url("data:image/svg+xml,%3Csvg width='341' height='421' viewBox='0 0 341 421' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M-258.536 396.856L-329.719 373.412C-338.484 370.525 -343.249 361.08 -340.362 352.315L-271.987 144.717C-269.1 135.952 -259.655 131.187 -250.89 134.074L-179.707 157.519C-69.5553 193.799 49.1512 133.914 85.431 23.7615L99.9575 -20.3434C102.844 -29.1081 112.29 -33.8731 121.054 -30.9864L328.652 37.3885C337.417 40.2752 342.182 49.7205 339.295 58.4852L324.769 102.59C244.953 344.925 -16.2016 476.672 -258.536 396.856Z' fill='%237F54B3'/%3E%3C/svg%3E");
 
-				padding-top: 36px;
+				padding-top: 74px;
 				overflow: clip;
 
 				img {
 					margin-right: -24px;
 					width: 100%;
+				}
+
+				@media only screen and (max-width: $break-mobile) {
+					display: none;
 				}
 			}
 		}
@@ -112,6 +129,25 @@
 
 	.fill-theme-color {
 		fill: var(--wp-admin-theme-color);
+	}
+
+	.components-button.woocommerce__mobile-app-welcome-modal__close-button {
+		width: 24px;
+		height: 24px;
+		min-width: 24px;
+		position: absolute;
+		right: 16px;
+		top: 16px;
+		margin: 0;
+		padding: 0;
+
+		svg {
+			fill: #fff;
+
+			@media only screen and (max-width: $break-mobile) {
+				fill: $gray-900;
+			}
+		}
 	}
 }
 .woo-icon {
@@ -280,3 +316,4 @@ button.components-button.send-magic-link-button {
 		}
 	}
 }
+

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/style.scss
@@ -18,7 +18,7 @@
 
 	@media only screen and (max-width: $break-mobile) {
 		min-width: 100%;
-		max-height: 575px;
+		max-height: 100%;
 	}
 
 	.components-modal__header {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49222.

This PR addresses the UI issues in the updated mobile app magic link modal, introduced in PR [#40613](https://github.com/woocommerce/woocommerce/pull/40613). The current modal presents some visual problems:

1. Insufficient padding between the "Sign into the app" text and icons.
2. The absence of the x close button in the top-right corner, which was part of the original design. (pbIJXs-2A7-p2)
3. It's not responsive on smaller screens, and the modal is not scrollable when the content exceeds the screen height.

| Before | After |
|--------|--------|
| <img alt="Screenshot 2024-07-08 at 16 28 28" src="https://github.com/woocommerce/woocommerce/assets/4344253/c5158b6c-3c22-42f4-8026-27c8cd46f561" /> | ![Screenshot 2024-10-22 at 11 20 57](https://github.com/user-attachments/assets/21abe36f-1493-4e36-8412-93520fe0e31c) |
| <img src="https://github.com/user-attachments/assets/839eafe5-9df9-46c8-afb6-1670629d1823" /> (non-scrollable) | ![Screenshot 2024-10-22 at 11 32 03](https://github.com/user-attachments/assets/2cbbdbcf-4877-4de1-be0f-12f420cadcbc)(scrollable) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh WooCommerce site.
2. Skip the Core Profiler.
3. Navigate to the “Get the free WooCommerce mobile app” task in the Things to do Next section.
4. Verify that:

- There is now adequate padding between the "Sign into the app" text and the icons.
- The x icon is visible in the top-right corner of the modal.
- The modal is responsive on smaller screens.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
