### PR TITLE
[e2e tests] Update locator for block's font weight combobox - fix mini-cart tests for WP6.7

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-font-weight-combobox-locator-wp6.7
+++ b/plugins/woocommerce/changelog/e2e-fix-font-weight-combobox-locator-wp6.7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: updated locator to work with WP6.7

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -187,7 +187,14 @@ test.describe(
 			await page.getByTitle( 'Product Count', { exact: true } ).click();
 			// customize font size and weight
 			await page.getByLabel( 'Large', { exact: true } ).click();
-			await page.getByRole( 'button', { name: 'Font weight' } ).click();
+
+			// This complicated locator is needed to make it work with both WP6.6 and WP6.7
+			// Once support for WP6.6 is dropped, this can be simplified to: `getByRole('combobox', { name: 'Font weight' })`
+			await page
+				.getByText( 'Font weight' )
+				.locator( 'xpath=..' )
+				.locator( 'button' )
+				.click();
 			// choose Light via kb press due to encountered issue with normal click
 			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'ArrowDown' );
@@ -229,7 +236,7 @@ test.describe(
 			);
 			await expect( page.locator( miniCartBlock ) ).toHaveAttribute(
 				'data-style',
-				'{"typography":{"fontWeight":"300"}}'
+				/"typography":{"fontWeight":"300"/
 			);
 			await page.locator( miniCartButton ).click();
 			await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WP6.7 updated the element for the blocks font weight combobox breaking the `mini-cart.spec.js`.
Updated the locator to work with both 6.6 and 6.7. Once 6.6 support is dropped we should update the locator to a simpler one (left a code comment for this).

### How to test the changes in this Pull Request:

Run `mini-cart.spec.js` with latest WP (6.6.2) and with 6.7-RC2. Both should pass.

```
WP_ENV_CORE=https://wordpress.org/latest.zip pnpm env:restart
pnpm test:e2e mini-cart.spec.js
```

```
WP_ENV_CORE=http://downloads.wordpress.org/release/wordpress-6.7-RC2.zip pnpm env:restart
pnpm test:e2e mini-cart.spec.js
```
