### PR TITLE
Delayed account creation: Prevent duplicate after saving content

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/block.json
@@ -7,9 +7,6 @@
 	"keywords": [
 		"WooCommerce"
 	],
-	"blockHooks": {
-		"woocommerce/order-confirmation-summary": "after"
-	},
 	"attributes": {
 		"customerEmail": {
 			"type": "string",

--- a/plugins/woocommerce/changelog/fix-duplicate-hooked-block-check
+++ b/plugins/woocommerce/changelog/fix-duplicate-hooked-block-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix for block hooks behind feature flag.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
@@ -43,7 +43,7 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 					return $hooked_block_types;
 				}
 
-				if ( ! str_contains( $context->content, '<!-- wp:woocommerce/order-confirmation-create-account' ) ) {
+				if ( ! str_contains( $context->content, '<!-- wp:' . $this->get_full_block_name() ) ) {
 					$hooked_block_types[] = $this->get_full_block_name();
 				}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
@@ -22,48 +22,69 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
-		add_filter( 'hooked_block_woocommerce/order-confirmation-create-account', array( $this, 'hooked_block_content' ), 10, 3 );
+
+		if ( $this->is_feature_enabled() ) {
+			$this->initialize_hooks();
+		}
 	}
 
 	/**
-	 * Undocumented function
+	 * Initialize hooks.
 	 *
-	 * @param array  $parsed_hooked_block Parsed hooked block.
-	 * @param array  $hooked_block_type Hooked block type.
-	 * @param string $relative_position Relative position.
-	 * @return array
+	 * @see https://developer.wordpress.org/reference/hooks/hooked_block/
 	 */
-	public function hooked_block_content( $parsed_hooked_block, $hooked_block_type, $relative_position ) {
-		if ( get_option( 'woocommerce_enable_delayed_account_creation', 'yes' ) === 'no' ) {
-			return null;
-		}
+	protected function initialize_hooks() {
+		// This does not use the Block Hooks Trait used in mini cart. The implementation is simpler because we support
+		// versions higher than WP 6.5 when hooks were introduced. They should be consolodated in the future.
+		add_filter(
+			'hooked_block_types',
+			function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+				if ( 'after' !== $relative_position || 'woocommerce/order-confirmation-summary' !== $anchor_block_type || ! $context instanceof \WP_Block_Template ) {
+					return $hooked_block_types;
+				}
 
-		if ( 'after' !== $relative_position || is_null( $parsed_hooked_block ) ) {
-			return $parsed_hooked_block;
-		}
+				if ( ! str_contains( $context->content, '<!-- wp:woocommerce/order-confirmation-create-account' ) ) {
+					$hooked_block_types[] = $this->get_full_block_name();
+				}
 
-		/* translators: %s: Site title */
-		$site_title_heading                  = sprintf( __( 'Create an account with %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) );
-		$parsed_hooked_block['innerContent'] = array(
-			'<div class="wp-block-woocommerce-order-confirmation-create-account alignwide">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading">' . esc_html( $site_title_heading ) . '</h3>
-			<!-- /wp:heading -->
-			<!-- wp:list {"className":"is-style-checkmark-list"} -->
-			<ul class="wp-block-list is-style-checkmark-list"><!-- wp:list-item -->
-			<li>' . esc_html__( 'Faster future purchases', 'woocommerce' ) . '</li>
-			<!-- /wp:list-item -->
-			<!-- wp:list-item -->
-			<li>' . esc_html__( 'Securely save payment info', 'woocommerce' ) . '</li>
-			<!-- /wp:list-item -->
-			<!-- wp:list-item -->
-			<li>' . esc_html__( 'Track orders &amp; view shopping history', 'woocommerce' ) . '</li>
-			<!-- /wp:list-item --></ul>
-			<!-- /wp:list -->
-			</div>',
+				return $hooked_block_types;
+			},
+			10,
+			4
 		);
+		add_filter(
+			'hooked_block_woocommerce/order-confirmation-create-account',
+			function ( $parsed_hooked_block, $hooked_block_type, $relative_position ) {
+				if ( 'after' !== $relative_position || is_null( $parsed_hooked_block ) ) {
+					return $parsed_hooked_block;
+				}
 
-		return $parsed_hooked_block;
+				/* translators: %s: Site title */
+				$site_title_heading                  = sprintf( __( 'Create an account with %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) );
+				$parsed_hooked_block['innerContent'] = array(
+					'<div class="wp-block-woocommerce-order-confirmation-create-account alignwide">
+				<!-- wp:heading {"level":3} -->
+                    <h3 class="wp-block-heading">' . esc_html( $site_title_heading ) . '</h3>
+				<!-- /wp:heading -->
+				<!-- wp:list {"className":"is-style-checkmark-list"} -->
+				<ul class="wp-block-list is-style-checkmark-list"><!-- wp:list-item -->
+                    <li>' . esc_html__( 'Faster future purchases', 'woocommerce' ) . '</li>
+				<!-- /wp:list-item -->
+				<!-- wp:list-item -->
+                    <li>' . esc_html__( 'Securely save payment info', 'woocommerce' ) . '</li>
+				<!-- /wp:list-item -->
+				<!-- wp:list-item -->
+                    <li>' . esc_html__( 'Track orders &amp; view shopping history', 'woocommerce' ) . '</li>
+				<!-- /wp:list-item --></ul>
+				<!-- /wp:list -->
+                    </div>',
+				);
+
+					return $parsed_hooked_block;
+			},
+			10,
+			4
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
@@ -63,20 +63,20 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 				$site_title_heading                  = sprintf( __( 'Create an account with %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) );
 				$parsed_hooked_block['innerContent'] = array(
 					'<div class="wp-block-woocommerce-order-confirmation-create-account alignwide">
-				<!-- wp:heading {"level":3} -->
+					<!-- wp:heading {"level":3} -->
                     <h3 class="wp-block-heading">' . esc_html( $site_title_heading ) . '</h3>
-				<!-- /wp:heading -->
-				<!-- wp:list {"className":"is-style-checkmark-list"} -->
-				<ul class="wp-block-list is-style-checkmark-list"><!-- wp:list-item -->
+					<!-- /wp:heading -->
+					<!-- wp:list {"className":"is-style-checkmark-list"} -->
+					<ul class="wp-block-list is-style-checkmark-list"><!-- wp:list-item -->
                     <li>' . esc_html__( 'Faster future purchases', 'woocommerce' ) . '</li>
-				<!-- /wp:list-item -->
-				<!-- wp:list-item -->
+                    <!-- /wp:list-item -->
+                    <!-- wp:list-item -->
                     <li>' . esc_html__( 'Securely save payment info', 'woocommerce' ) . '</li>
-				<!-- /wp:list-item -->
-				<!-- wp:list-item -->
+                    <!-- /wp:list-item -->
+                    <!-- wp:list-item -->
                     <li>' . esc_html__( 'Track orders &amp; view shopping history', 'woocommerce' ) . '</li>
-				<!-- /wp:list-item --></ul>
-				<!-- /wp:list -->
+                    <!-- /wp:list-item --></ul>
+                    <!-- /wp:list -->
                     </div>',
 				);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Register block hooks via PHP so we can check context manually. This prevents duplicates after saving content.

Closes #52452

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. in an experimental build, go to order confirmation template.
2. Select delayed account creation block, change to dark styles.
3. Go to frontend (incognito), process Checkout.
4. On Order Confirm page, see that there is 1 account creation form

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
