### PR TITLE
Check for valid session object before calling get_customer_id in Cart Route

### DIFF
--- a/plugins/woocommerce/changelog/52410-fix-52326-jwt-error-when-no-session
+++ b/plugins/woocommerce/changelog/52410-fix-52326-jwt-error-when-no-session
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure session exists before calling its functions in the Cart StoreApi route

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -188,6 +188,9 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return string
 	 */
 	protected function get_cart_token() {
+		// Ensure cart is loaded.
+		$this->cart_controller->load_cart();
+
 		if ( ! wc()->session ) {
 			return null;
 		}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -188,6 +188,10 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return string
 	 */
 	protected function get_cart_token() {
+		if ( ! wc()->session ) {
+			return null;
+		}
+
 		return JsonWebToken::create(
 			[
 				'user_id' => wc()->session->get_customer_id(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There was a report of fatal errors in the `get_cart_token` function of the `AbstractCartRoute`. This happens when the session object is null for whatever reason. This PR adds a check to return `null` in this case, which will result in the JWT token not being added as a header. I'm not entirely sure this is the correct behaviour so I'd like to check this.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #52326.

### How to test the changes in this Pull Request:

Not quite sure to be honest. I don't know when the session object would be null, as it's initialised [on the first line of get_response](https://github.com/woocommerce/woocommerce/blob/fix/52326-jwt-error-when-no-session/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php#L114). Would appreciate some help debugging this.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Make sure session exists before calling its functions in the Cart StoreApi route

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
