### PR TITLE
CYS: Remove unnecessary 'as' prop from SiteHub component

### DIFF
--- a/plugins/woocommerce/changelog/fix-as-prop-site-hub
+++ b/plugins/woocommerce/changelog/fix-as-prop-site-hub
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove unnecessary 'as' prop from SiteHub component
+
+

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/layout.tsx
@@ -163,7 +163,6 @@ export const Layout = () => {
 								animate={ 'view' }
 							>
 								<SiteHub
-									as={ motion.div }
 									variants={ {
 										view: { x: 0 },
 									} }

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/site-hub.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/site-hub.tsx
@@ -40,7 +40,6 @@ export const SiteHub = forwardRef(
 		}: {
 			isTransparent: boolean;
 			className: string;
-			as: string;
 			variants: motion.Variants;
 		},
 		ref

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/index.tsx
@@ -8,12 +8,7 @@ import { chevronLeft } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';
 import { getNewPath } from '@woocommerce/navigation';
 import { Sender } from 'xstate';
-import {
-	Notice,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore No types for this exist yet.
-	__unstableMotion as motion,
-} from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -382,7 +377,6 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 			) }
 			<div className="woocommerce-customize-store-header">
 				<SiteHub
-					as={ motion.div }
 					variants={ {
 						view: { x: 0 },
 					} }

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/index.tsx
@@ -7,13 +7,7 @@
 import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import {
-	Button,
-	Modal,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore No types for this exist yet.
-	__unstableMotion as motion,
-} from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -80,7 +74,6 @@ export const Transitional = ( {
 				</Modal>
 			) }
 			<SiteHub
-				as={ motion.div }
 				variants={ {
 					view: { x: 0 },
 				} }

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/launch-store-hub.tsx
@@ -98,7 +98,6 @@ export const LaunchYourStoreHubSidebar: React.FC< SidebarComponentProps > = (
 				animate={ 'view' }
 			>
 				<SiteHub
-					as={ motion.div }
 					variants={ {
 						view: { x: 0 },
 					} }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I might be missing something, but I think `motion.div` [doesn't accept](https://www.framer.com/motion/component/#props) an `as` prop, so we shouldn't define it. Otherwise, we end up with a markup that looks like `as=[object Object]`.

### How to test the changes in this Pull Request:

1. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
2. In the admin, go to WooCommerce > Customize Your Store.
3. Open the inspector in your browser devtools (<kbd>F12</kbd>) and search for the `.edit-site-site-hub` element. Verify it looks as usual and it doesn't have an `as` attribute:

Before | After
--- | ---
![Captura de pantalla de 2024-10-23 14-30-37](https://github.com/user-attachments/assets/e9fcf5a8-691c-4fdd-9752-0aa04fde476b) | ![Captura de pantalla de 2024-10-23 14-31-00](https://github.com/user-attachments/assets/0dd1eb9b-f5d7-4a00-af95-f9a54ac8519f)