### PR TITLE
Tweak the layout of the Add to cart block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -9,7 +9,7 @@
 		> .quantity:not(.wc-block-components-quantity-selector) .qty {
 			padding-top: 0;
 			padding-bottom: 0;
-			height: calc( 100% - 4px ); // 4px border width
+			height: calc(100% - 4px); // 4px border width
 		}
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -6,6 +6,11 @@
 	width: 400px;
 	.components-disabled {
 		display: flex;
+		> .quantity:not(.wc-block-components-quantity-selector) .qty {
+			padding-top: 0;
+			padding-bottom: 0;
+			height: calc( 100% - 4px ); // 4px border width
+		}
 	}
 }
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -36,7 +36,7 @@
 			justify-self: start;
 		}
 
-		> .quantity .qty {
+		> .quantity:not(.wc-block-components-quantity-selector) .qty {
 			margin-right: 0.5em;
 			padding-top: 0;
 			padding-bottom: 0;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -23,7 +23,6 @@
 		}
 
 		display: grid;
-		width: fit-content;
 
 		& > * {
 			// Hack to ensure input + button stat on the same row, together.
@@ -41,6 +40,10 @@
 			padding-top: 0;
 			padding-bottom: 0;
 			height: calc( 100% - 4px ); // 4px border width
+		}
+
+		&.grouped_form {
+			width: fit-content;
 		}
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -18,6 +18,10 @@
 	width: unset;
 
 	form.cart {
+		&:before {
+			grid-column: span 2; // ensure the form spans the full width of the container
+		}
+
 		display: grid;
 		grid-template-columns: max-content;
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -19,7 +19,7 @@
 
 	form.cart {
 		&:before {
-			grid-column: span 2; // ensure the form spans the full width of the container
+			grid-column: span 9999;
 		}
 
 		display: grid;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -19,6 +19,7 @@
 
 	form.cart {
 		&:before {
+			content: " ";
 			grid-column: span 9999;
 		}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -8,33 +8,49 @@
 		font-size: var(--wp--preset--font-size--small);
 		padding: 0.9rem 1.1rem;
 	}
+
 }
 
-.wc-block-add-to-cart-form.wc-block-add-to-cart-form--input {
+/*
+ * Set the layout of the add-to-cart form to a grid.
+ */
+.wp-block-woocommerce-add-to-cart-form {
 	width: unset;
 
-	.quantity {
-		display: inline-block;
-		float: none;
-		margin-right: 4px;
-		vertical-align: middle;
+	form.cart {
+		display: grid;
+		grid-template-columns: max-content;
 
+		& > * {
+			grid-column: span 2;
+		}
+
+		.quantity,
+		.single_add_to_cart_button {
+			grid-column: span 1;
+			justify-self: start;
+		}
+	}
+
+	.quantity {
+		margin-right: 4px;
 		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
 		.qty {
-			margin-right: 0.5rem;
+			margin-right: 0.5em;
+			padding-top: 0;
+			padding-bottom: 0;
+			height: calc( 100% - 4px ); // 4px border width
+
 			width: 3.631em;
 			text-align: center;
 		}
 	}
 }
 
+
 // Stepper CSS
 div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 	form.cart {
-		&:not(.grouped_form):not(.variations_form) {
-			display: block;
-		}
-
 		div.wc-block-components-quantity-selector {
 			display: inline-flex;
 			width: unset;
@@ -53,7 +69,8 @@ div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 		*
 		* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
 		*/
-		padding: 0.9rem 0;
+		padding: 0;
+		height: 100%;
 		margin-right: unset;
 		font-size: var(--wp--preset--font-size--small);
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -40,7 +40,7 @@
 			margin-right: 0.5em;
 			padding-top: 0;
 			padding-bottom: 0;
-			height: calc( 100% - 4px ); // 4px border width
+			height: calc(100% - 4px); // 4px border width
 		}
 
 		&.grouped_form {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -18,7 +18,7 @@
 	width: unset;
 
 	form.cart {
-		&:before {
+		&::before {
 			content: " ";
 			grid-column: span 9999;
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -24,15 +24,23 @@
 
 		display: grid;
 		grid-template-columns: max-content;
+		width: fit-content;
 
 		& > * {
 			grid-column: span 2;
 		}
 
-		.quantity,
-		.single_add_to_cart_button {
+		> .quantity,
+		> .single_add_to_cart_button {
 			grid-column: span 1;
 			justify-self: start;
+		}
+
+		> .quantity .qty {
+			margin-right: 0.5em;
+			padding-top: 0;
+			padding-bottom: 0;
+			height: calc( 100% - 4px ); // 4px border width
 		}
 	}
 
@@ -40,11 +48,6 @@
 		margin-right: 4px;
 		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
 		.qty {
-			margin-right: 0.5em;
-			padding-top: 0;
-			padding-bottom: 0;
-			height: calc( 100% - 4px ); // 4px border width
-
 			width: 3.631em;
 			text-align: center;
 		}
@@ -73,8 +76,7 @@ div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 		*
 		* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
 		*/
-		padding: 0;
-		height: 100%;
+		padding: 0.9rem 0;
 		margin-right: unset;
 		font-size: var(--wp--preset--font-size--small);
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -23,11 +23,11 @@
 		}
 
 		display: grid;
-		grid-template-columns: max-content;
 		width: fit-content;
 
 		& > * {
-			grid-column: span 2;
+			// Hack to ensure input + button stat on the same row, together.
+			grid-column: span 9999;
 		}
 
 		> .quantity,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -18,16 +18,17 @@
 	width: unset;
 
 	form.cart {
+		--whole-width-in-grid: span 9999; // A large number to span the whole width of the grid.
 		&::before {
 			content: " ";
-			grid-column: span 9999;
+			grid-column: var(--whole-width-in-grid);
 		}
 
 		display: grid;
 
-		& > * {
+		> * {
 			// Hack to ensure input + button stat on the same row, together.
-			grid-column: span 9999;
+			grid-column: var(--whole-width-in-grid);
 		}
 
 		> .quantity,

--- a/plugins/woocommerce/changelog/update-add-to-cart-layout-based-on-grid
+++ b/plugins/woocommerce/changelog/update-add-to-cart-layout-based-on-grid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak the layout of the Add to cart block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR iterates over the Add to Cart block to fix visual known issues with the quantity input + pay button.
It tries to mitigate a tricky visual issue when aligning and setting the same height for the quantity input and the `Add to cart` button.

Closes https://github.com/woocommerce/woocommerce/issues/52628

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Update your testing environment with the change introduced by this PR
2. Install `TT5`, `TT4`, and `TT3`
3. Install and activate the `WooCommerce Beta Tester` plugin
4. Enable the `add-to-cart-with-options-stepper-layout` feature

<img width="651" alt="Screenshot 2024-11-14 at 9 24 00 AM" src="https://github.com/user-attachments/assets/86a6cc93-47a0-4f71-b3d0-9abf0a024fd8">

5. Edit the Single Product template
6. Select the `Add to Cart` block
7. Confirm you can switch between Input and Stepper modes:

<img width="1148" alt="Screenshot 2024-11-14 at 9 25 32 AM" src="https://github.com/user-attachments/assets/034cdcb3-2914-4cd2-8ed2-ddbc83396296">


8. Confirm the PR sets properly the height of the Quantity input and the Add to Cart button in all their variations
 * Block editor context, in `Input` and `Stepper` mode
 * In the Frontend
   * With `TT5`, `TT4`, and `TT3`
   * in `Input` and `Stepper` block mode
   * With Simple products, Grouped products, `Add-ons`, etc

The following screenshots shows the different scenarios

### Block Editor / **Input**

before | after
-------|-------
<img width="318" alt="image" src="https://github.com/user-attachments/assets/bced8a92-83fb-44a6-8cf1-b0b43afd3396"> | <img width="306" alt="image" src="https://github.com/user-attachments/assets/740781d1-9d6e-4654-857b-d67e591e58bc">

### Block Editor / **Stepper**

before | after
-------|------
<img width="347" alt="image" src="https://github.com/user-attachments/assets/953a97e8-0c33-41d1-8356-c88353d0bfd0"> | <img width="306" alt="image" src="https://github.com/user-attachments/assets/b2d92711-379d-4073-83d0-13e7054e43d0">



### TT5 / Input / Simple Product 

before | after
-------|------
<img width="330" alt="image" src="https://github.com/user-attachments/assets/5e00f316-fedb-42b2-9661-7332fdae16e4"> | <img width="349" alt="image" src="https://github.com/user-attachments/assets/de620d82-40ab-4107-81a2-bd602774d171">

### TT5 / Stepper / Simple Product 

before | after
-------|------
<img width="336" alt="image" src="https://github.com/user-attachments/assets/e2166bbc-17ce-4ca0-b036-8e1072c0746d"> | <img width="341" alt="image" src="https://github.com/user-attachments/assets/a879122d-2658-4b93-b2f6-b934d9d90603">


### TT5 / Input / Simple Product + Add-ons

before | after
-------|------
<img width="890" alt="image" src="https://github.com/user-attachments/assets/b540fdca-c762-4ff8-a2dc-d11d45041c44"> | <img width="952" alt="image" src="https://github.com/user-attachments/assets/3b1bf19b-0009-4e0a-b041-6b57faf6f521">

### TT5 / Stepper / Simple Product + Add-ons

before | after
-------|------
<img width="896" alt="image" src="https://github.com/user-attachments/assets/d5f76e4e-2add-44bc-911e-52b7917d0dcb"> | <img width="911" alt="image" src="https://github.com/user-attachments/assets/268dfc80-ffb5-4fb3-81a8-ea13e40f3e47">

### TT5 / Input / Groups Product 

before | after
-------|------
<img width="655" alt="image" src="https://github.com/user-attachments/assets/6585f439-0d76-42b7-91e3-9353486d9062"> | <img width="642" alt="image" src="https://github.com/user-attachments/assets/9fde18ad-8fdc-409e-bbfe-f04ef178923d">

### TT5 / Stepper / Groups Product 

before | after
-------|------
<img width="665" alt="image" src="https://github.com/user-attachments/assets/0db7b447-5659-45f7-8e7e-128087997842">| <img width="676" alt="image" src="https://github.com/user-attachments/assets/0d5c6f4b-395f-455e-b60d-4b96c2044c0f">


#### Single Product / Input / Simple
TT3 | TT4 | TT5
------|-------|-----
<img width="351" alt="image" src="https://github.com/user-attachments/assets/377ed0a1-9cad-40ea-add9-cf9436c88078"> | <img width="314" alt="image" src="https://github.com/user-attachments/assets/59c42c7c-8a37-4d0f-8293-1a92b511752f"> | <img width="332" alt="image" src="https://github.com/user-attachments/assets/0d654553-a575-4f7f-8faf-ed20b4864494">

#### Single Product / Setter / Simple
TT3 | TT4 | TT5
----|-----|-----
<img width="383" alt="image" src="https://github.com/user-attachments/assets/a2887557-a469-4b60-9ebe-3acba75d7492"> | <img width="365" alt="image" src="https://github.com/user-attachments/assets/774d9a65-727b-4219-8cad-88a5b108e5fc">| <img width="433" alt="image" src="https://github.com/user-attachments/assets/bccf1b03-5760-45ba-a89e-c1fe2db8d619">


#### Single Product / Input / Grouped
TT3 | TT4 | TT5
------|------|-----
<img width="625" alt="image" src="https://github.com/user-attachments/assets/6dee8231-7b62-4f87-84fb-b00231f65bb1">|<img width="676" alt="image" src="https://github.com/user-attachments/assets/7a12096f-798e-4231-a428-6c95333ffd10">| <img width="744" alt="image" src="https://github.com/user-attachments/assets/cc42d34c-6fc2-41c3-969a-b075dbe567fa">


#### Single Product / Setter / Grouped
TT3 | TT4 | TT5
-----|-------|-----
<img width="604" alt="image" src="https://github.com/user-attachments/assets/0efce232-0ec0-43c8-829e-0f2cccf8a955">|<img width="657" alt="image" src="https://github.com/user-attachments/assets/6dc256a2-fb90-40bf-b45f-3f720cd12852">| <img width="707" alt="image" src="https://github.com/user-attachments/assets/b3e1f163-2e3e-41ff-9a25-e43b7470f4d2">


#### Single Product / Input / With Add-ons
TT3 | TT4 | TT5
-----|------|-----
<img width="618" alt="image" src="https://github.com/user-attachments/assets/d5b38a53-f491-4119-a2fa-1633fa93403b">|<img width="865" alt="image" src="https://github.com/user-attachments/assets/2b55f858-3291-41c5-8c96-ef734c96b036">| <img width="900" alt="image" src="https://github.com/user-attachments/assets/744f2977-9879-40c9-971a-99b07b8a8dc5">

#### Single Product / Setter / With Add-ons
TT3| TT4 | TT5
-------|---------|-----
<img width="603" alt="image" src="https://github.com/user-attachments/assets/1e1404b8-0029-407e-885c-91978cefa84c">| <img width="868" alt="image" src="https://github.com/user-attachments/assets/8b6ac6d9-b295-486a-bf93-45fc4cce839f"> | <img width="948" alt="image" src="https://github.com/user-attachments/assets/ba025bd7-4d6d-458f-80f1-0cbf1e9d0aa3">




<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
