### PR TITLE
Add global prop to Tracks events for user role

### DIFF
--- a/plugins/woocommerce/changelog/add-tracks-role-prop
+++ b/plugins/woocommerce/changelog/add-tracks-role-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add global prop to Tracks events for user role

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -68,8 +68,9 @@ class WC_Site_Tracking {
 		$server_details  = WC_Tracks::get_server_details();
 		$blog_details    = WC_Tracks::get_blog_details( $user->ID );
 		$tracks_identity = WC_Tracks_Client::get_identity( $user->ID );
+		$role_details    = WC_Tracks::get_role_details( $user );
 
-		$client_tracking_properties = array_merge( $server_details, $blog_details );
+		$client_tracking_properties = array_merge( $server_details, $blog_details, $role_details );
 		/**
 		 * Add global tracks event properties.
 		 *

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -68,6 +68,18 @@ class WC_Tracks {
 	}
 
 	/**
+	 * Get role-related details.
+	 *
+	 * @param WP_User $user The user object.
+	 * @return array The role details.
+	 */
+	public static function get_role_details( $user ) {
+		return array(
+			'_role' => $user && ! empty( $user->roles ) ? $user->roles[0] : '',
+		);
+	}
+
+	/**
 	 * Record an event in Tracks - this is the preferred way to record events from PHP.
 	 * Note: the event request won't be made if $properties has a member called `error`.
 	 *
@@ -130,7 +142,8 @@ class WC_Tracks {
 
 		$server_details = self::get_server_details();
 		$blog_details   = self::get_blog_details( $user->ID );
+		$role_details   = self::get_role_details( $user );
 
-		return array_merge( $properties, $data, $server_details, $identity, $blog_details );
+		return array_merge( $properties, $data, $server_details, $identity, $blog_details, $role_details );
 	}
 }

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -75,7 +75,10 @@ class WC_Tracks {
 	 */
 	public static function get_role_details( $user ) {
 		return array(
-			'_role' => $user && ! empty( $user->roles ) ? $user->roles[0] : '',
+			'role'                   => ! empty( $user->roles ) ? $user->roles[0] : '',
+			'can_install_plugins'    => $user->has_cap( 'install_plugins' ),
+			'can_activate_plugins'   => $user->has_cap( 'activate_plugins' ),
+			'can_manage_woocommerce' => $user->has_cap( 'manage_woocommerce' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -15,6 +15,9 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+
+		$user = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user );
 	}
 
 	/**
@@ -44,6 +47,20 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		);
 		$this->assertContains( '_ui', array_keys( $properties ) );
 		$this->assertContains( '_ut', array_keys( $properties ) );
+	}
+
+
+	/**
+	 * Test that the role property is added to the properties.
+	 */
+	public function test_addition_of_role() {
+		$properties = \WC_Tracks::get_properties(
+			'test_event',
+			array(),
+		);
+
+		$this->assertContains( '_role', array_keys( $properties ) );
+		$this->assertEquals( 'administrator', $properties['_role'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -59,8 +59,17 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 			array(),
 		);
 
-		$this->assertContains( '_role', array_keys( $properties ) );
-		$this->assertEquals( 'administrator', $properties['_role'] );
+		$this->assertContains( 'role', array_keys( $properties ) );
+		$this->assertEquals( 'administrator', $properties['role'] );
+
+		$this->assertContains( 'can_install_plugins', array_keys( $properties ) );
+		$this->assertEquals( true, $properties['can_install_plugins'] );
+
+		$this->assertContains( 'can_activate_plugins', array_keys( $properties ) );
+		$this->assertEquals( true, $properties['can_activate_plugins'] );
+
+		$this->assertContains( 'can_manage_woocommerce', array_keys( $properties ) );
+		$this->assertEquals( true, $properties['can_manage_woocommerce'] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52402

This PR adds global properties, `role`, `can_install_plugins`, `can_activate_plugins` and `can_manage_woo`, to Track data to capture the current user's role. By including this property, we aim to improve insights into how different user roles interact with WooCommerce features, helping to address potential permission-related issues better. The role property is derived from the first item in the current user's roles array, following WordPress conventions.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a new store, make sure to opt-in to Tracks.
1. Trigger a Tracks event by open up browser console and run `wcTracks.recordEvent('test_role', {})`
1. Go to networks tab and filter for `test_role`
1. Confirm that each Tracks event includes `role`, `can_install_plugins`, `can_activate_plugins` and `can_manage_woo` properties.
1. Go to `WooCommerce > Home` and click on an inbox note action button to trigger server-side event.
1. Go to `WooCommerce > Status > Logs` and find the `tracks-*` logs.
1. Confirm that the `role`, `can_install_plugins`, `can_activate_plugins` and `can_manage_woo` properties are included in the Tracks event.
1. Repeat the above steps with different user roles such as Shop Manager to ensure the role property is correctly captured.


<img width="1147" alt="Screenshot 2024-11-06 at 11 06 15" src="https://github.com/user-attachments/assets/900a5ca2-9a04-4a8a-8515-a34d92c80e8f">


<img width="1147" alt="Screenshot 2024-11-04 at 16 05 38" src="https://github.com/user-attachments/assets/27bbbe0e-c04c-43b3-8342-224c7efb6949">


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
