### PR TITLE
NOX: Fix offline payment methods back navigation

### DIFF
--- a/plugins/woocommerce/changelog/fix-offline-payment-gateways-navigate-back
+++ b/plugins/woocommerce/changelog/fix-offline-payment-gateways-navigate-back
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix offline payment methods back navigation with reactify-classic-payments-settings feature

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -204,8 +204,16 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * Output the gateway settings screen.
 	 */
 	public function admin_options() {
+		$offline_payment_gateways   = array( 'bacs', 'cheque', 'cod' );
+		$is_offline_payment_gateway = in_array( $this->id, $offline_payment_gateways, true );
+
 		echo '<h2>' . esc_html( $this->get_method_title() );
-		wc_back_link( __( 'Return to payments', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
+		wc_back_link(
+			__( 'Return to payments', 'woocommerce' ),
+			$is_offline_payment_gateway
+				? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=offline' )
+				: admin_url( 'admin.php?page=wc-settings&tab=checkout' )
+		);
 		echo '</h2>';
 		echo wp_kses_post( wpautop( $this->get_method_description() ) );
 		parent::admin_options();

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -11,6 +11,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -204,16 +205,17 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * Output the gateway settings screen.
 	 */
 	public function admin_options() {
-		$offline_payment_gateways   = array( 'bacs', 'cheque', 'cod' );
-		$is_offline_payment_gateway = in_array( $this->id, $offline_payment_gateways, true );
+		$is_reactify_enabled      = Features::is_enabled( 'reactify-classic-payments-settings' );
+		$offline_payment_gateways = array( 'bacs', 'cheque', 'cod' );
+		$is_offline_gateway       = in_array( $this->id, $offline_payment_gateways, true );
+
+		$return_url = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
+		if ( $is_reactify_enabled && $is_offline_gateway ) {
+			$return_url = add_query_arg( 'section', 'offline', $return_url );
+		}
 
 		echo '<h2>' . esc_html( $this->get_method_title() );
-		wc_back_link(
-			__( 'Return to payments', 'woocommerce' ),
-			$is_offline_payment_gateway
-				? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=offline' )
-				: admin_url( 'admin.php?page=wc-settings&tab=checkout' )
-		);
+		wc_back_link( __( 'Return to payments', 'woocommerce' ), $return_url );
 		echo '</h2>';
 		echo wp_kses_post( wpautop( $this->get_method_description() ) );
 		parent::admin_options();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52570

This PR ensures that the back button in offline payment method settings (BACS, Cheque, COD) navigates to the appropriate management screen based on the status of the `reactify-classic-payments-settings` feature flag:

1. When reactify-classic-payments-settings is enabled, the back button directs users to the Offline Payment Methods Management Screen (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=offline).
2. When reactify-classic-payments-settings is disabled, the back button directs users to the General Payments Management Screen (/wp-admin/admin.php?page=wc-settings&tab=checkout).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to any offline payment method (BACS, Cheque, COD) settings screen. (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs`)
2. Click the back button and confirm it redirects to the **General Payments Management** Screen (`/wp-admin/admin.php?page=wc-settings&tab=checkout`)
3. Enable the reactify-classic-payments-settings feature flag.
4. Repeat steps 2-3 and confirm the back button now redirects to the **Offline Payment Methods Management** Screen `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=offline`).

![image](https://github.com/user-attachments/assets/65bd410a-4073-4407-adfd-5a84134774e5)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
