### PR TITLE
Autoload woocommerce_allow_tracking option 

### DIFF
--- a/plugins/woocommerce/changelog/update-autoload-tracking-option
+++ b/plugins/woocommerce/changelog/update-autoload-tracking-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add autoloading for woocommerce_allow_tracking option

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -354,7 +354,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'start',
 					'default'       => 'no',
-					'autoload'      => false,
+					'autoload'      => true,
 				),
 				array(
 					'type' => 'sectionend',

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -272,6 +272,7 @@ class WC_Install {
 		),
 		'9.5.0' => array(
 			'wc_update_950_add_brands_enabled_option',
+			'wc_update_950_tracking_option_autoload',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2927,3 +2927,13 @@ function wc_update_940_remove_help_panel_highlight_shown() {
 function wc_update_950_add_brands_enabled_option() {
 	add_option( 'wc_feature_woocommerce_brands_enabled', 'yes' );
 }
+
+/**
+ * Autoloads woocommerce_allow_tracking option.
+ */
+function wc_update_950_tracking_option_autoload() {
+	$options = array(
+		'woocommerce_allow_tracking' => 'yes',
+	);
+	wp_set_option_autoload_values( $options );
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/50370. 

Adds autoloading for the  woocommerce_allow_tracking option, since queries for this value are made throughout WooCommerce admin screens and will provide a small performance optimization.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**New Installs**
1. Install [AAA Option Optimizer](https://wordpress.org/plugins/aaa-option-optimizer/)
3. Search for `woocommerce_allow_tracking` in AAA Option Optimizer: **Tools** > **Option Optimizer** > **All Options** > Search
4. See that Autoload is `on`.

**Existing Installs (database update)**
1. Install a previous version of WooCommerce (e.g. 9.3)
2. Install [AAA Option Optimizer](https://wordpress.org/plugins/aaa-option-optimizer/)
3. Search for `woocommerce_allow_tracking` in AAA Option Optimizer: **Tools** > **Option Optimizer** > **All Options** > Search
4. See that Autoload is `off`.
5. Upload a zip of WooCommerce containing this change (eg beta release or [this branch](https://betadownload.jetpack.me/data/woocommerce/update_autoload-tracking-option/woocommerce-dev.zip))
6. Go to WooCommerce homescreen and perform database update
6. Search for `woocommerce_allow_tracking` in AAA Option Optimizer: **Tools** > **Option Optimizer** > **All Options** > Search
7. See that Autoload is `on`.

<img width="1580" alt="tracking" src="https://github.com/user-attachments/assets/8f2e231e-865c-42f9-9e48-9dd60fa465c5">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
