### PR TITLE
Delayed Account Creation: Remove experimental flag to enable feature

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/edit.tsx
@@ -85,6 +85,8 @@ export const Edit = ( {
 		return null;
 	}
 
+	const generatePassword = getSetting( 'registrationGeneratePassword', true );
+
 	return (
 		<div { ...blockProps }>
 			<InnerBlocks
@@ -101,23 +103,26 @@ export const Edit = ( {
 			<Disabled>
 				<Form isEditor={ true } />
 			</Disabled>
-			<InspectorControls>
-				<PanelBody title={ __( 'Style', 'woocommerce' ) }>
-					<ToggleControl
-						label={ __( 'Dark mode inputs', 'woocommerce' ) }
-						help={ __(
-							'Inputs styled specifically for use on dark background colors.',
-							'woocommerce'
-						) }
-						checked={ attributes.hasDarkControls }
-						onChange={ () =>
-							setAttributes( {
-								hasDarkControls: ! attributes.hasDarkControls,
-							} )
-						}
-					/>
-				</PanelBody>
-			</InspectorControls>
+			{ ! generatePassword && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Style', 'woocommerce' ) }>
+						<ToggleControl
+							label={ __( 'Dark mode inputs', 'woocommerce' ) }
+							help={ __(
+								'Inputs styled specifically for use on dark background colors.',
+								'woocommerce'
+							) }
+							checked={ attributes.hasDarkControls }
+							onChange={ () =>
+								setAttributes( {
+									hasDarkControls:
+										! attributes.hasDarkControls,
+								} )
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/index.tsx
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, people } from '@wordpress/icons';
-import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { ExternalLink } from '@wordpress/components';
 import { ADMIN_URL } from '@woocommerce/settings';
 
@@ -14,32 +13,30 @@ import { ADMIN_URL } from '@woocommerce/settings';
 import metadata from './block.json';
 import { Save, Edit } from './edit';
 
-if ( isExperimentalBlocksEnabled() ) {
-	registerBlockType( metadata, {
-		apiVersion: 3,
-		description: (
-			<>
-				{ metadata.description }
-				<br />
-				<ExternalLink
-					href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=account` }
-				>
-					{ __( 'Manage account settings', 'woocommerce' ) }
-				</ExternalLink>
-			</>
+registerBlockType( metadata, {
+	apiVersion: 3,
+	description: (
+		<>
+			{ metadata.description }
+			<br />
+			<ExternalLink
+				href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=account` }
+			>
+				{ __( 'Manage account settings', 'woocommerce' ) }
+			</ExternalLink>
+		</>
+	),
+	icon: {
+		src: (
+			<Icon
+				icon={ people }
+				className="wc-block-editor-components-block-icon"
+			/>
 		),
-		icon: {
-			src: (
-				<Icon
-					icon={ people }
-					className="wc-block-editor-components-block-icon"
-				/>
-			),
-		},
-		attributes: {
-			...metadata.attributes,
-		},
-		edit: Edit,
-		save: Save,
-	} );
-}
+	},
+	attributes: {
+		...metadata.attributes,
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/plugins/woocommerce/changelog/add-enable-delayed-account-creation-50597
+++ b/plugins/woocommerce/changelog/add-enable-delayed-account-creation-50597
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enabled delayed account creation after checkout on the order confirmation page.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -264,6 +264,16 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			),
 		);
 
+		// Feature requires a block theme.
+		if ( ! wc_current_theme_is_fse_theme() ) {
+			$account_settings = array_filter(
+				$account_settings,
+				function ( $setting ) {
+					return 'woocommerce_enable_delayed_account_creation' !== $setting['id'];
+				},
+			);
+		}
+
 		// Change settings when using the block based checkout.
 		if ( CartCheckoutUtils::is_checkout_block_default() ) {
 			$account_settings = array_filter(

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -264,15 +264,6 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			),
 		);
 
-		if ( ! Features::is_enabled( 'experimental-blocks' ) ) {
-			$account_settings = array_filter(
-				$account_settings,
-				function ( $setting ) {
-					return 'woocommerce_enable_delayed_account_creation' !== $setting['id'];
-				},
-			);
-		}
-
 		// Change settings when using the block based checkout.
 		if ( CartCheckoutUtils::is_checkout_block_default() ) {
 			$account_settings = array_filter(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
@@ -109,7 +109,7 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 	 * @return bool
 	 */
 	protected function is_feature_enabled() {
-		return Features::is_enabled( 'experimental-blocks' ) && get_option( 'woocommerce_enable_delayed_account_creation', 'yes' ) === 'yes';
+		return get_option( 'woocommerce_enable_delayed_account_creation', 'yes' ) === 'yes';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -440,6 +440,7 @@ final class BlockTypesController {
 			'OrderConfirmation\AdditionalInformation',
 			'OrderConfirmation\AdditionalFieldsWrapper',
 			'OrderConfirmation\AdditionalFields',
+			'OrderConfirmation\CreateAccount',
 		);
 
 		$block_types = array_merge(
@@ -463,7 +464,6 @@ final class BlockTypesController {
 			$block_types[] = 'ProductFilterClearButton';
 			$block_types[] = 'ProductFilterCheckboxList';
 			$block_types[] = 'ProductFilterChips';
-			$block_types[] = 'OrderConfirmation\CreateAccount';
 		}
 
 		/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
@@ -67,7 +67,6 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_trash_failed_orders'              => 'relative_date_selector',
 			'woocommerce_trash_cancelled_orders'           => 'relative_date_selector',
 			'woocommerce_anonymize_completed_orders'       => 'relative_date_selector',
-			'woocommerce_enable_delayed_account_creation'  => 'checkbox',
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR enables delayed account creation in the production build. The testing instructions enclosed cover new functionality added whilst behind the experimental flag. If you're testing this PR, test after using `npm run build`. If you're testing the release, just follow the instructions as-is.

Closes #50597

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Non-Block Themes**

1. Use a non-block theme such as StoreFront. 
2. Go to WooCommerce > Settings > Accounts and Privacy
3. The _Account Creation - After checkout (recommended)_ setting is not visible.

**Block Themes**

1. Use a block theme such as Twenty Twenty Five.
2. Go to WooCommerce > Settings > Accounts and Privacy
3. The _Account Creation - After checkout (recommended)_ setting is visible.
4. Toggle off "enable guest checkout"
5. Confirm that the "After checkout (recommended)" option is is greyed out and hovering over its checkbox shows a tooltip.
6. Toggle on "enable guest checkout"
8. Toggle off all "Account creation" settings
9. Confirm the "Account creation options" (Send password setup link) settings are greyed out

**Block Hooks**

1. WooCommerce > Settings > Accounts and Privacy - turn on account creation options and enable guest checkout.
2. Go to Appearance > Templates, find "order confirmation" in the list and click the menu (three dots) by its preview. Reset changes if the option is there. If its not, skip this step.
3. In the preview, ensure the account creation block is shown (you will see a "create account" button quite prominent in the preview).
4. In another browser, logged out as a guest, add something to cart and go through the checkout flow. Ensure you checkout with an email you have not used before.
5. On the order confirmation page, confirm you see the create account section. There will be some default text on the left listing benefits, and a button on the right. There may be a password field depending on settings too. Leave this tab open for testing. Do not create an account yet.
6. Back in the site editor, edit the order confirmation template. When inside, make some changes to the account creation block; edit text, headings, and make some styling changes e.g. background color. Save the template.
7. Back in the guest browser, refresh and confirm the changes are reflected on the frontend. There should also only be one create account block visible at all times.
8. Back as admin, Go to WooCommerce > Settings > Accounts and Privacy. Turn off  _Account Creation - After checkout (recommended)_ and save changes.
9. Back in the guest browser, refresh and confirm the account section is no longer shown.

**Customer facing functionality**

1. Ensure the feature is enabled in settings: registration and _Account Creation - After checkout (recommended)_  is enabled, and a block theme is in use.
2. Under WooCommerce > Settings > Accounts and Privacy, "Send password setup link (recommended)" is enabled.
3. Logged out as a guest, add something to cart and go through the checkout flow. 
4. On the order confirmation page, confirm you see the create account section. 
5. Click the "create account" button.
6. The page will load and show a confirmation that your account was created. Confirm the links in this section work
7. Check your email inbox for the registration email/new account email.
8. Check you can access the "my account" page and the order you placed is visible under the orders section.
10.  Under WooCommerce > Settings > Accounts and Privacy, "Send password setup link (recommended)" is disabled.
11. Repeat steps 3-8, but this time ensure the confirmation page prompts you to set a secure password before creating an account. Ensure you checkout with a different guest email or the create account section will be hidden.
12. Logout and login again using the password you set.
13. Logout and place another order as a guest using the _same_ email as before. This time the create account section will not be visible on the order confirmation page. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
