### PR TITLE
[Experimental] Rating filter: fix block focus and visibility

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -32,6 +32,7 @@ import { EXCLUDED_BLOCKS } from '../../constants';
 import { Notice } from '../../components/notice';
 import type { Attributes } from './types';
 import './style.scss';
+import { InitialDisabled } from '../../components/initial-disabled';
 
 const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { attributes, setAttributes } = props;
@@ -189,30 +190,32 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 
 			<div { ...innerBlocksProps }>
-				{ showNoProductsNotice && (
-					<Notice>
-						{ __(
-							"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
-							'woocommerce'
-						) }
-					</Notice>
-				) }
-				<div
-					className={ clsx( {
-						'is-loading': isLoading,
-					} ) }
-				>
-					<BlockContextProvider
-						value={ {
-							filterData: {
-								items: displayedOptions,
-								isLoading,
-							},
-						} }
+				<InitialDisabled>
+					{ showNoProductsNotice && (
+						<Notice>
+							{ __(
+								"Your store doesn't have any products with ratings yet. This filter option will display when a product receives a review.",
+								'woocommerce'
+							) }
+						</Notice>
+					) }
+					<div
+						className={ clsx( {
+							'is-loading': isLoading,
+						} ) }
 					>
-						{ children }
-					</BlockContextProvider>
-				</div>
+						<BlockContextProvider
+							value={ {
+								filterData: {
+									items: displayedOptions,
+									isLoading,
+								},
+							} }
+						>
+							{ children }
+						</BlockContextProvider>
+					</div>
+				</InitialDisabled>
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/style.scss
@@ -1,6 +1,4 @@
 .wp-block-woocommerce-product-filter-rating {
-	display: grid;
-
 	.wc-block-components-product-rating {
 		margin-bottom: 0;
 		display: flex;

--- a/plugins/woocommerce/changelog/fix-rating-filter-minor-issues
+++ b/plugins/woocommerce/changelog/fix-rating-filter-minor-issues
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Experimental: Rating filter: fix block focus and visibility
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow-up #52152, this PR fixes some minor issues of the Rating block:
- When selecting the block from the editor canvas, the Rating block isn't selected but the its inner block. This PR utilizes the `<InitialDisabled>` component to enhance block selection by letting users focus on the Rating block first, then they can select inner blocks after that if need.
- The Rating block isn't hidden when there isn't any rating filter options.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
1. Add the `Product Filters` block to the `Product Catalog` template.
3. From the editor canvas, hover on the Rating block area and click to select it.
4. See the Rating block is selected, not its inner block.
5. Click on its inner block again, see they can be selected now.
6. Save the template and go to the shop page on the front end.
7. Try filtering the products to a set of products that don't have any rating.
8. See the Rating block is hidden.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
