### PR TITLE
fix: added noreferrer to printful link

### DIFF
--- a/plugins/woocommerce/changelog/fix-printful-noreferrer
+++ b/plugins/woocommerce/changelog/fix-printful-noreferrer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Printful link to use noopener,noreferrer

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/products/constants.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/products/constants.tsx
@@ -103,7 +103,11 @@ export const PrintfulAdvertProductPlacement = {
 	),
 	onClick: () => {
 		recordEvent( 'tasklist_product_printful_advert_click' );
-		window.open( 'https://woocommerce.com/products/printful', '_blank' );
+		window.open(
+			'https://woocommerce.com/products/printful',
+			'_blank',
+			'noopener,noreferrer'
+		);
 	},
 };
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/49349

Added noreferrer noopener to the window.open.

Although noted in the issue that noopener isn't necessary since it's implied by _blank, I've introduced it anyway for redundancy in safety.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go through or skip onboarding Core Profiler, choices aren't important
2. Click on 'Add a product' in the WC Home onboarding task list
3. Click on the Printful placement
4. Observe that it opens in a new tab
5. Assert that both `window.opener` and `document.referrer` in the printful tab are either undefined or empty strings.

<img width="973" alt="image" src="https://github.com/user-attachments/assets/1583654b-bd81-4567-8a8b-96f3a38dcf50">


<img width="167" alt="image" src="https://github.com/user-attachments/assets/cebfa079-8b24-4696-a43f-0d4a46305a24">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
