### PR TITLE
Improve stability of core profiler extensions e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-test-core-profiler
+++ b/plugins/woocommerce/changelog/fix-e2e-test-core-profiler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change e2e test to use plugin slugs instead for better stability in core profiler tests

--- a/plugins/woocommerce/client/admin/client/core-profiler/components/plugin-card/plugin-card.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/components/plugin-card/plugin-card.tsx
@@ -20,6 +20,7 @@ export const PluginCard = ( {
 	checked = false,
 	description,
 	learnMoreLink,
+	slug,
 }: {
 	// Checkbox will be hidden if true
 	installed?: boolean;
@@ -30,6 +31,7 @@ export const PluginCard = ( {
 	checked?: boolean;
 	onChange?: () => void;
 	learnMoreLink?: ReactNode;
+	slug?: string;
 } ) => {
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
@@ -38,6 +40,7 @@ export const PluginCard = ( {
 				'is-installed': installed,
 			} ) }
 			onClick={ onChange }
+			data-slug={ slug }
 		>
 			<div className="woocommerce-profiler-plugin-card-top">
 				{ ! installed && (

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins.tsx
@@ -226,6 +226,7 @@ export const Plugins = ( {
 										/>
 									) : null
 								}
+								slug={ plugin.key.replace( ':alt', '' ) }
 								title={ plugin.label }
 								description={ plugin.description }
 								learnMoreLink={ learnMoreLink }

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -348,25 +348,22 @@ test.describe(
 				).toBeVisible();
 				// confirm that the optional plugins are present
 				await expect(
-					page.locator( '.plugin-title', {
-						hasText: 'Pinterest for WooCommerce',
+					page.locator( 'tr' ).filter( {
+						has: page.locator(
+							// 50-50 share between Kliken and Pinterest plugin
+							'tr[data-slug=/kliken-ads-pixel-for-meta|pinterest-for-woocommerce/]'
+						),
 					} )
 				).toBeVisible();
 				await expect(
-					page.locator( '.plugin-title', {
-						hasText: /Google for WooCommerce|Google Listings & Ads/,
-					} )
+					page.locator( 'tr[data-slug="google-listings-and-ads"]' )
 				).toBeVisible();
 
 				await expect(
-					page.locator( '.plugin-title', {
-						hasText: 'MailPoet',
-					} )
+					page.locator( 'tr[data-slug="mailpoet"]' )
 				).toBeHidden();
 				await expect(
-					page.locator( '.plugin-title', {
-						hasText: 'Jetpack',
-					} )
+					page.locator( 'tr[data-slug="jetpack"]' )
 				).toBeHidden();
 			} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -349,23 +349,44 @@ test.describe(
 					} )
 				).toBeVisible();
 				// confirm that the optional plugins are present
-				const installedExtensionSlugs = [
-					'pinterest-for-woocommerce',
-					'google-listings-and-ads',
-				];
-
-				// Loop through the slugs and check if they are visible on the page using `data-slug`
-				for ( const slug of installedExtensionSlugs ) {
-					const pluginLocator = page.locator(
-						`[data-slug="${ slug }"]`
+				try {
+					await expect(
+						page.locator(
+							`[data-slug="pinterest-for-woocommerce"]`
+						)
+					).toBeVisible();
+				} catch {
+					console.log(
+						`Pinterest is not found or not visible on the page`
 					);
-					try {
-						await expect( pluginLocator ).toBeVisible();
-					} catch {
-						console.log(
-							`${ slug } is not found or not visible on the page`
-						);
-					}
+				}
+
+				try {
+					await expect(
+						page.locator( `[data-slug="google-listings-and-ads"]` )
+					).toBeVisible();
+				} catch {
+					console.log(
+						`Google for WooCommerce is not found or not visible on the page`
+					);
+				}
+
+				try {
+					await expect(
+						page.locator(
+							`[data-slug="mailchimp-for-woocommerce"]`
+						)
+					).toBeHidden();
+				} catch {
+					console.log( `MailChimp is found on the page` );
+				}
+
+				try {
+					await expect(
+						page.locator( `[data-slug="jetpack"]` )
+					).toBeHidden();
+				} catch {
+					console.log( `Jetpack is found on the page` );
 				}
 			} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses the following:

- Fix test for the recent change in OBW free extensions API which adds Kliken extension in place of Pinterest 50% of the time ([example error](https://github.com/woocommerce/woocommerce/actions/runs/11471615716/job/31923696530?pr=52213)).
- Add setting `woocommerce_remote_variant_assignment` to improve test predictability.
- Changes plugin detection using slug instead of plugin title to improve test stability since plugin titles can be changed while plugin slugs are somewhat permanent.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check code changes and ensure no e2e test failures on core profiler tests 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
