### PR TITLE
Do not listen to changes made through the Options API before init.

### DIFF
--- a/plugins/woocommerce/changelog/fix-52435-feature-options-listeners
+++ b/plugins/woocommerce/changelog/fix-52435-feature-options-listeners
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Limit the amount of Feature Controller logic that will run before init, to improve compatibility with translation-related changes in WP 6.7.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -92,7 +92,6 @@ class FeaturesController {
 	 */
 	public function __construct() {
 		self::add_filter( 'init', array( $this, 'start_listening_for_option_changes' ), 10, 0 );
-
 		self::add_filter( 'woocommerce_get_sections_advanced', array( $this, 'add_features_section' ), 10, 1 );
 		self::add_filter( 'woocommerce_get_settings_advanced', array( $this, 'add_feature_settings' ), 10, 2 );
 		self::add_filter( 'deactivated_plugin', array( $this, 'handle_plugin_deactivation' ), 10, 1 );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * Class to define the WooCommerce features that can be enabled and disabled by admin users,
  * provides also a mechanism for WooCommerce plugins to declare that they are compatible
  * (or incompatible) with a given feature.
+ *
+ * Features should not be enabled, or disabled, before init.
  */
 class FeaturesController {
 
@@ -89,8 +91,8 @@ class FeaturesController {
 	 * Creates a new instance of the class.
 	 */
 	public function __construct() {
-		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
-		self::add_filter( 'added_option', array( $this, 'process_added_option' ), 999, 3 );
+		self::add_filter( 'init', array( $this, 'start_listening_for_option_changes' ), 10, 0 );
+
 		self::add_filter( 'woocommerce_get_sections_advanced', array( $this, 'add_features_section' ), 10, 1 );
 		self::add_filter( 'woocommerce_get_settings_advanced', array( $this, 'add_feature_settings' ), 10, 2 );
 		self::add_filter( 'deactivated_plugin', array( $this, 'handle_plugin_deactivation' ), 10, 1 );
@@ -614,6 +616,19 @@ class FeaturesController {
 	 */
 	public function allow_activating_plugins_with_incompatible_features(): void {
 		$this->force_allow_enabling_plugins = true;
+	}
+
+	/**
+	 * Adds our callbacks for the `updated_option` and `added_option` filter hooks.
+	 *
+	 * We delay adding these hooks until `init`, because both callbacks need to load our list of feature definitions,
+	 * and building that list requires translating various strings (which should not be done earlier than `init`).
+	 *
+	 * @return void
+	 */
+	private function start_listening_for_option_changes(): void {
+		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
+		self::add_filter( 'added_option', array( $this, 'process_added_option' ), 999, 3 );
 	}
 
 	/**


### PR DESCRIPTION
Improves compatibility with WP 6.7 (and changes to l10n/i18n handling in that version), by limiting when we allow the list of feature definitions to be created.

---

Features can be enabled or disabled by creating or changing an option (via the [WordPress Options API](https://developer.wordpress.org/apis/options/)). For example, the following enables our Analytics feature:

```php
update_option( 'woocommerce_analytics_enabled', 'yes' );
```

To support this, WooCommerce uses filter hooks to listen for options being created or updated. To determine if the option is related to a WooCommerce feature, one part of its process is to look at a list of feature definitions. Building this list involves translating various strings (feature names, etc) which, as of WP 6.7, is frowned upon (see discussion in linked issue) if it takes place before `init`.

It seems quite reasonable that features would not be enabled or disabled before `init`, however, so in this change we only add our event listeners *after* `init` has started (in other words, on `init` priority `0`).

Closes #52435.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Setup: Make sure your site site is running the latest release candidate of [WordPress 6.7](https://make.wordpress.org/core/6-7/). Then start by installing and activating a non-default language. It doesn't especially matter which, but let's use French here:

```sh
wp core language install fr_FR
wp site switch-language fr_FR
wp language plugin update woocommerce
```

We are going to be looking out for *doing it wrong* notices. A handy means of detecting these is to install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/), but you can use any method you are familiar and comfortable with. Next, add the following code in a suitable location, such as `wp-content/mu-plugins/fix-52435.php`:

```php
<?php

add_action(
	'plugins_loaded',
	fn () => update_option( 'unrelated_option', uniqid() )
);
```

1. Using current `trunk` code (ie, without this change) refresh any frontend page. You should observe a *doing it wrong* error referencing `_load_textdomain_just_in_time` and **also referencing the woocommerce text domain**:

<div align="center"><img src="https://github.com/user-attachments/assets/beab4177-d030-431e-8501-fc0837968c20" alt="'Doing it wrong' error about translations, captured by Query Monitor" width="650"/></div>

3. Switch to this branch and repeat. The error should go away, but you may see very similar errors. For the purposes of this PR, that's fine so long as they do not reference the **woocommerce** text domain.

Lastly, but importantly, let's verify we can still enable and disable features by a couple of different channels. With this branch checked out:

1. Visit **WooCommerce ‣ Settings ‣ Advanced ‣ Features** and enable **Analytics** (or disable it, if it was already enabled).
2. Repeat in the opposite direction (disable it, or re-enable it, to get back to your original status).
3. The **Analytics** admin menu option should appear and disappear in alignment with the changes you made.
4. Now let's do the same, but using the Options API. We'll take advantage of WP CLI for this. Assuming we start by enabling:

```sh
wp option set woocommerce_analytics_enabled yes
```

5. Refresh the admin area; you should see that the **Analytics** menu item is present. Now disable:

```sh
wp option set woocommerce_analytics_enabled no
```

6. The **Analytics** menu item should disappear. You can of course do these tests in the other direction.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
