### PR TITLE
[CFE] Fix delayed account mobile styles

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/password-strength-meter/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/password-strength-meter/style.scss
@@ -1,13 +1,23 @@
 .wc-block-components-password-strength {
+	display: flex;
+	flex-direction: row;
+	gap: $gap-smaller;
+	height: 1em;
+	padding: $gap-smaller 0 0 0;
+	@include font-size(smaller);
+	align-items: center;
+	line-height: 1;
+	text-align: right;
+
 	&.hidden {
 		opacity: 0;
 	}
 	.wc-block-components-password-strength__meter {
-		margin: $gap-small 0 0;
+		margin: 0;
 		width: 100%;
 		display: block;
-		height: 6px;
-		border-radius: 4px;
+		height: $gap-smaller;
+		border-radius: #{$gap-smaller / 2};
 		border: 0;
 		background-color: $universal-border-light;
 		color: $alert-red;
@@ -16,7 +26,7 @@
 		&::-webkit-meter-inner-element {
 			background: none;
 			border: 0;
-			height: 6px;
+			height: $gap-smaller;
 			vertical-align: middle;
 		}
 		&::-webkit-meter-optimum-value,
@@ -25,9 +35,9 @@
 			background: none;
 			background-color: currentColor;
 			transition: 0.2s ease;
-			border-radius: 3px;
+			border-radius: #{$gap-smaller / 2};
 			border: 0;
-			height: 6px;
+			height: $gap-smaller;
 			vertical-align: middle;
 		}
 
@@ -37,19 +47,14 @@
 			background: none;
 			background-color: currentColor;
 			transition: 0.2s ease;
-			border-radius: 3px;
+			border-radius: #{$gap-smaller / 2};
 			border: 0;
-			height: 6px;
+			height: $gap-smaller;
 			vertical-align: middle;
 		}
 	}
 	.wc-block-components-password-strength__result {
-		@include font-size(smaller);
-		display: block;
-		text-align: right;
-		margin: $gap-smallest 0 0;
 		color: $alert-red;
-
 		&::after {
 			content: "\00a0 ";
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
@@ -1,7 +1,10 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .wc-block-order-confirmation-create-account {
 	display: flex;
 	flex-direction: row;
 	justify-content: center;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: $gap;
 	padding: $gap-larger;
@@ -12,6 +15,12 @@
 
 	> div {
 		flex: 1;
+	}
+
+	@media (max-width: #{$break-medium}) {
+		> div {
+			flex: 0 0 100%;
+		}
 	}
 
 	p {
@@ -40,7 +49,7 @@
 	form {
 		display: flex;
 		flex-direction: column;
-		gap: $gap;
+		gap: $gap-small;
 
 		p,
 		.wc-block-components-text-input {
@@ -66,7 +75,7 @@
 		}
 
 		.wc-block-components-password-strength.hidden {
-			display: none;
+			opacity: 1;
 		}
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
@@ -37,6 +37,8 @@
 			margin-bottom: 0 !important;
 		}
 		ul {
+			padding-left: 1em;
+
 			li {
 				margin-bottom: $gap;
 			}

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/summary/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .editor-styles-wrapper .wc-block-order-confirmation-summary,
 .wc-block-order-confirmation-summary {
 	margin-top: $gap-largest;
@@ -25,7 +27,7 @@
 			}
 		}
 
-		@media only screen and (max-width: 480px) {
+		@media (max-width: #{$break-small}) {
 			li {
 				width: 100%;
 

--- a/plugins/woocommerce-blocks/packages/components/validation-input-error/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/validation-input-error/style.scss
@@ -1,22 +1,26 @@
 .wc-block-components-validation-error {
-	@include font-size(smaller);
+
 	color: $alert-red;
 	max-width: 100%;
 	white-space: normal;
+	min-height: 1em;
+	padding: $gap-smaller 0 0 0;
+	@include font-size(smaller);
 
 	> p {
 		margin: 0;
-		padding: $gap-smaller 0 0 0;
+		padding: 0;
 		display: flex;
 		align-items: center;
 		gap: 2px;
+		line-height: 1;
 	}
 
 	svg {
 		fill: currentColor;
 		width: 1.5em;
 		height: 1.5em;
-		margin-top: -1px;
+		margin: -0.4735em 0 -0.4735em;
 	}
 }
 

--- a/plugins/woocommerce/changelog/fix-delayed-account-mobile-styles-52717
+++ b/plugins/woocommerce/changelog/fix-delayed-account-mobile-styles-52717
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix mobile styles for delayed account creation.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes styling on mobile, and tightens the spacing of the password validator to prevent layout shifting. This will be a CFE on WC 9.5.x.

- Password strength bar visible on initial view so its clear when it appears and does not cause layout shift
- Password strength bar uses flex box so the label is next to the bar itself so its not longer than other content below the field
- Password strength and validation errors are the same height 

Content shifting demo:

https://github.com/user-attachments/assets/b91a21ae-6b0a-43f2-a9bc-c031f7e24bd0

Mobile:

![Screenshot 2024-11-12 at 11 49 35](https://github.com/user-attachments/assets/fb52ca72-3ee5-492c-9253-a16d90864c29)

Closes #52717

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Place an order as a guest using a new email address
2. On the confirmation page, shrink down to mobile size and confirm the create account section wraps when you hit small breakpoints
3. Use the password field. Confirm the styling is ok and layout does not shift when the password strength meter appears

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
