### PR TITLE
Fix border cut issue on tasklist and inbox widgets

### DIFF
--- a/plugins/woocommerce/changelog/fix-tasklist-border-radius
+++ b/plugins/woocommerce/changelog/fix-tasklist-border-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix border cut issue on tasklist and inbox widgets in WooCommerce homescreen

--- a/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/block.scss
+++ b/plugins/woocommerce/client/admin/client/dashboard/dashboard-charts/block.scss
@@ -30,6 +30,8 @@
 }
 
 .woocommerce-dashboard__chart-block {
+	overflow: hidden;
+
 	.woocommerce-card__body {
 		padding: 0;
 		position: relative;

--- a/plugins/woocommerce/client/admin/client/inbox-panel/index.scss
+++ b/plugins/woocommerce/client/admin/client/inbox-panel/index.scss
@@ -2,6 +2,12 @@
 	margin: 0 $gap-large;
 }
 
+.woocommerce-homepage-notes-wrapper {
+	.components-card {
+		overflow: hidden;
+	}
+}
+
 .woocommerce-layout__inbox-panel-header {
 	padding: $gap-large;
 

--- a/plugins/woocommerce/client/admin/client/task-lists/task-lists.scss
+++ b/plugins/woocommerce/client/admin/client/task-lists/task-lists.scss
@@ -4,6 +4,7 @@
 		margin-left: auto;
 		margin-right: auto;
 		margin-bottom: $gap-large;
+		overflow: hidden;
 
 		.components-card__header.is-size-large {
 			padding-bottom: 12px;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52383

This PR addresses a visual bug on the WooCommerce homescreen where the bottom corners of the tasklist and inbox widgets have slight border cuts.

![img](https://private-user-images.githubusercontent.com/3747241/380773488-eef98460-7dc6-4765-9b38-df6882c91a9b.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzEzMDk2MTUsIm5iZiI6MTczMTMwOTMxNSwicGF0aCI6Ii8zNzQ3MjQxLzM4MDc3MzQ4OC1lZWY5ODQ2MC03ZGM2LTQ3NjUtOWIzOC1kZjY4ODJjOTFhOWIucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MTExMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDExMTFUMDcxNTE1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MDg0Zjg3M2I3NGVlMzQxODA3ZDM0YzBhZTEyNWVhZmQzMzM5N2Y0MzY4NDVmN2ZmZWMzNTdhYjVlNzk3OGU3NyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.Zq-VwXTNKMjnw6Cm0-TnRYoohJZN0fPcBQoK5iS61xI)

The issue is because Gutenberg 19.3 has updated the `Card` radius to Adopt new radius scale in
https://github.com/WordPress/gutenberg/pull/65053, which causes our content to overflow a
little bit and show the border cuts.

This PR fixes the issue by setting `overflow: hidden` on the tasklist and inbox widgets Card.

Alternatively, we can revert the Card radius to the old one but I think we should try to align with the WP components as much as possible so I didn't go this route.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that WordPress 6.7-RC1 or a compatible version is installed or Gutenberg >= 19.3.
2. Navigate to the WooCommerce homescreen.
3. Inspect the tasklist and inbox widgets and confirm that the borders are complete with no cuts at the bottom corners.

<img width="763" alt="Screenshot 2024-11-11 at 15 34 34" src="https://github.com/user-attachments/assets/f29c94a1-a67a-4403-a3d3-95b071549759">

<img width="852" alt="Screenshot 2024-11-11 at 15 34 04" src="https://github.com/user-attachments/assets/f3eebed5-fd12-4e3e-a350-9f2a410977b3">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
