### PR TITLE
Remove __experimentalGetTemplateForLink() from @wordpress/edit-site dependency

### DIFF
--- a/bin/patches/@wordpress__edit-site@5.15.0.patch
+++ b/bin/patches/@wordpress__edit-site@5.15.0.patch
@@ -42,3 +42,33 @@ index 2265f933ceec19f65ca6776c24c3f88b368d713f..e9e10980bfd1b584ab0a037c3b72edae
 +
 +export const { lock, unlock } = optInToUnstableAPIs();
  //# sourceMappingURL=lock-unlock.js.map
+diff --git a/build-module/store/actions.js b/build-module/store/actions.js
+index a2f9fcd42f..c6bbf6a8c7 100644
+--- a/build-module/store/actions.js
++++ b/build-module/store/actions.js
+@@ -240,7 +240,24 @@ export const setPage = page => async ({
+     page.path = getPathAndQueryString(entity?.link);
+   }
+ 
+-  const template = await registry.resolveSelect(coreStore).__experimentalGetTemplateForLink(page.path);
++  let fetchedTemplate;
++  try {
++    // This is NOT calling a REST endpoint but rather ends up with a response from
++    // an Ajax function which has a different shape from a WP_REST_Response.
++    fetchedTemplate = await apiFetch( {
++      url: addQueryArgs( page.path, {
++        '_wp-find-template': true,
++      } ),
++    } ).then( ( { data } ) => data );
++  } catch ( e ) {
++    // For non-FSE themes, it is possible that this request returns an error.
++  }
++
++  const template = await registry.resolveSelect(coreStore).getEntityRecord(
++    'postType',
++    'wp_template',
++    fetchedTemplate.id
++  );
+ 
+   if (!template) {
+     return;

--- a/plugins/woocommerce/changelog/fix-52617-remove-__experimentalGetTemplateForLink-usage-from-dependency
+++ b/plugins/woocommerce/changelog/fix-52617-remove-__experimentalGetTemplateForLink-usage-from-dependency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Remove __experimentalGetTemplateForLink() from @wordpress/edit-site dependency
+
+

--- a/plugins/woocommerce/client/admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/index.tsx
@@ -139,7 +139,7 @@ const markTaskComplete = async () => {
 	).getDefaultTemplateId( { slug: 'home' } );
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_admin_customize_store_completed: 'yes',
-		// we use this on the intro page to determine if this same theme was used in the last customization
+		// We use this on the intro page to determine if this same theme was used in the last customization.
 		woocommerce_admin_customize_store_completed_theme_id: currentTemplateId,
 	} );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ pnpmfileChecksum: y3ex4x7shfdnqpcpdnu67kmuvu
 
 patchedDependencies:
   '@wordpress/edit-site@5.15.0':
-    hash: 6y3l6gxu33zybfmvbjd23dtqda
+    hash: u2xn4lpm453vgqpkdgbivlveaa
     path: bin/patches/@wordpress__edit-site@5.15.0.patch
   '@wordpress/env@10.10.0':
     hash: udc4zzshwvoqfywbfiynuocs7e
@@ -4247,7 +4247,7 @@ importers:
         version: 3.6.1
       '@wordpress/edit-site':
         specifier: 5.15.0
-        version: 5.15.0(patch_hash=6y3l6gxu33zybfmvbjd23dtqda)(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 5.15.0(patch_hash=u2xn4lpm453vgqpkdgbivlveaa)(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@wordpress/element':
         specifier: wp-6.0
         version: 4.4.1
@@ -22566,7 +22566,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      react: 18.2.0
+      react: ^17.0.2
 
   react-number-format@4.9.3:
     resolution: {integrity: sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==}
@@ -22756,7 +22756,7 @@ packages:
   react-with-direction@1.4.0:
     resolution: {integrity: sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==}
     peerDependencies:
-      react: ^0.14 || ^15 || ^16
+      react: ^17.0.2
       react-dom: ^0.14 || ^15 || ^16
 
   react-with-styles-interface-css@4.0.3:
@@ -42857,7 +42857,7 @@ snapshots:
       - react-with-direction
       - supports-color
 
-  '@wordpress/edit-site@5.15.0(patch_hash=6y3l6gxu33zybfmvbjd23dtqda)(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@wordpress/edit-site@5.15.0(patch_hash=u2xn4lpm453vgqpkdgbivlveaa)(@babel/helper-module-imports@7.24.7)(@babel/types@7.25.2)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.0
       '@wordpress/a11y': 3.57.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/52623 and part of #52617.

In #52623 we removed all usages of `__experimentalGetTemplateForLink()` in our codebase. However, it looks like we had a pinned dependency that also had a call to that function. This PR adds a patch on top of it so we remove the `__experimentalGetTemplateForLink()` call and replace it with the function logic.

Note: I know that's a hacky work-around, the best approach would be to update the dependency. However, when I tried that, I noticed that we have a lot of code that depends on that specific version, so it's not possible to update without a big refactor. Considering we want to merge this in WC 9.4, I opted for the smallest change that fixes the issue.

### How to test the changes in this Pull Request:

1. Install the latest [Gutenberg Nightly](https://github.com/Automattic/gutenberg-nightlies/releases).
2. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
3. Go to WooCommerce > Customize Your Store. Verify there are no errors displayed on the screen.
4. Smoke test the CYS functionality: change the logo, fonts, colors, some patterns, etc. and save it. Make sure to open the assembler hub `/wp-admin/admin.php?page=wc-admin&customizing=true&path=%2Fcustomize-store%2Fassembler-hub`.
5. Verify at no moment you see an error.