### PR TITLE
[Settings] Add a warning notice to enable Gutenberg plugin

### DIFF
--- a/packages/js/settings-editor/changelog/add-gutenberg-warning-notice-settings
+++ b/packages/js/settings-editor/changelog/add-gutenberg-warning-notice-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Create a warning or notice to add Gutenberg

--- a/packages/js/settings-editor/src/index.tsx
+++ b/packages/js/settings-editor/src/index.tsx
@@ -2,15 +2,31 @@
  * External dependencies
  */
 import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { isGutenbergVersionAtLeast } from './utils';
 import { Layout } from './layout';
 
 const Sidebar = <div>Sidebar content goes here</div>;
 
 export const SettingsEditor = () => {
+	const isRequiredGutenbergVersion = isGutenbergVersionAtLeast( 19.0 );
+
+	if ( ! isRequiredGutenbergVersion ) {
+		return (
+			//  Temporary during development.
+			<div style={ { margin: 'auto' } }>
+				{ __(
+					'Please enable Gutenberg version 19.0 or higher for this feature',
+					'woocommerce'
+				) }
+			</div>
+		);
+	}
+
 	return (
 		<Layout
 			route={ {

--- a/packages/js/settings-editor/src/utils/index.ts
+++ b/packages/js/settings-editor/src/utils/index.ts
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+
+export function isGutenbergVersionAtLeast( version: number ) {
+	const adminSettings: { gutenberg_version?: string } = getSetting( 'admin' );
+	if ( adminSettings.gutenberg_version ) {
+		return parseFloat( adminSettings?.gutenberg_version ) >= version;
+	}
+	return false;
+}

--- a/packages/js/settings-editor/typings/index.d.ts
+++ b/packages/js/settings-editor/typings/index.d.ts
@@ -1,0 +1,13 @@
+declare module '@woocommerce/settings' {
+	export declare function getAdminLink( path: string ): string;
+	export declare function getSetting< T >(
+		name: string,
+		fallback?: unknown,
+		filter = ( val: unknown, fb: unknown ) =>
+			typeof val !== 'undefined' ? val : fb
+	): T;
+	export declare function isWpVersion(
+		version: string,
+		operator: '>' | '>=' | '=' | '<' | '<='
+	): boolean;
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52500

This PR introduces a warning message and conditional loading logic for new settings that rely on the Gutenberg plugin. 

This temporary solution follows the same approach used in the Product Editor and will be removed once Core support for the necessary APIs is available.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with `settings` feature flag enabled
2. Navigate to the `WooCommerce > Settings`
3. See the warning message
4. Install and activate the Gutenberg plugin > 19.0
5. Navigate to the `WooCommerce > Settings`
6. See the settings page load without the warning message

![Screenshot 2024-11-05 at 17 04 38](https://github.com/user-attachments/assets/87f99de9-7e51-4d80-9830-c41d65ae6aaa)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
