### PR TITLE
Product Collection: add "Products" suffix to couple of collections

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/featured.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/featured.tsx
@@ -13,7 +13,7 @@ import { CoreCollectionNames, CoreFilterNames } from '../types';
 
 const collection = {
 	name: CoreCollectionNames.FEATURED,
-	title: __( 'Featured', 'woocommerce' ),
+	title: __( 'Featured Products', 'woocommerce' ),
 	icon: <Icon icon={ starFilled } />,
 	description: __( 'Showcase your featured products.', 'woocommerce' ),
 	keywords: [ 'product collection' ],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/hand-picked.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/hand-picked.tsx
@@ -44,7 +44,7 @@ export const handPickedIcon = (
 
 const collection = {
 	name: CoreCollectionNames.HAND_PICKED,
-	title: __( 'Hand-Picked', 'woocommerce' ),
+	title: __( 'Hand-Picked Products', 'woocommerce' ),
 	icon: <Icon icon={ handPickedIcon } />,
 	description: __(
 		'Select specific products to recommend to customers.',

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/on-sale.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/on-sale.tsx
@@ -13,7 +13,7 @@ import { CoreCollectionNames, CoreFilterNames } from '../types';
 
 const collection = {
 	name: CoreCollectionNames.ON_SALE,
-	title: __( 'On Sale', 'woocommerce' ),
+	title: __( 'On Sale Products', 'woocommerce' ),
 	icon: <Icon icon={ percent } />,
 	description: __(
 		'Highlight products that are currently on sale.',

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/top-rated.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/collections/top-rated.tsx
@@ -13,7 +13,7 @@ import { CoreCollectionNames, CoreFilterNames } from '../types';
 
 const collection = {
 	name: CoreCollectionNames.TOP_RATED,
-	title: __( 'Top Rated', 'woocommerce' ),
+	title: __( 'Top Rated Products', 'woocommerce' ),
 	icon: <Icon icon={ starEmpty } />,
 	description: __(
 		'Recommend products with the highest review ratings.',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/collections.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/collections.block_theme.spec.ts
@@ -20,7 +20,7 @@ const test = base.extend< { pageObject: ProductCollectionPage } >( {
 } );
 
 test.describe( 'Product Collection: Collections', () => {
-	test( 'New Arrivals Collection can be added and displays proper products', async ( {
+	test( 'New Arrivals collection can be added and displays proper products', async ( {
 		pageObject,
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock( 'newArrivals' );
@@ -38,7 +38,7 @@ test.describe( 'Product Collection: Collections', () => {
 	// When creating reviews programmatically the ratings are not propagated
 	// properly so products order by rating is undeterministic in test env.
 	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'Top Rated Collection can be added and displays proper products', async ( {
+	test.skip( 'Top Rated Products collection can be added and displays proper products', async ( {
 		pageObject,
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock( 'topRated' );
@@ -62,7 +62,7 @@ test.describe( 'Product Collection: Collections', () => {
 	// There's no orders in test env so the order of Best Sellers
 	// is undeterministic in test env. Requires further work.
 	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'Best Sellers Collection can be added and displays proper products', async ( {
+	test.skip( 'Best Sellers collection can be added and displays proper products', async ( {
 		pageObject,
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock( 'bestSellers' );
@@ -85,7 +85,7 @@ test.describe( 'Product Collection: Collections', () => {
 		await expect( pageObject.products ).toHaveCount( 5 );
 	} );
 
-	test( 'On Sale Collection can be added and displays proper products', async ( {
+	test( 'On Sale Products collection can be added and displays proper products', async ( {
 		pageObject,
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock( 'onSale' );
@@ -106,7 +106,7 @@ test.describe( 'Product Collection: Collections', () => {
 		await expect( pageObject.products ).toHaveCount( 5 );
 	} );
 
-	test( 'Featured Collection can be added and displays proper products', async ( {
+	test( 'Featured Products collection can be added and displays proper products', async ( {
 		pageObject,
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock( 'featured' );
@@ -126,7 +126,7 @@ test.describe( 'Product Collection: Collections', () => {
 		await expect( pageObject.products ).toHaveCount( 4 );
 	} );
 
-	test( 'Product Catalog Collection can be added in post and syncs query with template', async ( {
+	test( 'Product Catalog collection can be added in post and syncs query with template', async ( {
 		pageObject,
 	} ) => {
 		await pageObject.createNewPostAndInsertBlock( 'productCatalog' );
@@ -176,7 +176,7 @@ test.describe( 'Product Collection: Collections', () => {
 			await expect( input ).toBeHidden();
 		} );
 
-		test( 'Top Rated', async ( { pageObject } ) => {
+		test( 'Top Rated Products', async ( { pageObject } ) => {
 			await pageObject.createNewPostAndInsertBlock( 'topRated' );
 			const input = await pageObject.getOrderByElement();
 
@@ -190,7 +190,7 @@ test.describe( 'Product Collection: Collections', () => {
 			await expect( input ).toBeHidden();
 		} );
 
-		test( 'On Sale', async ( { pageObject } ) => {
+		test( 'On Sale Products', async ( { pageObject } ) => {
 			await pageObject.createNewPostAndInsertBlock( 'onSale' );
 			const sidebarSettings = pageObject.locateSidebarSettings();
 			const input = sidebarSettings.getByLabel(
@@ -200,7 +200,7 @@ test.describe( 'Product Collection: Collections', () => {
 			await expect( input ).toBeHidden();
 		} );
 
-		test( 'Featured', async ( { pageObject } ) => {
+		test( 'Featured Products', async ( { pageObject } ) => {
 			await pageObject.createNewPostAndInsertBlock( 'featured' );
 			const sidebarSettings = pageObject.locateSidebarSettings();
 			const input = sidebarSettings.getByLabel(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -60,7 +60,6 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 		await expect( pageObject.productTitles ).toHaveText( sortedTitles );
 	} );
 
-	// Products can be filtered based on 'on sale' status.
 	test( 'Products can be filtered based on "on sale" status', async ( {
 		pageObject,
 	} ) => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -698,7 +698,7 @@ test.describe( 'Product Collection', () => {
 			await expect( pageObject.productTemplate ).toBeVisible();
 		} );
 
-		test( 'On Sale collection should be visible after Refresh', async ( {
+		test( 'On Sale Products collection should be visible after Refresh', async ( {
 			page,
 			pageObject,
 			editor,
@@ -713,7 +713,7 @@ test.describe( 'Product Collection', () => {
 
 			await expect( productTemplate ).toHaveCount( 2 );
 
-			// Refresh the template and verify "On Sale" collection is still visible
+			// Refresh the template and verify "On Sale Products" collection is still visible
 			await editor.saveSiteEditorEntities( {
 				isOnlyCurrentEntityDirty: true,
 			} );
@@ -721,7 +721,7 @@ test.describe( 'Product Collection', () => {
 			await expect( productTemplate ).toHaveCount( 2 );
 		} );
 
-		test( 'On Sale collection should be visible after Refresh in a Post', async ( {
+		test( 'On Sale Products collection should be visible after Refresh in a Post', async ( {
 			page,
 			pageObject,
 			editor,
@@ -729,7 +729,7 @@ test.describe( 'Product Collection', () => {
 			await pageObject.createNewPostAndInsertBlock( 'onSale' );
 			await expect( pageObject.productTemplate ).toBeVisible();
 
-			// Refresh the post and verify "On Sale" collection is still visible
+			// Refresh the post and verify "On Sale Products" collection is still visible
 			await editor.saveDraft();
 			await page.reload();
 			await expect( pageObject.productTemplate ).toBeVisible();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -90,10 +90,10 @@ export type Collections =
 
 const collectionToButtonNameMap = {
 	newArrivals: 'New Arrivals',
-	topRated: 'Top Rated',
+	topRated: 'Top Rated Products',
 	bestSellers: 'Best Sellers',
-	onSale: 'On Sale',
-	featured: 'Featured',
+	onSale: 'On Sale Products',
+	featured: 'Featured Products',
 	productCatalog: 'create your own',
 	myCustomCollection: 'My Custom Collection',
 	myCustomCollectionWithPreview: 'My Custom Collection with Preview',

--- a/plugins/woocommerce/changelog/add-rename-collections
+++ b/plugins/woocommerce/changelog/add-rename-collections
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Product Collection: Add "Products" suffix to some of the collection names


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/52209 we're exposing collections to the inserter. @imanish003 raised a valid point that some collections have confusing names when not presented in scope of Product Collection block.

In this PR we're adding "Products" suffix to a couple of them:

- Featured -> Featured Products
- On Sale -> On Sale Products
- Top Rated -> Top Rated Products
- Hand-picked -> Hand-picked Products

Other collections stay the same
- New Arrivals
- Best Sellers
- Related Products
- Upsells
- Cross-Sells

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Add Product Collection block
3. **Expected:** New names are reflected in Collection Chooser

Before | After
-- | --
<img width="635" alt="image" src="https://github.com/user-attachments/assets/01d3a322-6f43-4aef-888e-65d42fa6bb3b"> | <img width="631" alt="image" src="https://github.com/user-attachments/assets/11d38079-9cd5-4c52-b9f5-56f6b39591a5">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
