### PR TITLE
Fix additional field validation failing when text field is equal to 0

### DIFF
--- a/plugins/woocommerce/changelog/52782-fix-52111-additional-field-0
+++ b/plugins/woocommerce/changelog/52782-fix-52111-additional-field-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+A required text additional field will now accept 0 as a valid input.

--- a/plugins/woocommerce/changelog/52782-fix-52111-additional-field-0
+++ b/plugins/woocommerce/changelog/52782-fix-52111-additional-field-0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-A required text additional field will now accept 0 as a valid input.
+A required text additional field will now also accept 0 as a valid input.

--- a/plugins/woocommerce/changelog/52782-fix-52111-additional-field-0
+++ b/plugins/woocommerce/changelog/52782-fix-52111-additional-field-0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-A required text additional field will now also accept 0 as a valid input.
+A required text additional field will now accept 0 as a valid input.

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -391,7 +391,7 @@ class OrderController {
 		$address = array_merge( $address, $additional_fields );
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
-			if ( empty( $address[ $address_field_key ] ) && $address_field['required'] ) {
+			if ( ! isset( $address[ $address_field_key ] ) && $address_field['required'] ) {
 				/* translators: %s Field label. */
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woocommerce' ), $address_field['label'] ), $address_field_key );
 			}

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -391,7 +391,8 @@ class OrderController {
 		$address = array_merge( $address, $additional_fields );
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
-			if ( ! isset( $address[ $address_field_key ] ) && $address_field['required'] ) {
+			// If the field is required, but is not set or it's an empty string, we throw an error.
+			if ( $address_field['required'] && ( ! isset( $address[ $address_field_key ] ) || ( is_string( $address[ $address_field_key ] ) && '' === trim( $address[ $address_field_key ] ) ) ) ) {
 				/* translators: %s Field label. */
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woocommerce' ), $address_field['label'] ), $address_field_key );
 			}

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -391,8 +391,17 @@ class OrderController {
 		$address = array_merge( $address, $additional_fields );
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
-			// If the field is required, but is not set or it's an empty string, we throw an error.
-			if ( $address_field['required'] && ( ! isset( $address[ $address_field_key ] ) || ( is_string( $address[ $address_field_key ] ) && '' === trim( $address[ $address_field_key ] ) ) ) ) {
+			// Skip validation if field is not required.
+			if ( ! $address_field['required'] ) {
+				continue;
+			}
+
+			// Check if field is not set, is an empty string, or is an empty array.
+			$is_empty = ! isset( $address[ $address_field_key ] ) ||
+				( is_string( $address[ $address_field_key ] ) && '' === trim( $address[ $address_field_key ] ) ) ||
+				( is_array( $address[ $address_field_key ] ) && 0 === count( $address[ $address_field_key ] ) );
+
+			if ( $is_empty ) {
 				/* translators: %s Field label. */
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woocommerce' ), $address_field['label'] ), $address_field_key );
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the validation for additional fields. When a required text input has the value `0`, which is a valid number, the validation fails saying the field is empty. We want to allow the following as valid input `(int) 0`, `(string) 0`, and `false`. Extra checks have been added to allow these but error on anything else.

Closes #52111 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following code to either `functions.php` or using a code snippet plugin

```
add_action(
        'woocommerce_init',
        function() {
                woocommerce_register_additional_checkout_field(
                        array(
                                'id'            => 'mynamespace/number',
                                'label'         => 'Choose number',
                                'location'      => 'address',
                                'required'      => true
                        ),
                );
        }
);
```

2. Add a product to your cart and visit the checkout
3. Fill in all the required fields, and input `0` for Choose number.
4. Place the order and make sure the order goes through ok.
5. Check the order in the backend to make sure the value was stored correctly for Choose number field.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

A required text additional field will now accept 0 as a valid input.

</details>