### PR TITLE
[Settings] Update Modern Routes

### DIFF
--- a/packages/js/settings-editor/changelog/52757-update-settings-sidebar-components
+++ b/packages/js/settings-editor/changelog/52757-update-settings-sidebar-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Organizes unreleased component
+

--- a/packages/js/settings-editor/src/index.tsx
+++ b/packages/js/settings-editor/src/index.tsx
@@ -53,3 +53,5 @@ export const SettingsEditor = () => {
 		</GlobalStylesProvider>
 	);
 };
+
+export * from './sidebar';

--- a/packages/js/settings-editor/src/index.tsx
+++ b/packages/js/settings-editor/src/index.tsx
@@ -53,5 +53,3 @@ export const SettingsEditor = () => {
 		</GlobalStylesProvider>
 	);
 };
-
-export * from './sidebar';

--- a/packages/js/settings-editor/src/index.tsx
+++ b/packages/js/settings-editor/src/index.tsx
@@ -55,3 +55,4 @@ export const SettingsEditor = () => {
 };
 
 export * from './sidebar';
+export * from './route';

--- a/packages/js/settings-editor/src/index.tsx
+++ b/packages/js/settings-editor/src/index.tsx
@@ -55,4 +55,3 @@ export const SettingsEditor = () => {
 };
 
 export * from './sidebar';
-export * from './route';

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -36,11 +36,23 @@ const NotFound = () => {
 /**
  * Default route when active page is not found.
  *
+ * @param {string}                                       activePage - The active page.
+ * @param {typeof window.wcSettings.admin.settingsPages} pages      - The pages.
+ *
  */
-const getNotFoundRoute = ( activePage: string ): Route => ( {
+const getNotFoundRoute = (
+	activePage: string,
+	pages: typeof window.wcSettings.admin.settingsPages
+): Route => ( {
 	key: activePage,
 	areas: {
-		sidebar: null,
+		sidebar: (
+			<Sidebar
+				activePage={ activePage }
+				pages={ pages }
+				pageTitle={ 'Settings' }
+			/>
+		),
 		content: <NotFound />,
 		edit: null,
 	},
@@ -143,7 +155,7 @@ export const useActiveRoute = () => {
 		const pageSettings = settingsPages?.[ activePage ];
 
 		if ( ! pageSettings ) {
-			return getNotFoundRoute( activePage );
+			return getNotFoundRoute( activePage, settingsPages );
 		}
 
 		// Handle legacy pages.
@@ -152,6 +164,19 @@ export const useActiveRoute = () => {
 		}
 
 		// Handle modern pages.
-		return modernRoutes[ activePage ] || getNotFoundRoute( activePage );
+		if ( ! modernRoutes[ activePage ] ) {
+			return getNotFoundRoute( activePage, settingsPages );
+		}
+
+		const modernRoute = modernRoutes[ activePage ];
+		modernRoute.areas.sidebar = (
+			<Sidebar
+				activePage={ activePage }
+				pages={ settingsPages }
+				pageTitle={ pageSettings.label }
+			/>
+		);
+
+		return modernRoute;
 	}, [ settingsPages, location.params, modernRoutes ] );
 };

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -163,12 +163,14 @@ export const useActiveRoute = () => {
 			return getLegacyRoute( activePage, settingsPages );
 		}
 
+		const modernRoute = modernRoutes[ activePage ];
+
 		// Handle modern pages.
-		if ( ! modernRoutes[ activePage ] ) {
+		if ( ! modernRoute ) {
 			return getNotFoundRoute( activePage, settingsPages );
 		}
 
-		const modernRoute = modernRoutes[ activePage ];
+		// Sidebar is responsibility of WooCommerce, not extensions so add it here.
 		modernRoute.areas.sidebar = (
 			<Sidebar
 				activePage={ activePage }

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -24,7 +24,7 @@ import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 /**
  * Internal dependencies
  */
-import { Sidebar, SidebarNavigationScreenContent } from './sidebar';
+import { Sidebar } from './sidebar';
 import { Route, Location } from './types';
 
 const { useLocation } = unlock( routerPrivateApis );

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -16,8 +16,6 @@ import {
 } from '@wordpress/hooks';
 /* eslint-disable @woocommerce/dependency-group */
 // @ts-ignore No types for this exist yet.
-import SidebarNavigationScreen from '@wordpress/edit-site/build-module/components/sidebar-navigation-screen';
-// @ts-ignore No types for this exist yet.
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 // @ts-ignore No types for this exist yet.
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
@@ -26,7 +24,7 @@ import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 /**
  * Internal dependencies
  */
-import { Sidebar } from './sidebar';
+import { Sidebar, SidebarNavigationScreenContent } from './sidebar';
 import { Route, Location } from './types';
 
 const { useLocation } = unlock( routerPrivateApis );
@@ -69,12 +67,10 @@ const getLegacyRoute = (
 		key: activePage,
 		areas: {
 			sidebar: (
-				<SidebarNavigationScreen
-					title={ pageTitle }
-					isRoot
-					content={
-						<Sidebar activePage={ activePage } pages={ pages } />
-					}
+				<Sidebar
+					activePage={ activePage }
+					pages={ pages }
+					pageTitle={ pageTitle }
 				/>
 			),
 			content: <div>Content Placeholder</div>,

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -178,6 +178,8 @@ export const useActiveRoute = () => {
 				pageTitle={ pageSettings.label }
 			/>
 		);
+		// Make sure we have a key.
+		modernRoute.key = activePage;
 
 		return modernRoute;
 	}, [ settingsPages, location.params, modernRoutes ] );

--- a/packages/js/settings-editor/src/sidebar/index.tsx
+++ b/packages/js/settings-editor/src/sidebar/index.tsx
@@ -18,7 +18,7 @@ import { SettingItem } from './setting-item';
 
 const { Icon, ...icons } = IconPackage;
 
-export const SidebarNavigationScreenContent = ( {
+const SidebarNavigationScreenContent = ( {
 	activePage,
 	pages,
 }: {

--- a/packages/js/settings-editor/src/sidebar/index.tsx
+++ b/packages/js/settings-editor/src/sidebar/index.tsx
@@ -6,6 +6,8 @@ import { createElement } from '@wordpress/element';
 // @ts-expect-error missing type.
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+// @ts-ignore No types for this exist yet.
+import SidebarNavigationScreen from '@wordpress/edit-site/build-module/components/sidebar-navigation-screen';
 import * as IconPackage from '@wordpress/icons';
 /* eslint-enable @woocommerce/dependency-group */
 
@@ -16,7 +18,7 @@ import { SettingItem } from './setting-item';
 
 const { Icon, ...icons } = IconPackage;
 
-export const Sidebar = ( {
+export const SidebarNavigationScreenContent = ( {
 	activePage,
 	pages,
 }: {
@@ -45,5 +47,28 @@ export const Sidebar = ( {
 				);
 			} ) }
 		</ItemGroup>
+	);
+};
+
+export const Sidebar = ( {
+	activePage,
+	pages,
+	pageTitle,
+}: {
+	activePage: string;
+	pages: typeof window.wcSettings.admin.settingsPages;
+	pageTitle: string;
+} ) => {
+	return (
+		<SidebarNavigationScreen
+			title={ pageTitle }
+			isRoot
+			content={
+				<SidebarNavigationScreenContent
+					activePage={ activePage }
+					pages={ pages }
+				/>
+			}
+		/>
 	);
 };

--- a/packages/js/settings-editor/src/tests/route.test.tsx
+++ b/packages/js/settings-editor/src/tests/route.test.tsx
@@ -33,19 +33,11 @@ jest.mock( '@wordpress/edit-site/build-module/lock-unlock', () => ( {
 	unlock: jest.fn( ( apis ) => apis ),
 } ) );
 
-jest.mock(
-	'@wordpress/edit-site/build-module/components/sidebar-navigation-screen',
-	() => ( {
-		__esModule: true,
-		default: ( { children }: { children: React.ReactNode } ) => (
-			<div data-testid="sidebar-navigation-screen">{ children }</div>
-		),
-	} )
-);
-
 jest.mock( '../sidebar', () => ( {
 	__esModule: true,
-	Sidebar: jest.fn(),
+	Sidebar: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="sidebar-navigation-screen">{ children }</div>
+	),
 } ) );
 
 const mockSettingsPages = {
@@ -141,11 +133,11 @@ describe( 'route.tsx', () => {
 				admin: {
 					settingsPages: {
 						modern: {
-							is_modern: true,
 							label: 'Modern',
+							icon: 'published',
 							slug: 'modern',
-							icon: 'settings',
 							sections: [],
+							is_modern: true,
 						},
 					},
 				},
@@ -153,9 +145,7 @@ describe( 'route.tsx', () => {
 
 			( applyFilters as jest.Mock ).mockReturnValue( {
 				modern: {
-					key: 'modern',
 					areas: {
-						sidebar: null,
 						content: <div>Modern Page</div>,
 					},
 				},
@@ -163,6 +153,7 @@ describe( 'route.tsx', () => {
 
 			const { result } = renderHook( () => useActiveRoute() );
 			expect( result.current.key ).toBe( 'modern' );
+			expect( result.current.areas.sidebar ).toBeDefined();
 		} );
 	} );
 

--- a/plugins/woocommerce/changelog/52757-update-settings-sidebar-components
+++ b/plugins/woocommerce/changelog/52757-update-settings-sidebar-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Organizes unreleased component
+

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -39,6 +39,13 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		protected $label = '';
 
 		/**
+		 * Setting page is modern.
+		 *
+		 * @var bool
+		 */
+		protected $is_modern = false;
+
+		/**
 		 * Constructor.
 		 */
 		public function __construct() {
@@ -130,10 +137,11 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 			}
 
 			$pages[ $this->id ] = array(
-				'label'    => html_entity_decode( $this->label ),
-				'slug'     => $this->id,
-				'icon'     => $this->icon,
-				'sections' => $sections_data,
+				'label'     => html_entity_decode( $this->label ),
+				'slug'      => $this->id,
+				'icon'      => $this->icon,
+				'sections'  => $sections_data,
+				'is_modern' => $this->is_modern,
 			);
 
 			return $pages;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As a follow up to https://github.com/woocommerce/woocommerce/pull/52691, this PR handles a few loose ends:

* Reorganize `<Sidebar />` to contain `SidebarNavigationScreen`
* Make sure `NotFoundRoute` contains sidebar
* Makes sure Modern screens function and also contain sidebar

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add/active Gutenberg
2. Turn on Settings flag
3. WooCommerce > Settings. It should load without error
4. Use the [Settings Tester](https://github.com/woocommerce/woocommerce-settings-migration-tester) to test Modern screens. Clone it locally and `npm install && npm run plugin-zip`
5. Upload and activate the Tester, see the modern page added to Settings

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Organizes unreleased component

</details>
