### PR TITLE
Remove trigger_error from WooCommerce::__set

### DIFF
--- a/plugins/woocommerce/changelog/pr-52764
+++ b/plugins/woocommerce/changelog/pr-52764
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Replace trigger_error in WooCommerce::__set with an exception

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -209,13 +209,13 @@ final class WooCommerce {
 	 *
 	 * @param string $key Property name.
 	 * @param mixed  $value Property value.
+	 * @throws Exception Attempt to access a property that's private or protected.
 	 */
 	public function __set( string $key, $value ) {
 		if ( 'api' === $key ) {
 			$this->api = $value;
 		} elseif ( property_exists( $this, $key ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			trigger_error( 'Cannot access private property WooCommerce::$' . esc_html( $key ), E_USER_ERROR );
+			throw new Exception( 'Cannot access private property ' . __CLASS__ . '::$' . esc_html( $key ) );
 		} else {
 			$this->$key = $value;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Replaces `trigger_error` in `WooCommerce::__set` with an exception to prevent deprecation notices in PHP 8.4.

Closes #52737.

### How to test the changes in this Pull Request:

Right now the only private property in the `WooCommerce` class is `$api`, which gets special handling in the `__set` method. So we need to temporarily add one to the class, for example `private $foobar`.

Once you have done that run the following in the command line:

```
wp eval 'ini_set("display_errors", "1");WooCommerce::instance()->foobar = 34;'
```

...and you should get this:

```
Fatal error: Uncaught Exception: Cannot access private property WooCommerce::$foobar in
/woocommerce/plugins/woocommerce/includes/class-woocommerce.php:220
```

Then turn the property from `private` to `protected` and repeat the command, you should get the same result.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
