### PR TITLE
Fix "Finish setup" icon remains if tasks are disabled without being completed

### DIFF
--- a/plugins/woocommerce/changelog/fix-finish-setup-icon-display-logic
+++ b/plugins/woocommerce/changelog/fix-finish-setup-icon-display-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Finish setup" icon remains if tasks are disabled without being completed

--- a/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
@@ -180,7 +180,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const setupList = activeSetupList && getTaskList( activeSetupList );
 
-		const isSetupTaskListHidden = setupList?.isHidden ?? false;
+		const isSetupTaskListHidden = setupList ? setupList.isHidden : true; // If setupList is null, it means the setup task list is disabled.
 		const setupVisibleTasks = getVisibleTasks( setupList?.tasks || [] );
 		const extendedTaskList = getTaskList( 'extended' );
 
@@ -314,7 +314,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			},
 			visible: isAddProductPage(),
 		};
-
+		console.log( 'setupTaskListHidden', setupTaskListHidden );
 		const setup = {
 			name: 'setup',
 			title: __( 'Finish setup', 'woocommerce' ),

--- a/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
@@ -314,7 +314,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			},
 			visible: isAddProductPage(),
 		};
-		console.log( 'setupTaskListHidden', setupTaskListHidden );
+
 		const setup = {
 			name: 'setup',
 			title: __( 'Finish setup', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/34550.

If both the Task List and Extended task List are set to Disabled, the "Finish setup" icon should not be shown but a bug was causing it to be shown as we assumed that the Task List was enabled when `setupList` value was not set which is not correct.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new install with incomplete setup wizard tasks
2. On an admin settings page, click the "Finish setup" icon to see the unfinished tasks
3. Click the 'Help' dropdown below "Finish setup", then click on 'Setup wizard'
4. Disable both task lists: 
   - ![asdf](https://user-images.githubusercontent.com/19918755/187976665-aa3390d0-a1b5-42e6-8027-9c15ec843620.png)
5. Reload page
6. Confirm that the "Finish setup" icon is not shown

![Screenshot 2024-10-22 at 12 46 30](https://github.com/user-attachments/assets/c1341607-21be-498f-8887-d780c187cabf)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
