### PR TITLE
[Experimental] Attribute Filter: Respect Show Empty settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-attribute-filter-respect-hide-empty-settings
+++ b/plugins/woocommerce/changelog/fix-attribute-filter-respect-hide-empty-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Experimental: Respect empty filter options setting in the Attribute filter block.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -174,13 +174,23 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		$product_attribute = wc_get_attribute( $block_attributes['attributeId'] );
 		$attribute_counts  = $this->get_attribute_counts( $block, $product_attribute->slug, $block_attributes['queryType'] );
+		$hide_empty        = $block_attributes['hideEmpty'] ?? true;
 
-		$attribute_terms = get_terms(
-			array(
-				'taxonomy' => $product_attribute->slug,
-				'include'  => array_keys( $attribute_counts ),
-			)
-		);
+		if ( $hide_empty ) {
+			$attribute_terms = get_terms(
+				array(
+					'taxonomy' => $product_attribute->slug,
+					'include'  => array_keys( $attribute_counts ),
+				)
+			);
+		} else {
+			$attribute_terms = get_terms(
+				array(
+					'taxonomy'   => $product_attribute->slug,
+					'hide_empty' => false,
+				)
+			);
+		}
 
 		$selected_terms = array_filter(
 			explode(
@@ -207,19 +217,8 @@ final class ProductFilterAttribute extends AbstractBlock {
 				$attribute_terms
 			);
 
-			$filtered_options = array_filter(
-				$attribute_options,
-				function ( $option ) use ( $block_attributes ) {
-					$hide_empty = $block_attributes['hideEmpty'] ?? true;
-					if ( $hide_empty ) {
-						return $option['rawData']['count'] > 0;
-					}
-					return true;
-				}
-			);
-
 			$filter_context = array(
-				'items'   => $filtered_options,
+				'items'   => $attribute_options,
 				'actions' => array(
 					'toggleFilter' => "{$this->get_full_block_name()}::actions.toggleFilter",
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the issue of the Attribute Filter block that doesn't show empty options when the corresponding setting is enabled.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
1. Add a new attribute term without assigning any product to it.
2. Add the Product Filters block to the Product Catalog template.
4. Select the Attribute block, and change it to the matching attribute that has the term added in step 1.
5. Enable Styles > Empty filter options.
6. See the term added in step 1 appear.
7. Enable Product Counts.
8. See the count of new term shows zero.
9. Save and see the same option on the front end.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
