### PR TITLE
CYS: Prevent '0' to appear next to the Logo section

### DIFF
--- a/plugins/woocommerce/changelog/fix-cys-logo-0
+++ b/plugins/woocommerce/changelog/fix-cys-logo-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix '0' character appearing in some circumstances in the CYS logo section

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-logo.tsx
@@ -469,7 +469,7 @@ export const SidebarNavigationScreenLogo = ( {
 				<div className="woocommerce-customize-store__sidebar-logo-content">
 					<div className="woocommerce-customize-store__sidebar-group-header woocommerce-customize-store__logo-header-container">
 						<span>{ __( 'Logo', 'woocommerce' ) }</span>
-						{ siteLogoId && (
+						{ Boolean( siteLogoId ) && (
 							<DropdownMenu
 								icon={ moreVertical }
 								label={ __( 'Options', 'woocommerce' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some cases (ie: when loading), `siteLogoId` was `0`, and it was rendered on the screen. This is a tiny PR that fixes it. :slightly_smiling_face: 

### How to test the changes in this Pull Request:

1. Go to the section of adding a site logo in CYS (you can go directly to this URL: `/wp-admin/admin.php?page=wc-admin&customizing=true&path=%2Fcustomize-store%2Fassembler-hub%2Flogo`).
2. Verify at no moment there is a `0` on the right side of the `Logo` section title.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/1c854e11-3f7b-4fec-a89c-2625d6d52e18) | ![imatge](https://github.com/user-attachments/assets/1c64eb04-3ba3-4f3b-959d-8fd7dad7a2ae)