### PR TITLE
Checkout: Adjust paddings to align top of page order summary on mobile

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -1,6 +1,8 @@
 .wc-block-components-order-summary {
-	// Compensate for removing Panel.
-	padding: 0 $gap;
+	&.is-large {
+		// Compensate for removing Panel.
+		padding: 0 $gap;
+	}
 
 	.wc-block-components-order-summary__button-text {
 		font-weight: 500;
@@ -111,16 +113,5 @@
 	.wc-block-components-order-summary-item__individual-prices {
 		display: block;
 		padding-top: $gap-smaller;
-	}
-}
-
-.is-medium,
-.is-small,
-.is-mobile {
-	.wp-block-woocommerce-checkout-order-summary-block {
-		.wc-block-components-totals-wrapper {
-			padding-left: $gap-small;
-			padding-right: $gap-small;
-		}
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/style.scss
@@ -2,6 +2,12 @@
 	border: 1px solid $universal-border-light;
 	border-radius: 5px;
 
+	&.checkout-order-summary-block-fill-wrapper {
+		.wc-block-components-order-summary {
+			padding: 0 $gap;
+		}
+	}
+
 	.wc-block-components-formatted-money-amount {
 		font-weight: 600;
 	}

--- a/plugins/woocommerce/changelog/52604-dev-alignment-on-mobile-order-summary-48899
+++ b/plugins/woocommerce/changelog/52604-dev-alignment-on-mobile-order-summary-48899
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Adjust paddings on top of page order summary to better align on mobile.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a visual change to match alignment of the order summary on mobile to the rest of the checkout page.

We keep padding on the new bottom of page summary since it has a border and would look strange without it.

Closes #48899 

#### Before:

<img width="212" alt="BEFORE" src="https://github.com/user-attachments/assets/db3ceea5-d3b2-405f-9ade-433f08a1c858">

#### After:
<img width="211" alt="AFTER" src="https://github.com/user-attachments/assets/ede749e8-f256-4e96-878e-b4f1a7b48397">



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Visually determine if the new changes look good on mobile
2. Check on desktop  and other screen sizes for any visual regression

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Adjust paddings on top of page order summary to better align on mobile.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
