### PR TITLE
 CYS: direct all users to the non-AI flow 

### DIFF
--- a/plugins/woocommerce/changelog/fix-52548-cys-direct-all-users-to-non-ai-flow
+++ b/plugins/woocommerce/changelog/fix-52548-cys-direct-all-users-to-non-ai-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Direct all users to the non-AI flow in Customize Your Store

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
@@ -147,33 +147,5 @@ export const setFlags = async () => {
 		await Promise.all( Object.values( _featureFlags ) );
 	}
 
-	// Set FlowType flag. We want to set the flag only in the parent window.
-	if ( isWooExpress() && ! isIframe( window ) ) {
-		try {
-			const { status } = await fetchAiStatus();
-
-			const isAiOnline =
-				status.indicator !== 'critical' && status.indicator !== 'major';
-
-			// @ts-expect-error temp workaround;
-			window.cys_aiOnline = status;
-			trackEvent( 'customize_your_store_ai_status', {
-				online: isAiOnline ? 'yes' : 'no',
-			} );
-
-			// @ts-expect-error temp workaround;
-			window.cys_aiFlow = true;
-
-			return isAiOnline ? FlowType.AIOnline : FlowType.AIOffline;
-		} catch ( e ) {
-			// @ts-expect-error temp workaround;
-			window.cys_aiOnline = false;
-			trackEvent( 'customize_your_store_ai_status', {
-				online: 'no',
-			} );
-			return FlowType.AIOffline;
-		}
-	}
-
 	return FlowType.noAI;
 };

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
@@ -13,8 +13,6 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { FlowType, aiStatusResponse } from '../types';
 import { isIframe } from '~/customize-store/utils';
-import { isWooExpress } from '~/utils/is-woo-express';
-import { trackEvent } from '../tracking';
 
 export const fetchAiStatus = async (): Promise< aiStatusResponse > => {
 	const response = await fetch(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes the minimal required changes to direct all users to the non-AI flow. While a lot of other code can be removed, that will be handled as a different task: https://github.com/woocommerce/woocommerce/issues/52549.

Closes #52548.

### How to test the changes in this Pull Request:

0. Generate a ZIP from this branch or use [this one](https://github.com/user-attachments/files/17633249/woocommerce.zip) (when testing the release, simply use the release ZIP)
0. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
1. In a WordPress.com site, go to WooCommerce > Customize Your Store.
2. Verify there is no option to enter the AI flow:
![imatge](https://github.com/user-attachments/assets/44e49130-5018-4fe9-910a-5d2e45f9ec50)
3. Click on _Customize your store_. Verify you aren't requested to input a store description (which was the AI flow).
4. Go back to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fintro`.
5. Click on _Use the store designer_. Verify you aren't requested to input a store description (which was the AI flow).
6. In a non WordPress.com site, go to WooCommerce > Customize Your Store.
7. Do some smoke testing to verify nothing is broken.