### PR TITLE
Add new `include_status` filter on the `/products` endpoint

### DIFF
--- a/plugins/woocommerce/changelog/52780-52773-add-include-status-param
+++ b/plugins/woocommerce/changelog/52780-52773-add-include-status-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new `include_status` filter on the `/products` endpoint.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -173,6 +173,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		// Set post_status.
 		$args['post_status'] = $request['status'];
 
+		// Filter by a list of product statuses.
+		if ( ! empty( $request['include_status'] ) ) {
+			$args['post_status'] = $request['include_status'];
+		}
+
 		// Taxonomy query to filter products by type, category,
 		// tag, shipping class, and attribute.
 		$tax_query = array();
@@ -1595,6 +1600,17 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			'description'       => __( 'Limit results to those with a SKU that partial matches a string.', 'woocommerce' ),
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['include_status'] = array(
+			'description'       => __( 'Limit result set to products with any of the statuses.', 'woocommerce' ),
+			'type'              => 'array',
+			'item'              => array(
+				'type' => 'string',
+				'enum' => array_merge( array( 'any', 'trash' ), array_keys( get_post_statuses() ) ),
+			),
+			'sanitize_callback' => 'wp_parse_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1606,7 +1606,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$params['include_status'] = array(
 			'description'       => __( 'Limit result set to products with any of the statuses.', 'woocommerce' ),
 			'type'              => 'array',
-			'item'              => array(
+			'items'             => array(
 				'type' => 'string',
 				'enum' => array_merge( array( 'any', 'trash' ), array_keys( get_post_statuses() ) ),
 			),

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -575,6 +575,48 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the `include_status` parameter with any status returns all products.
+	 */
+	public function test_collection_filter_with_include_status_any() {
+		$all_statuses = get_post_statuses();
+		foreach ( $all_statuses as $status => $label ) {
+			WC_Helper_Product::create_simple_product(
+				true,
+				array(
+					'name'   => "$label Product",
+					'status' => $status,
+				)
+			);
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'include_status' => array( 'any' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$response_products = $response->get_data();
+
+		$statuses = array_unique(
+			array_map(
+				function ( $product ) {
+					return $product['status'];
+				},
+				$response_products
+			)
+		);
+		$this->assertCount( 4, $statuses );
+		$this->assertEqualsCanonicalizing(
+			array_keys( $all_statuses ),
+			$statuses
+		);
+	}
+
+	/**
 	 * Test the duplicate product endpoint with simple products.
 	 */
 	public function test_duplicate_simple_product() {

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -468,6 +468,113 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the `include_status` parameter correctly filters products by a single status.
+	 */
+	public function test_collection_filter_with_single_include_status() {
+		$draft_product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Draft Product',
+				'status' => 'draft',
+			)
+		);
+
+		WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Pending Product',
+				'status' => 'pending',
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'include_status' => array( 'draft' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_products = $response->get_data();
+
+		$this->assertCount( 1, $response_products );
+		$this->assertEquals( $draft_product->get_id(), $response_products[0]['id'] );
+		$this->assertEquals( 'draft', $response_products[0]['status'] );
+	}
+
+	/**
+	 * Test that the `include_status` parameter correctly filters products by multiple statuses.
+	 *
+	 * @return void
+	 */
+	public function test_collection_filter_with_multiple_include_status() {
+		WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Draft Product',
+				'status' => 'draft',
+			)
+		);
+
+		WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Pending Product',
+				'status' => 'pending',
+			)
+		);
+
+		WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name'   => 'Private Product',
+				'status' => 'private',
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'include_status' => array( 'draft', 'pending' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$response_products = $response->get_data();
+
+		$this->assertCount( 2, $response_products );
+
+		$statuses = array_map(
+			function ( $product ) {
+				return $product['status'];
+			},
+			$response_products
+		);
+
+		$this->assertContains( 'draft', $statuses );
+		$this->assertContains( 'pending', $statuses );
+		$this->assertNotContains( 'private', $statuses );
+	}
+
+	/**
+	 * Test that the `include_status` parameter correctly handles invalid status values.
+	 */
+	public function test_collection_filter_with_invalid_include_status() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'include_status' => array( 'invalid_status' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
 	 * Test the duplicate product endpoint with simple products.
 	 */
 	public function test_duplicate_simple_product() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the new `include_status` parameter to the `/products` endpoint.
It allows filtering products by multiple statuses simultaneously: `any`, `draft`, `pending`, `private`, and `publish`.

With this implementation, `include_status` takes precedence over `status`, if both of them are present.

Part of #52773

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have multiple products in different statuses (`draft`, `pending`, `private`, and `publish`).
2. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys` and add a new key with `Read/Write` permissions.
3. Make the following request using the consumer key and secret generated in the previous step, adding the `include_status` param:
```bash
curl --insecure -u [KEY]:[SECRET] --request GET --url 'https://[STORE_URL]/wp-json/wc/v3/products?include_status=draft' --header 'Content-Type: application/json'
```
4. Ensure the result returns only products with status `draft`.
5. Repeat the request with multiple statuses (comma-separated) and check the response makes sense.
6. Try with a non-existing status, it should return a 400 response.
7. Try with `any`, it should return all products independently of their status.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
 Add new `include_status` filter on the `/products` endpoint. 

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
