### PR TITLE
[dev] Monorepo: revert pr-lint-monorepo workflow filters to previous state.

### DIFF
--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,11 +1,11 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on:
     pull_request:
-        paths-ignore:
-            - '**/changelog/**'
-            - '.github/**'
-            - '!.github/workflows/pr-lint-monorepo.yml'
-            - '!.github/workflows/pr-lint-monorepo.yml'
+        paths:
+           - '.github/workflows/pr-lint-monorepo.yml'
+           - 'packages/**'
+           - 'plugins/**'
+           - '!**/changelog/**'
         branches:
             - 'trunk'
 

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,11 +1,11 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on:
     pull_request:
-        paths-ignore:
-            - '**/changelog/**'
-            - '.github/**'
-            - '!.github/workflows/pr-lint-monorepo.yml'
-            - '!.github/workflows/pr-lint-monorepo.yml'
+        paths:
+            - '.github/workflows/pr-lint-monorepo.yml'
+            - 'packages/**'
+            - 'plugins/**'
+            - '!**/changelog/**'
         branches:
             - 'trunk'
 

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,11 +1,11 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on:
     pull_request:
-        paths:
-            - '.github/workflows/pr-lint-monorepo.yml'
-            - 'packages/**'
-            - 'plugins/**'
-            - '!**/changelog/**'
+        paths-ignore:
+            - '**/changelog/**'
+            - '.github/**'
+            - '!.github/workflows/pr-lint-monorepo.yml'
+            - '!.github/workflows/pr-lint-monorepo.yml'
         branches:
             - 'trunk'
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restoring changes reverted by https://github.com/woocommerce/woocommerce/pull/52284 as footprint was in the jobs-related setting of repository: jobs are required but might not be executed if the scope of changes in PRs is unrelated. Something like a deadlock.

### How to test the changes in this Pull Request:

- CI checks shall pass
