### PR TITLE
[dev] CI: bump actions/download-artifact and actions/upload-artifact actions version to v4.

### DIFF
--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -26,7 +26,7 @@ jobs:
         run: bash bin/build-zip.sh
 
       - name: Upload the zip file as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -52,7 +52,7 @@ jobs:
           path: monorepo
 
       - name: Download WooCommerce ZIP
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: woocommerce
           path: tmp/woocommerce-build


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update `.github/workflows/mirrors.yml` to use up-to-date versions of actions.
V3 of the actions is deprecated, spotted in p1730849131961899-slack-C03CPM3UXDJ

### How to test the changes in this Pull Request:

None, `.github/workflows/pr-build-live-branch.yml` was used as a reference for changes, and it's working already.