### PR TITLE
PTK: Check to confirm `as_has_scheduled_action` exists before using to conditionally fire logger

### DIFF
--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -150,12 +150,16 @@ class BlockPatterns {
 			return;
 		}
 
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+
 		$patterns = $this->ptk_patterns_store->get_patterns();
 		if ( empty( $patterns ) ) {
 			// By only logging when patterns are empty and no fetch is scheduled,
 			// we ensure that warnings are only generated in genuinely problematic situations,
 			// such as when the pattern fetching mechanism has failed entirely.
-			if ( function_exists('as_has_scheduled_action') && ! as_has_scheduled_action( 'fetch_patterns' ) ) {
+			if ( call_user_func( $has_scheduled_action, 'fetch_patterns' ) ) {
 				wc_get_logger()->warning(
 					__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),
 				);

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -159,7 +159,7 @@ class BlockPatterns {
 			// By only logging when patterns are empty and no fetch is scheduled,
 			// we ensure that warnings are only generated in genuinely problematic situations,
 			// such as when the pattern fetching mechanism has failed entirely.
-			if ( call_user_func( $has_scheduled_action, 'fetch_patterns' ) ) {
+			if ( ! call_user_func( $has_scheduled_action, 'fetch_patterns' ) ) {
 				wc_get_logger()->warning(
 					__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),
 				);

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -155,7 +155,7 @@ class BlockPatterns {
 			// By only logging when patterns are empty and no fetch is scheduled,
 			// we ensure that warnings are only generated in genuinely problematic situations,
 			// such as when the pattern fetching mechanism has failed entirely.
-			if ( ! as_has_scheduled_action( 'fetch_patterns' ) ) {
+			if ( function_exists('as_has_scheduled_action') && ! as_has_scheduled_action( 'fetch_patterns' ) ) {
 				wc_get_logger()->warning(
 					__( 'Empty patterns received from the PTK Pattern Store', 'woocommerce' ),
 				);

--- a/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
+++ b/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php
@@ -94,7 +94,11 @@ class PTKPatternsStore {
 	 */
 	private function schedule_action_if_not_pending( $action ) {
 		$last_request = get_transient( 'last_fetch_patterns_request' );
-		if ( as_has_scheduled_action( $action ) || false !== $last_request ) {
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+		if ( call_user_func( $has_scheduled_action, $action ) || false !== $last_request ) {
 			return;
 		}
 


### PR DESCRIPTION
Add a check to confirm that `as_has_scheduled_action` exists in the condition that uses it to conditionally run the warning log.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In the previously added conditional check (from #51143) that is meant to ensure that warnings are only generated in genuinely problematic situations, the `as_has_scheduled_action` function is used to ensure the proper conditions. However, in some scenarios, this function is undefined - most likely when another plugin has bundled a much older version of Action Scheduler (lacking that function). This led to the following Fatal Error on the impacted sites:

```sh
Fatal error: Uncaught Error: Call to undefined function Automattic\WooCommerce\Blocks\as_has_scheduled_action() in /wordpress/plugins/woocommerce/9.4.0/src/Blocks/BlockPatterns.php:158
```


With commit `1906024187852840ba65fda462518ef61dbdf69a`, the logic was updated to ensure that `as_has_scheduled_action` or a less performant method is invoked if `as_has_scheduled_action` does not exist.


Currently, as_has_scheduled_action is used in other places without any condition to check its existent, should we update these part of the codebase:

https://github.com/woocommerce/woocommerce/blob/1906024187852840ba65fda462518ef61dbdf69a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php#L126-L134

https://github.com/woocommerce/woocommerce/blob/1906024187852840ba65fda462518ef61dbdf69a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php#L311-L314

https://github.com/woocommerce/woocommerce/blob/1906024187852840ba65fda462518ef61dbdf69a/plugins/woocommerce/src/Internal/TransientFiles/TransientFilesEngine.php#L316-L319

By following the [best practices for deconflicting different versions of Action Scheduler](https://developer.woocommerce.com/2021/10/12/best-practices-for-deconflicting-different-versions-of-action-scheduler/) and adding a condition to verify if the `as_has_scheduled_action` function exists, we can avoid these conflicts.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the woocommerce-smart-coupons extension - preferrably version 4.x.x.
2. Load your homepage
3. Confirm the site does not throw a fatal error and functions as expected.
4. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
5. Enable Allow usage of WooCommerce to be tracked
6. Save
7. Load your homepage.
8. Confirm the site does not throw a fatal error and functions as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->


</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Provide fallback in case `as_has_scheduled_action` doesn't exist.


</details>
