### PR TITLE
Update email preview to show processing order email

### DIFF
--- a/plugins/woocommerce/changelog/52225-email-preview-route
+++ b/plugins/woocommerce/changelog/52225-email-preview-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: This change replaces static email preview with order processing email. This is in development behind a hidden experimental flag and not yet ready for public use.
+
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -7,6 +7,8 @@
  * @version  2.6.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\EmailPreview;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -194,22 +196,8 @@ class WC_Admin {
 				die( 'Security check' );
 			}
 
-			// load the mailer class.
-			$mailer = WC()->mailer();
-
-			// get the preview email subject.
-			$email_heading = __( 'HTML email template', 'woocommerce' );
-
-			// get the preview email content.
-			ob_start();
-			include __DIR__ . '/views/html-email-template-preview.php';
-			$message = ob_get_clean();
-
-			// create a new email.
-			$email = new WC_Email();
-
-			// wrap the content with the email template and then add styles.
-			$message = apply_filters( 'woocommerce_mail_content', $email->style_inline( $mailer->wrap_message( $email_heading, $message ) ) );
+			$email_preview = wc_get_container()->get( EmailPreview::class );
+			$message       = $email_preview->render();
 
 			// print the preview email.
 			// phpcs:ignore WordPress.Security.EscapeOutput

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -721,6 +721,16 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
+	 * Set the object for the outgoing email.
+	 *
+	 * @param object $object Object this email is for, e.g. customer, or product.
+	 * @return void
+	 */
+	public function set_object( $object ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound
+		$this->object = $object;
+	}
+
+	/**
 	 * Send an email.
 	 *
 	 * @param string $to Email to.

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\CostOf
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\COTMigrationServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\DownloadPermissionsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\AssignDefaultCategoryServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\EmailPreviewServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\EnginesServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\FeaturesServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\LoggingServiceProvider;
@@ -63,6 +64,7 @@ final class Container {
 	private $service_providers = array(
 		AssignDefaultCategoryServiceProvider::class,
 		DownloadPermissionsAdjusterServiceProvider::class,
+		EmailPreviewServiceProvider::class,
 		OptionSanitizerServiceProvider::class,
 		OrdersDataStoreServiceProvider::class,
 		ProductAttributesLookupServiceProvider::class,

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Renders the email preview.
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin;
+
+use WC_Email;
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * EmailPreview Class.
+ */
+class EmailPreview {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function instance() {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Get the preview email content.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		return $this->render_legacy_preview_email();
+	}
+
+	/**
+	 * Get HTML of the legacy preview email.
+	 *
+	 * @return string
+	 */
+	private function render_legacy_preview_email() {
+		// load the mailer class.
+		$mailer = WC()->mailer();
+
+		// get the preview email subject.
+		$email_heading = __( 'HTML email template', 'woocommerce' );
+
+		// get the preview email content.
+		ob_start();
+		include WC()->plugin_path() . '/includes/admin/views/html-email-template-preview.php';
+		$message = ob_get_clean();
+
+		// create a new email.
+		$email = new WC_Email();
+
+		/**
+		 * Wrap the content with the email template and then add styles.
+		 *
+		 * @since 2.6.0
+		 */
+		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $mailer->wrap_message( $email_heading, $message ) ) );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
@@ -183,7 +183,7 @@ class EmailPreview {
 	 */
 	private function set_up_filters() {
 		// Always show shipping address in the preview email.
-		add_filter( 'woocommerce_order_needs_shipping_address', '__return_true' );
+		add_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
 		// Email templates fetch product from the database to show additional information, which are not
 		// saved in WC_Order_Item_Product. This filter enables fetching that data also in email preview.
 		add_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10, 1 );
@@ -193,7 +193,17 @@ class EmailPreview {
 	 * Clean up filters after email preview.
 	 */
 	private function clean_up_filters() {
-		remove_filter( 'woocommerce_order_needs_shipping_address', '__return_true' );
+		remove_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
 		remove_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10 );
+	}
+
+	/**
+	 * Enable shipping address in the preview email. Not using __return_true so
+	 * we don't accidentally remove the same filter used by other plugin or theme.
+	 *
+	 * @return true
+	 */
+	public function enable_shipping_address() {
+		return true;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
@@ -85,6 +85,13 @@ class EmailPreview {
 	 * @return string
 	 */
 	private function render_preview_email() {
+		/**
+		 * Always show shipping address in the preview email.
+		 *
+		 * @since 9.5.0
+		 */
+		add_filter( 'woocommerce_order_needs_shipping_address', '__return_true' );
+
 		$email = $this->get_email();
 
 		$order = $this->get_dummy_order();
@@ -119,6 +126,7 @@ class EmailPreview {
 
 		$address = $this->get_dummy_address();
 		$order->set_billing_address( $address );
+		$order->set_shipping_address( $address );
 
 		return $order;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
@@ -108,12 +108,8 @@ class EmailPreview {
 
 		$this->clean_up_filters();
 
-		/**
-		 * Wrap the content with the email template and then add styles.
-		 *
-		 * @since 9.5.0
-		 */
-		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $content ) );
+		/** This filter is documented in src/Internal/Admin/EmailPreview.php */
+		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $content ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
@@ -7,7 +7,10 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Email;
+use WC_Order;
+use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -41,6 +44,10 @@ class EmailPreview {
 	 * @return string
 	 */
 	public function render() {
+		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+			return $this->render_preview_email();
+		}
+
 		return $this->render_legacy_preview_email();
 	}
 
@@ -70,5 +77,80 @@ class EmailPreview {
 		 * @since 2.6.0
 		 */
 		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $mailer->wrap_message( $email_heading, $message ) ) );
+	}
+
+	/**
+	 * Render HTML content of the preview email.
+	 *
+	 * @return string
+	 */
+	private function render_preview_email() {
+		$email = $this->get_email();
+
+		$order = $this->get_dummy_order();
+		$email->set_object( $order );
+
+		$content = $email->get_content_html();
+
+		/**
+		 * Wrap the content with the email template and then add styles.
+		 *
+		 * @since 9.5.0
+		 */
+		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $content ) );
+	}
+
+	/**
+	 * Get a dummy order object without the need to create in the database.
+	 *
+	 * @return WC_Order
+	 */
+	private function get_dummy_order() {
+		$product = new WC_Product();
+		$product->set_name( 'Dummy Product' );
+		$product->set_price( 25 );
+
+		$order = new WC_Order();
+		$order->add_product( $product, 2 );
+		$order->set_id( 12345 );
+		$order->set_date_created( time() );
+		$order->set_currency( 'USD' );
+		$order->set_total( 100 );
+
+		$address = $this->get_dummy_address();
+		$order->set_billing_address( $address );
+
+		return $order;
+	}
+
+	/**
+	 * Get a dummy address.
+	 *
+	 * @return array
+	 */
+	private function get_dummy_address() {
+		return array(
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+			'company'    => 'Company',
+			'email'      => 'john@company.com',
+			'phone'      => '555-555-5555',
+			'address_1'  => '123 Fake Street',
+			'city'       => 'Faketown',
+			'postcode'   => '12345',
+			'country'    => 'US',
+			'state'      => 'CA',
+		);
+	}
+
+	/**
+	 * Get the email class for email preview.
+	 *
+	 * @return WC_Email
+	 */
+	private function get_email() {
+		$emails = WC()->mailer()->get_emails();
+		$email  = $emails['WC_Email_Customer_Processing_Order'];
+		return $email;
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview;
+
+/**
+ * Service provider for the EmailPreview namespace.
+ */
+class EmailPreviewServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The classes/interfaces that are serviced by this service provider.
+	 *
+	 * @var array
+	 */
+	protected $provides = array(
+		EmailPreview::class,
+	);
+
+	/**
+	 * Register the classes.
+	 */
+	public function register() {
+		$this->share( EmailPreview::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreviewTest.php
@@ -1,0 +1,68 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin;
+
+use Automattic\WooCommerce\Internal\Admin\EmailPreview;
+use WC_Emails;
+use WC_Unit_Test_Case;
+
+/**
+ * EmailPreviewTest test.
+ *
+ * @covers \Automattic\WooCommerce\Internal\Admin\EmailPreview
+ */
+class EmailPreviewTest extends WC_Unit_Test_Case {
+	/**
+	 * "System Under Test", an instance of the class to be tested.
+	 *
+	 * @var EmailPreview
+	 */
+	private $sut;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new EmailPreview();
+		new WC_Emails();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'no' );
+	}
+
+	/**
+	 * Tests that it returns legacy email preview when feature flag is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_it_returns_legacy_email_preview_by_default() {
+		$message        = $this->sut->render();
+		$legacy_title   = 'HTML email template';
+		$legacy_content = 'Lorem ipsum dolor sit amet';
+		$this->assertStringContainsString( $legacy_title, $message );
+		$this->assertStringContainsString( $legacy_content, $message );
+	}
+
+	/**
+	 * Tests that it returns processing order email preview when feature flag is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_it_returns_order_email_preview_under_feature_flag() {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
+		$message       = $this->sut->render();
+		$order_title   = 'Thank you for your order';
+		$order_content = "Just to let you know — we've received your order #12345, and it is now being processed:";
+		$order_product = 'Dummy Product';
+		$this->assertStringContainsString( $order_title, $message );
+		$this->assertStringContainsString( $order_content, $message );
+		$this->assertStringContainsString( $order_product, $message );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. When the feature flag is enabled, the static email preview is replaced with an order email. This functionality will later be improved to be more dynamic (different email types, more order data).

Closes #52225.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Settings > Emails` and click on email preview in the **Email template** section.
2. You should see a hardcoded email template including **Lorem ipsum** text. 

<img width="622" alt="Screenshot 2024-10-29 at 13 24 13" src="https://github.com/user-attachments/assets/0b256676-92b6-4ff0-a892-d02e51f1e16e">

3. Enable the `email_improvements` feature flag. It's hidden in the UI, so this needs to be done in the database 
    - Set the `woocommerce_feature_email_improvements_enabled` option to `yes`.
4. Reload the email preview.
5. You should now see the processing order email with a dummy order, product, and customer, none of which exists in the database. 

<img width="626" alt="Screenshot 2024-10-29 at 13 28 14" src="https://github.com/user-attachments/assets/987f94c4-1184-4653-b293-6d9039144000">

6. You should also see this email when the store has zero orders, no products, and no customers. 

<!-- End testing instructions -->