### PR TITLE
Add variations autoselect

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
@@ -18,6 +18,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"attributesAutoselectOnPageLoad": {
+			"type": "string",
+			"default": ""
+		},
 		"attributesUnattachedAction": {
 			"type": "string",
 			"default": ""

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
@@ -13,6 +13,14 @@
 			"type": "string",
 			"enum": [ "input", "stepper" ],
 			"default": "input"
+		},
+		"attributesAutoselectType": {
+			"type": "string",
+			"default": ""
+		},
+		"attributesUnattachedAction": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -1,16 +1,23 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useEffect, createInterpolateElement } from '@wordpress/element';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Skeleton } from '@woocommerce/base-components/skeleton';
 import { BlockEditProps } from '@wordpress/blocks';
-import { Disabled, Tooltip } from '@wordpress/components';
+import {
+	PanelBody,
+	Disabled,
+	Tooltip,
+	SelectControl,
+	ExternalLink,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { isSiteEditorPage } from '@woocommerce/utils';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -43,7 +50,7 @@ const isBlockifiedAddToCart = getSettingWithCoercion(
 );
 
 const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
-	const { setAttributes } = props;
+	const { attributes, setAttributes } = props;
 
 	const isStepperLayoutFeatureEnabled = getSettingWithCoercion(
 		'isStepperLayoutFeatureEnabled',
@@ -75,6 +82,30 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 		( select ) => isSiteEditorPage( select( 'core/edit-site' ) ),
 		[]
 	);
+
+	const {
+		attributesAutoselectType,
+		attributesUnattachedAction
+	} = attributes;
+
+	const InterfaceSettingsLink = () => {
+		const interfaceSettingsUrl = `${ getSetting(
+			'adminUrl'
+		) }admin.php?page=wc-settings&tab=interface`;
+
+		const linkText = createInterpolateElement(
+			`<a>${ __( 'Manage global attribute dropdowns options', 'woocommerce' ) }</a>`,
+			{
+				a: <ExternalLink href={ interfaceSettingsUrl } />,
+			}
+		);
+
+		return (
+			<div className="wc-block-editor-interface__link">
+				{ linkText }
+			</div>
+		);
+	};
 
 	return (
 		<>
@@ -180,6 +211,41 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 					</div>
 				</Tooltip>
 			</div>
+
+			<InspectorControls key="inspector">
+				<PanelBody>
+					<InterfaceSettingsLink />
+				</PanelBody>
+				<PanelBody title={ __( 'Attribute dropdowns options', 'woocommerce' ) }>
+					<SelectControl
+						label={ __( 'Auto-select behavior', 'woocommerce' ) }
+						help={ __( 'This controls which other attributes will be auto-selected when an attribute is changed. Only attributes with a single compatible value will be auto-selected.', 'woocommerce' ) }
+						value={ attributesAutoselectType }
+						options={ [
+							{ label: 'Default', value: '' },
+							{ label: 'None', value: 'none' },
+							{ label: 'Previous attribute fields', value: 'previous' },
+							{ label: 'All other attribute fields', value: 'all' },
+							{ label: 'Next attribute fields', value: 'next' },
+						] }
+						onChange={ ( value ) => setAttributes( { attributesAutoselectType: value } ) }
+						__nextHasNoMarginBottom
+					/>
+					<SelectControl
+						label="Values in conflict with current selection"
+						help={ __( 'This controls what to do with attribute values that conflict with the current selection.', 'woocommerce' ) }
+						value={ attributesUnattachedAction }
+						options={ [
+							{ label: __( 'Default',                                                                 'woocommerce' ), value: '' },
+							{ label: __( 'Hidden',                                                                  'woocommerce' ), value: 'hide' },
+							{ label: __( 'Grayed-out and disabled',                                                 'woocommerce' ), value: 'disable' },
+							{ label: __( 'Grayed-out but selectable (will clear all other attributes if selected)', 'woocommerce' ), value: 'gray' },
+						] }
+						onChange={ ( value ) => setAttributes( { attributesUnattachedAction: value } ) }
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
 		</>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -245,7 +245,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 						__nextHasNoMarginBottom
 					/>
 					<SelectControl
-						label="Values in conflict with current selection"
+						label={ __( 'Values in conflict with current selection', 'woocommerce' ) }
 						help={ __( 'This controls what to do with attribute values that conflict with the current selection.', 'woocommerce' ) }
 						value={ attributesUnattachedAction }
 						options={ [

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -94,7 +94,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 		) }admin.php?page=wc-settings&tab=interface`;
 
 		const linkText = createInterpolateElement(
-			`<a>${ __( 'Manage global attribute dropdowns options', 'woocommerce' ) }</a>`,
+			`<a>${ __( 'Manage default WooCommerce interface settings', 'woocommerce' ) }</a>`,
 			{
 				a: <ExternalLink href={ interfaceSettingsUrl } />,
 			}
@@ -222,11 +222,11 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 						help={ __( 'This controls which other attributes will be auto-selected when an attribute is changed. Only attributes with a single compatible value will be auto-selected.', 'woocommerce' ) }
 						value={ attributesAutoselectType }
 						options={ [
-							{ label: 'Default', value: '' },
-							{ label: 'None', value: 'none' },
-							{ label: 'Previous attribute fields', value: 'previous' },
-							{ label: 'All other attribute fields', value: 'all' },
-							{ label: 'Next attribute fields', value: 'next' },
+							{ label: __( 'Default',              'woocommerce' ), value: '' },
+							{ label: __( 'None',                 'woocommerce' ), value: 'none' },
+							{ label: __( 'Previous attributes',  'woocommerce' ), value: 'previous' },
+							{ label: __( 'All other attributes', 'woocommerce' ), value: 'all' },
+							{ label: __( 'Next attributes',      'woocommerce' ), value: 'next' },
 						] }
 						onChange={ ( value ) => setAttributes( { attributesAutoselectType: value } ) }
 						__nextHasNoMarginBottom

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -85,6 +85,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 
 	const {
 		attributesAutoselectType,
+		attributesAutoselectOnPageLoad,
 		attributesUnattachedAction
 	} = attributes;
 
@@ -229,6 +230,18 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 							{ label: __( 'Next attributes',      'woocommerce' ), value: 'next' },
 						] }
 						onChange={ ( value ) => setAttributes( { attributesAutoselectType: value } ) }
+						__nextHasNoMarginBottom
+					/>
+					<SelectControl
+						label={ __( 'Auto-select on page load', 'woocommerce' ) }
+						help={ __( 'This controls whether or not attributes with only one possible option will be auto-selected upon loading the page.', 'woocommerce' ) }
+						value={ attributesAutoselectOnPageLoad }
+						options={ [
+							{ label: __( 'Default', 'woocommerce' ), value: '' },
+							{ label: __( 'Yes',     'woocommerce' ), value: 'yes' },
+							{ label: __( 'No',      'woocommerce' ), value: 'no' },
+						] }
+						onChange={ ( ) => setAttributes( { attributesAutoselectOnPageLoad: ! attributesAutoselectOnPageLoad } ) }
 						__nextHasNoMarginBottom
 					/>
 					<SelectControl

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -37,3 +37,8 @@ input {
 		width: unset !important;
 	}
 }
+
+/* In sidebar without tabs (WP <=6.1) */
+.block-editor-block-card + div > .wc-block-editor-interface__link {
+	padding: 0 $gap $gap 52px;
+}

--- a/plugins/woocommerce/changelog/CATtheTech-variations-select
+++ b/plugins/woocommerce/changelog/CATtheTech-variations-select
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added auto-select for attribute fields; Possibility to display attributes in conflict

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -20,6 +20,8 @@ $highlightext:      desaturate(lighten($highlight, 80%), 18%) !default;  // Text
 $contentbg:         #fff !default;                                     // Content BG - Tabs (active state)
 $subtext:           #767676 !default;                                  // small, breadcrumbs etc
 
+$optionsdisabledtext: GrayText !default;                               // Text on disabled options
+
 // export vars as CSS vars
 :root {
 	--woocommerce: #{$woocommerce};
@@ -35,4 +37,5 @@ $subtext:           #767676 !default;                                  // small,
 	--wc-highligh-text: #{$highlightext};
 	--wc-content-bg: #{$contentbg};
 	--wc-subtext: #{$subtext};
+	--wc-options-disabled-text: #{$optionsdisabledtext};
 }

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -179,6 +179,15 @@
 				height: 3.5rem;
 				padding: 0.9rem 1.1rem;
 				font-size: var(--wp--preset--font-size--small);
+
+				option {
+					&.disabled,
+					&:disabled,
+					&:disabled[disabled] {
+						// Grayed-out & disabled options
+						color: --wc-option-disabled-text;
+					}
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -376,8 +376,10 @@
 		var form                       = event.data.variationForm,
 			attributes                 = form.getChosenAttributes(),
 			currentAttributes          = attributes.data;
-			attributesUnattachedAction = wc_add_to_cart_variation_params.attributesUnattachedAction ||
-										 'hide';
+			attributes_unattached_action =
+				form.$form.parent( 'div.wp-block-add-to-cart-form.wc-block-add-to-cart-form' ).data( 'attributesUnattachedAction' ) ||
+				wc_add_to_cart_variation_params.attributes_unattached_action ||
+				'hide';
 
 		if ( form.useAjax ) {
 			return;
@@ -801,6 +803,7 @@
 	 */
 	$.fn.wc_variations_attributes_autoselect = function( form, $eventTargetSelect ) {
 		var attributes_autoselect_type =
+				form.$form.parent( 'div.wp-block-add-to-cart-form.wc-block-add-to-cart-form' ).data( 'attributesAutoselectType' ) ||
 				wc_add_to_cart_variation_params.attributes_autoselect_type ||
 				'none';
 		if ( $eventTargetSelect.val() !== '' ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -414,7 +414,6 @@
 			var current_attr_select     = $( el ),
 				current_attr_name       = current_attr_select.data( 'attribute_name' ) || current_attr_select.attr( 'name' ),
 				show_option_none        = $( el ).data( 'show_option_none' ),
-				option_gt_filter        = ':gt(0)',
 				attached_options_count  = 0,
 				new_attr_select         = $( '<select/>' ),
 				selected_attr_val       = current_attr_select.val() || '',
@@ -465,7 +464,7 @@
 				// Legacy data attribute.
 				current_attr_select.data(
 					'attribute_options',
-					refSelect.find( 'option' + option_gt_filter ).get()
+					refSelect.find( 'option:not([value=""])' ).get()
 				);
 				current_attr_select.data( 'attribute_html', refSelect.html() );
 			}
@@ -516,7 +515,7 @@
 									}
 								} else {
 									// Attach all apart from placeholder.
-									new_attr_select.find( 'option' + option_gt_filter ).addClass( 'attached ' + variation_active );
+									new_attr_select.find( 'option:not([value=""])' ).addClass( 'attached ' + variation_active );
 								}
 							}
 						}
@@ -550,10 +549,9 @@
 			// - Placeholders are not set to be permanently visible.
 			if ( attached_options_count > 0 && selected_attr_val && selected_attr_val_valid && ( 'no' === show_option_none ) ) {
 				new_attr_select.find( 'option:first' ).remove();
-				option_gt_filter = '';
 			}
 
-			var unattached_options = new_attr_select.find( 'option' + option_gt_filter + ':not(.attached)' );
+			var unattached_options = new_attr_select.find( 'option:not([value=""], .attached)' );
 			switch ( attributes_unattached_action ) {
 				case 'hide':
 					// Hide unattached
@@ -572,7 +570,7 @@
 
 			// Finally, copy to DOM and set value.
 			current_attr_select.html( new_attr_select.html() );
-			current_attr_select.find( 'option' + option_gt_filter + ':not(.enabled)' ).prop( 'disabled', true );
+			current_attr_select.find( 'option:not([value=""], .enabled)' ).prop( 'disabled', true );
 
 			// Choose selected value.
 			if ( selected_attr_val ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -62,14 +62,11 @@
 						if ( $options.length === 1 ) {
 							// There is only one attribute to choose from
 							$el.val( $options.val() );
-							doCheckVariations = true;
+							$el.trigger( "change" ).trigger( "click" );
 						} else {
 							// More than one attribute to choose from, let the user choose
 						}
 				} );
-				if ( doCheckVariations ) {
-					$form.trigger( 'check_variations' );
-				}
 			}
 
 			$form.trigger( 'wc_variation_form', self );

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -4,7 +4,11 @@
 	 * VariationForm class which handles variation forms and attributes.
 	 */
 	var VariationForm = function( $form ) {
-		var self = this;
+		var self = this,
+			attributes_autoselect_on_page_load =
+				$form.parent( 'div.wp-block-add-to-cart-form.wc-block-add-to-cart-form' ).data( 'attributesAutoselectOnPageLoad' ) ||
+				wc_add_to_cart_variation_params.attributes_autoselect_on_page_load ||
+				'no';
 
 		self.$form                = $form;
 		self.$attributeFields     = $form.find( '.variations select' );
@@ -48,6 +52,26 @@
 		// Init after gallery.
 		setTimeout( function() {
 			$form.trigger( 'check_variations' );
+
+			if ( attributes_autoselect_on_page_load === 'yes' ) {
+				// Autoselect for all selects if there is only 1 option for each select
+				let doCheckVariations = false;
+				self.$attributeFields.each( function() {
+					const $el = $( this );
+						const $options = $el.find( 'option:not([value=""], [disabled], [class*="disabled"])' );
+						if ( $options.length === 1 ) {
+							// There is only one attribute to choose from
+							$el.val( $options.val() );
+							doCheckVariations = true;
+						} else {
+							// More than one attribute to choose from, let the user choose
+						}
+				} );
+				if ( doCheckVariations ) {
+					$form.trigger( 'check_variations' );
+				}
+			}
+
 			$form.trigger( 'wc_variation_form', self );
 			self.loading = false;
 		}, 100 );

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -476,7 +476,7 @@
 
 											if ( attr_val === option_value ) {
 												$possibleOptions = $possibleOptions.add( $option_element );
-												
+
 												if ( matching_variations.includes( variation ) ) {
 													$option_element.addClass( 'attached ' + variation_active );
 												}
@@ -538,8 +538,8 @@
 					unattached_options.addClass( 'disabled' );
 					break;
 			}
-			
-			
+
+
 			// Finally, copy to DOM and set value.
 			current_attr_select.html( new_attr_select.html() );
 			current_attr_select.find( 'option' + option_gt_filter + ':not(.enabled)' ).prop( 'disabled', true );

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -881,6 +881,7 @@
 				if ( $validOptions.length === 1 ) {
 					// Only 1 option (+ the "Choose an option" choice)
 					$selectElement.val( $validOptions.val() );
+					$selectElement.trigger( 'change' ).trigger( 'click' );
 				}
 			} );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -880,8 +880,10 @@
 				const $validOptions = $selectElement.children( 'option:not([value=""], [disabled], [class*="disabled"])' );
 				if ( $validOptions.length === 1 ) {
 					// Only 1 option (+ the "Choose an option" choice)
-					$selectElement.val( $validOptions.val() );
-					$selectElement.trigger( 'change' ).trigger( 'click' );
+					if ( $selectElement.val() !== $validOptions.val() ) {
+						$selectElement.val( $validOptions.val() );
+						$selectElement.trigger( 'change' ).trigger( 'click' );
+					}
 				}
 			} );
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -61,10 +61,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-accounts.php';
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-emails.php';
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-integrations.php';
-				$settings[] = include __DIR__ . '/settings/class-wc-settings-interface.php';
 				if ( \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
 					$settings[] = include __DIR__ . '/settings/class-wc-settings-site-visibility.php';
 				}
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-interface.php';
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-advanced.php';
 
 				self::$settings = apply_filters( 'woocommerce_get_settings_pages', $settings );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -61,6 +61,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-accounts.php';
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-emails.php';
 				$settings[] = include __DIR__ . '/settings/class-wc-settings-integrations.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-interface.php';
 				if ( \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'launch-your-store' ) ) {
 					$settings[] = include __DIR__ . '/settings/class-wc-settings-site-visibility.php';
 				}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
@@ -70,6 +70,22 @@ class WC_Settings_Interface extends WC_Settings_Page {
 				),
 
 				array(
+					'title'    => __( 'Values in conflict with current selection', 'woocommerce' ),
+					'desc'     => __( 'What to do with values that cannot be applied to current attributes selection.', 'woocommerce' ),
+					'id'       => 'attributes_unattached_action',
+					'class'    => 'wc-enhanced-select',
+					'css'      => 'min-width:300px;',
+					'default'  => 'delete',
+					'type'     => 'select',
+					'options'  => array(
+						'hide'    => __( 'Hidden', 'woocommerce' ),
+						'disable' => __( 'Grayed-out and disabled', 'woocommerce' ),
+						'gray'    => __( 'Grayed-out but selectable (will clear all other attributes if selected)', 'woocommerce' ),
+					),
+					'desc_tip' => true,
+				),
+
+				array(
 					'type' => 'sectionend',
 					'id'   => 'attributes_dropdown_options',
 				),

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * WooCommerce interface settings
+ *
+ * @package WooCommerce\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( class_exists( 'WC_Settings_Interface', false ) ) {
+	return new WC_Settings_Interface();
+}
+
+/**
+ * WC_Settings_Interface.
+ */
+class WC_Settings_Interface extends WC_Settings_Page {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id    = 'interface';
+		$this->label = __( 'Interface', 'woocommerce' );
+
+		parent::__construct();
+	}
+
+	/**
+	 * Get own sections.
+	 *
+	 * @return array
+	 */
+	protected function get_own_sections() {
+		return array(
+			'' => __( 'General', 'woocommerce' ),
+		);
+	}
+
+	/**
+	 * Get settings for the default section.
+	 *
+	 * @return array
+	 */
+	protected function get_settings_for_default_section() {
+		$settings =
+			array(
+				array(
+					'title' => __( 'Attribute dropdowns options', 'woocommerce' ),
+					'desc'  => __( 'Options for attribute dropdowns', 'woocommerce' ),
+					'type'  => 'title',
+					'id'    => 'attributes_dropdown_options',
+				),
+
+				array(
+					'title'    => __( 'Auto-select', 'woocommerce' ),
+					'desc'     => __( 'This controls what attributes will be auto-selected.', 'woocommerce' ),
+					'id'       => 'attributes_autoselect_type',
+					'class'    => 'wc-enhanced-select',
+					'css'      => 'min-width:300px;',
+					'default'  => null,
+					'type'     => 'select',
+					'options'  => array(
+						null       => 'None',
+						'previous' => 'Previous attributes',
+						'all'      => 'All attributes',
+						'next'     => 'Next attributes',
+					),
+					'desc_tip' => true,
+				),
+
+				array(
+					'type' => 'sectionend',
+					'id'   => 'attributes_dropdown_options',
+				),
+			);
+
+		$settings = apply_filters( 'woocommerce_interface_settings_general', $settings );
+		return $settings;
+	}
+
+	/**
+	 * Save settings.
+	 */
+	public function save() {
+		$this->save_settings_for_current_section();
+		$this->do_update_options_action();
+	}
+}
+
+return new WC_Settings_Interface;

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
@@ -47,24 +47,24 @@ class WC_Settings_Interface extends WC_Settings_Page {
 			array(
 				array(
 					'title' => __( 'Attribute dropdowns options', 'woocommerce' ),
-					'desc'  => __( 'Options for attribute dropdowns', 'woocommerce' ),
+					'desc'  => __( 'Options for attribute fields dropdowns', 'woocommerce' ),
 					'type'  => 'title',
 					'id'    => 'attributes_dropdown_options',
 				),
 
 				array(
 					'title'    => __( 'Auto-select', 'woocommerce' ),
-					'desc'     => __( 'This controls what attributes will be auto-selected.', 'woocommerce' ),
+					'desc'     => __( 'This controls what attribute fields will be auto-selected relative to the changed field.', 'woocommerce' ),
 					'id'       => 'attributes_autoselect_type',
 					'class'    => 'wc-enhanced-select',
 					'css'      => 'min-width:300px;',
-					'default'  => null,
+					'default'  => 'none',
 					'type'     => 'select',
 					'options'  => array(
-						null       => 'None',
-						'previous' => 'Previous attributes',
-						'all'      => 'All attributes',
-						'next'     => 'Next attributes',
+						'none'       => 'None',
+						'previous' => 'Previous attribute fields',
+						'all'      => 'All other attribute fields',
+						'next'     => 'Next attribute fields',
 					),
 					'desc_tip' => true,
 				),

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
@@ -70,6 +70,14 @@ class WC_Settings_Interface extends WC_Settings_Page {
 				),
 
 				array(
+					'title'    => __( 'Auto-select on page load', 'woocommerce' ),
+					'desc'     => __( 'This controls whether or not attributes with only one possible option will be auto-selected upon loading the page.', 'woocommerce' ),
+					'id'       => 'attributes_autoselect_on_page_load',
+					'default'  => 'no',
+					'type'     => 'checkbox',
+				),
+
+				array(
 					'title'    => __( 'Values in conflict with current selection', 'woocommerce' ),
 					'desc'     => __( 'This controls what to do with attribute values that conflict with the current selection.', 'woocommerce' ),
 					'id'       => 'attributes_unattached_action',

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-interface.php
@@ -47,31 +47,31 @@ class WC_Settings_Interface extends WC_Settings_Page {
 			array(
 				array(
 					'title' => __( 'Attribute dropdowns options', 'woocommerce' ),
-					'desc'  => __( 'Options for attribute fields dropdowns', 'woocommerce' ),
+					'desc'  => __( 'Default options for attribute dropdowns', 'woocommerce' ),
 					'type'  => 'title',
 					'id'    => 'attributes_dropdown_options',
 				),
 
 				array(
-					'title'    => __( 'Auto-select', 'woocommerce' ),
-					'desc'     => __( 'This controls what attribute fields will be auto-selected relative to the changed field.', 'woocommerce' ),
+					'title'    => __( 'Auto-select behavior', 'woocommerce' ),
+					'desc'     => __( 'This controls which other attributes will be auto-selected when an attribute is changed. Only attributes with a single compatible value will be auto-selected.', 'woocommerce' ),
 					'id'       => 'attributes_autoselect_type',
 					'class'    => 'wc-enhanced-select',
 					'css'      => 'min-width:300px;',
 					'default'  => 'none',
 					'type'     => 'select',
 					'options'  => array(
-						'none'       => 'None',
-						'previous' => 'Previous attribute fields',
-						'all'      => 'All other attribute fields',
-						'next'     => 'Next attribute fields',
+						'none'     => __( 'None', 'woocommerce' ),
+						'previous' => __( 'Previous attributes', 'woocommerce' ),
+						'all'      => __( 'All attributes', 'woocommerce' ),
+						'next'     => __( 'Next attributes', 'woocommerce' ),
 					),
 					'desc_tip' => true,
 				),
 
 				array(
 					'title'    => __( 'Values in conflict with current selection', 'woocommerce' ),
-					'desc'     => __( 'What to do with values that cannot be applied to current attributes selection.', 'woocommerce' ),
+					'desc'     => __( 'This controls what to do with attribute values that conflict with the current selection.', 'woocommerce' ),
 					'id'       => 'attributes_unattached_action',
 					'class'    => 'wc-enhanced-select',
 					'css'      => 'min-width:300px;',

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -602,6 +602,7 @@ class WC_Frontend_Scripts {
 					'i18n_make_a_selection_text'       => esc_attr__( 'Please select some product options before adding this product to your cart.', 'woocommerce' ),
 					'i18n_unavailable_text'            => esc_attr__( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce' ),
 					'i18n_reset_alert_text'            => esc_attr__( 'Your selection has been reset. Please select some product options before adding this product to your cart.', 'woocommerce' ),
+					'attributes_autoselect_type'       => get_option( 'attributes_autoselect_type' ),
 				);
 				break;
 			case 'wc-country-select':

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -603,6 +603,7 @@ class WC_Frontend_Scripts {
 					'i18n_unavailable_text'            => esc_attr__( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce' ),
 					'i18n_reset_alert_text'            => esc_attr__( 'Your selection has been reset. Please select some product options before adding this product to your cart.', 'woocommerce' ),
 					'attributes_autoselect_type'       => get_option( 'attributes_autoselect_type' ),
+					'attributes_unattached_action'     => get_option( 'attributes_unattached_action' ),
 				);
 				break;
 			case 'wc-country-select':

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -597,13 +597,14 @@ class WC_Frontend_Scripts {
 				wc_get_template( 'single-product/add-to-cart/variation.php' );
 
 				$params = array(
-					'wc_ajax_url'                      => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-					'i18n_no_matching_variations_text' => esc_attr__( 'Sorry, no products matched your selection. Please choose a different combination.', 'woocommerce' ),
-					'i18n_make_a_selection_text'       => esc_attr__( 'Please select some product options before adding this product to your cart.', 'woocommerce' ),
-					'i18n_unavailable_text'            => esc_attr__( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce' ),
-					'i18n_reset_alert_text'            => esc_attr__( 'Your selection has been reset. Please select some product options before adding this product to your cart.', 'woocommerce' ),
-					'attributes_autoselect_type'       => get_option( 'attributes_autoselect_type' ),
-					'attributes_unattached_action'     => get_option( 'attributes_unattached_action' ),
+					'wc_ajax_url'                        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+					'i18n_no_matching_variations_text'   => esc_attr__( 'Sorry, no products matched your selection. Please choose a different combination.', 'woocommerce' ),
+					'i18n_make_a_selection_text'         => esc_attr__( 'Please select some product options before adding this product to your cart.', 'woocommerce' ),
+					'i18n_unavailable_text'              => esc_attr__( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce' ),
+					'i18n_reset_alert_text'              => esc_attr__( 'Your selection has been reset. Please select some product options before adding this product to your cart.', 'woocommerce' ),
+					'attributes_autoselect_type'         => get_option( 'attributes_autoselect_type' ),
+					'attributes_unattached_action'       => get_option( 'attributes_unattached_action' ),
+					'attributes_autoselect_on_page_load' => get_option( 'attributes_autoselect_on_page_load' ),
 				);
 				break;
 			case 'wc-country-select':


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
TL;DR: Added options to auto-select variation attributes that only have one possible value.
- Added a new settings tab: Interface
- Added the functionality to auto-select attributes according to other selected attributes (both per-block and globally)
- Added the functionality to auto-select attributes right after page loads (both per-block and globally)
- Added the functionality to display attributes in conflict and select what to do with them (both per-block and globally)
- The initial options are now filtered once after page load, according to possible variations
- Replaced `option_gt_filter` by `[value=""]` for readability, simplicity, and avoid corner cases
- All defaults mirror current behaviors

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prepare a new test product

1. Create a new product with the following settings:
    1. `Product type`: `Variable product`
    2. `Attributes`:
        1. `"Type"`: `"T-Shirt"`
        2. `"Colour"`: `"Red|Blue"`
        3. `"Size"`: `"L|XL"`
        3. Click on `Save attributes`
    3. `Variations`:
        1. `Type`: `"T-Shirt"`, `Colour`: `"Red"`, `Size`: `"L"`
        2. `Type`: `"T-Shirt"`, `Colour`: `"Red"`, `Size`: `"XL"`
        3. `Type`: `"T-Shirt"`, `Colour`: `"Blue"`, `Size`: `"XL"`
    4. Enable each variations and set a price
    5. Click on `Save variations`
2. Save and publish the new product

#### Configuring new settings

1. Navigate to `<YOUR_SITE_URL>/wp-admin/admin.php?page=wc-settings&tab=interface`
    (`Woocommerce > settings > Interface`)
2. Under `Attribute dropdown options`:
    1. Set `Auto-select behavior` to `All attributes`
    2. Check `"Auto-select on page load"`
    3. Set `Values in conflict with current selection` to `Grayed out and disabled`

#### Testing auto-select on page load behavior

1. Navigate the test product
2. Refresh the tab
3. The attributes should now be auto-selected (on page load) to:
    1. `Type`: `"T-Shirt"` (this is because `Type` has only 1 possible value (`"T-Shirt"`))
    2. `Colour`: `"Choose an option"` (`""`)
    3. `Size`: `"Choose an option"` (`""`)

#### Testing auto-select behavior

1. Navigate to the test product
2. Refresh the tab
3. The attributes should now be auto-selected (on page load) to:
    1. `Type`: `"T-Shirt"`
4. Select `Colour` > `"Blue"`
5. The remaining options will now be auto-selected according to the value set in `Configuring new settings` > `step #2.1`
6. In this case, `Size` will be auto-selected to `"XL"`

#### Testing the conflicting attribute values behavior

1. Navigate to the test product
2. Refresh the tab
3. Select `Colour` > `"Red"`,  `Size` > `"L"`
4. Click on the `Colour` attribute
5. Here is what will happen to the `"Blue"` option in the `Colour` dropdown, because it is conflicting with other attributes, according to the value set in `Configuring new settings` > `step #2.1`
    1. `Hidden`: The `"Blue"` option is not there, it was hidden from view (temporarily removed from DOM) (default action and behavior in the current version of woocommerce)
    1. `Grayed-out and disabled`: The `"Blue"` option is still there, but disabled and grayed-out (the option itself is disabled)
    1. `Grayed-out but selectable (will clear all other attribute if selected)`: The `"Blue"` option is still there, but grayed-out (the option itself is still enabled, but clicking it will produce an impossile variation, making all attributes reset)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Added auto-select for attribute fields; Possibility to Display attributes in conflict

<!-- #### Comment -->
<!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
