### PR TITLE
Optimize Coming Soon badge performance with early exits

### DIFF
--- a/plugins/woocommerce/changelog/perf-coming-soon-badge
+++ b/plugins/woocommerce/changelog/perf-coming-soon-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Optimize Coming Soon badge performance with early exits

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -27,8 +27,8 @@ class ComingSoonAdminBarBadge {
 	 * @internal
 	 */
 	public function init_hooks() {
-		// Early exit if user is not logged in or doesn't have admin capabilities.
-		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+		// Early exit if the user is not logged in as administrator / shop manager.
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonAdminBarBadge.php
@@ -18,6 +18,20 @@ class ComingSoonAdminBarBadge {
 	 * @internal
 	 */
 	final public function init() {
+		add_action( 'init', array( $this, 'init_hooks' ) );
+	}
+
+	/**
+	 * Sets up the hooks if user has required capabilities.
+	 *
+	 * @internal
+	 */
+	public function init_hooks() {
+		// Early exit if user is not logged in or doesn't have admin capabilities.
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		add_action( 'admin_bar_menu', array( $this, 'site_visibility_badge' ), 31 );
 		add_action( 'wp_head', array( $this, 'output_css' ) );
 		add_action( 'admin_head', array( $this, 'output_css' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50789

This change reduces unnecessary code execution and improves overall performance by isolating the Coming Soon badge functionality to only run for authenticated admin users.

- Add early exit in setup_hooks() for non-admin users
- Move hook registration to init to ensure WordPress is loaded
- Prevent badge-related actions from being registered for non-privileged users


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Create a site with this branch**

1. As an admin user:
   - Log in as administrator
   - Verify the Coming Soon badge still appears in admin bar on both frontend and wp-admin pages
   - Verify badge styling remains intact

2. As a non-admin user:
   - Log in as a regular subscriber/customer
   - Verify the Coming Soon badge does not appear
   - Inspect page source to confirm badge CSS is not loaded

3. As a guest user:
   - Log out completely
   - Verify the Coming Soon badge does not appear
   - Inspect page source to confirm badge CSS is not loaded

![Screenshot 2024-10-31 at 14 13 41](https://github.com/user-attachments/assets/9db95070-dc2f-4af6-80a0-c8c867681f82)


CSS selector ` #wp-admin-bar-woocommerce-site-visibility-badge`

![Screenshot 2024-10-31 at 14 10 28](https://github.com/user-attachments/assets/26f208c3-ddf0-4d77-84a1-59ac2a861825)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
