### PR TITLE
Fix Upsells and Cross-Sells selection changes depending on block position

### DIFF
--- a/plugins/woocommerce/changelog/fix-52170_upsells_selection_changes_depending_on_block_position
+++ b/plugins/woocommerce/changelog/fix-52170_upsells_selection_changes_depending_on_block_position
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix Upsells and Cross-Sells selection changes depending on block position #52235

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -189,7 +189,7 @@ class ProductQuery extends AbstractBlock {
 				'query_loop_block_query_vars',
 				array( $this, 'build_query' ),
 				10,
-				1
+				2
 			);
 		}
 
@@ -239,11 +239,13 @@ class ProductQuery extends AbstractBlock {
 	 * Return a custom query based on attributes, filters and global WP_Query.
 	 *
 	 * @param WP_Query $query The WordPress Query.
+	 * @param WP_Block $block The block being rendered.
 	 * @return array
 	 */
-	public function build_query( $query ) {
-		$parsed_block = $this->parsed_block;
-		if ( ! $this->is_woocommerce_variation( $parsed_block ) ) {
+	public function build_query( $query, $block ) {
+		$parsed_block                = $this->parsed_block;
+		$is_product_collection_block = $block->context['query']['isProductCollectionBlock'] ?? false;
+		if ( ! $this->is_woocommerce_variation( $parsed_block ) || $is_product_collection_block ) {
 			return $query;
 		}
 
@@ -514,7 +516,6 @@ class ProductQuery extends AbstractBlock {
 			'attributes_filter_query_args' => $attributes_filter_query_args,
 			'rating_filter_query_args'     => array( RatingFilter::RATING_QUERY_VAR ),
 		);
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductQuery.php
@@ -242,7 +242,7 @@ class ProductQuery extends AbstractBlock {
 	 * @param WP_Block $block The block being rendered.
 	 * @return array
 	 */
-	public function build_query( $query, $block ) {
+	public function build_query( $query, $block = null ) {
 		$parsed_block                = $this->parsed_block;
 		$is_product_collection_block = $block->context['query']['isProductCollectionBlock'] ?? false;
 		if ( ! $this->is_woocommerce_variation( $parsed_block ) || $is_product_collection_block ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
@@ -41,7 +41,6 @@ class RelatedProducts extends AbstractBlock {
 			10,
 			2
 		);
-
 	}
 
 	/**
@@ -79,7 +78,7 @@ class RelatedProducts extends AbstractBlock {
 				'query_loop_block_query_vars',
 				array( $this, 'build_query' ),
 				10,
-				1
+				2
 			);
 		}
 
@@ -90,11 +89,13 @@ class RelatedProducts extends AbstractBlock {
 	 * Return a custom query based on attributes, filters and global WP_Query.
 	 *
 	 * @param WP_Query $query The WordPress Query.
+	 * @param WP_Block $block The block being rendered.
 	 * @return array
 	 */
-	public function build_query( $query ) {
-		$parsed_block = $this->parsed_block;
-		if ( ! $this->is_related_products_block( $parsed_block ) ) {
+	public function build_query( $query, $block ) {
+		$is_product_collection_block = $block->context['query']['isProductCollectionBlock'] ?? false;
+		$parsed_block                = $this->parsed_block;
+		if ( ! $this->is_related_products_block( $parsed_block ) || $is_product_collection_block ) {
 			return $query;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
@@ -93,7 +93,7 @@ class RelatedProducts extends AbstractBlock {
 	 * @return array
 	 */
 	public function build_query( $query, $block ) {
-		$parsed_block                = $this->parsed_block;
+		$parsed_block = $this->parsed_block;
 		if ( ! $this->is_related_products_block( $parsed_block, $block ) ) {
 			return $query;
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
@@ -92,7 +92,7 @@ class RelatedProducts extends AbstractBlock {
 	 * @param WP_Block $block The block being rendered.
 	 * @return array
 	 */
-	public function build_query( $query, $block ) {
+	public function build_query( $query, $block = null ) {
 		$parsed_block = $this->parsed_block;
 		if ( ! $this->is_related_products_block( $parsed_block, $block ) ) {
 			return $query;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
@@ -93,9 +93,8 @@ class RelatedProducts extends AbstractBlock {
 	 * @return array
 	 */
 	public function build_query( $query, $block ) {
-		$is_product_collection_block = $block->context['query']['isProductCollectionBlock'] ?? false;
 		$parsed_block                = $this->parsed_block;
-		if ( ! $this->is_related_products_block( $parsed_block ) || $is_product_collection_block ) {
+		if ( ! $this->is_related_products_block( $parsed_block, $block ) ) {
 			return $query;
 		}
 
@@ -137,12 +136,14 @@ class RelatedProducts extends AbstractBlock {
 	/**
 	 * Determines whether the block is a related products block.
 	 *
-	 * @param array $block The block.
+	 * @param array $parsed_block The parsed block.
+	 * @param array $rendered_block The rendered block.
 	 *
 	 * @return bool Whether the block is a related products block.
 	 */
-	private function is_related_products_block( $block ) {
-		if ( ProductQuery::is_woocommerce_variation( $block ) && isset( $block['attrs']['namespace'] ) && 'woocommerce/related-products' === $block['attrs']['namespace'] ) {
+	private function is_related_products_block( $parsed_block, $rendered_block = null ) {
+		$is_product_collection_block = $rendered_block->context['query']['isProductCollectionBlock'] ?? false;
+		if ( ProductQuery::is_woocommerce_variation( $parsed_block ) && isset( $parsed_block['attrs']['namespace'] ) && 'woocommerce/related-products' === $parsed_block['attrs']['namespace'] && ! $is_product_collection_block ) {
 			return true;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR resolves an issue when adding a `Product Collection` block with the type `Upsells` or `Cross-Sells`, the product(s) displayed in the upsells (or cross-sells) section were changing depending on the block's position within the ´Single Product` block template.

~The related products added a filter on `query_loop_block_query_vars` that inadvertently affected the result of upsells and cross-sells below.~

~Partially address [#52170](https://github.com/woocommerce/woocommerce/issues/52170) since it only fixes the problem for the `Single Product` template.~


When Product Collection (and its collections) and [Products (Beta)](https://github.com/woocommerce/woocommerce/blob/23e3979e5819ec3ba344929ab5020b7326d511eb/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/product-query.tsx) block (and it's variations like "Related Products") are used on the same post, they don't seem to play well together. The reason is they are sharing the `query_loop_block_query_vars` hook. Please take a look at [this comment](https://github.com/woocommerce/woocommerce/pull/52235#pullrequestreview-2387605411).

Closes #52170.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a `Product Collection` block in `Single Product` template.

https://github.com/user-attachments/assets/0f76903d-1e37-4339-a387-ea33ea181072

2. Add it before the `Group`.
3. Choose the "Upsells" collection.
4. Verify the result shown in the front end is correct and doesn't change depending on the position (when it's below the `Group` or above).
5. Repeat step 3, but now choose "Cross-Sells". Verify that Cross-Sells work as expected as well.
6. In the block settings, change the product reference option from "From the current product" to "From a specific product".
8. Select a specific product.
9. Verify that the upsells and cross-sells are shown correctly, regardless of the block's position.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>