### PR TITLE
[e2e tests] Add sharding for core e2e tests with external environments

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-core-e2e-sharding-config-for-external-envs
+++ b/plugins/woocommerce/changelog/e2e-update-core-e2e-sharding-config-for-external-envs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -625,7 +625,14 @@
 					"name": "Core e2e tests - default Pressable site",
 					"testType": "e2e",
 					"command": "test:e2e:with-env default-pressable",
-					"shardingArguments": [],
+					"shardingArguments": [
+						"--shard=1/6",
+						"--shard=2/6",
+						"--shard=3/6",
+						"--shard=4/6",
+						"--shard=5/6",
+						"--shard=6/6"
+					],
 					"changes": [],
 					"events": [
 						"release-checks",
@@ -641,7 +648,14 @@
 					"name": "Core e2e tests - default WPCOM site",
 					"testType": "e2e",
 					"command": "test:e2e:with-env default-wpcom",
-					"shardingArguments": [],
+					"shardingArguments": [
+						"--shard=1/6",
+						"--shard=2/6",
+						"--shard=3/6",
+						"--shard=4/6",
+						"--shard=5/6",
+						"--shard=6/6"
+					],
 					"changes": [],
 					"events": [
 						"release-checks",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Core e2e tests for default Pressable and WPCOM envs are not sharded and take a lot of time to  run. Added sharding arguments to the config to speed up the runs.

### How to test the changes in this Pull Request:

CI should be green.
Tested the sharded run with [this run](https://github.com/woocommerce/woocommerce/actions/runs/11632233914).
