### PR TITLE
Update E2E tests to work with WP 6.7 RC2

### DIFF
--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-latest.zip",
+	"core": "https://wordpress.org/wordpress-6.7-RC2.zip",
 	"phpVersion": "7.4",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
@@ -61,6 +61,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 	} );
 
 	test( `Registered collections should be available in Collection chooser`, async ( {
+		page,
 		pageObject,
 		editor,
 		admin,
@@ -73,15 +74,11 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			} )
 			.click();
 
-		const productCollectionBlock = editor.canvas.getByLabel(
-			'Block: Product Collection'
-		);
-
 		for ( const myCollection of Object.values(
 			MY_REGISTERED_COLLECTIONS
 		) ) {
 			await expect(
-				productCollectionBlock.getByRole( 'button', {
+				page.getByRole( 'button', {
 					name: myCollection.name,
 					exact: true,
 				} )

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -45,7 +45,7 @@ test.describe( 'Template customization', () => {
 				// See: https://github.com/woocommerce/woocommerce/issues/42221
 				await expect(
 					page.getByRole( 'heading', {
-						name: `Editing ${ templateTypeName }: ${ testData.templateName }`,
+						name: `${ testData.templateName } · ${ templateTypeName }`,
 					} )
 				).toBeVisible();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -53,7 +53,7 @@ test.describe( 'Template customization', () => {
 				// See: https://github.com/woocommerce/woocommerce/issues/42221
 				await expect(
 					page.getByRole( 'heading', {
-						name: `Editing ${ templateTypeName }: ${ testData.templateName }`,
+						name: `${ testData.templateName } · ${ templateTypeName }`,
 					} )
 				).toBeVisible();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
@@ -78,7 +78,7 @@ test.describe( 'Template part customization', () => {
 			// See: https://github.com/woocommerce/woocommerce/issues/42221
 			await expect(
 				page.getByRole( 'heading', {
-					name: `Editing template part: ${ templateName }`,
+					name: `${ templateName } · Template Part`,
 				} )
 			).toBeVisible();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
@@ -78,7 +78,7 @@ test.describe( 'Template part customization', () => {
 			// See: https://github.com/woocommerce/woocommerce/issues/42221
 			await expect(
 				page.getByRole( 'heading', {
-					name: `Editing template part: ${ templateName }`,
+					name: `${ templateName } · Template Part`,
 				} )
 			).toBeVisible();
 

--- a/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -73,7 +73,12 @@ export class Editor extends CoreEditor {
 
 	async revertTemplate( { templateName }: { templateName: string } ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
-		await this.page.getByLabel( templateName, { exact: true } ).click();
+		// WP 6.7 issue: https://github.com/WordPress/gutenberg/issues/66585.
+		// Template-parts have aria-label="[object Object]" hence switching
+		// from using label to button.
+		await this.page
+			.getByRole( 'button', { name: templateName, exact: true } )
+			.click();
 
 		await this.page.getByLabel( 'Actions' ).click();
 		await this.page

--- a/plugins/woocommerce/changelog/test-verify-ci-with-wp-6-7-rc2
+++ b/plugins/woocommerce/changelog/test-verify-ci-with-wp-6-7-rc2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+E2E tests: update tests to WordPress 6.7


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Bump WordPress version used for E2E tests to 6.7 RC2 (go back to `wordpress-latest` once 6.7 is released) and adjust the tests

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI should be green.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
