### PR TITLE
Hide All Products from inserter (soft-deprecation)

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/block.json
@@ -6,7 +6,7 @@
 	"title": "Product Collection",
 	"description": "Display a collection of products from your store.",
 	"category": "woocommerce",
-	"keywords": [ "WooCommerce", "Products (Beta)", "products" ],
+	"keywords": [ "WooCommerce", "Products (Beta)", "all products" ],
 	"textdomain": "woocommerce",
 	"attributes": {
 		"queryId": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/products/all-products/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/products/all-products/block.json
@@ -15,7 +15,8 @@
 			"full"
 		],
 		"html": false,
-		"multiple": false
+		"multiple": false,
+		"inserter": false
 	},
 	"attributes": {
 		"columns": {

--- a/plugins/woocommerce/changelog/update-43410-hide-all-products
+++ b/plugins/woocommerce/changelog/update-43410-hide-all-products
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+All Products: hide from inserter (soft-deprecation)

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -17,7 +17,6 @@ const singleProductPrice = '555.00';
 // - Product Gallery (Beta) - it's not intended to be used in posts
 const blocks = [
 	'Active Filters',
-	'All Products',
 	'All Reviews',
 	'Best Selling Products',
 	'Customer account',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -80,8 +80,15 @@ test.describe(
 			await fillPageTitle( page, testPage.title );
 			await insertBlockByShortcut( page, 'Filter by Price' );
 			const wordPressVersion = await getInstalledWordPressVersion();
-			await insertBlock( page, 'All Products', wordPressVersion );
-			await publishPage( page, testPage.title );
+			await insertBlock( page, 'Product Collection', wordPressVersion );
+			// Choose default collection
+			await this.editor.canvas
+				.locator(
+					'[data-type="woocommerce/product-collection"] .components-placeholder'
+				)
+				.getByRole( 'button', { name: 'create your own', exact: true } )
+				.click();
+			await await publishPage( page, testPage.title );
 
 			// go to the page to test filtering products by price
 			await page.goto( testPage.slug );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -22,10 +22,12 @@ const test = baseTest.extend( {
 	testPageTitlePrefix: 'Products filter',
 } );
 
-const chooseCollectionInPage = async ( admin, editor ) => {
-	const placeholderSelector = editor.canvas.locator(
-		'[data-type="woocommerce/product-collection"] .components-placeholder'
-	);
+const chooseCollectionInPage = async ( page ) => {
+	const placeholderSelector = page
+		.frameLocator( 'iframe[name="editor-canvas"]' )
+		.locator(
+			'[data-type="woocommerce/product-collection"] .components-placeholder'
+		);
 
 	const chooseCollectionFromPlaceholder = async () => {
 		await placeholderSelector
@@ -40,7 +42,7 @@ const chooseCollectionInPage = async ( admin, editor ) => {
 			} )
 			.click();
 
-		await admin.page
+		await page
 			.locator(
 				'.wc-blocks-product-collection__collections-dropdown-content'
 			)
@@ -103,19 +105,26 @@ test.describe(
 		} );
 
 		test( 'filter products by prices on the created page', async ( {
-			admin,
-			editor,
 			page,
 			testPage,
 		} ) => {
-			const sortingProductsDropdown = '.wc-block-sort-select__select';
+			const productTitleSelector = 'h3.wp-block-post-title';
+			const product1 = page
+				.locator( productTitleSelector )
+				.filter( { hasText: `${ simpleProductName } 1` } );
+			const product2 = page
+				.locator( productTitleSelector )
+				.filter( { hasText: `${ simpleProductName } 2` } );
+			const product3 = page
+				.locator( productTitleSelector )
+				.filter( { hasText: `${ simpleProductName } 3` } );
 
 			await goToPageEditor( { page } );
 			await fillPageTitle( page, testPage.title );
 			await insertBlockByShortcut( page, 'Filter by Price' );
 			const wordPressVersion = await getInstalledWordPressVersion();
 			await insertBlock( page, 'Product Collection', wordPressVersion );
-			await chooseCollectionInPage( admin, editor );
+			await chooseCollectionInPage( page );
 			await publishPage( page, testPage.title );
 
 			// go to the page to test filtering products by price
@@ -144,12 +153,6 @@ test.describe(
 			await page
 				.getByRole( 'textbox', { name: 'Filter products by maximum' } )
 				.fill( '$50' );
-			// click and sort products to allow changes to take effect
-			await page.locator( sortingProductsDropdown ).click();
-			await page
-				.locator( sortingProductsDropdown )
-				.selectOption( 'Popularity' );
-			// to avoid flakiness
 			await page
 				.getByRole( 'textbox', {
 					name: 'Filter products by maximum price',
@@ -161,32 +164,14 @@ test.describe(
 					// initial (pre-request) render.
 				} );
 
-			await expect(
-				page
-					.locator( 'h2.wc-block-grid__product-title' )
-					.filter( { hasText: `${ simpleProductName } 1` } )
-			).toBeVisible();
-			await expect(
-				page
-					.locator( 'h2.wc-block-grid__product-title' )
-					.filter( { hasText: `${ simpleProductName } 2` } )
-			).toBeVisible();
-			await expect(
-				page
-					.locator( 'h2.wc-block-grid__product-title' )
-					.filter( { hasText: `${ simpleProductName } 3` } )
-			).toBeHidden();
+			await expect( product1 ).toBeVisible();
+			await expect( product2 ).toBeVisible();
+			await expect( product3 ).toBeHidden();
 
 			// filter by between $100 and $200 and verify the results
 			await page
 				.getByRole( 'textbox', { name: 'Filter products by maximum' } )
 				.fill( '$200' );
-			// click and sort products to allow changes to take effect
-			await page.locator( sortingProductsDropdown ).click();
-			await page
-				.locator( sortingProductsDropdown )
-				.selectOption( 'Default sorting' );
-			// to avoid flakiness
 			await page
 				.getByRole( 'textbox', {
 					name: 'Filter products by maximum price',
@@ -200,12 +185,6 @@ test.describe(
 			await page
 				.getByRole( 'textbox', { name: 'Filter products by minimum' } )
 				.fill( '$100' );
-			// click and sort products to allow changes to take effect
-			await page.locator( sortingProductsDropdown ).click();
-			await page
-				.locator( sortingProductsDropdown )
-				.selectOption( 'Latest' );
-			// to avoid flakiness
 			await page
 				.getByRole( 'textbox', {
 					name: 'Filter products by maximum price',
@@ -217,21 +196,9 @@ test.describe(
 					// initial (pre-request) render.
 				} );
 
-			await expect(
-				page
-					.locator( 'h2.wc-block-grid__product-title' )
-					.filter( { hasText: `${ simpleProductName } 1` } )
-			).toBeHidden();
-			await expect(
-				page
-					.locator( 'h2.wc-block-grid__product-title' )
-					.filter( { hasText: `${ simpleProductName } 2` } )
-			).toBeHidden();
-			await expect(
-				page
-					.locator( 'h2.wc-block-grid__product-title' )
-					.filter( { hasText: `${ simpleProductName } 3` } )
-			).toBeVisible();
+			await expect( product1 ).toBeHidden();
+			await expect( product2 ).toBeHidden();
+			await expect( product3 ).toBeVisible();
 		} );
 	}
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -22,6 +22,38 @@ const test = baseTest.extend( {
 	testPageTitlePrefix: 'Products filter',
 } );
 
+const chooseCollectionInPage = async ( admin, editor ) => {
+	const placeholderSelector = editor.canvas.locator(
+		'[data-type="woocommerce/product-collection"] .components-placeholder'
+	);
+
+	const chooseCollectionFromPlaceholder = async () => {
+		await placeholderSelector
+			.getByRole( 'button', { name: 'create your own', exact: true } )
+			.click();
+	};
+
+	const chooseCollectionFromDropdown = async () => {
+		await placeholderSelector
+			.getByRole( 'button', {
+				name: 'Choose collection',
+			} )
+			.click();
+
+		await admin.page
+			.locator(
+				'.wc-blocks-product-collection__collections-dropdown-content'
+			)
+			.getByRole( 'button', { name: 'create your own', exact: true } )
+			.click();
+	};
+
+	return await Promise.any( [
+		chooseCollectionFromPlaceholder(),
+		chooseCollectionFromDropdown(),
+	] );
+};
+
 test.describe(
 	'Filter items in the shop by product price',
 	{
@@ -71,6 +103,8 @@ test.describe(
 		} );
 
 		test( 'filter products by prices on the created page', async ( {
+			admin,
+			editor,
 			page,
 			testPage,
 		} ) => {
@@ -81,14 +115,8 @@ test.describe(
 			await insertBlockByShortcut( page, 'Filter by Price' );
 			const wordPressVersion = await getInstalledWordPressVersion();
 			await insertBlock( page, 'Product Collection', wordPressVersion );
-			// Choose default collection
-			await this.editor.canvas
-				.locator(
-					'[data-type="woocommerce/product-collection"] .components-placeholder'
-				)
-				.getByRole( 'button', { name: 'create your own', exact: true } )
-				.click();
-			await await publishPage( page, testPage.title );
+			await chooseCollectionInPage( admin, editor );
+			await publishPage( page, testPage.title );
 
 			// go to the page to test filtering products by price
 			await page.goto( testPage.slug );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/43410

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### All Products is not available in the inserter

1. Create new post
2. Try to insert "All Products"
3. Expected:
    - All Products blocks is not available in the inserter
    - Product Collection is suggested instead (most likely it won't be the first block but should be available to insert)

<img width="421" alt="image" src="https://github.com/user-attachments/assets/6c17eba3-ce42-43c2-b480-266334478e97">

### Previously added All Products block work just fine

1. Use the last public version of WooCommerce (or checkout to `trunk` if you test locally)
2. Create new post
3. Add All Products block and save the post
4. Switch to this version of WooCommerce (or checkout to `update/43410-hide-all-products` branch if you test locally)
5. Visit the post
6. Expected:
    - All Products is correctly displayed in Editor
    - All Products is correctly displayed in the frontend

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
