### PR TITLE
CYS: stop using __experimentalGetTemplateForLink() function

### DIFF
--- a/plugins/woocommerce/changelog/fix-52617-stop-using-__experimentalGetTemplateForLink
+++ b/plugins/woocommerce/changelog/fix-52617-stop-using-__experimentalGetTemplateForLink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fix CYS error with latest Gutenberg nightly builds

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/block-editor-container.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/block-editor-container.tsx
@@ -38,14 +38,10 @@ import { useIsActiveNewNeutralVariation } from './hooks/use-is-active-new-neutra
 export const BlockEditorContainer = () => {
 	const settings = useSiteEditorSettings();
 
-	const currentTemplate:
-		| {
-				id: string;
-		  }
-		| undefined = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( select ) =>
 			// @ts-expect-error No types for this exist yet.
-			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			select( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
@@ -61,7 +57,7 @@ export const BlockEditorContainer = () => {
 
 	const [ blocks, , onChange ] = useEditorBlocks(
 		templateType,
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const urlParams = useQuery();

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/hooks/use-insert-pattern.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/hooks/use-insert-pattern.ts
@@ -27,16 +27,16 @@ import { trackEvent } from '../../tracking';
 export const useInsertPattern = () => {
 	const isActiveNewNeutralVariation = useIsActiveNewNeutralVariation();
 
-	const currentTemplate = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( sel ) =>
 			// @ts-expect-error No types for this exist yet.
-			sel( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			sel( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ blocks ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const insertedPatternRef = useRef< string | null >( null );

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/pattern-screen/sidebar-pattern-screen.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/pattern-screen/sidebar-pattern-screen.tsx
@@ -108,16 +108,16 @@ export const SidebarPatternScreen = ( { category }: { category: string } ) => {
 
 	const refElement = useRef< HTMLDivElement >( null );
 
-	const currentTemplate = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( sel ) =>
 			// @ts-expect-error No types for this exist yet.
-			sel( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			sel( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ blocks ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const isEditorLoading = useIsSiteEditorLoading();

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -53,20 +53,16 @@ export const SaveHub = () => {
 	const { sendEvent } = useContext( CustomizeStoreContext );
 	const [ isResolving, setIsResolving ] = useState< boolean >( false );
 
-	const currentTemplate:
-		| {
-				id: string;
-		  }
-		| undefined = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( select ) =>
 			// @ts-expect-error No types for this exist yet.
-			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			select( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ blocks ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const isNoBlocksPlaceholderPresent =

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-footer/sidebar-navigation-screen-footer.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-footer/sidebar-navigation-screen-footer.tsx
@@ -53,16 +53,16 @@ export const SidebarNavigationScreenFooter = ( {
 
 	const { isLoading, patterns } = usePatternsByCategory( 'woo-commerce' );
 
-	const currentTemplate = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( select ) =>
 			// @ts-expect-error No types for this exist yet.
-			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			select( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ mainTemplateBlocks ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const [ blocks, , onChange ] = useEditorBlocks(

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-header/sidebar-navigation-screen-header.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-header/sidebar-navigation-screen-header.tsx
@@ -54,16 +54,16 @@ export const SidebarNavigationScreenHeader = ( {
 
 	const { isLoading, patterns } = usePatternsByCategory( 'woo-commerce' );
 
-	const currentTemplate = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( select ) =>
 			// @ts-expect-error No types for this exist yet.
-			select( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			select( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ mainTemplateBlocks ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const [ blocks, , onChange ] = useEditorBlocks(

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage-ptk/sidebar-navigation-screen-homepage-ptk.tsx
@@ -66,16 +66,16 @@ export const SidebarNavigationScreenHomepagePTK = ( {
 	const isNetworkOffline = useNetworkStatus();
 	const isPTKPatternsAPIAvailable = context.isPTKPatternsAPIAvailable;
 
-	const currentTemplate = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( sel ) =>
 			// @ts-expect-error No types for this exist yet.
-			sel( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			sel( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ blocks ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const numberOfPatternsAdded = useMemo( () => {

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage/sidebar-navigation-screen-homepage.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-homepage/sidebar-navigation-screen-homepage.tsx
@@ -55,16 +55,16 @@ export const SidebarNavigationScreenHomepage = ( {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const { selectedPattern, setSelectedPattern } = useSelectedPattern();
 
-	const currentTemplate = useSelect(
+	const currentTemplateId: string | undefined = useSelect(
 		( sel ) =>
 			// @ts-expect-error No types for this exist yet.
-			sel( coreStore ).__experimentalGetTemplateForLink( '/' ),
+			sel( coreStore ).getDefaultTemplateId( { slug: 'home' } ),
 		[]
 	);
 
 	const [ blocks, , onChange ] = useEditorBlocks(
 		'wp_template',
-		currentTemplate?.id ?? ''
+		currentTemplateId || ''
 	);
 
 	const onClickPattern = useCallback(

--- a/plugins/woocommerce/client/admin/client/customize-store/data/actions.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/data/actions.ts
@@ -61,7 +61,7 @@ export const updateTemplatePrePTK = async ( {
 
 	// Ensure that the patterns are up to date because we populate images and content in previous step.
 	invalidateResolutionForStoreSelector( 'getBlockPatterns' );
-	invalidateResolutionForStoreSelector( '__experimentalGetTemplateForLink' );
+	invalidateResolutionForStoreSelector( 'getDefaultTemplateId' );
 
 	const patterns = ( await resolveSelect(
 		coreStore
@@ -108,10 +108,10 @@ export const updateTemplatePrePTK = async ( {
 	// Replace the logo width with the default width.
 	content = setLogoWidth( content );
 
-	const currentTemplate = await resolveSelect(
+	const currentTemplateId: string | undefined = await resolveSelect(
 		coreStore
 		// @ts-ignore No types for this exist yet.
-	).__experimentalGetTemplateForLink( '/' );
+	).getDefaultTemplateId( { slug: 'home' } );
 
 	// @ts-ignore No types for this exist yet.
 	const { saveEntityRecord } = dispatch( coreStore );
@@ -141,9 +141,9 @@ export const updateTemplatePrePTK = async ( {
 		),
 		saveEntityRecord(
 			'postType',
-			currentTemplate.type,
+			'wp_template',
 			{
-				id: currentTemplate.id,
+				id: currentTemplateId,
 				content,
 			},
 			{
@@ -159,7 +159,7 @@ const updateTemplatePTK = async () => {
 
 	// Ensure that the patterns are up to date because we populate images and content in previous step.
 	invalidateResolutionForStoreSelector( 'getBlockPatterns' );
-	invalidateResolutionForStoreSelector( '__experimentalGetTemplateForLink' );
+	invalidateResolutionForStoreSelector( 'getDefaultTemplateId' );
 	registerCoreBlocks( __experimentalGetCoreBlocks() );
 
 	const DEFAULT_PATTERNS = {
@@ -207,10 +207,10 @@ const updateTemplatePTK = async () => {
 	// Replace the logo width with the default width.
 	content = setLogoWidth( content );
 
-	const currentTemplate = await resolveSelect(
+	const currentTemplateId: string | undefined = await resolveSelect(
 		coreStore
 		// @ts-ignore No types for this exist yet.
-	).__experimentalGetTemplateForLink( '/' );
+	).getDefaultTemplateId( { slug: 'home' } );
 
 	// @ts-ignore No types for this exist yet.
 	const { saveEntityRecord } = dispatch( coreStore );
@@ -240,9 +240,9 @@ const updateTemplatePTK = async () => {
 		),
 		saveEntityRecord(
 			'postType',
-			currentTemplate.type,
+			'wp_template',
 			{
-				id: currentTemplate.id,
+				id: currentTemplateId,
 				content,
 			},
 			{

--- a/plugins/woocommerce/client/admin/client/customize-store/design-with-ai/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-with-ai/index.tsx
@@ -98,20 +98,18 @@ export const DesignWithAiController = ( {
 			: state.value;
 
 	return (
-		<>
-			<div
-				className={ `woocommerce-design-with-ai__container woocommerce-design-with-ai-wizard__step-${ currentNodeCssLabel }` }
-			>
-				{ CurrentComponent ? (
-					<CurrentComponent
-						sendEvent={ send }
-						context={ state.context }
-					/>
-				) : (
-					<div />
-				) }
-			</div>
-		</>
+		<div
+			className={ `woocommerce-design-with-ai__container woocommerce-design-with-ai-wizard__step-${ currentNodeCssLabel }` }
+		>
+			{ CurrentComponent ? (
+				<CurrentComponent
+					sendEvent={ send }
+					context={ state.context }
+				/>
+			) : (
+				<div />
+			) }
+		</div>
 	);
 };
 
@@ -127,11 +125,9 @@ export const DesignWithAi: CustomizeStoreComponent = ( {
 		return null;
 	}
 	return (
-		<>
-			<DesignWithAiController
-				parentMachine={ parentMachine }
-				parentContext={ context }
-			/>
-		</>
+		<DesignWithAiController
+			parentMachine={ parentMachine }
+			parentContext={ context }
+		/>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/index.tsx
@@ -78,15 +78,13 @@ export const DesignWithNoAiController = ( {
 	}, [ CurrentComponent, currentNodeMeta?.component ] );
 
 	return (
-		<>
-			<div className={ `woocommerce-design-without-ai__container` }>
-				{ CurrentComponent ? (
-					<CurrentComponent sendEvent={ send } />
-				) : (
-					<div />
-				) }
-			</div>
-		</>
+		<div className={ `woocommerce-design-without-ai__container` }>
+			{ CurrentComponent ? (
+				<CurrentComponent sendEvent={ send } />
+			) : (
+				<div />
+			) }
+		</div>
 	);
 };
 
@@ -96,11 +94,9 @@ export const DesignWithoutAi: CustomizeStoreComponent = ( {
 	context,
 } ) => {
 	return (
-		<>
-			<DesignWithNoAiController
-				parentMachine={ parentMachine }
-				parentContext={ context }
-			/>
-		</>
+		<DesignWithNoAiController
+			parentMachine={ parentMachine }
+			parentContext={ context }
+		/>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/index.tsx
@@ -140,8 +140,7 @@ const markTaskComplete = async () => {
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_admin_customize_store_completed: 'yes',
 		// we use this on the intro page to determine if this same theme was used in the last customization
-		woocommerce_admin_customize_store_completed_theme_id:
-			currentTemplateId,
+		woocommerce_admin_customize_store_completed_theme_id: currentTemplateId,
 	} );
 };
 

--- a/plugins/woocommerce/client/admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/index.tsx
@@ -133,15 +133,15 @@ const redirectToThemes = ( _context: customizeStoreStateMachineContext ) => {
 };
 
 const markTaskComplete = async () => {
-	const currentTemplate = await resolveSelect(
+	const currentTemplateId: string | undefined = await resolveSelect(
 		coreStore
 		// @ts-expect-error No types for this exist yet.
-	).__experimentalGetTemplateForLink( '/' );
+	).getDefaultTemplateId( { slug: 'home' } );
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_admin_customize_store_completed: 'yes',
 		// we use this on the intro page to determine if this same theme was used in the last customization
 		woocommerce_admin_customize_store_completed_theme_id:
-			currentTemplate.id ?? undefined,
+			currentTemplateId,
 	} );
 };
 

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
@@ -44,38 +44,19 @@ export const fetchCustomizeStoreCompleted = async () => {
 };
 
 export const fetchIntroData = async () => {
-	const currentTemplatePromise =
-		// @ts-expect-error No types for this exist yet.
-		resolveSelect( coreStore ).__experimentalGetTemplateForLink( '/' );
-
-	const maybePreviousTemplatePromise = resolveSelect(
-		OPTIONS_STORE_NAME
-	).getOption( 'woocommerce_admin_customize_store_completed_theme_id' );
-
 	const getTaskPromise = resolveSelect( ONBOARDING_STORE_NAME ).getTask(
 		'customize-store'
 	);
-
+	
 	const themeDataPromise = fetchThemeCards();
-
-	const [ currentTemplate, maybePreviousTemplate, task, themeData ] =
-		await Promise.all( [
-			currentTemplatePromise,
-			maybePreviousTemplatePromise,
-			getTaskPromise,
-			themeDataPromise,
-		] );
-
-	let currentThemeIsAiGenerated = false;
-	if (
-		maybePreviousTemplate &&
-		currentTemplate?.id === maybePreviousTemplate
-	) {
-		currentThemeIsAiGenerated = true;
-	}
-
+	
+	const [ task, themeData ] =
+	await Promise.all( [
+		getTaskPromise,
+		themeDataPromise,
+	] );
 	const customizeStoreTaskCompleted = task?.isComplete;
-
+	
 	interface Theme {
 		stylesheet?: string;
 	}
@@ -86,7 +67,7 @@ export const fetchIntroData = async () => {
 		customizeStoreTaskCompleted,
 		themeData,
 		activeTheme: theme.stylesheet || '',
-		currentThemeIsAiGenerated,
+		currentThemeIsAiGenerated: false,
 	};
 };
 

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
@@ -44,19 +44,38 @@ export const fetchCustomizeStoreCompleted = async () => {
 };
 
 export const fetchIntroData = async () => {
+	const currentTemplatePromise =
+		// @ts-expect-error No types for this exist yet.
+		resolveSelect( coreStore ).getDefaultTemplateId( { slug: 'home' } );
+
+	const maybePreviousTemplatePromise = resolveSelect(
+		OPTIONS_STORE_NAME
+	).getOption( 'woocommerce_admin_customize_store_completed_theme_id' );
+
 	const getTaskPromise = resolveSelect( ONBOARDING_STORE_NAME ).getTask(
 		'customize-store'
 	);
-	
+
 	const themeDataPromise = fetchThemeCards();
-	
-	const [ task, themeData ] =
-	await Promise.all( [
-		getTaskPromise,
-		themeDataPromise,
-	] );
+
+	const [ currentTemplateId, maybePreviousTemplate, task, themeData ] =
+		await Promise.all( [
+			currentTemplatePromise,
+			maybePreviousTemplatePromise,
+			getTaskPromise,
+			themeDataPromise,
+		] );
+
+	let currentThemeIsAiGenerated = false;
+	if (
+		maybePreviousTemplate &&
+		currentTemplateId === maybePreviousTemplate
+	) {
+		currentThemeIsAiGenerated = true;
+	}
+
 	const customizeStoreTaskCompleted = task?.isComplete;
-	
+
 	interface Theme {
 		stylesheet?: string;
 	}
@@ -67,7 +86,7 @@ export const fetchIntroData = async () => {
 		customizeStoreTaskCompleted,
 		themeData,
 		activeTheme: theme.stylesheet || '',
-		currentThemeIsAiGenerated: false,
+		currentThemeIsAiGenerated,
 	};
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces usages of `__experimentalGetTemplateForLink()` with `getDefaultTemplateId()` across the CYS codebase so it works with the latest Gutenberg builds, which removed that experimental function.

Closes #52617.

### How to test the changes in this Pull Request:

1. Install the latest [Gutenberg Nightly](https://github.com/Automattic/gutenberg-nightlies/releases).
2. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
3. Go to WooCommerce > Customize Your Store. Verify there are no errors displayed on the screen.
4. Smoke test the CYS functionality: change the logo, fonts, colors, some patterns, etc. and save it.
5. Verify at no moment you see an error.