### PR TITLE
Store customization: add missing context for "Paid" string

### DIFF
--- a/plugins/woocommerce/changelog/add-context-paid-translation
+++ b/plugins/woocommerce/changelog/add-context-paid-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Internationalization: provide additional context for "Paid" label in the sstore customization page to avoid mistranslations.

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/theme-card.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/theme-card.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Link } from '@woocommerce/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -53,7 +53,7 @@ export const ThemeCard = ( {
 				) }
 				{ ! is_free && (
 					<span className="theme-card__paid">
-						{ __( 'Paid', 'woocommerce' ) }
+						{ _x( 'Paid', 'Indicates a premium theme. See screen shot for context: https://cloudup.com/cnz0SDTaPz4', 'woocommerce' ) }
 					</span>
 				) }
 				<span className="theme-card__free">{ price }</span>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In languages other than English, "Paid" is translated differently whether it's referring to something that has been paid, or something that is not free.

Let's provide the necessary context to avoid mistranslations. In this case, the label was translated to "has been paid" in the interface in French for example, because of the other "paid" string in the codebase.

In the context I added, I provided a Cloudup-hosted screenshot to match the other context provided for some of the other strings in the codebase.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]
> Not much to test on this one, the string should continue to be outputted regardless of the language.

1. Start a new site.
2. Install the WooCommerce plugin.
3. Go through the onboarding flow until you get to the "customize store" page.
4. Ensure the "Paid" label is displayed properly.

### Changelog entry

> [!WARNING]
> I had forgotten about this part of the PR template, and already created the changelog entry manually via `vendor/bin changelogger`. I believe it does the same thing as filling in the information below.

<!-- You can optionally choose to nter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
