### PR TITLE
Add "Manual (menu order)" sorting option to Product Collection block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
@@ -60,7 +60,7 @@ const orderOptions = [
 	{
 		// In WooCommerce, "Manual (menu order)" refers to a custom ordering set by the store owner.
 		// Products can be manually arranged in the desired order in the WooCommerce admin panel.
-		value: 'menu_order/desc',
+		value: 'menu_order/asc',
 		label: __( 'Manual (menu order)', 'woocommerce' ),
 	},
 ];

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control.tsx
@@ -57,6 +57,12 @@ const orderOptions = [
 		value: 'rating/desc',
 		label: __( 'Top Rated', 'woocommerce' ),
 	},
+	{
+		// In WooCommerce, "Manual (menu order)" refers to a custom ordering set by the store owner.
+		// Products can be manually arranged in the desired order in the WooCommerce admin panel.
+		value: 'menu_order/desc',
+		label: __( 'Manual (menu order)', 'woocommerce' ),
+	},
 ];
 
 const OrderByControl = ( props: QueryControlProps ) => {

--- a/plugins/woocommerce/changelog/52221-add-49529-product-collection-manual-sorting-option
+++ b/plugins/woocommerce/changelog/52221-add-49529-product-collection-manual-sorting-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Collection: Add "Manual (menu order)" sorting option

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -53,7 +53,7 @@ class ProductCollection extends AbstractBlock {
 	 *
 	 * @var array
 	 */
-	protected $custom_order_opts = array( 'popularity', 'rating', 'post__in', 'price', 'sales' );
+	protected $custom_order_opts = array( 'popularity', 'rating', 'post__in', 'price', 'sales', 'menu_order' );
 
 
 	/**
@@ -1066,6 +1066,13 @@ class ProductCollection extends AbstractBlock {
 			return array(
 				'isProductCollection' => true,
 				'orderby'             => $orderby,
+			);
+		}
+
+		if ( 'menu_order' === $orderby ) {
+			return array(
+				'orderby' => 'menu_order',
+				'order'   => 'DESC',
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -1072,7 +1072,7 @@ class ProductCollection extends AbstractBlock {
 		if ( 'menu_order' === $orderby ) {
 			return array(
 				'orderby' => 'menu_order',
-				'order'   => 'DESC',
+				'order'   => 'ASC',
 			);
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductCollection.php
@@ -1278,4 +1278,17 @@ class ProductCollection extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wc_product_meta_lookup.total_sales DESC', $query->request );
 	}
+
+	/**
+	 * Test the menu_order sorting functionality.
+	 */
+	public function test_menu_order_sorting() {
+		$parsed_block                              = $this->get_base_parsed_block();
+		$parsed_block['attrs']['query']['orderBy'] = 'menu_order';
+		$parsed_block['attrs']['query']['order']   = 'asc';
+		$merged_query                              = $this->initialize_merged_query( $parsed_block );
+
+		$this->assertEquals( 'menu_order', $merged_query['orderby'] );
+		$this->assertEquals( 'ASC', $merged_query['order'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #49529

This PR introduces a new "Manual (menu order)" sorting option for the Product Collection block, enhancing user control over product display order within collections. 

The menu order is a built-in WooCommerce feature that assigns a custom ordering value to each product. This value can be easily set and modified in the WooCommerce admin panel in Product > All Products by dragging and dropping the products in the Products list table. Alternatively, You can set the menu order when editing a product in the admin panel.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->
**Prerequisite:**
Set the menu order for a few products in the Products list table in the WooCommerce admin panel.
- You can use Products > All Products > Sorting tab to drag and drop the products to set the menu order as shown in the screenshot below:
![image](https://github.com/user-attachments/assets/a95b1f20-7538-4f50-832a-db9eb5571d59)

- Alternatively, you can set the menu order when editing a product as shown in the screenshot below:
![image](https://github.com/user-attachments/assets/344f8848-3e9c-47da-b60c-9521f136c75a)

**Steps:**

1. Create a new post and add a Product Collection block.
2. Click on "create your own" button.
3. In inspector controls, verify that the "Manual (menu order)" sorting option is available in "Order By" dropdown.
4. Select the "Manual (menu order)" option and verify that the products are sorted based on the menu order on Editor side.
	- Sidenote: Products will be sorted in ascending order. Means, the product with the lowest menu order value will be displayed first. This is similar to how the Products list table is sorted in the WooCommerce admin panel.
5. Publish the post and verify that the products are sorted based on the menu order on the frontend.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Collection: Add "Manual (menu order)" sorting option
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
