### PR TITLE
Fix visual issue in the Display Style of the Product Categories List block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-categories/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-categories/block.tsx
@@ -76,6 +76,7 @@ const ProductCategoriesBlock = ( {
 				>
 					<ToggleGroupControl
 						label={ __( 'Display style', 'woocommerce' ) }
+						isBlock
 						value={ isDropdown ? 'dropdown' : 'list' }
 						onChange={ ( value: string ) =>
 							setAttributes( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-categories/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-categories/block.tsx
@@ -12,8 +12,12 @@ import {
 	PanelBody,
 	ToggleControl,
 	Placeholder,
+
+	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
+
+	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-categories/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-categories/edit.tsx
@@ -10,7 +10,9 @@ import Block from './block';
 import './editor.scss';
 import type { ProductCategoriesBlockProps } from './types';
 
-export const Edit = ( props: ProductCategoriesBlockProps ): JSX.Element => {
+export default function ProductCategoriesEdit(
+	props: ProductCategoriesBlockProps
+): JSX.Element {
 	const blockProps = useBlockProps();
 
 	return (
@@ -18,4 +20,4 @@ export const Edit = ( props: ProductCategoriesBlockProps ): JSX.Element => {
 			<Block { ...props } />
 		</div>
 	);
-};
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-categories/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-categories/index.tsx
@@ -7,11 +7,11 @@ import { Icon, listView } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import './editor.scss';
 import metadata from './block.json';
-import './style.scss';
-import { Edit } from './edit';
+import Edit from './edit';
 import type { ProductCategoriesIndexProps } from './types';
+import './editor.scss';
+import './style.scss';
 
 registerBlockType( metadata, {
 	icon: {

--- a/plugins/woocommerce/changelog/update-fix-product-categories-list-settings-sidebar-layout
+++ b/plugins/woocommerce/changelog/update-fix-product-categories-list-settings-sidebar-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix visual issue in the Display Style of the Product Categories List block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a visual issue reported here https://github.com/woocommerce/woocommerce/issues/52224

Closes https://github.com/woocommerce/woocommerce/issues/52224

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Let's follow the steps to reproduce the issue

1. Create a post or page.
2. Add the Product Categories List block.
3. **Before**
    Notice the List Settings > Display Style options look a bit weird.
4. After. Confirm the toggle component looks as expected


Before | After
-----|-----
<img width="282" alt="image" src="https://github.com/user-attachments/assets/58544dfd-edc7-4109-8004-ffc42d4bad75">| <img width="281" alt="image" src="https://github.com/user-attachments/assets/5a68b0a4-ed06-4e4a-9a00-a00058b31081">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
