### PR TITLE
Remove double changelog entry which causes CI to fail

### DIFF
--- a/plugins/woocommerce/changelog/52240-fix-52175-gtin-import-mapper
+++ b/plugins/woocommerce/changelog/52240-fix-52175-gtin-import-mapper
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Adds the missing global_unique_id field to the product import mapper


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce/pull/52240#issuecomment-2441306079