### PR TITLE
Fix description toolbar toggle

### DIFF
--- a/packages/js/product-editor/changelog/fix-52238_description_toolbar_toggle
+++ b/packages/js/product-editor/changelog/fix-52238_description_toolbar_toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix toggle state issue within description modal editor when toggling block inserter and document overview.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This addresses an issue when toggling the left side nav within the description block editor within the new product editor.
Instead of managing the state with `useState` I moved it to a `useReducer`.

Closes #52238

https://github.com/user-attachments/assets/4a236405-c593-477f-adb1-96300493f68f

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product form under **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add new**
3. Scroll down to the description
4. Click **Full editor** when the toolbar shows up
5. Now select the plus icon in the top left
6. Click the 3 lines icon now ( document viewer ), it should open the document viewer
7. Click the 3 lines again, it should close the sidebar
8. Click the 3 lines again, it should open the document viewer
9. Now click the plus icon, it should switch to the "add block" sidebar
10. Click the plus icon again, it should close the sidebar.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
