### PR TITLE
Replace and remove feature gating class use with get environment type

### DIFF
--- a/plugins/woocommerce/changelog/update-47694_replace_FeatureGating_use_with_get_environment_type
+++ b/plugins/woocommerce/changelog/update-47694_replace_FeatureGating_use_with_get_environment_type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removed final use of the FeatureGating class and deprecated it.

--- a/plugins/woocommerce/src/Admin/DeprecatedClassFacade.php
+++ b/plugins/woocommerce/src/Admin/DeprecatedClassFacade.php
@@ -38,7 +38,7 @@ class DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname;
+	protected static $facade_over_classname = '';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -58,7 +58,9 @@ class DeprecatedClassFacade {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->instance = new static::$facade_over_classname();
+		if ( '' !== static::$facade_over_classname ) {
+			$this->instance = new static::$facade_over_classname();
+		}
 	}
 
 	/**
@@ -73,6 +75,13 @@ class DeprecatedClassFacade {
 			static::$deprecated_in_version,
 			static::$facade_over_classname . '::' . $function
 		);
+		
+		if ( '' !== static::$facade_over_classname ) {
+			$message = $message . sprintf(
+				' Use %s instead.',
+				static::$facade_over_classname . '::' . $function
+			);
+		}
 
 		// Only log when the message has not been logged before.
 		if ( ! in_array( $message, self::$logged_messages, true ) ) {
@@ -89,6 +98,10 @@ class DeprecatedClassFacade {
 	 */
 	public function __call( $name, $arguments ) {
 		self::log_deprecation( $name );
+
+		if ( ! isset( $this->instance ) ) {
+			return;
+		}
 
 		return call_user_func_array(
 			array(
@@ -107,6 +120,10 @@ class DeprecatedClassFacade {
 	 */
 	public static function __callStatic( $name, $arguments ) {
 		self::log_deprecation( $name );
+
+		if ( '' === static::$facade_over_classname ) {
+			return;
+		}
 
 		return call_user_func_array(
 			array(

--- a/plugins/woocommerce/src/Admin/DeprecatedClassFacade.php
+++ b/plugins/woocommerce/src/Admin/DeprecatedClassFacade.php
@@ -75,7 +75,7 @@ class DeprecatedClassFacade {
 			static::$deprecated_in_version,
 			static::$facade_over_classname . '::' . $function
 		);
-		
+
 		if ( '' !== static::$facade_over_classname ) {
 			$message = $message . sprintf(
 				' Use %s instead.',

--- a/plugins/woocommerce/src/Blocks/Assets/Api.php
+++ b/plugins/woocommerce/src/Blocks/Assets/Api.php
@@ -78,7 +78,7 @@ class Api {
 		// Use wc- prefix here to prevent collisions when WC Core version catches up to a version previously used by the WC Blocks feature plugin.
 		$this->wc_version    = 'wc-' . Constants::get_constant( 'WC_VERSION' );
 		$this->package       = $package;
-		$this->disable_cache = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || ! $this->package->feature()->is_production_environment();
+		$this->disable_cache = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || wp_get_environment_type() !== 'production';
 
 		// If the site is accessed via HTTPS, change the transient key. This is to prevent the script URLs being cached
 		// with the first scheme they are accessed on after cache expiry.
@@ -258,7 +258,7 @@ class Api {
 		$script_data = $this->get_script_data( $relative_src, $dependencies );
 
 		if ( in_array( $handle, $script_data['dependencies'], true ) ) {
-			if ( $this->package->feature()->is_development_environment() ) {
+			if ( wp_get_environment_type() === 'development' ) {
 				$dependencies = array_diff( $script_data['dependencies'], [ $handle ] );
 					add_action(
 						'admin_notices',

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -17,7 +17,6 @@ use Automattic\WooCommerce\Blocks\QueryFilters;
 use Automattic\WooCommerce\Blocks\Domain\Services\CreateAccount;
 use Automattic\WooCommerce\Blocks\Domain\Services\Notices;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
-use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\Domain\Services\GoogleAnalytics;
 use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
@@ -223,12 +222,6 @@ class Bootstrap {
 	 * Register core dependencies with the container.
 	 */
 	protected function register_dependencies() {
-		$this->container->register(
-			FeatureGating::class,
-			function () {
-				return new FeatureGating();
-			}
-		);
 		$this->container->register(
 			AssetApi::class,
 			function ( Container $container ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -47,12 +47,15 @@ class Package {
 	 *
 	 * @param string        $version        Version of the plugin.
 	 * @param string        $plugin_path    Path to the main plugin file.
-	 * @param FeatureGating $feature_gating Feature gating class instance.
+	 * @param FeatureGating $deprecated 	Deprecated Feature gating class.
 	 */
-	public function __construct( $version, $plugin_path, FeatureGating $feature_gating ) {
+	public function __construct( $version, $plugin_path, $deprecated = null ) {
+		if ( null !== $deprecated ) {
+			wc_deprecated_argument( 'FeatureGating', '9.5', 'FeatureGating class is deprecated, please use wp_get_environment_type() instead.' );
+			$this->feature_gating = new FeatureGating();
+		}
 		$this->version        = $version;
 		$this->path           = $plugin_path;
-		$this->feature_gating = $feature_gating;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -51,7 +51,7 @@ class Package {
 	 */
 	public function __construct( $version, $plugin_path, $deprecated = null ) {
 		if ( null !== $deprecated ) {
-			wc_deprecated_argument( 'FeatureGating', '9.5', 'FeatureGating class is deprecated, please use wp_get_environment_type() instead.' );
+			wc_deprecated_argument( 'FeatureGating', '9.6', 'FeatureGating class is deprecated, please use wp_get_environment_type() instead.' );
 			$this->feature_gating = new FeatureGating();
 		}
 		$this->version        = $version;

--- a/plugins/woocommerce/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Package.php
@@ -47,15 +47,15 @@ class Package {
 	 *
 	 * @param string        $version        Version of the plugin.
 	 * @param string        $plugin_path    Path to the main plugin file.
-	 * @param FeatureGating $deprecated 	Deprecated Feature gating class.
+	 * @param FeatureGating $deprecated     Deprecated Feature gating class.
 	 */
 	public function __construct( $version, $plugin_path, $deprecated = null ) {
 		if ( null !== $deprecated ) {
 			wc_deprecated_argument( 'FeatureGating', '9.6', 'FeatureGating class is deprecated, please use wp_get_environment_type() instead.' );
 			$this->feature_gating = new FeatureGating();
 		}
-		$this->version        = $version;
-		$this->path           = $plugin_path;
+		$this->version = $version;
+		$this->path    = $plugin_path;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
@@ -1,23 +1,23 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
+use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
+
 /**
  * Service class that used to handle feature flags. That functionality
  * is removed now and it is only used to determine "environment".
  *
  * @internal
+ * 
+ * @deprecated since 9.5.0, use wp_get_environment_type() instead.
  */
-class FeatureGating {
+class FeatureGating extends DeprecatedClassFacade {
 	/**
-	 * Current environment
+	 * The version that this class was deprecated in.
 	 *
 	 * @var string
 	 */
-	private $environment;
-
-	const PRODUCTION_ENVIRONMENT  = 'production';
-	const DEVELOPMENT_ENVIRONMENT = 'development';
-	const TEST_ENVIRONMENT        = 'test';
+	protected static $deprecated_in_version = '9.5.0';
 
 	/**
 	 * Constructor
@@ -25,58 +25,5 @@ class FeatureGating {
 	 * @param string $environment Hardcoded environment value. Useful for tests.
 	 */
 	public function __construct( $environment = 'unset' ) {
-		$this->environment = $environment;
-		$this->load_environment();
-	}
-
-	/**
-	 * Set correct environment.
-	 */
-	public function load_environment() {
-		if ( 'unset' === $this->environment ) {
-			if ( file_exists( __DIR__ . '/../../../../blocks.ini' ) ) {
-				$allowed_environments = [ self::PRODUCTION_ENVIRONMENT, self::DEVELOPMENT_ENVIRONMENT, self::TEST_ENVIRONMENT ];
-				$woo_options          = parse_ini_file( __DIR__ . '/../../../../blocks.ini' );
-				$this->environment    = is_array( $woo_options ) && in_array( $woo_options['woocommerce_blocks_env'], $allowed_environments, true ) ? $woo_options['woocommerce_blocks_env'] : self::PRODUCTION_ENVIRONMENT;
-			} else {
-				$this->environment = self::PRODUCTION_ENVIRONMENT;
-			}
-		}
-	}
-
-	/**
-	 * Returns the current environment value.
-	 *
-	 * @return string
-	 */
-	public function get_environment() {
-		return $this->environment;
-	}
-
-	/**
-	 * Checks if we're executing the code in an development environment.
-	 *
-	 * @return boolean
-	 */
-	public function is_development_environment() {
-		return self::DEVELOPMENT_ENVIRONMENT === $this->environment;
-	}
-
-	/**
-	 * Checks if we're executing the code in a production environment.
-	 *
-	 * @return boolean
-	 */
-	public function is_production_environment() {
-		return self::PRODUCTION_ENVIRONMENT === $this->environment;
-	}
-
-	/**
-	 * Checks if we're executing the code in a test environment.
-	 *
-	 * @return boolean
-	 */
-	public function is_test_environment() {
-		return self::TEST_ENVIRONMENT === $this->environment;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
  *
  * @internal
  * 
- * @deprecated since 9.5.0, use wp_get_environment_type() instead.
+ * @deprecated since 9.6.0, use wp_get_environment_type() instead.
  */
 class FeatureGating extends DeprecatedClassFacade {
 	/**
@@ -17,7 +17,7 @@ class FeatureGating extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '9.5.0';
+	protected static $deprecated_in_version = '9.6.0';
 
 	/**
 	 * Constructor

--- a/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/FeatureGating.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
  * is removed now and it is only used to determine "environment".
  *
  * @internal
- * 
+ *
  * @deprecated since 9.6.0, use wp_get_environment_type() instead.
  */
 class FeatureGating extends DeprecatedClassFacade {

--- a/plugins/woocommerce/src/Blocks/Package.php
+++ b/plugins/woocommerce/src/Blocks/Package.php
@@ -66,9 +66,11 @@ class Package {
 	 * Returns an instance of the FeatureGating class.
 	 *
 	 * @return FeatureGating
+	 * @deprecated since 9.5.0, use wp_get_environment_type() instead.
 	 */
 	public static function feature() {
-		return self::get_package()->feature();
+		wc_deprecated_function( 'Package::feature', '9.5.0', 'wp_get_environment_type' );
+		return new FeatureGating();
 	}
 
 	/**
@@ -93,8 +95,7 @@ class Package {
 					$version = '11.8.0-dev';
 					return new NewPackage(
 						$version,
-						dirname( __DIR__, 2 ),
-						new FeatureGating()
+						dirname( __DIR__, 2 )
 					);
 				}
 			);

--- a/plugins/woocommerce/src/Blocks/Package.php
+++ b/plugins/woocommerce/src/Blocks/Package.php
@@ -66,10 +66,10 @@ class Package {
 	 * Returns an instance of the FeatureGating class.
 	 *
 	 * @return FeatureGating
-	 * @deprecated since 9.5.0, use wp_get_environment_type() instead.
+	 * @deprecated since 9.6.0, use wp_get_environment_type() instead.
 	 */
 	public static function feature() {
-		wc_deprecated_function( 'Package::feature', '9.5.0', 'wp_get_environment_type' );
+		wc_deprecated_function( 'Package::feature', '9.6.0', 'wp_get_environment_type' );
 		return new FeatureGating();
 	}
 

--- a/plugins/woocommerce/src/Blocks/Package.php
+++ b/plugins/woocommerce/src/Blocks/Package.php
@@ -66,10 +66,10 @@ class Package {
 	 * Returns an instance of the FeatureGating class.
 	 *
 	 * @return FeatureGating
-	 * @deprecated since 9.6.0, use wp_get_environment_type() instead.
+	 * @deprecated since 9.6, use wp_get_environment_type() instead.
 	 */
 	public static function feature() {
-		wc_deprecated_function( 'Package::feature', '9.6.0', 'wp_get_environment_type' );
+		wc_deprecated_function( 'Package::feature', '9.6', 'wp_get_environment_type' );
 		return new FeatureGating();
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockPatterns/BlockPatterns.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockPatterns/BlockPatterns.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\Blocks\Patterns\PatternRegistry;
 use Automattic\WooCommerce\Blocks\BlockPatterns as TestedBlockPatterns;
 use Automattic\WooCommerce\Blocks\Patterns\PTKPatternsStore;
 use Automattic\WooCommerce\Blocks\Domain\Package;
-use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\AIContent\PatternsHelper;
 
 /**
@@ -45,7 +44,7 @@ class BlockPatterns extends \WP_UnitTestCase {
 
 		delete_site_transient( 'woocommerce_blocks_patterns' );
 
-		$package                  = new Package( '0.1.0', __DIR__, new FeatureGating() );
+		$package                  = new Package( '0.1.0', __DIR__ );
 		$this->pattern_registry   = $this->createMock( PatternRegistry::class );
 		$this->ptk_patterns_store = $this->createMock( PTKPatternsStore::class );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Package.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Package.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\Domain;
 
 use Automattic\WooCommerce\Blocks\Domain\Package as TestedPackage;
-use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**
  * Tests the Package class
@@ -14,7 +13,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 class Package extends \WP_UnitTestCase {
 
 	private function get_package() {
-		return new TestedPackage( '1.0.0', __DIR__, new FeatureGating() );
+		return new TestedPackage( '1.0.0', __DIR__ );
 	}
 
 	public function test_get_version() {

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/DeleteDraftOrders.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Tests\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
-use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use WC_Order;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
@@ -29,7 +28,7 @@ class DeleteDraftOrders extends TestCase {
 	protected function setUp(): void {
 		global $wpdb;
 
-		$this->draft_orders_instance = new DraftOrders( new Package( 'test', './', new FeatureGating( 2 ) ) );
+		$this->draft_orders_instance = new DraftOrders( new Package( 'test', './' ) );
 
 		$order = new WC_Order();
 		$order->set_status( DraftOrders::STATUS );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This replaces the two instances left where we used the `FeatureGating` class and replaced it with the `wp_get_environment_type()` function.
The PR also deprecates the `FeatureGating` class.

Closes #47694, and https://github.com/woocommerce/woocommerce/issues/47695 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build this branch and update a couple of the templates like checkout and cart, make sure everything works correctly ( without errors in the log )
2. Visit the checkout and cart pages on the front end and make sure everything works correctly ( without errors in the log )
3. Set the `WP_ENVIRONMENT_TYPE` constant to `local` or `development` in your `wp-config.php` file and make sure `SCRIPT_DEBUG` is set to `false`.
4. Check cart/checkout blocks load normally on the frontend.
5. To see the contents of the transient, when running a production build (and assuming you are using WP Local), open database > adminer and check the wp_options table for the option named _transient_woocommerce_blocks_asset_api_script_data. It should not exist, as it doesn't enable caching in `local` or `development` environments.
6. Set the `WP_ENVIRONMENT_TYPE` constant to `production` in your `wp-config.php` file and make sure `SCRIPT_DEBUG` is set to `false`.
7. Check cart/checkout blocks load normally on the frontend. 
8. Check the transient option again, it should contain JSON containing the list of assets/dependencies etc.
9. Install and enable this plugin from this Gist -> https://gist.github.com/louwie17/676721680b03762e88946c0270073f13 
[test-featuregating-plugin.zip](https://github.com/user-attachments/files/17734281/test-featuregating-plugin.zip)
10. Open the sites log file, it should show two debug messages:
```
The FeatureGating argument is deprecated since version 9.5. FeatureGating class is deprecated, please use wp_get_environment_type() instead.
```
and
```
Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating::is_production_environment is deprecated since version 9.5.0! Use ::is_production_environment instead.
```


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
