### PR TITLE
Fix OBW continue button overlaps with checkbox in mobile screens

### DIFF
--- a/plugins/woocommerce/changelog/fix-obw-continue-button-overlap
+++ b/plugins/woocommerce/changelog/fix-obw-continue-button-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix OBW continue button overlap with checkbox in mobile screens

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -33,12 +33,6 @@
 	.woocommerce-profiler-button-container {
 		width: 100%;
 		max-width: 404px;
-		@include breakpoint("<782px") {
-			position: absolute;
-			bottom: 20px;
-			padding: 0 20px;
-			max-width: 100%;
-		}
 	}
 
 	.woocommerce-profiler-button {
@@ -471,6 +465,7 @@
 	flex-direction: column;
 	.woocommerce-profiler-business-information__content {
 		max-width: 615px;
+		min-height: 750px;
 		width: 100%;
 		display: flex;
 		align-self: center;

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -465,7 +465,6 @@
 	flex-direction: column;
 	.woocommerce-profiler-business-information__content {
 		max-width: 615px;
-		min-height: 750px;
 		width: 100%;
 		display: flex;
 		align-self: center;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/47206.

OBW continue button overlaps with the checkbox in mobile view. This PR fixes the issue by removing the absolute positioning of the continue button in the mobile view. This leads to the continue button being placed below the checkbox in mobile view. 

This is a quick fix. It doesn't seem to match the original design (Y5pUYSJPsGEud1vknUZhi8-fi-141_20233), but it is consistent with other steps in OBW, so I implemented this way. If we want to change it to match the original design, we can do it for all steps in a separate PR.

Before

https://github.com/user-attachments/assets/eb945ffd-2503-444b-ad18-79aabd820ddb

After:

https://github.com/user-attachments/assets/4f471347-2fe8-415d-b95d-1a2fa50d4c5d


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- Go to Setup Wizard
- Open up developer console and set to responsive width around 481px - 520px
- Go to Tell us a bit about your store step
- Observe the continue button doesn't overlap with the checkbox

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>