### PR TITLE
[Experimental] Expose filter params through block context

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
@@ -17,7 +17,7 @@
 		"interactivity": true
 	},
 	"usesContext": [
-		"queryId"
+		"filterParams"
 	],
 	"attributes": {
 		"clearButton": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
@@ -60,7 +60,7 @@
 	},
 	"usesContext": [
 		"query",
-		"queryId"
+		"filterParams"
 	],
 	"attributes": {
 		"attributeId": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
@@ -13,6 +13,6 @@
 		"interactivity": true,
 		"html": false
 	},
-	"usesContext": [ "query", "queryId" ],
+	"usesContext": [ "query", "filterParams" ],
 	"attributes": {}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -17,7 +17,7 @@
 	],
 	"usesContext": [
 		"query",
-		"queryId"
+		"filterParams"
 	],
 	"attributes": {
 		"className": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
@@ -78,7 +78,7 @@
 	},
 	"usesContext": [
 		"query",
-		"queryId"
+		"filterParams"
 	],
 	"example": {
 		"attributes": {

--- a/plugins/woocommerce/changelog/feat-filter-params-context
+++ b/plugins/woocommerce/changelog/feat-filter-params-context
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Experimental: process filter params on in Product Filters and pass it down through block context.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -21,7 +21,7 @@ final class ProductFilterActive extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$query_id = $block->context['queryId'] ?? 0;
+		$filter_params = $block->context['filterParams'] ?? array();
 
 		/**
 		 * Filters the active filter data provided by filter blocks.
@@ -46,7 +46,7 @@ final class ProductFilterActive extends AbstractBlock {
 		 * @param array $params The query param parsed from the URL.
 		 * @return array Active filters data.
 		 */
-		$active_filters = apply_filters( 'collection_active_filters_data', array(), $this->get_filter_query_params( $query_id ) );
+		$active_filters = apply_filters( 'collection_active_filters_data', array(), $filter_params );
 
 		$context = array(
 			'hasSelectedFilters' => ! empty( $active_filters ) ?? false,
@@ -78,47 +78,6 @@ final class ProductFilterActive extends AbstractBlock {
 				},
 				''
 			)
-		);
-	}
-
-	/**
-	 * Parse the filter parameters from the URL.
-	 * For now we only get the global query params from the URL. In the future,
-	 * we should get the query params based on $query_id.
-	 *
-	 * @param int $query_id Query ID.
-	 * @return array Parsed filter params.
-	 */
-	private function get_filter_query_params( $query_id ) {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-
-		$parsed_url = wp_parse_url( esc_url_raw( $request_uri ) );
-
-		if ( empty( $parsed_url['query'] ) ) {
-			return array();
-		}
-
-		parse_str( $parsed_url['query'], $url_query_params );
-
-		/**
-		 * Filters the active filter data provided by filter blocks.
-		 *
-		 * @since 11.7.0
-		 *
-		 * @param array $filter_param_keys The active filters data
-		 * @param array $url_param_keys    The query param parsed from the URL.
-		 *
-		 * @return array Active filters params.
-		 */
-		$filter_param_keys = array_unique( apply_filters( 'collection_filter_query_param_keys', array(), array_keys( $url_query_params ) ) );
-
-		return array_filter(
-			$url_query_params,
-			function ( $key ) use ( $filter_param_keys ) {
-				return in_array( $key, $filter_param_keys, true );
-			},
-			ARRAY_FILTER_USE_KEY
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -192,12 +192,13 @@ final class ProductFilterAttribute extends AbstractBlock {
 			);
 		}
 
-		$selected_terms = array_filter(
-			explode(
-				',',
-				get_query_var( 'filter_' . str_replace( 'pa_', '', $product_attribute->slug ) )
-			)
-		);
+		$filter_param_key = 'filter_' . str_replace( 'pa_', '', $product_attribute->slug );
+		$filter_params    = $block->context['filterParams'] ?? array();
+		$selected_terms   = array();
+
+		if ( $filter_params && ! empty( $filter_params[ $filter_param_key ] ) ) {
+			$selected_terms = array_filter( explode( ',', $filter_params[ $filter_param_key ] ) );
+		}
 
 		$filter_context = array();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -120,11 +120,12 @@ final class ProductFilterPrice extends AbstractBlock {
 			return '';
 		}
 
-		$price_range = $this->get_filtered_price( $block );
-		$min_range   = $price_range['min_price'] ?? 0;
-		$max_range   = $price_range['max_price'] ?? 0;
-		$min_price   = intval( get_query_var( self::MIN_PRICE_QUERY_VAR, $min_range ) );
-		$max_price   = intval( get_query_var( self::MAX_PRICE_QUERY_VAR, $max_range ) );
+		$price_range   = $this->get_filtered_price( $block );
+		$min_range     = $price_range['min_price'] ?? 0;
+		$max_range     = $price_range['max_price'] ?? 0;
+		$filter_params = $block->context['filterParams'] ?? array();
+		$min_price     = intval( $filter_params[ self::MIN_PRICE_QUERY_VAR ] ?? $min_range );
+		$max_price     = intval( $filter_params[ self::MAX_PRICE_QUERY_VAR ] ?? $max_range );
 
 		$filter_context = array(
 			'price'   => array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -77,7 +77,7 @@ final class ProductFilterRating extends AbstractBlock {
 		}
 
 		$active_ratings = array_map(
-			function( $rating ) {
+			function ( $rating ) {
 				return array(
 					/* translators: %d is the rating value. */
 					'title'      => sprintf( __( 'Rated %d out of 5', 'woocommerce' ), $rating ),
@@ -115,8 +115,9 @@ final class ProductFilterRating extends AbstractBlock {
 		$rating_counts = $this->get_rating_counts( $block );
 
 		// Pick the selected ratings from the query string.
-		$query           = isset( $_GET[ self::RATING_FILTER_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::RATING_FILTER_QUERY_VAR ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$selected_rating = array_filter( explode( ',', $query ) );
+		$filter_params   = $block->context['filterParams'] ?? array();
+		$rating_query    = $filter_params[ self::RATING_FILTER_QUERY_VAR ] ?? '';
+		$selected_rating = array_filter( explode( ',', $rating_query ) );
 
 		/*
 		 * Get the rating items
@@ -238,7 +239,7 @@ final class ProductFilterRating extends AbstractBlock {
 
 		$selected_items = array_reduce(
 			$rating_counts,
-			function( $carry, $rating ) use ( $ratings_array, $show_counts ) {
+			function ( $carry, $rating ) use ( $ratings_array, $show_counts ) {
 				if ( in_array( (string) $rating['rating'], $ratings_array, true ) ) {
 					$count       = $rating['count'];
 					$count_label = $show_counts ? "($count)" : '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -125,7 +125,8 @@ final class ProductFilterStatus extends AbstractBlock {
 
 		$stock_status_data       = $this->get_stock_status_counts( $block );
 		$stock_statuses          = wc_get_product_stock_status_options();
-		$query                   = isset( $_GET[ self::STOCK_STATUS_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::STOCK_STATUS_QUERY_VAR ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$filter_params           = $block->context['filterParams'] ?? array();
+		$query                   = $filter_params[ self::STOCK_STATUS_QUERY_VAR ] ?? '';
 		$selected_stock_statuses = array_filter( explode( ',', $query ) );
 
 		$filter_options = array_map(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -61,23 +61,31 @@ class ProductFilters extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$inner_blocks = array_reduce(
+		$query_id      = $block->context['queryId'] ?? 0;
+		$filter_params = $this->get_filter_params( $query_id );
+		$block_context = array_merge(
+			$block->context,
+			array(
+				'filterParams' => $filter_params,
+			),
+		);
+		$inner_blocks  = array_reduce(
 			$block->parsed_block['innerBlocks'],
-			function ( $carry, $parsed_block ) use ( $block ) {
-				$carry .= ( new \WP_Block( $parsed_block, $block->context ) )->render();
+			function ( $carry, $parsed_block ) use ( $block_context ) {
+				$carry .= ( new \WP_Block( $parsed_block, $block_context ) )->render();
 				return $carry;
 			},
 			''
 		);
-		$icontext     = array(
+		$icontext      = array(
 			'isOverlayOpened' => false,
-			'params'          => $this->get_filter_query_params( 0 ),
-			'originalParams'  => $this->get_filter_query_params( 0 ),
+			'params'          => $filter_params,
+			'originalParams'  => $filter_params,
 		);
-		$classes      = array(
+		$classes       = array(
 			'wc-block-product-filters' => true,
 		);
-		$styles       = array(
+		$styles        = array(
 			'--wc-product-filters-text-color'       => StyleAttributesUtils::get_text_color_class_and_style( $attributes )['value'],
 			'--wc-product-filters-background-color' => StyleAttributesUtils::get_background_color_class_and_style( $attributes )['value'],
 		);
@@ -203,7 +211,7 @@ class ProductFilters extends AbstractBlock {
 	 * @param int $query_id Query ID.
 	 * @return array Parsed filter params.
 	 */
-	private function get_filter_query_params( $query_id ) {
+	private function get_filter_params( $query_id ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Relates https://github.com/woocommerce/woocommerce/issues/52442. Blocked by #52279 

Instead of getting the selected filters directly from the URL, this PR exposes filter params processed in Product Filters through context to inner filter blocks. By doing so:
- We can later support local Product Collection block through query ID.
- We only process the URL one time, in a single place, reducing the security risk of processing the URL.
- Gaining more control over the selected filters.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
1. Ensure all filter blocks still work as before.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
