### PR TITLE
Optimize `test_import_sample_products` unit test performance

### DIFF
--- a/plugins/woocommerce/changelog/52523-dev-improve-import-sample-products-test
+++ b/plugins/woocommerce/changelog/52523-dev-improve-import-sample-products-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Optimize `test_import_sample_products` unit test performance

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
@@ -17,9 +17,7 @@ define( 'WP_RUN_CORE_TESTS', false );
 
 /**
  * WC Tests API Onboarding Tasks
- * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- * @group run-in-separate-process
  */
 class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
@@ -109,8 +109,6 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		echo print_r( $data, true );
-
 		$this->assertEquals( 200, $response->get_status() );
 
 		$this->assertArrayHasKey( 'failed', $data );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
@@ -57,19 +57,19 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
-		$this->remove_color_or_logo_attribute_taxonomy();
+		$this->cleanup_test_product_attributes();
 		TaskLists::clear_lists();
 		TaskLists::init_default_lists();
 	}
 
 	/**
-	 * Remove product attributes that where created in previous tests.
+	 * Clean up product attribute taxonomies created during tests.
 	 */
-	public function remove_color_or_logo_attribute_taxonomy() {
+	public function cleanup_test_product_attributes() {
 		$taxonomies = get_taxonomies();
 		foreach ( (array) $taxonomies as $taxonomy ) {
-			// pa - product attribute.
-			if ( 'pa_color' === $taxonomy || 'pa_logo' === $taxonomy ) {
+			// pa_ prefix indicates product attribute taxonomy.
+			if ( in_array( $taxonomy, array( 'pa_color', 'pa_logo', 'pa_size' ), true ) ) {
 				unregister_taxonomy( $taxonomy );
 			}
 		}
@@ -81,7 +81,7 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	public function test_import_sample_products() {
 		wp_set_current_user( $this->user );
 
-		$this->remove_color_or_logo_attribute_taxonomy();
+		$this->cleanup_test_product_attributes();
 
 		// Downloading product images are slow and tests shouldn't rely on external resources so we mock the request.
 		add_filter(
@@ -108,6 +108,8 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/import_sample_products' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
+
+		echo print_r( $data, true );
 
 		$this->assertEquals( 200, $response->get_status() );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
@@ -82,6 +82,8 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$this->remove_color_or_logo_attribute_taxonomy();
+
+		// Downloading product images are slow and tests shouldn't rely on external resources so we mock the request.
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $parsed_args, $url ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce/issues/45601

This PR improves the slow-running import sample products test.

I found that it's slow because it downloads images from the internet. It takes 0.3s per image, with 9 images, so it takes ~3s to download images. I initially wanted to speed up the image download or parallelize it so that users could import their products faster. Still, I found that the network speed mainly limits the image download, and it takes work to parallelize it. So, I decided to fake the image download instead to speed up the test.

Changes: 

1. Optimizing `WC_Admin_Tests_API_Onboarding_Tasks::test_import_sample_products` by using the `pre_http_request` filter to fake image downloads, addressing the bottleneck caused by real HTTP requests during testing.

2. Remove the `@runTestsInSeparateProcesses` Annotations to avoid unnecessary process separation. The test was using `@runTestsInSeparateProcesses` because it was slow, but now it's fast enough to run without it.

This could reduce `WC_Admin_Tests_API_Onboarding_Tasks` test time from 26s to less than 1s.

Before:

<img width="1144" alt="Screenshot 2024-11-04 at 14 24 19" src="https://github.com/user-attachments/assets/723fe73f-07b1-403e-bc12-80cde3326508">

After:

<img width="1147" alt="Screenshot 2024-11-04 at 14 23 55" src="https://github.com/user-attachments/assets/e5448ddf-1900-4641-8914-982ca7ac185b">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Confirm CI tests pass.
2.Confirm that the test `WC_Admin_Tests_API_Onboarding_Tasks::test_import_sample_products` doesn't show under `You should really speed up these slow tests (>1000ms)...` in the test output.

**If you want to test locally:**

1. Apply this PR to your local WooCommerce repository.
2. Start wp env
3. Run `pnpm --filter @woocommerce/plugin-woocommerce run test:php:env -- --filter WC_Admin_Tests_API_Onboarding_Tasks`
2. Confirm that `You should really speed up these slow tests (>1000ms)...` doesn't list `WC_Admin_Tests_API_Onboarding_Tasks::test_import_sample_products`



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Optimize `test_import_sample_products` unit test performance

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
