### PR TITLE
[WordPress 6.7] Fix image aspect ratio in product grid blocks 

### DIFF
--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -21,6 +21,7 @@ body.wc-block-product-gallery-modal-open {
 
 	img {
 		height: auto;
+		width: 100%;
 		max-width: 100%;
 
 		&[hidden] {

--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -21,10 +21,7 @@ body.wc-block-product-gallery-modal-open {
 
 	img {
 		height: auto;
-		width: auto;
 		max-width: 100%;
-		// Handle user agent stylesheet applied in WordPress 6.7
-		contain-intrinsic-size: 300px 300px;
 
 		&[hidden] {
 			display: none;

--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -23,6 +23,8 @@ body.wc-block-product-gallery-modal-open {
 		height: auto;
 		width: auto;
 		max-width: 100%;
+		// Handle user agent stylesheet applied in WordPress 6.7
+		contain-intrinsic-size: 300px 300px;
 
 		&[hidden] {
 			display: none;

--- a/plugins/woocommerce/changelog/fix-52382
+++ b/plugins/woocommerce/changelog/fix-52382
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product grid blocks: fix Image aspect ratio with WordPress 6.7


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

What an interesting and weird issue.

WordPress 6.7 added [Auto Sizes for Lazy Loaded Images](https://make.wordpress.org/core/2024/10/18/auto-sizes-for-lazy-loaded-images-in-wordpress-6-7/). Pretty cool.

The above kind of implies requirement that `<img>` elements have width and height attributes. Because according to HTML specs (which not every browser follows):
> without specified dimensions, the image will likely render with 300x150 dimensions because sizes="auto" implies contain-intrinsic-size: 300px 150px in [the Rendering section](https://html.spec.whatwg.org/multipage/rendering.html#img-contain-size).

Hence in Chrome user agent stylesheet applies the following if the image has no dimensions specified:

```
img:is([sizes="auto" i], [sizes^="auto," i]) {
    contain: size !important;
    contain-intrinsic-size: 300px 150px;
}
```

In great (and funny!) article: https://ericportis.com/posts/2023/auto-sizes-pretty-much-requires-width-and-height/ related to that topic, author says:

> That says: are we dealing with an <img> with sizes=auto? Then its natural dimensions are 300×150. NO EXCEPTIONS.

> [300×150 was chosen](https://github.com/whatwg/html/issues/9448#issuecomment-1625060436) because that’s what [<video>](https://html.spec.whatwg.org/multipage/media.html#the-video-element:default-object-size) and [<canvas>](https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element:~:text=The%20width%20attribute%20defaults%20to%20300%2C%20and%20the%20height%20attribute%20defaults%20to%20150.) do; all of these elements use this smallish-but-non-zero default size in order to encourage you to do better.

Anyway, it [feels buggy](https://www.reddit.com/r/chrome/comments/1adr2tv/is_sizesauto_buggy_in_chrome_121/) but it's according to specs! Hence applying `width: 100%` and not `auto` as per article's suggestion.

Closes https://github.com/woocommerce/woocommerce/issues/52382
Closes https://github.com/woocommerce/woocommerce/issues/52165

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:



1. Create a new post
2. Insert Top Rated Products or other AbstractProductGrid block
3. Change the align option to "Wide width" or "Full width"
4. **Expected:** Images keep aspect ratio
5. Save and go to frontend
6. **Expected:** Images keep aspect ratio

- Test with WordPress 6.6 AND 6.7!
- Verify it in different browsers as well!

Before | After
-- | --
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/4f791f71-c0a1-4c49-8469-d3dd66544056"> | <img width="1415" alt="image" src="https://github.com/user-attachments/assets/d831df0d-5a09-4719-95cd-2c94da81ae39">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
