### PR TITLE
Add support for IPs with port in WC_Geolocation::get_ip_address

### DIFF
--- a/plugins/woocommerce/changelog/pr-52551
+++ b/plugins/woocommerce/changelog/pr-52551
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add support for IPs with port in WC_Geolocation::get_ip_address

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -83,7 +83,11 @@ class WC_Geolocation {
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 			// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2
 			// Make sure we always only send through the first IP in the list which should always be the client IP.
-			return (string) rest_is_ip_address( trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) );
+			$value = trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) );
+			// Account for the '<IPv4 address>:<port>', '[<IPv6>]' and '[<IPv6>]:<port>' cases, removing the port.
+			// The regular expression is oversimplified on purpose, later 'rest_is_ip_address' will do the actual IP address validation.
+			$value = preg_replace( '/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\:.*|\[([^]]+)\].*/', '$1$2', $value );
+			return (string) rest_is_ip_address( $value );
 		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
 			return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/geolocation/class-wc-test-gelocation.php
@@ -24,6 +24,19 @@ class WC_Tests_Geolocation extends WC_Unit_Test_Case {
 		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '2620:0:ccc::2, 2001:4860:4860::8888';
 		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '208.67.220.220:1234';
+		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '208.67.220.220:1234, 8.8.8.8';
+		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '[2620:0:ccc::2]';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '[2620:0:ccc::2], 2001:4860:4860::8888';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '[2620:0:ccc::2]:1234';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '[2620:0:ccc::2]:1234, 2001:4860:4860::8888';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
 		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 
 		$_SERVER['REMOTE_ADDR'] = '208.67.220.220';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

According to [Wikipedia](https://en.wikipedia.org/wiki/X-Forwarded-For), the value of the `X-Forwarded-For` header can take the formats `<IPv4>:<port>`, `[<IPv6>]` and `[<IPv6>]:<port>`, additionally to raw IP addresses (for each value of the comma-separated list). This pull request modifies `WC_Geolocation::get_ip_address()` to account for these formats.

Closes #52390.

### How to test the changes in this Pull Request:

Run the unit tests for the `WC_Geolocation` class. You can also manually test other values using WP CLI, e.g.:

```
wp eval '$_SERVER["HTTP_X_FORWARDED_FOR"]="1.2.3.4:56"; echo WC_Geolocation:
:get_ip_address();'
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
