### PR TITLE
Fix JS translations broken when plugin folder name is not "woocommece"

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-js-i18n
+++ b/plugins/woocommerce-beta-tester/changelog/fix-js-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc plugin file path

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
@@ -92,7 +92,7 @@ class WC_Beta_Tester {
 	public function __construct() {
 		$this->plugin_name   = plugin_basename( WC_BETA_TESTER_FILE );
 		$this->plugin_config = array(
-			'plugin_file'        => 'woocommerce/woocommerce.php',
+			'plugin_file'        => WC_PLUGIN_BASENAME,
 			'slug'               => 'woocommerce',
 			'proper_folder_name' => 'woocommerce',
 			'api_url'            => 'https://api.wordpress.org/plugins/info/1.0/woocommerce.json',

--- a/plugins/woocommerce/changelog/52448-fix-js-i18n
+++ b/plugins/woocommerce/changelog/52448-fix-js-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed issue with translation loading for React-based WooCommerce pages when non-standard plugin directory names are used.

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -6,7 +6,6 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Admin\PageController;
-use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Internal\Admin\Loader;
 
 /**

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Admin\PageController;
+use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Internal\Admin\Loader;
 
 /**
@@ -294,8 +295,8 @@ class Translations {
 			return $file;
 		}
 
-		// Make sure we're handing the correct domain (could be woocommerce or woocommerce-admin).
-		$plugin_domain = explode( '/', plugin_basename( __FILE__ ) )[0];
+		// Make sure we're handing the correct domain.
+		$plugin_domain = 'woocommerce';
 		if ( $plugin_domain !== $domain ) {
 			return $file;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -21,6 +21,13 @@ class Translations {
 	protected static $instance = null;
 
 	/**
+	 * Plugin domain.
+	 *
+	 * @var string
+	 */
+	private static $plugin_domain = 'woocommerce';
+
+	/**
 	 * Get class instance.
 	 */
 	public static function get_instance() {
@@ -243,9 +250,8 @@ class Translations {
 	 * and wp_set_script_translations().
 	 */
 	private function generate_translation_strings() {
-		$plugin_domain = explode( '/', plugin_basename( __FILE__ ) )[0];
-		$locale        = determine_locale();
-		$lang_dir      = WP_LANG_DIR . '/plugins/';
+		$locale   = determine_locale();
+		$lang_dir = WP_LANG_DIR . '/plugins/';
 
 		// Bail early if not localized.
 		if ( 'en_US' === $locale ) {
@@ -259,7 +265,7 @@ class Translations {
 		$access_type = get_filesystem_method();
 		if ( 'direct' === $access_type ) {
 			\WP_Filesystem();
-			$this->build_and_save_translations( $lang_dir, $plugin_domain, $locale );
+			$this->build_and_save_translations( $lang_dir, self::$plugin_domain, $locale );
 		} else {
 			// I'm reluctant to add support for other filesystems here as it would require
 			// user's input on activating plugin - which I don't think is common.
@@ -295,8 +301,7 @@ class Translations {
 		}
 
 		// Make sure we're handing the correct domain.
-		$plugin_domain = 'woocommerce';
-		if ( $plugin_domain !== $domain ) {
+		if ( self::$plugin_domain !== $domain ) {
 			return $file;
 		}
 
@@ -312,11 +317,10 @@ class Translations {
 	 * @param string $filename Activated plugin filename.
 	 */
 	public function potentially_generate_translation_strings( $filename ) {
-		$plugin_domain           = explode( '/', plugin_basename( __FILE__ ) )[0];
 		$activated_plugin_domain = explode( '/', $filename )[0];
 
 		// Ensure we're only running only on activation hook that originates from our plugin.
-		if ( $plugin_domain === $activated_plugin_domain ) {
+		if ( self::$plugin_domain === $activated_plugin_domain ) {
 			$this->generate_translation_strings();
 		}
 	}
@@ -341,16 +345,14 @@ class Translations {
 			return;
 		}
 
-		// Make sure we're handing the correct domain (could be woocommerce or woocommerce-admin).
-		$plugin_domain = explode( '/', plugin_basename( __FILE__ ) )[0];
-		$locales       = array();
-		$language_dir  = WP_LANG_DIR . '/plugins/';
+		$locales      = array();
+		$language_dir = WP_LANG_DIR . '/plugins/';
 
 		// Gather the locales that were updated in this operation.
 		foreach ( $hook_extra['translations'] as $translation ) {
 			if (
 				'plugin' === $translation['type'] &&
-				$plugin_domain === $translation['slug']
+				self::$plugin_domain === $translation['slug']
 			) {
 				$locales[] = $translation['language'];
 			}
@@ -360,7 +362,7 @@ class Translations {
 		foreach ( $locales as $locale ) {
 			// So long as this function is hooked to the 'upgrader_process_complete' action,
 			// WP_Filesystem should be hooked up to be able to call build_and_save_translations.
-			$this->build_and_save_translations( $language_dir, $plugin_domain, $locale );
+			$this->build_and_save_translations( $language_dir, self::$plugin_domain, $locale );
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52215

This PR resolves an issue where translations do not load correctly in the Core Profiler and other React-based WooCommerce pages when the plugin directory name differs from the expected standard. 

The issue is caused by the way translations are loaded in the `Translations.php` file. The plugin domain is checked by comparing the plugin directory name with the domain. If the directory name does not match the domain, the translation file is not loaded. This was needed because the domain could be `woocommoerce` or `woocommerce-admin` before merging the wc admin plugin into the core.

Since the domain is always `woocommerce` now, the check for the directory name is no longer needed.

Besides, this PR replaced the `plugin_file` value with `WC_PLUGIN_BASENAME` constant in the beta tester to avoid the same issue. That was causing a `PHP Warning` during the translation update process.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set the site language to a non-English language, such as Spanish.
2. Enable translations by navigating to https://your-site.com/wp-admin/update-core.php.
3. Go to the Core Profiler
4. Confirm that all Core Profiler strings display correctly in the chosen language.
5. Test other React-based WooCommerce pages to ensure translations are applied.

**Optional:**

1. Build the woocommerce beta tester plugin.
2. Upload and activate the plugin.
3. SSH into the site and `tail -f wp-content/debug.log`
4. Change site language to another language.
5. Navigate to https://your-site.com/wp-admin/update-core.php and update translations.
6. Confirm that debug.log does not contain `PHP Warning:  file_get_contents(/srv/htdocs/wp-content/plugins/woocommerce/woocommerce.php): Failed to open stream: No such file or directory in /srv/htdocs/__wp__/wp-includes/functions.php on line 6864`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixed issue with translation loading for React-based WooCommerce pages when non-standard plugin directory names are used.


</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
