### PR TITLE
Add experimental-blocks flag to live branches userscript

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/add-experimental-blocks-flag-to-live-branch-userscript
+++ b/plugins/woocommerce-beta-tester/changelog/add-experimental-blocks-flag-to-live-branch-userscript
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add experimental-blocks flag to the live branch user script.
+
+

--- a/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
+++ b/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
@@ -108,6 +108,7 @@
 			const featureFlags = [
 				'async-product-editor-category-field',
 				'launch-your-store',
+				'experimental-blocks',
 				'minified-js',
 				'product-custom-fields',
 				'reactify-classic-payments-settings',

--- a/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
+++ b/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
@@ -108,11 +108,11 @@
 			const featureFlags = [
 				'async-product-editor-category-field',
 				'launch-your-store',
-				'experimental-blocks',
 				'minified-js',
 				'product-custom-fields',
 				'reactify-classic-payments-settings',
 				'settings',
+				'experimental-blocks',
 			];
 
 			const contents = `

--- a/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
+++ b/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WooCommerce Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.1
+// @version      1.1.1
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds `experimental-blocks` flag to the live branches user script to make testing blocks on JN sites easier.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the script manually using Tampermonkey: https://github.com/woocommerce/woocommerce/blob/94d0a93604e5c7587acc7dfd9520a5f9d9395382/plugins/woocommerce-beta-tester/userscripts/wc-live-branches.user.js
2. Reload this page after installation.
3. Observe that the feature flag options are now available in WooCommerce Live Branches > Expand for JN site options
4. Tick the experimental-blocks checkbox.
5. Create Jurassic Ninja site for this branch.
6. Wait for the site to be created.
7. Add a new post.
8. Confirm that you can search for Product Filters (Experimental) and add it to the canvas.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
