### PR TITLE
Checkout: Make return to cart button text editable

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { CART_URL } from '@woocommerce/block-settings';
 import { Icon, arrowLeft } from '@wordpress/icons';
 
@@ -11,13 +10,15 @@ import { Icon, arrowLeft } from '@wordpress/icons';
 import './style.scss';
 
 interface ReturnToCartButtonProps {
-	link?: string | undefined;
+	href?: string | undefined;
+	children: React.ReactNode;
 }
 
 const ReturnToCartButton = ( {
-	link,
+	href,
+	children,
 }: ReturnToCartButtonProps ): JSX.Element | null => {
-	const cartLink = link || CART_URL;
+	const cartLink = href || CART_URL;
 	if ( ! cartLink ) {
 		return null;
 	}
@@ -27,7 +28,7 @@ const ReturnToCartButton = ( {
 			className="wc-block-components-checkout-return-to-cart-button"
 		>
 			<Icon icon={ arrowLeft } />
-			{ __( 'Return to Cart', 'woocommerce' ) }
+			{ children }
 		</a>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/attributes.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/attributes.tsx
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { defaultPlaceOrderButtonLabel } from './constants';
+import {
+	defaultPlaceOrderButtonLabel,
+	defaultReturnToCartButtonLabel,
+} from './constants';
 
 export default {
 	cartPageId: {
@@ -26,5 +29,9 @@ export default {
 	placeOrderButtonLabel: {
 		type: 'string',
 		default: defaultPlaceOrderButtonLabel,
+	},
+	returnToCartButtonLabel: {
+		type: 'string',
+		default: defaultReturnToCartButtonLabel,
 	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
@@ -23,11 +23,13 @@ const Block = ( {
 	showReturnToCart,
 	className,
 	placeOrderButtonLabel,
+	returnToCartButtonLabel,
 }: {
 	cartPageId: number;
 	showReturnToCart: boolean;
 	className?: string;
 	placeOrderButtonLabel: string;
+	returnToCartButtonLabel: string;
 } ): JSX.Element => {
 	const { paymentMethodButtonLabel } = useCheckoutSubmit();
 
@@ -47,8 +49,10 @@ const Block = ( {
 			<div className="wc-block-checkout__actions_row">
 				{ showReturnToCart && (
 					<ReturnToCartButton
-						link={ getSetting( 'page-' + cartPageId, false ) }
-					/>
+						href={ getSetting( 'page-' + cartPageId, false ) }
+					>
+						{ returnToCartButtonLabel }
+					</ReturnToCartButton>
 				) }
 				<PlaceOrderButton
 					label={ label }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/constants.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/constants.tsx
@@ -4,3 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 export const defaultPlaceOrderButtonLabel = __( 'Place Order', 'woocommerce' );
+export const defaultReturnToCartButtonLabel = __(
+	'Return to Cart',
+	'woocommerce'
+);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -5,19 +5,24 @@ import clsx from 'clsx';
 import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import PageSelector from '@woocommerce/editor-components/page-selector';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
-import { getSetting } from '@woocommerce/settings';
 import { ReturnToCartButton } from '@woocommerce/base-components/cart-checkout';
 import EditableButton from '@woocommerce/editor-components/editable-button';
-import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
  * Internal dependencies
  */
-import { defaultPlaceOrderButtonLabel } from './constants';
+import {
+	defaultPlaceOrderButtonLabel,
+	defaultReturnToCartButtonLabel,
+} from './constants';
 
 export const Edit = ( {
 	attributes,
@@ -27,6 +32,7 @@ export const Edit = ( {
 		showReturnToCart: boolean;
 		cartPageId: number;
 		placeOrderButtonLabel: string;
+		returnToCartButtonLabel: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
@@ -35,6 +41,7 @@ export const Edit = ( {
 		cartPageId = 0,
 		showReturnToCart = false,
 		placeOrderButtonLabel,
+		returnToCartButtonLabel,
 	} = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
 	const currentPostId = useSelect(
@@ -94,16 +101,21 @@ export const Edit = ( {
 			</InspectorControls>
 			<div className="wc-block-checkout__actions">
 				<div className="wc-block-checkout__actions_row">
-					<Noninteractive>
-						{ showReturnToCart && (
-							<ReturnToCartButton
-								link={ getSetting(
-									'page-' + cartPageId,
-									false
-								) }
+					{ showReturnToCart && (
+						<ReturnToCartButton href="#cart-page-placeholder">
+							<RichText
+								multiline={ false }
+								allowedFormats={ [] }
+								value={ returnToCartButtonLabel }
+								placeholder={ defaultReturnToCartButtonLabel }
+								onChange={ ( content ) => {
+									setAttributes( {
+										returnToCartButtonLabel: content,
+									} );
+								} }
 							/>
-						) }
-					</Noninteractive>
+						</ReturnToCartButton>
+					) }
 					<EditableButton
 						className={ clsx(
 							'wc-block-cart__submit-button',

--- a/plugins/woocommerce/changelog/add-49337-editable-return-to-cart-link
+++ b/plugins/woocommerce/changelog/add-49337-editable-return-to-cart-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow the text of the return to cart link to be edited in the checkout block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows the "return to cart" link text to be edited. The original text is the default.

Closes #49337

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Before testing this PR ensure you have a checkout block setup which has the option to display the "return to cart" link already configured
2. Checkout and build this PR. Check the "return to cart" link is still shown on your checkout page
3. Edit the checkout page.
4. Focus on the "return to cart" link and edit the text
5. Save changes
6. Confirm the new text is shown on the checkout frontend

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
