### PR TITLE
Speed up `wc_customer_bought_product`

### DIFF
--- a/plugins/woocommerce/changelog/tweak-speedup-bought-product-function
+++ b/plugins/woocommerce/changelog/tweak-speedup-bought-product-function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Speed up `wc_customer_bought_product` by using `GROUP BY` instead of `DISTINCT`

--- a/plugins/woocommerce/changelog/tweak-speedup-bought-product-function
+++ b/plugins/woocommerce/changelog/tweak-speedup-bought-product-function
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Speed up `wc_customer_bought_product` by using `GROUP BY` instead of `DISTINCT`
+Speed up `wc_customer_bought_product` by refactoring the DB query logic

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -410,7 +410,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 		return $result;
 	}
 
-	$transient_name    = 'wc_customer_bought_product_' . md5( $customer_email . $user_id );
+	$transient_name    = 'wc_customer_bought_product_' . md5( $customer_email . $user_id . $product_id );
 	$transient_version = WC_Cache_Helper::get_transient_version( 'orders' );
 	$transient_value   = get_transient( $transient_name );
 

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -451,19 +451,20 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 				$user_id_clause = 'OR o.customer_id = ' . absint( $user_id );
 			}
 			$sql    = "
-SELECT DISTINCT im.meta_value FROM $order_table AS o
+SELECT im.meta_value FROM $order_table AS o
 INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON o.id = i.order_id
 INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
 WHERE o.status IN ('" . implode( "','", $statuses ) . "')
 AND im.meta_key IN ('_product_id', '_variation_id' )
 AND im.meta_value != 0
 AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_clause )
+GROUP BY im.meta_value
 ";
 			$result = $wpdb->get_col( $sql );
 		} else {
 			$result = $wpdb->get_col(
 				"
-SELECT DISTINCT im.meta_value FROM {$wpdb->posts} AS p
+SELECT im.meta_value FROM {$wpdb->posts} AS p
 INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
 INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON p.ID = i.order_id
 INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
@@ -472,6 +473,7 @@ AND pm.meta_key IN ( '_billing_email', '_customer_user' )
 AND im.meta_key IN ( '_product_id', '_variation_id' )
 AND im.meta_value != 0
 AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )
+GROUP BY im.meta_value
 		"
 			); // WPCS: unprepared SQL ok.
 		}


### PR DESCRIPTION
Instead of using `DISTINCT`, use `GROUP BY`

### Changes proposed in this Pull Request:

`DISTINCT` is slow because it needs to process and eliminate duplicate rows after retrieving all matching records.

By switching to `GROUP BY` we use more efficient grouping operations, especially on large datasets.

Relates to https://github.com/Automattic/woocommerce.com/issues/22171.

<img width="1508" alt="1" src="https://github.com/user-attachments/assets/30401463-4757-4517-95d3-b84a2874ef1a">

### How to test the changes in this Pull Request:

Can use same testing instructions as in #48139.