### PR TITLE
Update to e2e helper plugin to allow WC updates

### DIFF
--- a/plugins/woocommerce/changelog/e2e-dev-update-plugin-to-allow-installs
+++ b/plugins/woocommerce/changelog/e2e-dev-update-plugin-to-allow-installs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update e2e helper plugin to allow install of WC versions

--- a/plugins/woocommerce/tests/e2e-pw/bin/woocommerce-cleanup.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/woocommerce-cleanup.php
@@ -23,13 +23,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Register the REST API route for installing a plugin.
  */
 function wc_cleanup_register_routes() {
-	register_rest_route( 'wc-cleanup/v1', '/install-plugin', array(
-		'methods'  => 'GET',
-		'callback' => 'wc_cleanup_install_plugin',
-		'permission_callback' => function() {
-			return current_user_can( 'install_plugins' );
-		},
-	) );
+	register_rest_route(
+		'wc-cleanup/v1',
+		'/install-plugin',
+		array(
+			'methods'             => 'GET',
+			'callback'            => 'wc_cleanup_install_plugin',
+			'permission_callback' => function () {
+				return current_user_can( 'install_plugins' );
+			},
+		)
+	);
 }
 add_action( 'rest_api_init', 'wc_cleanup_register_routes' );
 
@@ -46,7 +50,7 @@ function wc_cleanup_install_plugin( WP_REST_Request $request ) {
 		return new WP_REST_Response( array( 'error' => 'Invalid URL' ), 400 );
 	}
 
-	// Ensure the URL is for WooCommerce only
+	// Ensure the URL is for WooCommerce only.
 	if ( ! preg_match( '/woocommerce/', $url ) ) {
 		return new WP_REST_Response( array( 'error' => 'URL must be for WooCommerce plugin' ), 400 );
 	}
@@ -57,12 +61,12 @@ function wc_cleanup_install_plugin( WP_REST_Request $request ) {
 	include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 	include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-	// Extract plugin slug from URL
-	$plugin_slug = basename( parse_url( $url, PHP_URL_PATH ), '.zip' );
+	// Extract plugin slug from URL.
+	$plugin_slug = basename( wp_parse_url( $url, PHP_URL_PATH ), '.zip' );
 
-	// Check if the plugin is already installed
+	// Check if the plugin is already installed.
 	$installed_plugins = get_plugins();
-	$plugin_file = null;
+	$plugin_file       = null;
 
 	foreach ( $installed_plugins as $file => $plugin_data ) {
 		if ( strpos( $file, $plugin_slug ) !== false ) {
@@ -72,12 +76,12 @@ function wc_cleanup_install_plugin( WP_REST_Request $request ) {
 	}
 
 	if ( $plugin_file ) {
-		// Deactivate and uninstall the plugin if it is already installed
+		// Deactivate and uninstall the plugin if it is already installed.
 		deactivate_plugins( $plugin_file );
 		delete_plugins( array( $plugin_file ) );
 	}
 
-	// Check if the plugin folder exists and delete it
+	// Check if the plugin folder exists and delete it.
 	$plugin_dir = WP_PLUGIN_DIR . '/' . $plugin_slug;
 	if ( is_dir( $plugin_dir ) ) {
 		global $wp_filesystem;
@@ -89,17 +93,17 @@ function wc_cleanup_install_plugin( WP_REST_Request $request ) {
 	}
 
 	$upgrader = new Plugin_Upgrader();
-	$result = $upgrader->install( $url );
+	$result   = $upgrader->install( $url );
 
 	if ( is_wp_error( $result ) ) {
 		return new WP_REST_Response( array( 'error' => $result->get_error_message() ), 500 );
 	}
 
-	// Activate the plugin after installation
+	// Activate the plugin after installation.
 	$plugin_file = $plugin_slug . '/' . $plugin_slug . '.php';
 	activate_plugin( $plugin_file );
 
-	// Trigger WooCommerce database update if required
+	// Trigger WooCommerce database update if required.
 	if ( function_exists( 'WC_Install' ) ) {
 		WC_Install::update();
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes some updates to the external site e2e helper plugin.  The plugin has a separate API endpoint now that will allow you to pass it a URL for a plugin that it will install/activate/run the DB update for.  The plugin will do a basic check to see if the URL includes "woocommerce" and it requires authentication.  With the plugin installed, you can make a GET request to:

http://your.web.host/wp-json/wc-cleanup/v1/install-plugin?url=https://github.com/woocommerce/woocommerce/releases/download/9.4.0-rc.1/woocommerce.zip

I tested it with betas, RCs and release zip files and all seem to work.  The nightly build doesn't seem to work this way -- I'm not entirely sure why (they fail to install).  Does that sound workable?

Closes # https://github.com/woocommerce/woocommerce/issues/49695

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using one of our test sites, or a local site, install the plugin (here's a zip copy for testing: 
[woocommerce-cleanup.zip](https://github.com/user-attachments/files/17527535/woocommerce-cleanup.zip))
2. Copy the URL of one of the releases for WC from [the GitHub releases page](https://github.com/woocommerce/woocommerce/releases).  Grab the .zip URL under assets.
3. Using Postman or your other favourite API client, send a request to http://your.web.host/wp-json/wc-cleanup/v1/install-plugin?url=<the url for the github release you want>.  You'll need to use Basic authentication with the username and password for an admin user on your test site.

If WC is installed, it should update it to the version you specified.  If it isn't installed, it should install it.

<!-- End testing instructions -->

