### PR TITLE
Add To Cart with Options - remove flex rule on editor side

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -4,9 +4,6 @@
 	display: flex;
 	flex-direction: column;
 	width: 400px;
-	.components-disabled {
-		display: flex;
-	}
 }
 
 .wc-block-editor-quantity-selector-style {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During testing with TT5, I observed that the “Add to Cart with Options” using the Stepper layout appears differently in the editor compared to the frontend. This discrepancy is due to the `flex` rule, which remains applied in the editor but was removed from the frontend as per this pull request: https://github.com/woocommerce/woocommerce/pull/52481.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2ae55ac4-aa1a-4689-aea7-1692e665154e) | ![image](https://github.com/user-attachments/assets/3a687962-9928-4b75-830b-2eb8de7d66d1) | 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce Beta Tester:
[woocommerce-beta-tester.zip](https://github.com/user-attachments/files/17629774/woocommerce-beta-tester.zip)
2. Visit `wp-admin/tools.php?page=woocommerce-admin-test-helper`.
3. Enable `add-to-cart-with-options-stepper-layout` feature.
4. Enable TT5
5. Visit the Single Product Template.
6. Ensure that the Quantity Selector setting is available.
7. Enable it
8. Ensure that the layout looks like the image in the after column
9. Save.
10. Visit a simple product.
11. Ensure that the layout looks like the editor side.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add To Cart with Options - remove flex rule on editor side

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
