### PR TITLE
Record `Cancel` and `Close` events on modal to change collection type

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/collection-selection-modal.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/collection-selection-modal.tsx
@@ -20,7 +20,8 @@ const PatternSelectionModal = ( props: {
 	tracksLocation: string;
 	closePatternSelectionModal: () => void;
 } ) => {
-	const { clientId, attributes, tracksLocation } = props;
+	const { clientId, attributes, tracksLocation, closePatternSelectionModal } =
+		props;
 	const { collection } = attributes;
 	// @ts-expect-error Type definitions for this function are missing
 	// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/wordpress__blocks/store/actions.d.ts
@@ -42,11 +43,25 @@ const PatternSelectionModal = ( props: {
 		}
 	};
 
+	const handleModalClose = ( action: 'cancel' | 'close' ) => {
+		recordEvent(
+			'blocks_product_collection_collection_replaced_from_placeholder',
+			{
+				action,
+				location: tracksLocation,
+			}
+		);
+		closePatternSelectionModal();
+	};
+
+	const onCancelClick = () => handleModalClose( 'cancel' );
+	const onCloseModal = () => handleModalClose( 'close' );
+
 	return (
 		<Modal
 			overlayClassName="wc-blocks-product-collection__modal"
 			title={ __( 'What products do you want to show?', 'woocommerce' ) }
-			onRequestClose={ props.closePatternSelectionModal }
+			onRequestClose={ onCloseModal }
 			// @ts-expect-error Type definitions are missing in the version we are using i.e. 19.1.5,
 			size={ 'large' }
 		>
@@ -56,10 +71,7 @@ const PatternSelectionModal = ( props: {
 					onCollectionClick={ selectCollectionName }
 				/>
 				<div className="wc-blocks-product-collection__footer">
-					<Button
-						variant="tertiary"
-						onClick={ props.closePatternSelectionModal }
-					>
+					<Button variant="tertiary" onClick={ onCancelClick }>
 						{ __( 'Cancel', 'woocommerce' ) }
 					</Button>
 					<Button variant="primary" onClick={ onContinueClick }>

--- a/plugins/woocommerce/changelog/add-52312_track-cancel-and-close-pc-modal
+++ b/plugins/woocommerce/changelog/add-52312_track-cancel-and-close-pc-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Record Cancel and Close events on modal to change collection type #52314


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to start tracking when the user presses the `Cancel` or `Close` buttons in the modal to change the collection type.

![Image](https://github.com/user-attachments/assets/601f3461-045c-470a-ace5-02cf160ae45e)

Closes #52312.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Preparations

1. Create new post
2. Open your browser Dev Tools (Cmd + Opt + I on Mac)
3. In Console tab paste this code and submit by enter

`localStorage.setItem( 'debug', 'wc-admin:*' )`

4. Enable "Verbose" logging level:
 
<img width="658" alt="image" src="https://github.com/woocommerce/woocommerce/assets/20098064/586d091c-901f-4175-bcb6-125830a255a4">

#### Event is fired in the right moment

1. In the post insert a `Product Collection` block.
2. Choose a collection, for example: Featured.
3. Click "Choose collection" in a toolbar.
4. Press `Cancel`.
5. Verify that the event `wcadmin_blocks_product_collection_collection_replaced_from_placeholder` is recorded with the props
```
action: "cancel"
location: "page"
```
6. Click "Choose collection" in a toolbar again.
7. Now press the `X` to close the modal.
8. Verify that the event `wcadmin_blocks_product_collection_collection_replaced_from_placeholder` is recorded with the props
```
action: "close"
location: "page"
```

Example events:

https://github.com/user-attachments/assets/9b0fadee-6c65-40b7-9326-56329b2a9122


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
