### PR TITLE
Increase CSS specificity to fix Shipping/Local pickup buttons on WPCOM

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -1,4 +1,4 @@
-.wc-block-checkout__shipping-method-container {
+div.wc-block-checkout__shipping-method-container {
 	width: 100%;
 	display: flex;
 	gap: $gap;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -1,4 +1,4 @@
-div.wc-block-checkout__shipping-method-container {
+.wc-block-checkout__shipping-method .wc-block-checkout__shipping-method-container {
 	width: 100%;
 	display: flex;
 	gap: $gap;

--- a/plugins/woocommerce/changelog/fix-local-pickup-buttons-wpcom
+++ b/plugins/woocommerce/changelog/fix-local-pickup-buttons-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve shipping method block CSS specificity to prevent a display issue for admin accounts on WordPress.com


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add `div` to the `.wc-block-checkout__shipping-method-container` CSS selector. This is required because when logged in as admin on WPCOM, the `wp-components` stylesheet is loaded (Unable to find the cause and will escalate!) but for now this fixes the problem.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #52297

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new site on WPCOM and install this branch using [WooCommerce Beta Tester](https://github.com/woocommerce/woocommerce/releases/tag/wc-beta-tester-2.5.0)
2. Add a Local Pickup option (WC -> Settings -> Shipping -> Local Pickup) 
3. Add a Shipping option
4. Add an item to your cart and go to the Checkout block, ensure the "Shipping/Local pickup" buttons display correctly, like so (The text can be different)

<img width="634" alt="image" src="https://github.com/user-attachments/assets/1d0fd07f-5603-4e10-b038-91e93c598ccc">

6. Test on a non WPCOM site too, the buttons should display the same.
7. Test in the editor, the buttons should still be editable, and display correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
