### PR TITLE
Fix core profiler dropdown not closing when the arrow down icon is clicked

### DIFF
--- a/plugins/woocommerce/changelog/fix-core-profiler-dropdowns
+++ b/plugins/woocommerce/changelog/fix-core-profiler-dropdowns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unable to close the Core Profiler dropdowns by clicking the dropdown self

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -17,6 +17,17 @@
 	.woocommerce-layout__main {
 		padding-right: 0;
 	}
+
+	.woocommerce-select-control__control.is-active,
+	.woocommerce-select-control__control-input[aria-expanded="true"] {
+		// Disable pointer events when select control is already active so that we can close the dropdown by clicking on the component itself.
+		pointer-events: none;
+	}
+
+	.woocommerce-select-control__control-input,
+	.components-base-control__help {
+		cursor: pointer;
+	}
 }
 
 .woocommerce-profiler-page__content {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/38842

This PR addresses an issue where the dropdowns in the Core Profiler do not close when the dropdown icon is clicked. The fix ensures that clicking the dropdown icon properly toggles its visibility.


I didn't find any other dropdowns other than core profiler dropdowns that have this issue. It looks like only core profiler use `SelectControl` component with `help` prop that shows the dropdown icon. So, I only added the fix to the core profiler dropdowns as it might not be necessary for other dropdowns and might cause issues if we add it to all dropdowns as Moon mentioned in the issue https://github.com/woocommerce/woocommerce/issues/38842#issuecomment-1601862209.


Before:

https://github.com/user-attachments/assets/5d623ccf-ebea-4c21-aa5c-64d85114c466

After:

https://github.com/user-attachments/assets/242623b5-9b15-4383-82bd-d72df2f84598


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-info`
2. Click on the `WHICH INDUSTRY IS YOUR BUSINESS IN?` dropdown.
3. Click the dropdown icon (down arrow).
4. Confirm that the dropdown closes when clicking the icon, as expected

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

