### PR TITLE
Fix coming soon template layout issue with tall images and header spacing

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/entire-site.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/entire-site.scss
@@ -86,7 +86,7 @@ body:has(.woocommerce-coming-soon-banner) {
 			line-height: normal;
 			text-align: center;
 			text-decoration: none;
-			padding: 17px 16px;
+			padding: 12px 16px;
 		}
 	}
 
@@ -143,10 +143,6 @@ body:has(.woocommerce-coming-soon-banner) {
 		.wp-block-cover__background {
 			background-color: var(--woocommerce-coming-soon-color) !important;
 		}
-	}
-
-	.woocommerce-coming-soon-header {
-		height: 40px;
 	}
 
 	h1.wp-block-heading.woocommerce-coming-soon-banner {

--- a/plugins/woocommerce/changelog/fix-coming-soon-entire-site-template
+++ b/plugins/woocommerce/changelog/fix-coming-soon-entire-site-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix header with an image in Coming Soon page template causes text overlap and spacing

--- a/plugins/woocommerce/patterns/coming-soon-entire-site.php
+++ b/plugins/woocommerce/patterns/coming-soon-entire-site.php
@@ -22,8 +22,8 @@ if ( 'twentytwentyfour' === $current_theme ) {
 <!-- wp:woocommerce/coming-soon {"color":"#bea0f2","storeOnly":false,"className":"woocommerce-coming-soon-entire-site wp-block-woocommerce-background-color"} -->
 <div class="woocommerce-coming-soon-entire-site wp-block-woocommerce-coming-soon wp-block-woocommerce-background-color"><!-- wp:cover {"minHeight":100,"minHeightUnit":"vh","isDark":false,"className":"coming-soon-is-vertically-aligned-center coming-soon-cover","layout":{"type":"default"}} -->
 <div class="wp-block-cover is-light coming-soon-is-vertically-aligned-center coming-soon-cover" style="min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style=""></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"woocommerce-coming-soon-banner-container","layout":{"type":"default"}} -->
-<div class="wp-block-group woocommerce-coming-soon-banner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"3px","bottom":"20px"}}},"className":"woocommerce-coming-soon-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide woocommerce-coming-soon-header has-background" style="padding-top:3px;padding-bottom:20px"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+<div class="wp-block-group woocommerce-coming-soon-banner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"10px","bottom":"14px"}}},"className":"woocommerce-coming-soon-header","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide woocommerce-coming-soon-header has-background" style="padding-top:10px;padding-bottom:14px"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex"}} -->
 <div class="wp-block-group"><!-- wp:site-logo {"width":60} /-->
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52367

This PR addresses a layout issue in the upcoming template where replacing header blocks with a tall image results in overlapping text content. This update ensures that the content is pushed down accordingly when a tall image is used in place of header elements to prevent overlap.

I noticed that the social login button and header size do not match the design, so this PR also fixes the social login button / header size to match the design.

The social login button padding is too large. The Figam shows that the padding is 17px, but it doesn't consider the text height. The actual padding is 12px. This PR reduces the padding to 12px to match the design.

![Screenshot 2024-11-12 at 12 40 19](https://github.com/user-attachments/assets/6c228bf2-6114-4e60-a93f-b0b37f1a2a0b)

Also the header padding doesn't match the design. The header full height should be 80px.

![Screenshot 2024-11-12 at 12 40 42](https://github.com/user-attachments/assets/86c71aab-ed5b-42f0-a708-17709edcf570)

Figma: 0BWMerqRR1f468EwC7g5tg-fi-3652_27480

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce site
2. Go through the Core Profiler onboarding wizard
3. Click on the "Coming Soon" badge on the admin bar
4. Click on the link that takes you to the site editor
5. Remove the Site Title and Socials/Login button blocks
6. Add an image block
7. Upload a tall-ish image
8. Confirm that the tall image does not overlap the text content below, and that the layout adjusts to accommodate the image height.
9. Confirm that the social login button and header size match the design (The header size might still a bit different due to cover block padding is set to 1em so it might not be exactly 16px).

Optional:

- Confirm that existing site that modified the coming soon template still works as expected, not causing breaking change.

![Screenshot 2024-11-12 at 12 32 22](https://github.com/user-attachments/assets/f48df59e-0477-4e07-ae29-773d871782f6)


<img width="1460" alt="Coming soon template" src="https://github.com/user-attachments/assets/74b4bca2-5069-4910-b333-041e2430ef82">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>