### PR TITLE
[WordPress 6.7] Make sure Product Image Gallery renders placeholder in Editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
@@ -35,30 +35,16 @@ const Placeholder = () => {
 	);
 };
 
-type Context = {
-	postId: string;
-	postType: string;
-	queryId: string;
-};
-
-interface Props extends BlockEditProps< BlockAttributes > {
-	context: Context;
-}
-
-const Edit = ( { context }: Props ) => {
+const Edit = () => {
 	const blockProps = useBlockProps();
 
-	if ( isEmptyObject( context ) ) {
-		return (
-			<div { ...blockProps }>
-				<Disabled>
-					<Placeholder />
-				</Disabled>
-			</div>
-		);
-	}
-	// We have work on this case when we will work on the Single Product block.
-	return <></>;
+	return (
+		<div { ...blockProps }>
+			<Disabled>
+				<Placeholder />
+			</Disabled>
+		</div>
+	);
 };
 
 export default Edit;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/product-image-gallery/edit.tsx
@@ -2,11 +2,8 @@
  * External dependencies
  */
 import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
-import { isEmptyObject } from '@woocommerce/types';
 import { useBlockProps } from '@wordpress/block-editor';
-import { BlockAttributes } from '@wordpress/blocks';
 import { Disabled } from '@wordpress/components';
-import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/changelog/fix-52394
+++ b/plugins/woocommerce/changelog/fix-52394
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Image Gallery: Render placeholder in Editor in WordPress 6.7


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Till WordPress 6.6 there was no context provided to Product Image Gallery in Single Product template. Since WordPress 6.7 there's context provided in the template:

```
{ postType: 'product' }
```

hence the condition `if ( isEmptyObject( context ) ) {` didn't pass and nothing was rendered in the Editor even though the block was there. But I'm not sure what would be the reason of putting this condition in the first place, @thealexandrelara and @gigitux, do you know by any chance?

I'm removing this condition so the content can be rendered.

Closes https://github.com/woocommerce/woocommerce/issues/52394

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Editor > Single Product template
2. **Expected:** There's placeholder for Product Image Gallery
3. Verify in WordPress 6.7 AND 6.6

Before | After
-- | --
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/1f6b6e19-7d0f-4f6a-a0ac-c1c5a6ec504f"> | <img width="1170" alt="image" src="https://github.com/user-attachments/assets/7d33585e-20cb-4d22-9275-77a02e983746">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
