### PR TITLE
Add deprecated note to existing coming soon templates and apply fix from previous PR

### DIFF
--- a/plugins/woocommerce/changelog/fix-apply-fix-from-52726
+++ b/plugins/woocommerce/changelog/fix-apply-fix-from-52726
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply fix from #52726 to new coming soon template

--- a/plugins/woocommerce/patterns/coming-soon-entire-site.php
+++ b/plugins/woocommerce/patterns/coming-soon-entire-site.php
@@ -1,4 +1,7 @@
 <?php
+// Note: This pattern is deprecated, it will be removed once newsletter feature flag is deployed.
+// If you are updating this pattern, please also update page-coming-soon-default.php.
+
 /**
  * Title: Coming Soon Entire Site
  * Slug: woocommerce/coming-soon-entire-site

--- a/plugins/woocommerce/patterns/coming-soon-entire-site.php
+++ b/plugins/woocommerce/patterns/coming-soon-entire-site.php
@@ -1,6 +1,8 @@
 <?php
-// Note: This pattern is deprecated, it will be removed once newsletter feature flag is deployed.
-// If you are updating this pattern, please also update page-coming-soon-default.php.
+/**
+ * Note: This pattern is deprecated, it will be removed once newsletter feature flag is deployed.
+ * If you are updating this pattern, please also update page-coming-soon-default.php.
+ */
 
 /**
  * Title: Coming Soon Entire Site

--- a/plugins/woocommerce/patterns/coming-soon-store-only.php
+++ b/plugins/woocommerce/patterns/coming-soon-store-only.php
@@ -1,6 +1,8 @@
 <?php
-// Note: This pattern is deprecated, it will be removed once newsletter feature flag is deployed.
-// If you are updating this pattern, please also update page-coming-soon-with-header-footer.php.
+/**
+ * Note: This pattern is deprecated, it will be removed once newsletter feature flag is deployed.
+ * If you are updating this pattern, please also update page-coming-soon-with-header-footer.php.
+ */
 
 /**
  * Title: Coming Soon Store Only

--- a/plugins/woocommerce/patterns/coming-soon-store-only.php
+++ b/plugins/woocommerce/patterns/coming-soon-store-only.php
@@ -1,4 +1,7 @@
 <?php
+// Note: This pattern is deprecated, it will be removed once newsletter feature flag is deployed.
+// If you are updating this pattern, please also update page-coming-soon-with-header-footer.php.
+
 /**
  * Title: Coming Soon Store Only
  * Slug: woocommerce/coming-soon-store-only

--- a/plugins/woocommerce/patterns/page-coming-soon-default.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-default.php
@@ -17,12 +17,11 @@ if ( 'twentytwentyfour' === $current_theme ) {
 	$cardo_font_family = 'heading';
 }
 ?>
-
 <!-- wp:woocommerce/coming-soon {"color":"#bea0f2","storeOnly":false,"className":"woocommerce-coming-soon-entire-site wp-block-woocommerce-background-color"} -->
 <div class="woocommerce-coming-soon-entire-site wp-block-woocommerce-coming-soon wp-block-woocommerce-background-color"><!-- wp:cover {"minHeight":100,"minHeightUnit":"vh","isDark":false,"className":"coming-soon-is-vertically-aligned-center coming-soon-cover","layout":{"type":"default"}} -->
 <div class="wp-block-cover is-light coming-soon-is-vertically-aligned-center coming-soon-cover" style="min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style=""></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"woocommerce-coming-soon-banner-container","layout":{"type":"default"}} -->
-<div class="wp-block-group woocommerce-coming-soon-banner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"3px","bottom":"20px"}}},"className":"woocommerce-coming-soon-header","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide woocommerce-coming-soon-header has-background" style="padding-top:3px;padding-bottom:20px"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+<div class="wp-block-group woocommerce-coming-soon-banner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"10px","bottom":"14px"}}},"className":"woocommerce-coming-soon-header","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide woocommerce-coming-soon-header has-background" style="padding-top:10px;padding-bottom:14px"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex"}} -->
 <div class="wp-block-group"><!-- wp:site-logo {"width":60} /-->
 

--- a/plugins/woocommerce/patterns/page-coming-soon-default.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-default.php
@@ -17,6 +17,7 @@ if ( 'twentytwentyfour' === $current_theme ) {
 	$cardo_font_family = 'heading';
 }
 ?>
+
 <!-- wp:woocommerce/coming-soon {"color":"#bea0f2","storeOnly":false,"className":"woocommerce-coming-soon-entire-site wp-block-woocommerce-background-color"} -->
 <div class="woocommerce-coming-soon-entire-site wp-block-woocommerce-coming-soon wp-block-woocommerce-background-color"><!-- wp:cover {"minHeight":100,"minHeightUnit":"vh","isDark":false,"className":"coming-soon-is-vertically-aligned-center coming-soon-cover","layout":{"type":"default"}} -->
 <div class="wp-block-cover is-light coming-soon-is-vertically-aligned-center coming-soon-cover" style="min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style=""></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"woocommerce-coming-soon-banner-container","layout":{"type":"default"}} -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to https://github.com/woocommerce/woocommerce/pull/52726.

I have no ideal approach to maintain a working copy of the coming soon templates while working on new changes. Importing the PHP files doesn't work either since I believe Gutenberg relies on the original file contents instead of derived code.

As a workaround, I added deprecated note in the old templates and applied the previous PR's fix.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check the code change in `page-coming-soon-default.php` and confirm it's exactly the same with [this diff](https://github.com/woocommerce/woocommerce/pull/52726/files#diff-c4be290c3a8ce11a87e99f3173f932fdaacbbad79e1d0d4de969b98c3d5c8992R25-R26)
2. Check deprecated notes added

#### Optional (Test using previous PR instructions):

1. Go to `Tools > WCA Test Helper > Features` and activate `coming-soon-newsletter-template` feature flag
3. Go through the Core Profiler onboarding wizard
4. Click on the "Coming Soon" badge on the admin bar
5. Click on the link that takes you to the site editor
6. In site editor, expand the `Design` tab and select `Default Coming Soon` template
7. Remove the Site Title and Socials/Login button blocks
8. Add an image block
9. Upload a tall-ish image
10. Confirm that the tall image does not overlap the text content below, and that the layout adjusts to accommodate the image height.
11. Confirm that the social login button and header size match the design (The header size might still a bit different due to cover block padding is set to 1em so it might not be exactly 16px).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
