### PR TITLE
dev: wcadmin webpack dev server

### DIFF
--- a/plugins/woocommerce-beta-tester/api/api.php
+++ b/plugins/woocommerce-beta-tester/api/api.php
@@ -68,3 +68,4 @@ require 'remote-logging/remote-logging.php';
 require 'tools/wccom-request-errors.php';
 require 'tools/set-wccom-base-url.php';
 require 'tools/reset-launch-your-store.php';
+require 'tools/set-wc-admin-assets-url.php';

--- a/plugins/woocommerce-beta-tester/api/tools/set-wc-admin-assets-url.php
+++ b/plugins/woocommerce-beta-tester/api/tools/set-wc-admin-assets-url.php
@@ -1,0 +1,62 @@
+<?php 
+defined( 'ABSPATH' ) || exit;
+
+register_woocommerce_admin_test_helper_rest_route(
+	'/tools/set-wc-admin-assets-base-url/v1',
+	'tools_set_wc_admin_assets_base_url',
+	array(
+		'methods' => 'POST',
+		'args'    => array(
+			'url' => array(
+				'description' => 'WC Admin Assets URL Filter',
+				'type'        => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'esc_url_raw',
+			),
+		),
+	)
+);
+
+register_woocommerce_admin_test_helper_rest_route(
+	'/tools/get-wc-admin-assets-base-url/v1',
+	'tools_get_wc_admin_assets_base_url',
+	array(
+		'methods' => 'GET',
+	)
+);
+
+/**
+ * A tool to set the base URL for the WC Admin Assets filter.
+ *
+ * @param WP_REST_Request $request Request object.
+ */
+function tools_set_wc_admin_assets_base_url( $request ) {
+	$url = $request->get_param( 'url' );
+
+    if ( empty( $url ) || $url === '') {
+        delete_option( 'wc_admin_test_helper_filter_admin_assets_base_url' );
+    } else {
+        update_option( 'wc_admin_test_helper_filter_admin_assets_base_url', $url );
+    }
+	return new WP_REST_Response( $url, 200 );
+}
+
+/**
+ * A tool to get the base URL for WC Admin Assets filter.
+ */
+function tools_get_wc_admin_assets_base_url() {
+	$url = get_option( 'wc_admin_test_helper_filter_admin_assets_base_url' , '' );
+
+	return new WP_REST_Response( $url, 200 );
+}
+
+
+if ( ! empty( get_option( 'wc_admin_test_helper_filter_admin_assets_base_url', '' ) ) ) {
+    add_filter( 'woocommerce_admin_asset_url', 'modify_plugin_url', 10, 5 );
+    
+    function modify_plugin_url( $url, $path, $file, $suffix, $ext ) {
+        return trailingslashit(get_option( 'wc_admin_test_helper_filter_admin_assets_base_url' )) . $file . $suffix . '.' . $ext;
+    }
+}
+
+

--- a/plugins/woocommerce-beta-tester/src/tools/commands/index.js
+++ b/plugins/woocommerce-beta-tester/src/tools/commands/index.js
@@ -28,6 +28,10 @@ import {
 	SetWccomBaseUrl,
 	UPDATE_WCCOM_BASE_URL_ACTION_NAME,
 } from './set-wccom-base-url';
+import {
+	SetWcAdminAssetsBaseUrl,
+	UPDATE_WC_ADMIN_ASSETS_BASE_URL_ACTION_NAME,
+} from './set-wc-admin-assets-base-url';
 
 export default [
 	{
@@ -119,5 +123,10 @@ export default [
 		command: 'Reset Launch Your Store',
 		description: 'Resets Launch Your Store and coming soon mode changes.',
 		action: 'resetLaunchYourStore',
+	},
+	{
+		command: 'WC Admin Assets Webpack Dev Server URL',
+		description: <SetWcAdminAssetsBaseUrl />,
+		action: UPDATE_WC_ADMIN_ASSETS_BASE_URL_ACTION_NAME,
 	},
 ];

--- a/plugins/woocommerce-beta-tester/src/tools/commands/set-wc-admin-assets-base-url.js
+++ b/plugins/woocommerce-beta-tester/src/tools/commands/set-wc-admin-assets-base-url.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { TextControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '../data/constants';
+
+export const UPDATE_WC_ADMIN_ASSETS_BASE_URL_ACTION_NAME =
+	'updateWcAdminAssetsBaseUrl';
+
+export const SetWcAdminAssetsBaseUrl = () => {
+	const url = useSelect(
+		( select ) => select( STORE_KEY ).getWcAdminAssetsBaseUrl(),
+		[]
+	);
+	const { updateCommandParams } = useDispatch( STORE_KEY );
+
+	function onUpdate( newUrl ) {
+		updateCommandParams( UPDATE_WC_ADMIN_ASSETS_BASE_URL_ACTION_NAME, {
+			url: newUrl,
+		} );
+	}
+
+	return (
+		<div className="wcadmin-assets-base-url-control">
+			{ url === undefined ? (
+				<p>Loading...</p>
+			) : (
+				<TextControl value={ url } onChange={ onUpdate } />
+			) }
+		</div>
+	);
+};

--- a/plugins/woocommerce-beta-tester/src/tools/data/actions.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/actions.js
@@ -326,3 +326,13 @@ export function* resetLaunchYourStore() {
 		} );
 	} );
 }
+
+export function* updateWcAdminAssetsBaseUrl( { url } ) {
+	yield runCommand( 'Set WC Admin Assets Base URL', function* () {
+		yield apiFetch( {
+			path: '/wc-admin-test-helper/tools/set-wc-admin-assets-base-url/v1',
+			method: 'POST',
+			data: { url },
+		} );
+	} );
+}

--- a/plugins/woocommerce-beta-tester/src/tools/data/reducer.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/reducer.js
@@ -16,6 +16,7 @@ const DEFAULT_STATE = {
 		updateWccomRequestErrorsMode: {},
 		fakeWooPayments: {},
 		updateWccomBaseUrl: { url: '' },
+		updateWcAdminAssetsBaseUrl: { url: '' },
 	},
 	status: '',
 	dbUpdateVersions: [],

--- a/plugins/woocommerce-beta-tester/src/tools/data/resolvers.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/resolvers.js
@@ -20,6 +20,7 @@ import { TRIGGER_UPDATE_CALLBACKS_ACTION_NAME } from '../commands/trigger-update
 import { UPDATE_WCCOM_REQUEST_ERRORS_MODE } from '../commands/set-wccom-request-errors';
 import { FAKE_WOO_PAYMENTS_ACTION_NAME } from '../commands/fake-woo-payments';
 import { UPDATE_WCCOM_BASE_URL_ACTION_NAME } from '../commands/set-wccom-base-url';
+import { UPDATE_WC_ADMIN_ASSETS_BASE_URL_ACTION_NAME } from '../commands/set-wc-admin-assets-base-url';
 
 export function* getCronJobs() {
 	const path = `${ API_NAMESPACE }/tools/get-cron-list/v1`;
@@ -163,6 +164,25 @@ export function* getWccomBaseUrl() {
 		yield updateCommandParams( UPDATE_WCCOM_BASE_URL_ACTION_NAME, {
 			url: url || 'https://woocommerce.com/',
 		} );
+	} catch ( error ) {
+		throw new Error( error );
+	}
+}
+
+export function* getWcAdminAssetsBaseUrl() {
+	const path = `${ API_NAMESPACE }/tools/get-wc-admin-assets-base-url/v1`;
+
+	try {
+		const url = yield apiFetch( {
+			path,
+			method: 'GET',
+		} );
+		yield updateCommandParams(
+			UPDATE_WC_ADMIN_ASSETS_BASE_URL_ACTION_NAME,
+			{
+				url,
+			}
+		);
 	} catch ( error ) {
 		throw new Error( error );
 	}

--- a/plugins/woocommerce-beta-tester/src/tools/data/selectors.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/selectors.js
@@ -49,3 +49,7 @@ export function getIsFakeWooPaymentsEnabled( state ) {
 export function getWccomBaseUrl( state ) {
 	return state.params.updateWccomBaseUrl.url;
 }
+
+export function getWcAdminAssetsBaseUrl( state ) {
+	return state.params.updateWcAdminAssetsBaseUrl.url;
+}

--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -281,9 +281,13 @@ if ( ! isProduction || WC_ADMIN_PHASE === 'development' ) {
 			devMiddleware: {
 				writeToDisk: true,
 			},
-			allowedHosts: 'auto',
+			allowedHosts: 'all',
 			host: 'localhost',
 			port: 8887,
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+			},
+			watchFiles: [ 'node_modules/@woocommerce/**' ],
 			proxy: {
 				'/build': {
 					pathRewrite: {

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -94,7 +94,25 @@ class WCAdminAssets {
 			$suffix       = self::should_use_minified_js_file( $script_debug ) ? '.min' : '';
 		}
 
-		return plugins_url( self::get_path( $ext ) . $file . $suffix . '.' . $ext, WC_ADMIN_PLUGIN_FILE );
+		$asset_url = plugins_url( self::get_path( $ext ) . $file . $suffix . '.' . $ext, WC_ADMIN_PLUGIN_FILE );
+
+		/**
+		 * Overrides the WC Admin asset URLs. These are the JS and CSS built files from woocommerce/client/admin
+		 *
+		 * @param string $file    The base filename for the asset file.
+		 * @param string $suffix  Additional suffix for the filename, if needed. E.g .min.js
+		 * @param string $ext     The file extension for the asset file. Typically .js or .css
+		 *
+		 * @return string The filtered URL for the specified asset file.
+		 */
+		return apply_filters(
+			'woocommerce_admin_asset_url',
+			$asset_url,
+			self::get_path( $ext ),
+			$file,
+			$suffix,
+			$ext
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Adds a filter to modify the WC Admin Assets URL for dev purposes or otherwise.
- Adds a tool in WC Beta Tester to allow plugin users to modify the WC Admin Assets URL filter
- Small changes to webpack.config.js to allow any origin


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a development environment as usual, it should work as expected without any breakage
2. Build WC Beta Tester (go to ./plugins/woocommerce-beta-tester and `pnpm run build`)
3. Ensure that WC Beta Tester path is loaded as a plugin in .wp-env.override.json
4. Go to Tools tab in WC Beta Tester and set the WC Admin Assets Webpack Dev Server URL to `http://localhost:8887`
5. Go to ./plugins/woocommerce and run `pnpm run watch:build`
6. Open another terminal and to go ./plugins/woocommerce/client/admin and run `HOT=true npx webpack serve`
7. Refresh WC Admin and observe that it loads WC Admin JS and CSS from localhost:8887 instead of the usual
8. Make a change in a file within ./plugins/woocommerce/client/admin/ and see the hot reload 

https://github.com/user-attachments/assets/73c25b1d-0db3-4553-9799-39cd4d84eab2

Note that hot reload doesn't seem fully reliable as it crashes sometimes due to `Uncaught TypeError: currentUpdateRuntime is undefined`. I haven't figured this out but this is as far as I got. I figure this PR still has value as you can still gain some benefit from using `webpack serve` without hot reload and it'll still be some improvement over the current rsync and serve via WP assets.

There is still room for improvement to the webpack build speed I believe, as it currently takes about ~2.8-5s for the incremental build. Ideally this should be under 2s.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
