### PR TITLE
Fix storybook wireit commands conflict

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -74,11 +74,11 @@
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"rimraf": "./node_modules/rimraf/bin.js",
 		"start": "rimraf build/* && cross-env BABEL_ENV=default CHECK_CIRCULAR_DEPS=true webpack --watch",
-		"storybook": "pnpm watch:build:project:storybook",
-		"storybook:build": "pnpm build:project:storybook",
+		"storybook": "pnpm watch:build:storybook",
+		"storybook:build": "pnpm build:storybook",
 		"storybook:deploy": "rimraf ./storybook/dist/* && pnpm run storybook:build && gh-pages -d ./storybook/dist",
-		"build:project:storybook": "wireit",
-		"watch:build:project:storybook": "wireit",
+		"build:storybook": "wireit",
+		"watch:build:storybook": "wireit",
 		"test:js": "wp-scripts test-unit-js --config tests/js/jest.config.json",
 		"test:debug": "ndb .",
 		"test:e2e": "sh ./bin/check-env.sh && pnpm playwright test --config=tests/e2e/playwright.config.ts",
@@ -393,7 +393,7 @@
 				"dependencyOutputs"
 			]
 		},
-		"build:project:storybook": {
+		"build:storybook": {
 			"command": "storybook build  -c ./storybook -o ./storybook/dist",
 			"env": {
 				"BABEL_ENV": "development"
@@ -416,7 +416,7 @@
 			"command": "webpack --watch",
 			"service": true
 		},
-		"watch:build:project:storybook": {
+		"watch:build:storybook": {
 			"command": "storybook dev  -c ./storybook -p 6006 --ci",
 			"service": true
 		},

--- a/plugins/woocommerce/changelog/fix-storybook_wireit_commands
+++ b/plugins/woocommerce/changelog/fix-storybook_wireit_commands
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Update storybook build commands to avoid conflicts with the build:project wildcard.

--- a/tools/storybook/package.json
+++ b/tools/storybook/package.json
@@ -11,12 +11,10 @@
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
 	"scripts": {
-		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:project:.*$/'",
-		"build:project": "pnpm --if-present '/^build:project:.*$/'",
-		"build:project:storybook": "wireit",
-		"watch:build": "pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel '/^watch:build:project:storybook$/'",
-		"watch:build:project": "pnpm --if-present '/^watch:build:project:.*$/'",
-		"watch:build:project:storybook": "wireit",
+		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:(project|storybook):?.*$/'",
+		"build:storybook": "wireit",
+		"watch:build": "pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel '/^watch:build:storybook$/'",
+		"watch:build:storybook": "wireit",
 		"copy-blocks-storybook-iframe": "cp ../../plugins/woocommerce-blocks/storybook/dist/iframe.html ./storybook-static/assets/woocommerce-blocks",
 		"storybook-rtl": "USE_RTL_STYLE=true pnpm storybook",
 		"preinstall": "npx only-allow pnpm"
@@ -61,7 +59,7 @@
 		"wireit": "0.14.3"
 	},
 	"wireit": {
-		"build:project:storybook": {
+		"build:storybook": {
 			"command": "storybook build -c ./.storybook --quiet && pnpm run copy-blocks-storybook-iframe",
 			"env": {
 				"STORYBOOK": "true",
@@ -85,7 +83,7 @@
 				"dependencyOutputs"
 			]
 		},
-		"watch:build:project:storybook": {
+		"watch:build:storybook": {
 			"command": "storybook dev -c ./.storybook -p 6007 --ci",
 			"service": true,
 			"env": {

--- a/tools/storybook/package.json
+++ b/tools/storybook/package.json
@@ -11,7 +11,7 @@
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
 	"scripts": {
-		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:(project|storybook):?.*$/'",
+		"build": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"$npm_package_name...\" '/^build:(project:|storybook).*$/'",
 		"build:storybook": "wireit",
 		"watch:build": "pnpm --if-present --workspace-concurrency=Infinity --filter=\"$npm_package_name...\" --parallel '/^watch:build:storybook$/'",
 		"watch:build:storybook": "wireit",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a follow up of this PR ( https://github.com/woocommerce/woocommerce/pull/51701 ) where I introduced wireit commands for storybook using the `build:project:<project name>` format. This caused an issue where storybook build commands where run for the normal build and E2E tests, when that was not necessary.
This is because we tend to use the `build:project:*` regex to run most of our commands.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the `pnpm run build` command and make sure it doesn't trigger the `build:storybook` command
2. Run the `pnpm --filter=@woocommerce/plugin-woocommerce watch:build` and make sure the `watch:build:storybook` is not run. You can pump it into a log file and wait 2 minutes to make search easier: `pnpm --filter=@woocommerce/plugin-woocommerce watch:build > output.log`
3. On a fresh clone or run `git clean -xdf` run `pnpm i` again.
4. Run `pnpm --filter=@woocommerce/storybook run build` it should finish successfully
5. Run `npx http-server tools/storybook/storybook-static` and go to the URL
6. It should render the storybook correctly.
7. Run `pnpm --filter=@woocommerce/storybook run watch:build` and go to `localhost:6007`
8. It should render storybook correctly, including the blocks addition ( you should be able to view the blocks storybook individually on `localhost:6006`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
