### PR TITLE
Cherry-pick PR#52055

### DIFF
--- a/plugins/woocommerce/changelog/51843-fix-l10n-too-early
+++ b/plugins/woocommerce/changelog/51843-fix-l10n-too-early
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Removes several side effects in the code base that caused translations to be loaded too early.

--- a/plugins/woocommerce/changelog/51843-fix-l10n-too-early
+++ b/plugins/woocommerce/changelog/51843-fix-l10n-too-early
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Removes several side effects in the code base that caused translations to be loaded too early.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -223,6 +223,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Fix - Use `get_filtered_ids` consistently in `reports/taxes` and `reports/taxes/stats` datastores [#51219](https://github.com/woocommerce/woocommerce/pull/51219)
 * Fix - wc_get_cart_url should only return current URL if on the cart page. This excludes the usage of WOOCOMMERCE_CART. [#51384](https://github.com/woocommerce/woocommerce/pull/51384)
 * Fix - Wrap parse_str under a check to resolve deprecation notice [#51474](https://github.com/woocommerce/woocommerce/pull/51474)
+* Fix - Removes several side effects in the code base that caused translations to be loaded too early [#52055](https://github.com/woocommerce/woocommerce/pull/52055)
 * Add - BFCM promo card support (data to be served by WCCOM API) [#51739](https://github.com/woocommerce/woocommerce/pull/51739)
 * Add - Add core feature for site visibility badge [#51664](https://github.com/woocommerce/woocommerce/pull/51664)
 * Add - Added a Load More button to product lists on the Extensions page, to request additional search results from WooCommerce.com. [#51413](https://github.com/woocommerce/woocommerce/pull/51413)

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -80,13 +80,24 @@ class BlockPatterns {
 		$this->pattern_registry   = $pattern_registry;
 		$this->ptk_patterns_store = $ptk_patterns_store;
 
-		$this->dictionary = PatternsHelper::get_patterns_dictionary();
-
 		add_action( 'init', array( $this, 'register_block_patterns' ) );
 
 		if ( Features::is_enabled( 'pattern-toolkit-full-composability' ) ) {
 			add_action( 'init', array( $this, 'register_ptk_patterns' ) );
 		}
+	}
+
+	/**
+	 * Returns the Patterns dictionary.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function get_patterns_dictionary() {
+		if ( $this->dictionary === null ) {
+			$this->dictionary = PatternsHelper::get_patterns_dictionary();
+		}
+
+		return $this->dictionary;
 	}
 
 	/**
@@ -123,7 +134,7 @@ class BlockPatterns {
 		foreach ( $files as $file ) {
 			$pattern_data = get_file_data( $file, $default_headers );
 
-			$this->pattern_registry->register_block_pattern( $file, $pattern_data, $this->dictionary );
+			$this->pattern_registry->register_block_pattern( $file, $pattern_data, $this->get_patterns_dictionary() );
 		}
 	}
 
@@ -158,7 +169,7 @@ class BlockPatterns {
 			$pattern['slug']    = $pattern['name'];
 			$pattern['content'] = $pattern['html'];
 
-			$this->pattern_registry->register_block_pattern( $pattern['ID'], $pattern, $this->dictionary );
+			$this->pattern_registry->register_block_pattern( $pattern['ID'], $pattern, $this->get_patterns_dictionary() );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -93,7 +93,7 @@ class BlockPatterns {
 	 * @return array|WP_Error
 	 */
 	private function get_patterns_dictionary() {
-		if ( $this->dictionary === null ) {
+		if ( null === $this->dictionary ) {
 			$this->dictionary = PatternsHelper::get_patterns_dictionary();
 		}
 

--- a/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PatternRegistry.php
@@ -12,20 +12,15 @@ class PatternRegistry {
 	const SLUG_REGEX            = '/^[A-z0-9\/_-]+$/';
 	const COMMA_SEPARATED_REGEX = '/[\s,]+/';
 
-
 	/**
-	 * Associates pattern slugs with their localized labels for categorization.
+	 * Returns pattern slugs with their localized labels for categorization.
+	 *
 	 * Each key represents a unique pattern slug, while the value is the localized label.
 	 *
-	 * @var array $category_labels
+	 * @return array<string, string>
 	 */
-	private $category_labels;
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->category_labels = [
+	private function get_category_labels() {
+		return [
 			'woo-commerce'     => __( 'WooCommerce', 'woocommerce' ),
 			'intro'            => __( 'Intro', 'woocommerce' ),
 			'featured-selling' => __( 'Featured Selling', 'woocommerce' ),
@@ -148,10 +143,10 @@ class PatternRegistry {
 			}
 		}
 
-        // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
+		// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
 		$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', 'woocommerce' );
 		if ( ! empty( $pattern_data['description'] ) ) {
-            // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
+			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.LowLevelTranslationFunction
 			$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'woocommerce' );
 		}
 
@@ -186,13 +181,15 @@ class PatternRegistry {
 			}
 		}
 
+		$category_labels = $this->get_category_labels();
+
 		if ( ! empty( $pattern_data['categories'] ) ) {
 			foreach ( $pattern_data['categories'] as $key => $category ) {
 				$category_slug = _wp_to_kebab_case( $category );
 
 				$pattern_data['categories'][ $key ] = $category_slug;
 
-				$label = isset( $this->category_labels[ $category_slug ] ) ? $this->category_labels[ $category_slug ] : self::kebab_to_capital_case( $category_slug );
+				$label = $category_labels[ $category_slug ] ?? self::kebab_to_capital_case( $category_slug );
 
 				register_block_pattern_category(
 					$category_slug,


### PR DESCRIPTION
- Cherry-picks #52055 to `release/9.4`.
- Except for the changelog, diff should be near identical to the original PR, but please note that there was a conflict in `src/Blocks/BlockPatterns.php` since the `trunk` version has diverged a little from 9.4.
- Testing instructions are as per the original PR (and were very broad, but I'll copy them below for completeness).

---

### Testing instructions

Without this PR (use `release/9.4`):

- Use WordPress 6.7
- Set site language to something other than en_US
- Ensure all translations are installed
- See warning about WooCommerce causing translations to be loaded too early
- See that none of the strings are actually translated

With this PR (use this fix branch):

- Use WordPress 6.7
- Set site language to something other than en_US
- Ensure all translations are installed
- See no warnings.
- See that strings are actually translated
