### PR TITLE
Fix block theming doc links

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -1452,7 +1452,7 @@
         {
           "post_title": "Template structure & Overriding templates via a theme",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/template-structure.md",
-          "hash": "a82d885c8395385dc51c976b2b51eec88cdcce72bf905fda78f97d77533ce079",
+          "hash": "8bb4925cfc5ca1f9d8839675fafbf1941d6a23ae257827cead075bd4956b80bc",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/template-structure.md",
           "id": "34bfebec9fc45e680976814928a7b8a1778af14e"
         },
@@ -1461,7 +1461,7 @@
           "menu_title": "Set up and use a child theme",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/set-up-a-child-theme.md",
-          "hash": "b362d5ddd34d8b81f6a2ee2369dd2cd68e51700836a85f96d629e87d564b0844",
+          "hash": "e343a623970fb22db7e109e0623d877ba42d5938885dde99a5701fa42bf7d197",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/set-up-a-child-theme.md",
           "id": "00b6916595cbde7766f080260a9ea26f53f3271c"
         },
@@ -1470,7 +1470,7 @@
           "menu_title": "Image sizing",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/image-sizes.md",
-          "hash": "9883e7931ff8bd56dcd707974fe8ec992f21148818206aec354b0368dc999239",
+          "hash": "94d30b875d0c26b88ebd040a686f802f974f89997a30954fc5bb448de57aefdc",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/image-sizes.md",
           "id": "3f5301ac3040d38bc449b440733da6a466209df3",
           "links": {
@@ -1805,5 +1805,5 @@
       "categories": []
     }
   ],
-  "hash": "c018c42bc44d2921bec1ad8bae379066e257f0c5bf3293657b927c8060e756c7"
+  "hash": "c09b2c5235000d3821c3f4390f0c5aaf21308dcf1bd2b3bcbe0dbe8be5edb461"
 }

--- a/docs/theme-development/image-sizes.md
+++ b/docs/theme-development/image-sizes.md
@@ -4,7 +4,7 @@ menu_title: Image sizing
 tags: reference
 ---
 
-**Note:** this document was created for use when developing classic themes (as opposed to block themes). Check this other document for [block theme development](../../plugins/woocommerce-blocks/docs/designers/theming/README.md).
+**Note:** this document was created for use when developing classic themes (as opposed to block themes). Check this other document for [block theme development](/docs/block-theme-development/theming-woo-blocks.md).
 
 To display images in your catalog, WooCommerce registers a few image sizes which define the actual image dimensions to be used. These sizes include:
 

--- a/docs/theme-development/set-up-a-child-theme.md
+++ b/docs/theme-development/set-up-a-child-theme.md
@@ -4,7 +4,7 @@ menu_title: Set up and use a child theme
 tags: how-to
 ---
 
-**Note:** This document is intended for creating and using classic child themes. For a comprehensive guide on creating a child block theme and understanding the differences between a classic and block theme, please refer to [WooCommerce block theme development](../../plugins/woocommerce-blocks/docs/designers/theming/README.md) and [WordPress block child theme development](https://learn.wordpress.org/lesson-plan/create-a-basic-child-theme-for-block-themes/).
+**Note:** This document is intended for creating and using classic child themes. For a comprehensive guide on creating a child block theme and understanding the differences between a classic and block theme, please refer to [WooCommerce block theme development](/docs/block-theme-development/theming-woo-blocks.md) and [WordPress block child theme development](https://learn.wordpress.org/lesson-plan/create-a-basic-child-theme-for-block-themes/).
 
 
 Sometimes, you might need to customize your theme or WooCommerce beyond what is possible via the options. These guidelines will teach you the basics of how to go about customizing your site by using a child theme.

--- a/docs/theme-development/template-structure.md
+++ b/docs/theme-development/template-structure.md
@@ -4,7 +4,7 @@ post_title: Template structure & Overriding templates via a theme
 
 ---
 
-**NOTE** This document makes reference to classic themes which use PHP templates. If you are working on a block theme with HTML templates, [please check the Theming docs for block themes](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/designers/theming/README.md).
+**NOTE** This document makes reference to classic themes which use PHP templates. If you are working on a block theme with HTML templates, [please check the Theming docs for block themes](/docs/block-theme-development/theming-woo-blocks.md).
 Overview
 
 ---

--- a/plugins/woocommerce-blocks/docs/README.md
+++ b/plugins/woocommerce-blocks/docs/README.md
@@ -111,7 +111,7 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 
 > The following document explains how to to create block themes that work in WooCommerce and how to customize the styles of WooCommerce blocks.
 
--   [Theming](designers/theming/README.md)
+-   [Theming](/docs/block-theme-development/theming-woo-blocks.md)
 
 ## Block References
 

--- a/plugins/woocommerce/changelog/fix-theming-docs-links
+++ b/plugins/woocommerce/changelog/fix-theming-docs-links
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix some broken links in the theming documentation
+
+

--- a/plugins/woocommerce/templates/templates/blockified/README.md
+++ b/plugins/woocommerce/templates/templates/blockified/README.md
@@ -1,3 +1,3 @@
 # Blockified templates
 
-This folder contains the blockified versions of the WooCommerce block templates. You can read more about overriding these templates in the [_Theming_ docs for block themes](../../../../woocommerce-blocks/docs/designers/theming/README.md#block-templates).
+This folder contains the blockified versions of the WooCommerce block templates. You can read more about overriding these templates in the [_Theming_ docs for block themes](/docs/block-theme-development/theming-woo-blocks.md#block-templates).


### PR DESCRIPTION
It looks like we had some broken links in our theme documentation. This PR fixes them.

### How to test the changes in this Pull Request:

_(No need to test when testing the release)_

1. Go through each modified file and verify the new link works.