### PR TITLE
Add support for `email` query parameter in `OrderActionsRestController`

### DIFF
--- a/plugins/woocommerce/changelog/52454-51797-allow-email-param
+++ b/plugins/woocommerce/changelog/52454-51797-allow-email-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for `email` query parameter in `OrderActionsRestController`.

--- a/plugins/woocommerce/src/Internal/Orders/OrderActionsRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderActionsRestController.php
@@ -68,11 +68,18 @@ class OrderActionsRestController extends RestApiControllerBase {
 	 */
 	private function get_args_for_order_actions(): array {
 		return array(
-			'id' => array(
+			'id'    => array(
 				'description' => __( 'Unique identifier of the order.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
+			),
+			'email' => array(
+				'description'       => __( 'Email address to send the order details to.', 'woocommerce' ),
+				'type'              => 'string',
+				'format'            => 'email',
+				'required'          => false,
+				'validate_callback' => 'rest_validate_request_arg',
 			),
 		);
 	}
@@ -105,6 +112,11 @@ class OrderActionsRestController extends RestApiControllerBase {
 		$order    = wc_get_order( $order_id );
 		if ( ! $order ) {
 			return new WP_Error( 'woocommerce_rest_invalid_order', __( 'Invalid order ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$email = $request->get_param( 'email' );
+		if ( $email ) {
+			$order->set_billing_email( $email );
 		}
 
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment

--- a/plugins/woocommerce/src/Internal/Orders/OrderActionsRestController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderActionsRestController.php
@@ -119,6 +119,10 @@ class OrderActionsRestController extends RestApiControllerBase {
 			$order->set_billing_email( $email );
 		}
 
+		if ( ! is_email( $order->get_billing_email() ) ) {
+			return new WP_Error( 'woocommerce_rest_missing_email', __( 'Order does not have an email address.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		/** This action is documented in includes/admin/meta-boxes/class-wc-meta-box-order-actions.php */
 		do_action( 'woocommerce_before_resend_order_emails', $order, 'customer_invoice' );

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderActionsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderActionsRestControllerTest.php
@@ -93,4 +93,53 @@ class OrderActionsRestControllerTest extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 403, $response->get_status() );
 	}
+
+	/**
+	 * Test sending order details email with a custom email.
+	 */
+	public function test_send_order_details_with_custom_email() {
+		$order = wc_create_order();
+		$order->set_billing_email( 'customer@email.com' );
+		$order->save();
+
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() . '/actions/send_order_details' );
+		$request->add_header( 'User-Agent', 'some app' );
+		$request->set_param( 'email', 'another@email.com' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'message', $data );
+		$this->assertEquals( 'Order details email sent to customer.', $data['message'] );
+
+		$notes = wc_get_order_notes( array( 'order_id' => $order->get_id() ) );
+		$this->assertCount( 1, $notes );
+		$this->assertEquals( 'Order details sent to another@email.com, via some app.', $notes[0]->content );
+	}
+
+	/**
+	 * Test sending order details email with an invalid email parameter.
+	 */
+	public function test_send_order_details_with_invalid_email_param() {
+		$order = wc_create_order();
+		$order->save();
+
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() . '/actions/send_order_details' );
+		$request->add_header( 'User-Agent', 'some app' );
+		$request->set_param( 'email', 'invalid-email' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_invalid_param', $data['code'] );
+		$this->assertEquals( 'Invalid parameter(s): email', $data['message'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderActionsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderActionsRestControllerTest.php
@@ -142,4 +142,26 @@ class OrderActionsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'rest_invalid_param', $data['code'] );
 		$this->assertEquals( 'Invalid parameter(s): email', $data['message'] );
 	}
+
+	/**
+	 * Test sending order details email when the order does not have an email.
+	 */
+	public function test_send_order_details_without_order_email() {
+		$order = wc_create_order();
+		$order->set_billing_email( '' );
+		$order->save();
+
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/' . $order->get_id() . '/actions/send_order_details' );
+		$request->add_header( 'User-Agent', 'some app' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'woocommerce_rest_missing_email', $data['code'] );
+		$this->assertEquals( 'Order does not have an email address.', $data['message'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/issues/51797#issuecomment-2440688059

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an order if you don't have one in your store.
2. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys` and add a new key with `Read/Write` permissions.
3. Make the following request using the consumer key and secret generated in the previous step, to send the order details with the custom `email` param:
```bash
curl --insecure -u [KEY]:[SECRET] --request POST --url 'https://store.local/wp-json/wc/v3/orders/[ORDER_NUMBER]/actions/send_order_details?email=[EMAIL]' --header 'Content-Type: application/json'
```
4. It should respond with:
```json
{"message": "Order details email sent to customer."}
```
5. Make sure you got a message in the customer email with the subject: `Details for order #{id} on {store}`.
6. Open the order on the admin and check the order notes, there should be a new note `Order details sent to [EMAIL], via [VIA]`.
7. Try making the request with an empty `email` param and an invalid email and check the response is:
```json
{
  "code": "rest_invalid_param",
  "message": "Invalid parameter(s): email",
  "data": {
    "status": 400,
    "params": {
      "email": "Invalid email address."
    },
    "details": {
      "email": {
        "code": "rest_invalid_email",
        "message": "Invalid email address.",
        "data": null
      }
    }
  }
}
```
8. Create an order without email from the admin and make this request again:
```bash
curl --insecure -u [KEY]:[SECRET] --request POST --url 'https://store.local/wp-json/wc/v3/orders/[ORDER_NUMBER]/actions/send_order_details' --header 'Content-Type: application/json'
```
9. Make sure it returns the following response:
```json
{
  "code": "woocommerce_rest_missing_email",
  "message": "Order does not have an email address.",
  "data": {
    "status": 400
  }
}
```
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add support for `email` query parameter in `OrderActionsRestController`.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
