### PR TITLE
fix: changed core profiler industry types to the correct format

### DIFF
--- a/packages/js/data/changelog/fix-core-profiler-api-types
+++ b/packages/js/data/changelog/fix-core-profiler-api-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix types in profiler api for business info

--- a/packages/js/data/src/onboarding/actions.ts
+++ b/packages/js/data/src/onboarding/actions.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
-import { controls } from '@wordpress/data';
+import { controls, dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -324,6 +324,11 @@ export function* updateProfileItems( items: ProfileItems ) {
 		yield setError( 'updateProfileItems', error );
 		yield setIsRequesting( 'updateProfileItems', false );
 		throw error;
+	} finally {
+		yield dispatch( OPTIONS_STORE_NAME ).invalidateResolution(
+			'getOption',
+			[ 'woocommerce_onboarding_profile' ]
+		);
 	}
 }
 

--- a/packages/js/data/src/onboarding/actions.ts
+++ b/packages/js/data/src/onboarding/actions.ts
@@ -303,6 +303,14 @@ export function* updateProfileItems( items: ProfileItems ) {
 	yield setIsRequesting( 'updateProfileItems', true );
 	yield setError( 'updateProfileItems', null );
 
+	// Remove keys for values that are null or undefined because the API doesn't accept them
+	const filteredItems = Object.fromEntries(
+		Object.entries( items ).filter(
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			( [ _unused, value ] ) => value !== null && value !== undefined
+		)
+	);
+
 	try {
 		const results: {
 			items: ProfileItems;
@@ -310,7 +318,7 @@ export function* updateProfileItems( items: ProfileItems ) {
 		} = yield apiFetch( {
 			path: `${ WC_ADMIN_NAMESPACE }/onboarding/profile`,
 			method: 'POST',
-			data: items,
+			data: filteredItems,
 		} );
 
 		if ( results && results.status === 'success' ) {

--- a/packages/js/data/src/onboarding/actions.ts
+++ b/packages/js/data/src/onboarding/actions.ts
@@ -303,14 +303,6 @@ export function* updateProfileItems( items: ProfileItems ) {
 	yield setIsRequesting( 'updateProfileItems', true );
 	yield setError( 'updateProfileItems', null );
 
-	// Remove keys for values that are null or undefined because the API doesn't accept them
-	const filteredItems = Object.fromEntries(
-		Object.entries( items ).filter(
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			( [ _unused, value ] ) => value !== null && value !== undefined
-		)
-	);
-
 	try {
 		const results: {
 			items: ProfileItems;
@@ -318,7 +310,7 @@ export function* updateProfileItems( items: ProfileItems ) {
 		} = yield apiFetch( {
 			path: `${ WC_ADMIN_NAMESPACE }/onboarding/profile`,
 			method: 'POST',
-			data: filteredItems,
+			data: items,
 		} );
 
 		if ( results && results.status === 'success' ) {

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -89,9 +89,16 @@ export type OnboardingState = {
 	jetpackAuthUrls: Record< string, GetJetpackAuthUrlResponse >;
 };
 
-export type Industry = {
-	slug: string;
-};
+export type Industry =
+	| 'clothing_and_accessories'
+	| 'food_and_drink'
+	| 'electronics_and_computers'
+	| 'health_and_beauty'
+	| 'education_and_learning'
+	| 'home_furniture_and_garden'
+	| 'arts_and_crafts'
+	| 'sports_and_recreation'
+	| 'other';
 
 export type GetJetpackAuthUrlResponse = {
 	url: string;
@@ -143,6 +150,9 @@ export type ProfileItems = {
 	setup_client?: boolean | null;
 	skipped?: boolean | null;
 	is_plugins_page_skipped?: boolean | null;
+	business_choice?: string | null;
+	selling_online_answer?: string | null;
+	selling_platforms?: string[] | null;
 	/** @deprecated This is always null, the theme step has been removed since WC 7.7. */
 	theme?: string | null;
 	wccom_connected?: boolean | null;

--- a/packages/js/data/src/types/wp-data.ts
+++ b/packages/js/data/src/types/wp-data.ts
@@ -16,7 +16,7 @@ export type WPDataSelectors = {
 export type WPDataActions = {
 	startResolution: ( selector: string, args?: unknown[] ) => void;
 	finishResolution: ( selector: string, args?: unknown[] ) => void;
-	invalidateResolution: ( selector: string ) => void;
+	invalidateResolution: ( selector: string, args?: unknown[] ) => void;
 	invalidateResolutionForStore: ( selector: string ) => void;
 	invalidateResolutionForStoreSelector: ( selector: string ) => void;
 };

--- a/plugins/woocommerce/changelog/fix-core-profiler-industry
+++ b/plugins/woocommerce/changelog/fix-core-profiler-industry
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix incorrect industry type in profiler api

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -282,7 +282,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 				'items'             => array(
-					'type' => 'object',
+					'type' => 'string',
 				),
 			),
 			'product_types'           => array(
@@ -441,6 +441,27 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'business_choice'         => array(
+				'type'              => 'string',
+				'description'       => __( 'Business choice.', 'woocommerce' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+			),
+			'selling_online_answer'   => array(
+				'type'              => 'string',
+				'description'       => __( 'Selling online answer.', 'woocommerce' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+			),
+			'selling_platforms'      => array(
+				'type'              => 'array',
+				'description'       => __( 'Selling platforms.', 'woocommerce' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'items'             => array(
+					'type' => 'string',
+				),
 			),
 		);
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -280,6 +280,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'description'       => __( 'Industry.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
+				'nullable'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 				'items'             => array(
 					'type' => 'string',
@@ -426,6 +427,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'description'       => __( 'Store email address.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
+				'nullable'          => true,
 				'validate_callback' => array( __CLASS__, 'rest_validate_marketing_email' ),
 			),
 			'is_store_country_set'    => array(
@@ -447,20 +449,23 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'description' => __( 'Business choice.', 'woocommerce' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
+				'nullable'    => true,
 			),
 			'selling_online_answer'   => array(
 				'type'        => 'string',
 				'description' => __( 'Selling online answer.', 'woocommerce' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
+				'nullable'    => true,
 			),
 			'selling_platforms'       => array(
-				'type'        => 'array',
+				'type'        => array( 'array', 'null' ),
 				'description' => __( 'Selling platforms.', 'woocommerce' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
+				'nullable'    => true,
 				'items'       => array(
-					'type' => 'string',
+					'type' => array( 'array', 'null' ),
 				),
 			),
 		);

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -443,23 +443,23 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'business_choice'         => array(
-				'type'              => 'string',
-				'description'       => __( 'Business choice.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
+				'type'        => 'string',
+				'description' => __( 'Business choice.', 'woocommerce' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
 			),
 			'selling_online_answer'   => array(
-				'type'              => 'string',
-				'description'       => __( 'Selling online answer.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
+				'type'        => 'string',
+				'description' => __( 'Selling online answer.', 'woocommerce' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
 			),
-			'selling_platforms'      => array(
-				'type'              => 'array',
-				'description'       => __( 'Selling platforms.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'items'             => array(
+			'selling_platforms'       => array(
+				'type'        => 'array',
+				'description' => __( 'Selling platforms.', 'woocommerce' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+				'items'       => array(
 					'type' => 'string',
 				),
 			),
@@ -482,7 +482,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			( $is_agree_marketing || ! empty( $value ) ) &&
 			! is_email( $value ) ) {
 			return new \WP_Error( 'rest_invalid_email', __( 'Invalid email address', 'woocommerce' ) );
-		};
+		}
 		return true;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -465,7 +465,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'    => true,
 				'nullable'    => true,
 				'items'       => array(
-					'type' => array( 'array', 'null' ),
+					'type' => array( 'string', 'null' ),
 				),
 			),
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
@@ -62,11 +62,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		// Test updating 2 fields separately.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
 		$request->set_headers( array( 'content-type' => 'application/json' ) );
-		$industry = array(
-			array(
-				'slug' => 'health-beauty',
-			),
-		);
+		$industry = array( 'health-beauty' );
 		$request->set_body(
 			wp_json_encode(
 				array(
@@ -114,7 +110,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'health-beauty', $data['industry'][0]['slug'] );
+		$this->assertEquals( 'health-beauty', $data['industry'][0] );
 		$this->assertEquals( 'storefront', $data['theme'] );
 	}
 
@@ -150,6 +146,9 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'store_email', $properties );
 		$this->assertArrayHasKey( 'is_store_country_set', $properties );
 		$this->assertArrayHasKey( 'is_plugins_page_skipped', $properties );
+		$this->assertArrayHasKey( 'business_choice', $properties );
+		$this->assertArrayHasKey( 'selling_online_answer', $properties );
+		$this->assertArrayHasKey( 'selling_platforms', $properties );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
@@ -127,7 +127,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 18, $properties );
+		$this->assertCount( 21, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );


### PR DESCRIPTION
- changed profiler API to match what we're actually storing, Industry[]
- changed some core profiler steps to use the API instead of saving options directly

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While working on some improvements to the Core Profiler I noticed that the industry types were wrong, and it was not caught because we were directly writing to the options instead of using the API.

This PR changes the Core Profiler to use the API instead, which performs validation and also supports merging a partial update into the object.

Merging a partial update was something that was done previously by fetching in the frontend and merging in the frontend. This can result in stale contents, but this condition was not triggered as there was no further update to the object in the later steps. (I noticed it as I started writing new content in the mentioned work above)

Aside from that there should be no actual change to the content being persisted.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up WooCommerce and go through the Core Profiler
2. The two pages that saw code changes are the User Profile and the Business Info pages. Check that the fields are correctly persisted - this can be done by either checking using WC Admin Test Helper or by completing the Core Profiler and revisiting it to see that the previously entered information is correctly populated. (With the exception of the data opt-in as that's being worked on in another PR)
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
