### PR TITLE
[e2e tests] Remove check for http reponse when visiting the editor

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-http-response-check-on-editor-navigation
+++ b/plugins/woocommerce/changelog/e2e-remove-http-response-check-on-editor-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: update utils to not wait for http reponse when navigating to editor page

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -42,24 +42,14 @@ const getCanvas = async ( page ) => {
 };
 
 const goToPageEditor = async ( { page } ) => {
-	const responsePromise = page.waitForResponse(
-		( response ) =>
-			response.url().includes( '//page' ) && response.status() === 200
-	);
 	await page.goto( 'wp-admin/post-new.php?post_type=page' );
 	await disableWelcomeModal( { page } );
 	await closeChoosePatternModal( { page } );
-	await responsePromise;
 };
 
 const goToPostEditor = async ( { page } ) => {
-	const responsePromise = page.waitForResponse(
-		( response ) =>
-			response.url().includes( '//single' ) && response.status() === 200
-	);
 	await page.goto( 'wp-admin/post-new.php' );
 	await disableWelcomeModal( { page } );
-	await responsePromise;
 };
 
 const fillPageTitle = async ( page, title ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates in Gutenberg break the check for http response when visiting the editor.
We should not have this check anyway, any following actions should have implicit or explicit checks.
Removed the checks.

### How to test the changes in this Pull Request:

- CI green.
- Run the tests using the goToPageEditor or goToPostEditor utils without Gutenberg, with Gutenberg stable and with Gutenberg nightly. They should all pass. Without the change the runs with Gutenberg nightly will fail.

```
pnpm test:e2e merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js
```

```
pnpm test:e2e:with-env gutenberg-nightly merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js
```

```
pnpm test:e2e:with-env gutenberg-stable merchant/create-cart-block.spec.js merchant/create-checkout-block.spec.js merchant/create-page.spec.js merchant/create-post.spec.js merchant/create-woocommerce-blocks.spec.js merchant/create-woocommerce-patterns.spec.js
```
