### PR TITLE
Tweak "Add to Cart" layout also for Variant products

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -16,7 +16,7 @@
  */
 .wp-block-woocommerce-add-to-cart-form {
 	width: unset;
-
+	.variations_button,
 	form.cart {
 		--whole-width-in-grid: span 9999; // A large number to span the whole width of the grid.
 		&::before {

--- a/plugins/woocommerce/changelog/update-add-to-cart-variable-product
+++ b/plugins/woocommerce/changelog/update-add-to-cart-variable-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak "Add to Cart" layout also for Variant products


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a visual layout issue with the `Quantity` input field and the `Add to Cart` button. 
Although we've improved it in this [PR](https://github.com/woocommerce/woocommerce/pull/52648), it doesn't cover the issue for Variant product.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Update your testing environment with the change introduced by this PR
2. Install `TT5`, `TT4`, `TT3`.
3. Ensure to have a Variable product
4. Confirm, with these changes, the `Quantity` and `Add to Cart` elements have the same height


**TT5**

Before | After
-------|------
<img width="413" alt="image" src="https://github.com/user-attachments/assets/87700788-e261-4a3f-ac90-f3ee79f5c8e7">|<img width="350" alt="image" src="https://github.com/user-attachments/assets/d59eee48-dbbf-4077-805e-bfe9e17a8a93">


**TT4**

Before | After
-------|------
<img width="356" alt="image" src="https://github.com/user-attachments/assets/8789e6c2-ec69-409e-9dad-0d24d192ae08">|<img width="321" alt="image" src="https://github.com/user-attachments/assets/a32c46b9-cc39-4b76-8f69-9c01ca4beb33">


**TT3**

Before | After
-------|------
<img width="333" alt="image" src="https://github.com/user-attachments/assets/0d63faec-5af7-4aa4-bf50-4b3d69a0d977">|<img width="329" alt="image" src="https://github.com/user-attachments/assets/2c99b776-f37c-4761-babc-04c18ab1f865">


6. Visit the Product Catalog template.
Ensure that the Add To Cart Button block has the border radius.
Visit the /shop page.
The Add To Cart Button block doesn't have the border radius.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
