### PR TITLE
Checkout: Add entities for checkout fields that can be toggled on/off

### DIFF
--- a/docs/building-a-woo-store/block-references.md
+++ b/docs/building-a-woo-store/block-references.md
@@ -425,7 +425,7 @@ Display a checkout form so your customers can submit orders.
 -   **Ancestor:** 
 -   **Parent:** 
 -	**Supports:** align (wide), ~~html~~, ~~multiple~~
--	**Attributes:** align, isPreview, requireApartmentField, requireCompanyField, requirePhoneField, showApartmentField, showCompanyField, showFormStepNumbers, showPhoneField
+-	**Attributes:** align, isPreview, showFormStepNumbers
 
 ## Actions - woocommerce/checkout-actions-block
 

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -3,14 +3,12 @@
     {
       "post_title": "WooCommerce developer documentation",
       "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/README.md",
-      "hash": "e2fcc6ad9781cad5abc6ae17f31eae7c930fc07c37848d7a8141fa5bbe13110f",
+      "hash": "30f0a75b508a1dd7dd3c2f322daa0a4fb7bafee0856ccf9f3ffd1ce0bf8d3422",
       "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/README.md",
       "id": "65f434b31529b2793f7f7adcadfec487c797bdd2",
       "links": {
-        "getting-started/developer-tools.md": "2ed3659ae0153c8fb3252c417bb0eb43ea60f862",
         "extension-development/building-your-first-extension.md": "278c2822fe06f1ab72499a757ef0c4981cfbffb5",
-        "extension-development/how-to-design-a-simple-extension.md": "375f7e18a2e656e662d3189041caeb9c80e7c9e3",
-        "contributing-docs/style-guide.md": "5020907d57ae845a6477a36f59ec8c2f5f7b4b01"
+        "extension-development/how-to-design-a-simple-extension.md": "375f7e18a2e656e662d3189041caeb9c80e7c9e3"
       }
     }
   ],
@@ -25,12 +23,9 @@
           "menu_title": "Theming for Woo Blocks",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/block-theme-development/theming-woo-blocks.md",
-          "hash": "ffd64cc65f0f570cd32cfbb5a78ff87391c68e9a7122617d8d689772b58379f2",
+          "hash": "cec80a34a38b7286be676a35624e2e441f5ccbb1aa318def6afe56a5a2bb6558",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/block-theme-development/theming-woo-blocks.md",
-          "id": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6",
-          "links": {
-            "../building-a-woo-store/block-references.md": "1fbe91d7fa4fafaf35f0297e4cee1e7958756aed"
-          }
+          "id": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
         },
         {
           "post_title": "CSS styling for themes",
@@ -79,7 +74,7 @@
           "post_title": "Blocks reference",
           "menu_title": "Blocks Reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/building-a-woo-store/block-references.md",
-          "hash": "8f0edfe9aa2bb36103f78f38aa61b871d0c5dfa5d76e4cb6f762c5b7648405f8",
+          "hash": "fee3ebe3c18bb39f0a8e9e1f43fe8153b4b5664913cd50b6e3c078ede151601b",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/building-a-woo-store/block-references.md",
           "id": "1fbe91d7fa4fafaf35f0297e4cee1e7958756aed"
         },
@@ -105,12 +100,9 @@
           "menu_title": "Slot and Fill",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/slot-fills.md",
-          "hash": "9502f8cd0af0594c36e0f527472d6d785bb1394c970be35355a652aa8ddad4bb",
+          "hash": "a232ca3d53f10857170113f6dc5b37ac7ae629e852629bac015a8d3c2cd1bbc4",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/slot-fills.md",
-          "id": "e388101586765dd9aca752d66d667d74951a1504",
-          "links": {
-            "./available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
-          }
+          "id": "e388101586765dd9aca752d66d667d74951a1504"
         },
         {
           "post_title": "Cart and Checkout - Handling scripts, styles, and data",
@@ -144,12 +136,9 @@
           "menu_title": "Available Slots",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-slot-fills.md",
-          "hash": "c9f76b6a6ba72e33f55a9efa7fd24078cdc1505eddd3e60c81096a9ec9e915b8",
+          "hash": "444d9892cb6552c8394ecdf81816952987b59bc79fa53f3083c3d14a89d1e961",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-slot-fills.md",
-          "id": "c7ac16eee5540b06b6db928f5d03282ff177e84e",
-          "links": {
-            "./slot-fills.md": "e388101586765dd9aca752d66d667d74951a1504"
-          }
+          "id": "c7ac16eee5540b06b6db928f5d03282ff177e84e"
         },
         {
           "post_title": "Cart and Checkout - Additional checkout fields",
@@ -172,7 +161,7 @@
               "menu_title": "Totals Footer Item",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
-              "hash": "5868d840f3c60a2ca33db3f6f7e1182a50da9be6a93a80469e4f4322c432e295",
+              "hash": "6cf668422809b036dca7c1996ae907497a38631dd5bfb7e67d6bf3620425e411",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
               "id": "90a9b8df374082f1713866a58b810303adb4d3da"
             },
@@ -181,7 +170,7 @@
               "menu_title": "Order Summary Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
-              "hash": "3af0250666a92fe13bed7b4867b82954777dec01c28ba7f28f829126ffa3ae86",
+              "hash": "1796f53f3d67dd6b47fe8d7f67cbd69bddcaa6416bb5a0cc1a0fc99f42ea9d10",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
               "id": "78eb3b135f82a3624a49979e3e93334295abd060"
             },
@@ -190,7 +179,7 @@
               "menu_title": "Coupons",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
-              "hash": "7bf1e0d29203102e9c8c34150a78f8af35dbc47ad2c2ebcc7663354063c0cc98",
+              "hash": "9ce61079d75f991137c771f044812c385db165256723a814ed44ba9caf297f13",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
               "id": "5a022617f3d0267c9b771374f28970e779a6e99d"
             },
@@ -199,7 +188,7 @@
               "menu_title": "Checkout and Place Order Button",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
-              "hash": "1b4eab1657ce3a82b492fe418b76078789779061b5ff8ffd9b1af939e49f342a",
+              "hash": "9ef672160e407cebef3b163414834a6f6f67cd7d677aa399a4312883e0827131",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
               "id": "c97ca710c2e8107bf90915e038a34c8a1016c63a"
             },
@@ -208,7 +197,7 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "f88dd38ed6a603704ae57863fac80ff8f10722fad91c2cc6d5bab443dd3293c5",
+              "hash": "f83254846b98a94f5c895f4a0a6719b281cba81884edb45e413a644967d28f73",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
             },
@@ -217,7 +206,7 @@
               "menu_title": "Inner Block Types",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
-              "hash": "dadef9b92c330c905273831abeee4b02e02741686557e3866f90778e7109311a",
+              "hash": "7f8f59cf376c801b6c2870af356fac28f403c890d1652039f302e244159ee7db",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "id": "3167c9602b1bd3b206226a0d4415944a5f647495"
             }
@@ -279,12 +268,9 @@
               "menu_title": "Legacy Hooks",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/hooks/migrated-hooks.md",
-              "hash": "a61a130e3a5a37cea065601750497e2df03e32c4ddcbeb5e6c284547f4b10e36",
+              "hash": "be4cf6862932c6696568b210e5f6ae4bd5313dacfb66724e23fab830baeb94e1",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/hooks/migrated-hooks.md",
-              "id": "5264fa45d393327b2c9cffb038c4d3670879d911",
-              "links": {
-                "../../extensibility-in-blocks/README.md": "ef684d3345f67690b37179cd879a40072f5c6f80"
-              }
+              "id": "5264fa45d393327b2c9cffb038c4d3670879d911"
             }
           ],
           "categories": []
@@ -404,12 +390,9 @@
           "menu_title": "Displaying custom fields in theme",
           "tags": "code-snippet",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/code-snippets/displaying_custom_fields_in_your_theme_or_site.md",
-          "hash": "a98f7e6a8d51c7317473ea6c15a1a9bb983f3e78fe39601a8999ac403da70d1a",
+          "hash": "013acf9daaef92daf49e49315b2c0eba730b96adb8078eaab1146db4afc5270b",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/code-snippets/displaying_custom_fields_in_your_theme_or_site.md",
-          "id": "3e3fd004afda355cf9dbb05f0967523d6d0da1ce",
-          "links": {
-            "./_media/custom-field-value.png": "5cb89aed1378d83bb33df02266a61e83f0e274d1"
-          }
+          "id": "3e3fd004afda355cf9dbb05f0967523d6d0da1ce"
         },
         {
           "post_title": "Disabling Marketplace Suggestions Programmatically",
@@ -423,12 +406,9 @@
           "post_title": "Customizing checkout fields using actions and filters",
           "tags": "code-snippet",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/code-snippets/customising-checkout-fields.md",
-          "hash": "a18c788943a1841be742aaa34669c436aaebf266d3492959ade0d0d0654b0275",
+          "hash": "ce63f640d5b91d85c3bbb80128d8a19e9c00d1c0e252abd4f958e29dcc1e60ce",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/code-snippets/customising-checkout-fields.md",
-          "id": "83097d3b7414557fc80dcf9f8f1a708bbdcdd884",
-          "links": {
-            "../cart-and-checkout-blocks/additional-checkout-fields.md": "cb5dd8d59043a4e53929121b45da7b33b1661ab8"
-          }
+          "id": "83097d3b7414557fc80dcf9f8f1a708bbdcdd884"
         },
         {
           "post_title": "Code snippets for configuring special tax scenarios",
@@ -502,7 +482,7 @@
       "categories": []
     },
     {
-      "content": "\nInterested in joining the Woo contributor community? The links in this doc summarize and direct you to the order of operations you will need to make your first contribution. If you are a seasoned WooCommerce developer, feel free to skip ahead and utilize the template links, or the reference docs and guides below.\n\n## Contributing to WooCommerce Core\n\nThe WooCommerce core plugin code can be found in our [monorepo](https://github.com/woocommerce/woocommerce). Here you can contribute to: \n\n- [WooCommerce Core Plugin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce)\n- [WooCommerce Blocks](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-blocks) \n\n### Code of Conduct\n\nContributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md) to get familiar with our standards and processes.\n\n### Contributor Guidelines\n\nOur [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) layout the first steps to contributing.\n\n- [Prerequisites and developer tools to get started](https://github.com/woocommerce/woocommerce/blob/trunk/README.md#getting-started)\n- [PNPM commands, plugin development environment packages, and troubleshooting](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md)\n- [Coding standards, E2E testing links](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) \n\n### Templates, Bug Reports, and Feature Requests\n\n- [Pull Request template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md)\n- [Core Issue template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE.md)\n- [Bug Report template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/1-bug-report.yml)\n- [Enhancement template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/2-enhancement.yml)\n- [Feature requests](https://woocommerce.com/feature-requests/woocommerce/)\n\n### Security\n\nSecurity and safety for data management are incredibly important to us at Woo. Please check out the [Automattic security policy](https://automattic.com/security/) to learn about our foundational requirements.\n\nPlease report any vulnerabilities or security issues by reading through Woo's security policy [here](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md).\n\n\n\n\n\n",
+      "content": "\nInterested in joining the Woo contributor community? The links in this doc summarize and direct you to the order of operations you will need to make your first contribution. If you are a seasoned WooCommerce developer, feel free to skip ahead and utilize the template links, or the reference docs and guides below.\n\n## Contributing to WooCommerce Core\n\nThe WooCommerce core plugin code can be found in our [monorepo](https://github.com/woocommerce/woocommerce). Here you can contribute to: \n\n- [WooCommerce Core Plugin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce)\n- [WooCommerce Admin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-admin)\n- [WooCommerce Blocks](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-blocks) \n\n### Code of Conduct\n\nContributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md) to get familiar with our standards and processes.\n\n### Contributor Guidelines\n\nOur [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) layout the first steps to contributing.\n\n- [Prerequisites and developer tools to get started](https://github.com/woocommerce/woocommerce/blob/trunk/README.md#getting-started)\n- [PNPM commands, plugin development environment packages, and troubleshooting](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md)\n- [Coding standards, E2E testing links](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) \n\n### Templates, Bug Reports, and Feature Requests\n\n- [Pull Request template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md)\n- [Core Issue template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE.md)\n- [Bug Report template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/1-bug-report.yml)\n- [Enhancement template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/2-enhancement.yml)\n- [Feature requests](https://woocommerce.com/feature-requests/woocommerce/)\n\n### Security\n\nSecurity and safety for data management are incredibly important to us at Woo. Please check out the [Automattic security policy](https://automattic.com/security/) to learn about our foundational requirements.\n\nPlease report any vulnerabilities or security issues by reading through Woo's security policy [here](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md).\n\n\n\n\n\n",
       "category_slug": "contributing",
       "category_title": "Contribute to Woo",
       "posts": [
@@ -607,7 +587,7 @@
           "post_title": "Technical Documentation Style Guide",
           "menu_title": "Style Guide",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/contributing-docs/style-guide.md",
-          "hash": "00ebb98b3d8c2d31b9fc3d63a7f1a4f9c64f226c0dfeb420218b21a446d06d98",
+          "hash": "1f7b619b73e05f0e607aa8959f598254b7af9adb5375f25df668a104eeadba5e",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/contributing-docs/style-guide.md",
           "id": "5020907d57ae845a6477a36f59ec8c2f5f7b4b01"
         },
@@ -647,7 +627,7 @@
       "categories": []
     },
     {
-      "content": "\n\nThese documents are all dealing with extensibility in the various WooCommerce Blocks.\n\n## Imports and dependency extraction\n\nThe documentation in this section will use window globals in code examples, for example:\n\n```js\nconst { registerCheckoutFilters } = window.wc.blocksCheckout;\n```\n\nHowever, if you're using `@woocommerce/dependency-extraction-webpack-plugin` for enhanced dependency management you can instead use ES module syntax:\n\n```js\nimport { registerCheckoutFilters } from '@woocommerce/blocks-checkout';\n```\n\nSee <https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin> for more information.\n\n## Hooks (actions and filters)\n\n| Document                      | Description                                             |\n| ----------------------------- | ------------------------------------------------------- |\n| [Actions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/actions.md) | Documentation covering action hooks on the server side. |\n| [Filters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/filters.md) | Documentation covering filter hooks on the server side. |\n| [Migrated Hooks](../cart-and-checkout-blocks/hooks/migrated-hooks.md) | Documentation covering the migrated WooCommerce core hooks. |\n\n## REST API\n\n| Document                                                                                       | Description                                                         |\n| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |\n| [Exposing your data in the Store API.](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-add-data.md)                 | Explains how you can add additional data to Store API endpoints.    |\n| [Available endpoints to extend with ExtendSchema](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md) | A list of all available endpoints to extend.                        |\n| [Available Formatters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-formatters.md)                               | Available `Formatters` to format data for use in the Store API.     |\n| [Updating the cart with the Store API](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md)              | Update the server-side cart following an action from the front-end. |\n\n## Checkout Payment Methods\n\n| Document                                                                               | Description                                                                                                 |\n| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |\n| [Checkout Flow and Events](../cart-and-checkout-blocks/checkout-payment-methods/checkout-flow-and-events.md)     | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to. |\n| [Payment Method Integration](../cart-and-checkout-blocks//checkout-payment-methods/payment-method-integration.md) | Information about implementing payment methods.                                                             |\n| [Filtering Payment Methods](../cart-and-checkout-blocks/checkout-payment-methods/filtering-payment-methods.md)   | Information about filtering the payment methods available in the Checkout Block.                            |\n\n## Checkout Block\n\nIn addition to the reference material below, [please see the `block-checkout` package documentation](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/README.md) which is used to extend checkout with Filters, Slot Fills, and Inner Blocks.\n\n| Document                                                                                         | Description                                                                                                       |\n|--------------------------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------------------------- |\n| [How the Checkout Block processes an order](../cart-and-checkout-blocks/how-checkout-processes-an-order.md) | The detailed inner workings of the Checkout Flow.                                                                 |\n| [IntegrationInterface](../cart-and-checkout-blocks/integration-interface.md)                                | The `IntegrationInterface` class and how to use it to register scripts, styles, and data with WooCommerce Blocks. |\n| [Available Filters](../cart-and-checkout-blocks/available-filters/README.md)                                       | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.                |\n| [Slots and Fills](../cart-and-checkout-blocks/slot-fills.md)                                                | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.                       |\n| [Available Slot Fills](../cart-and-checkout-blocks/available-slot-fills.md)                                 | Available Slots that you can use and their positions in Cart and Checkout.                                        |\n| [DOM Events](../cart-and-checkout-blocks/dom-events.md)                                                     | A list of DOM Events used by some blocks to communicate between them and with other parts of WooCommerce.         |\n| [Filter Registry](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/filter-registry/README.md)                          | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n| [Additional Checkout Fields](../cart-and-checkout-blocks/additional-checkout-fields.md)                     | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n",
+      "content": "\n\nThese documents are all dealing with extensibility in the various WooCommerce Blocks.\n\n## Imports and dependency extraction\n\nThe documentation in this section will use window globals in code examples, for example:\n\n```js\nconst { registerCheckoutFilters } = window.wc.blocksCheckout;\n```\n\nHowever, if you're using `@woocommerce/dependency-extraction-webpack-plugin` for enhanced dependency management you can instead use ES module syntax:\n\n```js\nimport { registerCheckoutFilters } from '@woocommerce/blocks-checkout';\n```\n\nSee <https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin> for more information.\n\n## Hooks (actions and filters)\n\n| Document                      | Description                                             |\n| ----------------------------- | ------------------------------------------------------- |\n| [Actions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/actions.md) | Documentation covering action hooks on the server side. |\n| [Filters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/filters.md) | Documentation covering filter hooks on the server side. |\n| [Migrated Hooks](/docs/cart-and-checkout-legacy-hooks/) | Documentation covering the migrated WooCommerce core hooks. |\n\n## REST API\n\n| Document                                                                                       | Description                                                         |\n| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |\n| [Exposing your data in the Store API.](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-add-data.md)                 | Explains how you can add additional data to Store API endpoints.    |\n| [Available endpoints to extend with ExtendSchema](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md) | A list of all available endpoints to extend.                        |\n| [Available Formatters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-formatters.md)                               | Available `Formatters` to format data for use in the Store API.     |\n| [Updating the cart with the Store API](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md)              | Update the server-side cart following an action from the front-end. |\n\n## Checkout Payment Methods\n\n| Document                                                                               | Description                                                                                                 |\n| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |\n| [Checkout Flow and Events](/docs/cart-and-checkout-checkout-flow-and-events/)     | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to. |\n| [Payment Method Integration](/docs/cart-and-checkout-payment-method-integration-for-the-checkout-block/) | Information about implementing payment methods.                                                             |\n| [Filtering Payment Methods](/docs/cart-and-checkout-filtering-payment-methods-in-the-checkout-block/)   | Information about filtering the payment methods available in the Checkout Block.                            |\n\n## Checkout Block\n\nIn addition to the reference material below, [please see the `block-checkout` package documentation](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/README.md) which is used to extend checkout with Filters, Slot Fills, and Inner Blocks.\n\n| Document                                                                                         | Description                                                                                                       |\n|--------------------------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------------------------- |\n| [How the Checkout Block processes an order](/docs/cart-and-checkout-how-the-checkout-block-processes-an-order/) | The detailed inner workings of the Checkout Flow.                                                                 |\n| [IntegrationInterface](/docs/cart-and-checkout-handling-scripts-styles-and-data/)                                | The `IntegrationInterface` class and how to use it to register scripts, styles, and data with WooCommerce Blocks. |\n| [Available Filters](/docs/category/cart-and-checkout-blocks/available-filters/)                                       | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.                |\n| [Slots and Fills](/docs/cart-and-checkout-slot-and-fill/)                                                | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.                       |\n| [Available Slot Fills](/docs/cart-and-checkout-available-slots/)                                 | Available Slots that you can use and their positions in Cart and Checkout.                                        |\n| [DOM Events](/docs/cart-and-checkout-dom-events/)                                                     | A list of DOM Events used by some blocks to communicate between them and with other parts of WooCommerce.         |\n| [Filter Registry](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/filter-registry/README.md)                          | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n| [Additional Checkout Fields](/docs/cart-and-checkout-additional-checkout-fields/)                     | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n",
       "category_slug": "extensibility-in-blocks",
       "category_title": "Extensibility in Blocks",
       "posts": [],
@@ -721,7 +701,7 @@
           "menu_title": "Creating custom settings",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/implementing-settings.md",
-          "hash": "4fcbf84bc9c3ee55359f3471b86e15c73a20dcb3eeb59616f51707e6af9d8ae3",
+          "hash": "5cab83a84bb7eb11090bac244754fdae1f8aef1030850d12c29c09054c50bc61",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/implementing-settings.md",
           "id": "58bcbd3a0cd3b3e5fe738c3bb625cf9b7747c99a"
         },
@@ -844,7 +824,7 @@
           "menu_title": "Build your first extension",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/building-your-first-extension.md",
-          "hash": "aa3d4af8edf0186a13f713c1e8682db832719c84fd0165faa84a06138afca951",
+          "hash": "b875dda72e3d4b26a06969f76abc1d99e55137d85ba22aa1671915625de851da",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/building-your-first-extension.md",
           "id": "278c2822fe06f1ab72499a757ef0c4981cfbffb5"
         },
@@ -871,12 +851,9 @@
           "menu_title": "Add a section to a settings tab",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/adding-a-section-to-a-settings-tab.md",
-          "hash": "4a6239626d9d680599245a426ac541ccda0b85324bbb2b6880d2a63649f3cd65",
+          "hash": "400124b03f0d2f53736012100d2be87e77a7bc9c72a5c6af143f62d84321b09d",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/adding-a-section-to-a-settings-tab.md",
-          "id": "a88144dff894408f31a80c96dcee3bd5126ecd28",
-          "links": {
-            "./settings-api.md": "ed56b97b9de350074a302373ebaaa5dcce727e8b"
-          }
+          "id": "a88144dff894408f31a80c96dcee3bd5126ecd28"
         }
       ],
       "categories": []
@@ -1032,7 +1009,7 @@
           "menu_title": "Payment Token API",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/payments/payment-token-api.md",
-          "hash": "ebbf30a95471cc877a6c5f7c0a9e454e1c875c14dc0e630203b8e27b8eec198a",
+          "hash": "ee6753e946e6533dff62a26ece1911442080de12d449c4d5d28fe1e68adc72b7",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/payments/payment-token-api.md",
           "id": "5f345b53875981703d4b80e8d04eae2daafe4c81"
         },
@@ -1049,12 +1026,9 @@
           "menu_title": "Payment Gateway API",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/payments/payment-gateway-api.md",
-          "hash": "581e12563987918af732bf8a2df7277ba5bec513e944d2c8729ed6a8f6e2b3d0",
+          "hash": "7a8441ba0c0aa74aa727209674b5412502232e1bec230c2aee3984f3ff01d610",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/payments/payment-gateway-api.md",
-          "id": "b337203996650b567f91c70306e1010d6f1ae552",
-          "links": {
-            "../cart-and-checkout-blocks/checkout-payment-methods/payment-method-integration.md": "c9a763b6976ecf03aeb961577c17c31f1ac7c420"
-          }
+          "id": "b337203996650b567f91c70306e1010d6f1ae552"
         }
       ],
       "categories": []
@@ -1180,7 +1154,7 @@
           "post_title": "Writing high quality testing instructions",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/quality-and-best-practices/writing-high-quality-testing-instructions.md",
-          "hash": "5624992fc77063d7ce9a1aee00103f7a67d3acd8147a0f4ec0d4f159d0ac4cad",
+          "hash": "51fb384f8b1dfcb82fdbad6db08145b2c51dba6227529b8b54e2a281fc4b8ef7",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/quality-and-best-practices/writing-high-quality-testing-instructions.md",
           "id": "56a8ef0ef0afec9c884f655e7fdd23d9666c9d00"
         },
@@ -1456,7 +1430,7 @@
       "categories": []
     },
     {
-      "content": "\nProperly setting up your test environment and writing tests when contributing to WooCommerce core are essential parts of our development pipeline. The links below are also included in our [Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) on GitHub.\n\nIf you have any questions about testing please reach out to the developer community in our public channels([Developer Blog](https://developer.woocommerce.com/blog/), [GitHub Discussions](https://github.com/woocommerce/woocommerce/discussions), or [Community Slack](https://woocommerce.com/community-slack/)).\n\n## Unit Testing\n\n[End-to-end tests](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw) are powered by `Playwright`. The test site is spun up using `wp-env` ([recommended](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)), but we will continue to support `e2e-environment` in the meantime, and slowly [deprecate](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md) `Puppeteer` testing. \n\n## API Testing\n\n`api-core-tests` is a [package](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/api-core-tests) that contains automated API tests for WooCommerce, based on `Playwright` and `wp-env`. It supersedes the SuperTest based `api-core-tests` package and `e2e-environment` setup, which we will gradually deprecate.\n\n## Calls for Testing\n\nKeep tabs on calls for testing on our developer blog, and make sure to read our beta testing instructions to help us build new features and enhancements.\n",
+      "content": "\nProperly setting up your test environment and writing tests when contributing to WooCommerce core are essential parts of our development pipeline. The links below are also included in our [Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) on GitHub.\n\nIf you have any questions about testing please reach out to the developer community in our public channels([Developer Blog](https://developer.woocommerce.com/blog/), [GitHub Discussions](https://github.com/woocommerce/woocommerce/discussions), or [Community Slack](https://woocommerce.com/community-slack/)).\n\n## Unit Testing\n\n[End-to-end tests](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw) are powered by `Playwright`. The test site is spun up using `wp-env` ([recommended](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)), but we will continue to support `e2e-environment` in the meantime, and slowly [deprecate](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md) `Puppeteer` testing. \n\n## API Testing\n\n`api-core-tests` is a [package](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/api-core-tests#guide-for-writing-api-tests) that contains automated API tests for WooCommerce, based on `Playwright` and `wp-env`. It supersedes the SuperTest based `api-core-tests` package and `e2e-environment` setup, which we will gradually deprecate.\n\n## Calls for Testing\n\nKeep tabs on calls for testing on our developer blog, and make sure to read our beta testing instructions to help us build new features and enhancements.\n",
       "category_slug": "testing",
       "category_title": "Testing",
       "posts": [
@@ -1472,7 +1446,7 @@
       "categories": []
     },
     {
-      "content": "\nLearn to design and integrate custom themes in WooCommerce, focusing on responsive design and ecommerce optimization.\n\nFor blocks themes, see our [block theme documentation](../block-theme-development/README.md).\n",
+      "content": "\nLearn to design and integrate custom themes in WooCommerce, focusing on responsive design and ecommerce optimization.\n\nFor blocks themes, see our [block theme documentation](/docs/category/block-theme-development).\n",
       "category_slug": "theme-development",
       "category_title": "Classic Theme Development",
       "posts": [
@@ -1496,35 +1470,28 @@
         {
           "post_title": "Template structure & Overriding templates via a theme",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/template-structure.md",
-          "hash": "15032a714679dcd7677c6d8a5456ec68fcd5b6d546537b9bdc8f788b02cead62",
+          "hash": "932567a5d398a8624fbb0bf64bd7a913902fe3c4f4933fc434ea2a7915085d45",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/template-structure.md",
-          "id": "34bfebec9fc45e680976814928a7b8a1778af14e",
-          "links": {
-            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
-          }
+          "id": "34bfebec9fc45e680976814928a7b8a1778af14e"
         },
         {
           "post_title": "How to set up and use a child theme",
           "menu_title": "Set up and use a child theme",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/set-up-a-child-theme.md",
-          "hash": "7323bec1e33861f2c829bf6fcfaa8785492ef0e26ce0e4237d5c5aca2433dd36",
+          "hash": "e343a623970fb22db7e109e0623d877ba42d5938885dde99a5701fa42bf7d197",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/set-up-a-child-theme.md",
-          "id": "00b6916595cbde7766f080260a9ea26f53f3271c",
-          "links": {
-            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
-          }
+          "id": "00b6916595cbde7766f080260a9ea26f53f3271c"
         },
         {
           "post_title": "Image sizing for theme developers",
           "menu_title": "Image sizing",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/image-sizes.md",
-          "hash": "32f6a87356b84c0d464bc43787dc186036d8f39ff33f648d494c1f0bde726fde",
+          "hash": "94d30b875d0c26b88ebd040a686f802f974f89997a30954fc5bb448de57aefdc",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/image-sizes.md",
           "id": "3f5301ac3040d38bc449b440733da6a466209df3",
           "links": {
-            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6",
             "./thumbnail-image-regeneration.md": "733e1b16276d64f128ba0e337ca68ec3de0bf68f"
           }
         },
@@ -1533,7 +1500,7 @@
           "menu_title": "Fix outdated templates",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/fixing-outdated-woocommerce-templates.md",
-          "hash": "6ae1db55359ff5ce357f249d24d5a7ef8708b20d54b4f6ec185b4216a35d645e",
+          "hash": "1b57eba543bb25708fbc4d4ff5802385d06ff2df6f2486f77e6924cb1d44b8d1",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/fixing-outdated-woocommerce-templates.md",
           "id": "1fa09bbc2137a65288cc1576c1053224db7187ed"
         },
@@ -1550,18 +1517,15 @@
           "post_title": "Classic theme development handbook",
           "menu_title": "Classic theme development",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/classic-theme-developer-handbook.md",
-          "hash": "9412e945748544612970da03520eb85d96707ae5bd7e838d2d92e8539ebe7f74",
+          "hash": "0a8c8178ad4a83cd3d44f931cc37635e8f8cf26a53f0ee1bc1a0e6a7ca117ece",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/classic-theme-developer-handbook.md",
-          "id": "c2fde53e1dc3efbded3cfe1fb4df27136a3799a4",
-          "links": {
-            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
-          }
+          "id": "c2fde53e1dc3efbded3cfe1fb4df27136a3799a4"
         }
       ],
       "categories": []
     },
     {
-      "content": "\nThis section covers general guidelines, and best practices to follow in order to ensure your product experience aligns with WooCommerce for ease of use, seamless integration, and strong adoption.\n\nWe strongly recommend you review the current [WooCommerce setup experience](https://woocommerce.com/documentation/plugins/woocommerce/getting-started/) to get familiar with the user experience and taxonomy.\n\nWe also recommend you review the [WordPress core guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) to ensure your product isn't breaking any rules, and review [this helpful resource](https://woocommerce.com/document/grammar-punctuation-style-guide/) on content style.\n\n## General\n\nUse existing WordPress/WooCommerce UI, built in components (text fields, checkboxes, etc) and existing menu structures.\n\nPlugins which draw on WordPress' core design aesthetic will benefit from future updates to this design as WordPress continues to evolve. If you need to make an exception for your product, be prepared to provide a valid use case.\n\n- [WordPress Components library](https://wordpress.github.io/gutenberg/?path=/story/docs-introduction--page)\n- [Figma for WordPress](https://make.wordpress.org/design/2018/11/19/figma-for-wordpress/) | ([WordPress Design Library Figma](https://www.figma.com/file/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library))\n- [WooCommerce Component Library](https://woocommerce.github.io/woocommerce/)\n",
+      "content": "\nThis section covers general guidelines, and best practices to follow in order to ensure your product experience aligns with WooCommerce for ease of use, seamless integration, and strong adoption.\n\nWe strongly recommend you review the current [WooCommerce setup experience](https://woocommerce.com/documentation/plugins/woocommerce/getting-started/) to get familiar with the user experience and taxonomy.\n\nWe also recommend you review the [WordPress core guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) to ensure your product isn't breaking any rules, and review [this helpful resource](https://woocommerce.com/document/grammar-punctuation-style-guide/) on content style.\n\n## General\n\nUse existing WordPress/WooCommerce UI, built in components (text fields, checkboxes, etc) and existing menu structures.\n\nPlugins which draw on WordPress' core design aesthetic will benefit from future updates to this design as WordPress continues to evolve. If you need to make an exception for your product, be prepared to provide a valid use case.\n\n- [WordPress Components library](https://wordpress.github.io/gutenberg/?path=/story/docs-introduction--page)\n- [Figma for WordPress](https://make.wordpress.org/design/2018/11/19/figma-for-wordpress/) | ([WordPress Design Library Figma](https://www.figma.com/file/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library))\n- [WooCommerce Component Library](https://woocommerce.github.io/woocommerce-admin/)\n",
       "category_slug": "user-experience-extensions",
       "category_title": "Extension Guidelines",
       "posts": [
@@ -1859,5 +1823,5 @@
       "categories": []
     }
   ],
-  "hash": "4e196eeda1dae178865578d1f813596514125b32529dab6f55f4000abfddaeaa"
+  "hash": "927cb05cafccf0bbc4de96489f8e372c14cb05ff48698519eefbdfc92625573f"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -3,12 +3,14 @@
     {
       "post_title": "WooCommerce developer documentation",
       "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/README.md",
-      "hash": "30f0a75b508a1dd7dd3c2f322daa0a4fb7bafee0856ccf9f3ffd1ce0bf8d3422",
+      "hash": "e2fcc6ad9781cad5abc6ae17f31eae7c930fc07c37848d7a8141fa5bbe13110f",
       "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/README.md",
       "id": "65f434b31529b2793f7f7adcadfec487c797bdd2",
       "links": {
+        "getting-started/developer-tools.md": "2ed3659ae0153c8fb3252c417bb0eb43ea60f862",
         "extension-development/building-your-first-extension.md": "278c2822fe06f1ab72499a757ef0c4981cfbffb5",
-        "extension-development/how-to-design-a-simple-extension.md": "375f7e18a2e656e662d3189041caeb9c80e7c9e3"
+        "extension-development/how-to-design-a-simple-extension.md": "375f7e18a2e656e662d3189041caeb9c80e7c9e3",
+        "contributing-docs/style-guide.md": "5020907d57ae845a6477a36f59ec8c2f5f7b4b01"
       }
     }
   ],
@@ -23,9 +25,12 @@
           "menu_title": "Theming for Woo Blocks",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/block-theme-development/theming-woo-blocks.md",
-          "hash": "cec80a34a38b7286be676a35624e2e441f5ccbb1aa318def6afe56a5a2bb6558",
+          "hash": "ffd64cc65f0f570cd32cfbb5a78ff87391c68e9a7122617d8d689772b58379f2",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/block-theme-development/theming-woo-blocks.md",
-          "id": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
+          "id": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6",
+          "links": {
+            "../building-a-woo-store/block-references.md": "1fbe91d7fa4fafaf35f0297e4cee1e7958756aed"
+          }
         },
         {
           "post_title": "CSS styling for themes",
@@ -100,9 +105,12 @@
           "menu_title": "Slot and Fill",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/slot-fills.md",
-          "hash": "a232ca3d53f10857170113f6dc5b37ac7ae629e852629bac015a8d3c2cd1bbc4",
+          "hash": "9502f8cd0af0594c36e0f527472d6d785bb1394c970be35355a652aa8ddad4bb",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/slot-fills.md",
-          "id": "e388101586765dd9aca752d66d667d74951a1504"
+          "id": "e388101586765dd9aca752d66d667d74951a1504",
+          "links": {
+            "./available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+          }
         },
         {
           "post_title": "Cart and Checkout - Handling scripts, styles, and data",
@@ -136,9 +144,12 @@
           "menu_title": "Available Slots",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-slot-fills.md",
-          "hash": "444d9892cb6552c8394ecdf81816952987b59bc79fa53f3083c3d14a89d1e961",
+          "hash": "c9f76b6a6ba72e33f55a9efa7fd24078cdc1505eddd3e60c81096a9ec9e915b8",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-slot-fills.md",
-          "id": "c7ac16eee5540b06b6db928f5d03282ff177e84e"
+          "id": "c7ac16eee5540b06b6db928f5d03282ff177e84e",
+          "links": {
+            "./slot-fills.md": "e388101586765dd9aca752d66d667d74951a1504"
+          }
         },
         {
           "post_title": "Cart and Checkout - Additional checkout fields",
@@ -161,7 +172,7 @@
               "menu_title": "Totals Footer Item",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
-              "hash": "6cf668422809b036dca7c1996ae907497a38631dd5bfb7e67d6bf3620425e411",
+              "hash": "5868d840f3c60a2ca33db3f6f7e1182a50da9be6a93a80469e4f4322c432e295",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
               "id": "90a9b8df374082f1713866a58b810303adb4d3da"
             },
@@ -170,7 +181,7 @@
               "menu_title": "Order Summary Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
-              "hash": "1796f53f3d67dd6b47fe8d7f67cbd69bddcaa6416bb5a0cc1a0fc99f42ea9d10",
+              "hash": "3af0250666a92fe13bed7b4867b82954777dec01c28ba7f28f829126ffa3ae86",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
               "id": "78eb3b135f82a3624a49979e3e93334295abd060"
             },
@@ -179,7 +190,7 @@
               "menu_title": "Coupons",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
-              "hash": "9ce61079d75f991137c771f044812c385db165256723a814ed44ba9caf297f13",
+              "hash": "7bf1e0d29203102e9c8c34150a78f8af35dbc47ad2c2ebcc7663354063c0cc98",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
               "id": "5a022617f3d0267c9b771374f28970e779a6e99d"
             },
@@ -188,7 +199,7 @@
               "menu_title": "Checkout and Place Order Button",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
-              "hash": "9ef672160e407cebef3b163414834a6f6f67cd7d677aa399a4312883e0827131",
+              "hash": "1b4eab1657ce3a82b492fe418b76078789779061b5ff8ffd9b1af939e49f342a",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
               "id": "c97ca710c2e8107bf90915e038a34c8a1016c63a"
             },
@@ -197,7 +208,7 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "f83254846b98a94f5c895f4a0a6719b281cba81884edb45e413a644967d28f73",
+              "hash": "f88dd38ed6a603704ae57863fac80ff8f10722fad91c2cc6d5bab443dd3293c5",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
             },
@@ -206,7 +217,7 @@
               "menu_title": "Inner Block Types",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
-              "hash": "7f8f59cf376c801b6c2870af356fac28f403c890d1652039f302e244159ee7db",
+              "hash": "dadef9b92c330c905273831abeee4b02e02741686557e3866f90778e7109311a",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "id": "3167c9602b1bd3b206226a0d4415944a5f647495"
             }
@@ -268,9 +279,12 @@
               "menu_title": "Legacy Hooks",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/hooks/migrated-hooks.md",
-              "hash": "be4cf6862932c6696568b210e5f6ae4bd5313dacfb66724e23fab830baeb94e1",
+              "hash": "a61a130e3a5a37cea065601750497e2df03e32c4ddcbeb5e6c284547f4b10e36",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/hooks/migrated-hooks.md",
-              "id": "5264fa45d393327b2c9cffb038c4d3670879d911"
+              "id": "5264fa45d393327b2c9cffb038c4d3670879d911",
+              "links": {
+                "../../extensibility-in-blocks/README.md": "ef684d3345f67690b37179cd879a40072f5c6f80"
+              }
             }
           ],
           "categories": []
@@ -390,9 +404,12 @@
           "menu_title": "Displaying custom fields in theme",
           "tags": "code-snippet",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/code-snippets/displaying_custom_fields_in_your_theme_or_site.md",
-          "hash": "013acf9daaef92daf49e49315b2c0eba730b96adb8078eaab1146db4afc5270b",
+          "hash": "a98f7e6a8d51c7317473ea6c15a1a9bb983f3e78fe39601a8999ac403da70d1a",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/code-snippets/displaying_custom_fields_in_your_theme_or_site.md",
-          "id": "3e3fd004afda355cf9dbb05f0967523d6d0da1ce"
+          "id": "3e3fd004afda355cf9dbb05f0967523d6d0da1ce",
+          "links": {
+            "./_media/custom-field-value.png": "5cb89aed1378d83bb33df02266a61e83f0e274d1"
+          }
         },
         {
           "post_title": "Disabling Marketplace Suggestions Programmatically",
@@ -406,9 +423,12 @@
           "post_title": "Customizing checkout fields using actions and filters",
           "tags": "code-snippet",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/code-snippets/customising-checkout-fields.md",
-          "hash": "ce63f640d5b91d85c3bbb80128d8a19e9c00d1c0e252abd4f958e29dcc1e60ce",
+          "hash": "a18c788943a1841be742aaa34669c436aaebf266d3492959ade0d0d0654b0275",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/code-snippets/customising-checkout-fields.md",
-          "id": "83097d3b7414557fc80dcf9f8f1a708bbdcdd884"
+          "id": "83097d3b7414557fc80dcf9f8f1a708bbdcdd884",
+          "links": {
+            "../cart-and-checkout-blocks/additional-checkout-fields.md": "cb5dd8d59043a4e53929121b45da7b33b1661ab8"
+          }
         },
         {
           "post_title": "Code snippets for configuring special tax scenarios",
@@ -482,7 +502,7 @@
       "categories": []
     },
     {
-      "content": "\nInterested in joining the Woo contributor community? The links in this doc summarize and direct you to the order of operations you will need to make your first contribution. If you are a seasoned WooCommerce developer, feel free to skip ahead and utilize the template links, or the reference docs and guides below.\n\n## Contributing to WooCommerce Core\n\nThe WooCommerce core plugin code can be found in our [monorepo](https://github.com/woocommerce/woocommerce). Here you can contribute to: \n\n- [WooCommerce Core Plugin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce)\n- [WooCommerce Admin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-admin)\n- [WooCommerce Blocks](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-blocks) \n\n### Code of Conduct\n\nContributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md) to get familiar with our standards and processes.\n\n### Contributor Guidelines\n\nOur [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) layout the first steps to contributing.\n\n- [Prerequisites and developer tools to get started](https://github.com/woocommerce/woocommerce/blob/trunk/README.md#getting-started)\n- [PNPM commands, plugin development environment packages, and troubleshooting](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md)\n- [Coding standards, E2E testing links](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) \n\n### Templates, Bug Reports, and Feature Requests\n\n- [Pull Request template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md)\n- [Core Issue template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE.md)\n- [Bug Report template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/1-bug-report.yml)\n- [Enhancement template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/2-enhancement.yml)\n- [Feature requests](https://woocommerce.com/feature-requests/woocommerce/)\n\n### Security\n\nSecurity and safety for data management are incredibly important to us at Woo. Please check out the [Automattic security policy](https://automattic.com/security/) to learn about our foundational requirements.\n\nPlease report any vulnerabilities or security issues by reading through Woo's security policy [here](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md).\n\n\n\n\n\n",
+      "content": "\nInterested in joining the Woo contributor community? The links in this doc summarize and direct you to the order of operations you will need to make your first contribution. If you are a seasoned WooCommerce developer, feel free to skip ahead and utilize the template links, or the reference docs and guides below.\n\n## Contributing to WooCommerce Core\n\nThe WooCommerce core plugin code can be found in our [monorepo](https://github.com/woocommerce/woocommerce). Here you can contribute to: \n\n- [WooCommerce Core Plugin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce)\n- [WooCommerce Blocks](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-blocks) \n\n### Code of Conduct\n\nContributing to an open source project requires cooperation amongst individuals and organizations all working to make our project a stable and safe place to build and ask questions. Please thoroughly read our [Code of Conduct](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md) to get familiar with our standards and processes.\n\n### Contributor Guidelines\n\nOur [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) layout the first steps to contributing.\n\n- [Prerequisites and developer tools to get started](https://github.com/woocommerce/woocommerce/blob/trunk/README.md#getting-started)\n- [PNPM commands, plugin development environment packages, and troubleshooting](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md)\n- [Coding standards, E2E testing links](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) \n\n### Templates, Bug Reports, and Feature Requests\n\n- [Pull Request template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md)\n- [Core Issue template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE.md)\n- [Bug Report template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/1-bug-report.yml)\n- [Enhancement template](https://github.com/woocommerce/woocommerce/blob/trunk/.github/ISSUE_TEMPLATE/2-enhancement.yml)\n- [Feature requests](https://woocommerce.com/feature-requests/woocommerce/)\n\n### Security\n\nSecurity and safety for data management are incredibly important to us at Woo. Please check out the [Automattic security policy](https://automattic.com/security/) to learn about our foundational requirements.\n\nPlease report any vulnerabilities or security issues by reading through Woo's security policy [here](https://github.com/woocommerce/woocommerce/blob/trunk/SECURITY.md).\n\n\n\n\n\n",
       "category_slug": "contributing",
       "category_title": "Contribute to Woo",
       "posts": [
@@ -587,7 +607,7 @@
           "post_title": "Technical Documentation Style Guide",
           "menu_title": "Style Guide",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/contributing-docs/style-guide.md",
-          "hash": "1f7b619b73e05f0e607aa8959f598254b7af9adb5375f25df668a104eeadba5e",
+          "hash": "00ebb98b3d8c2d31b9fc3d63a7f1a4f9c64f226c0dfeb420218b21a446d06d98",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/contributing-docs/style-guide.md",
           "id": "5020907d57ae845a6477a36f59ec8c2f5f7b4b01"
         },
@@ -627,7 +647,7 @@
       "categories": []
     },
     {
-      "content": "\n\nThese documents are all dealing with extensibility in the various WooCommerce Blocks.\n\n## Imports and dependency extraction\n\nThe documentation in this section will use window globals in code examples, for example:\n\n```js\nconst { registerCheckoutFilters } = window.wc.blocksCheckout;\n```\n\nHowever, if you're using `@woocommerce/dependency-extraction-webpack-plugin` for enhanced dependency management you can instead use ES module syntax:\n\n```js\nimport { registerCheckoutFilters } from '@woocommerce/blocks-checkout';\n```\n\nSee <https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin> for more information.\n\n## Hooks (actions and filters)\n\n| Document                      | Description                                             |\n| ----------------------------- | ------------------------------------------------------- |\n| [Actions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/actions.md) | Documentation covering action hooks on the server side. |\n| [Filters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/filters.md) | Documentation covering filter hooks on the server side. |\n| [Migrated Hooks](/docs/cart-and-checkout-legacy-hooks/) | Documentation covering the migrated WooCommerce core hooks. |\n\n## REST API\n\n| Document                                                                                       | Description                                                         |\n| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |\n| [Exposing your data in the Store API.](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-add-data.md)                 | Explains how you can add additional data to Store API endpoints.    |\n| [Available endpoints to extend with ExtendSchema](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md) | A list of all available endpoints to extend.                        |\n| [Available Formatters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-formatters.md)                               | Available `Formatters` to format data for use in the Store API.     |\n| [Updating the cart with the Store API](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md)              | Update the server-side cart following an action from the front-end. |\n\n## Checkout Payment Methods\n\n| Document                                                                               | Description                                                                                                 |\n| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |\n| [Checkout Flow and Events](/docs/cart-and-checkout-checkout-flow-and-events/)     | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to. |\n| [Payment Method Integration](/docs/cart-and-checkout-payment-method-integration-for-the-checkout-block/) | Information about implementing payment methods.                                                             |\n| [Filtering Payment Methods](/docs/cart-and-checkout-filtering-payment-methods-in-the-checkout-block/)   | Information about filtering the payment methods available in the Checkout Block.                            |\n\n## Checkout Block\n\nIn addition to the reference material below, [please see the `block-checkout` package documentation](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/README.md) which is used to extend checkout with Filters, Slot Fills, and Inner Blocks.\n\n| Document                                                                                         | Description                                                                                                       |\n|--------------------------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------------------------- |\n| [How the Checkout Block processes an order](/docs/cart-and-checkout-how-the-checkout-block-processes-an-order/) | The detailed inner workings of the Checkout Flow.                                                                 |\n| [IntegrationInterface](/docs/cart-and-checkout-handling-scripts-styles-and-data/)                                | The `IntegrationInterface` class and how to use it to register scripts, styles, and data with WooCommerce Blocks. |\n| [Available Filters](/docs/category/cart-and-checkout-blocks/available-filters/)                                       | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.                |\n| [Slots and Fills](/docs/cart-and-checkout-slot-and-fill/)                                                | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.                       |\n| [Available Slot Fills](/docs/cart-and-checkout-available-slots/)                                 | Available Slots that you can use and their positions in Cart and Checkout.                                        |\n| [DOM Events](/docs/cart-and-checkout-dom-events/)                                                     | A list of DOM Events used by some blocks to communicate between them and with other parts of WooCommerce.         |\n| [Filter Registry](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/filter-registry/README.md)                          | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n| [Additional Checkout Fields](/docs/cart-and-checkout-additional-checkout-fields/)                     | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n",
+      "content": "\n\nThese documents are all dealing with extensibility in the various WooCommerce Blocks.\n\n## Imports and dependency extraction\n\nThe documentation in this section will use window globals in code examples, for example:\n\n```js\nconst { registerCheckoutFilters } = window.wc.blocksCheckout;\n```\n\nHowever, if you're using `@woocommerce/dependency-extraction-webpack-plugin` for enhanced dependency management you can instead use ES module syntax:\n\n```js\nimport { registerCheckoutFilters } from '@woocommerce/blocks-checkout';\n```\n\nSee <https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin> for more information.\n\n## Hooks (actions and filters)\n\n| Document                      | Description                                             |\n| ----------------------------- | ------------------------------------------------------- |\n| [Actions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/actions.md) | Documentation covering action hooks on the server side. |\n| [Filters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/hooks/filters.md) | Documentation covering filter hooks on the server side. |\n| [Migrated Hooks](../cart-and-checkout-blocks/hooks/migrated-hooks.md) | Documentation covering the migrated WooCommerce core hooks. |\n\n## REST API\n\n| Document                                                                                       | Description                                                         |\n| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |\n| [Exposing your data in the Store API.](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-add-data.md)                 | Explains how you can add additional data to Store API endpoints.    |\n| [Available endpoints to extend with ExtendSchema](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md) | A list of all available endpoints to extend.                        |\n| [Available Formatters](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-formatters.md)                               | Available `Formatters` to format data for use in the Store API.     |\n| [Updating the cart with the Store API](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/rest-api/extend-rest-api-update-cart.md)              | Update the server-side cart following an action from the front-end. |\n\n## Checkout Payment Methods\n\n| Document                                                                               | Description                                                                                                 |\n| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |\n| [Checkout Flow and Events](../cart-and-checkout-blocks/checkout-payment-methods/checkout-flow-and-events.md)     | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to. |\n| [Payment Method Integration](../cart-and-checkout-blocks//checkout-payment-methods/payment-method-integration.md) | Information about implementing payment methods.                                                             |\n| [Filtering Payment Methods](../cart-and-checkout-blocks/checkout-payment-methods/filtering-payment-methods.md)   | Information about filtering the payment methods available in the Checkout Block.                            |\n\n## Checkout Block\n\nIn addition to the reference material below, [please see the `block-checkout` package documentation](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/README.md) which is used to extend checkout with Filters, Slot Fills, and Inner Blocks.\n\n| Document                                                                                         | Description                                                                                                       |\n|--------------------------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------------------------------- |\n| [How the Checkout Block processes an order](../cart-and-checkout-blocks/how-checkout-processes-an-order.md) | The detailed inner workings of the Checkout Flow.                                                                 |\n| [IntegrationInterface](../cart-and-checkout-blocks/integration-interface.md)                                | The `IntegrationInterface` class and how to use it to register scripts, styles, and data with WooCommerce Blocks. |\n| [Available Filters](../cart-and-checkout-blocks/available-filters/README.md)                                       | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.                |\n| [Slots and Fills](../cart-and-checkout-blocks/slot-fills.md)                                                | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.                       |\n| [Available Slot Fills](../cart-and-checkout-blocks/available-slot-fills.md)                                 | Available Slots that you can use and their positions in Cart and Checkout.                                        |\n| [DOM Events](../cart-and-checkout-blocks/dom-events.md)                                                     | A list of DOM Events used by some blocks to communicate between them and with other parts of WooCommerce.         |\n| [Filter Registry](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/packages/checkout/filter-registry/README.md)                          | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n| [Additional Checkout Fields](../cart-and-checkout-blocks/additional-checkout-fields.md)                     | The filter registry allows callbacks to be registered to manipulate certain values.                               |\n",
       "category_slug": "extensibility-in-blocks",
       "category_title": "Extensibility in Blocks",
       "posts": [],
@@ -701,7 +721,7 @@
           "menu_title": "Creating custom settings",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/implementing-settings.md",
-          "hash": "5cab83a84bb7eb11090bac244754fdae1f8aef1030850d12c29c09054c50bc61",
+          "hash": "4fcbf84bc9c3ee55359f3471b86e15c73a20dcb3eeb59616f51707e6af9d8ae3",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/implementing-settings.md",
           "id": "58bcbd3a0cd3b3e5fe738c3bb625cf9b7747c99a"
         },
@@ -824,7 +844,7 @@
           "menu_title": "Build your first extension",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/building-your-first-extension.md",
-          "hash": "b875dda72e3d4b26a06969f76abc1d99e55137d85ba22aa1671915625de851da",
+          "hash": "aa3d4af8edf0186a13f713c1e8682db832719c84fd0165faa84a06138afca951",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/building-your-first-extension.md",
           "id": "278c2822fe06f1ab72499a757ef0c4981cfbffb5"
         },
@@ -851,9 +871,12 @@
           "menu_title": "Add a section to a settings tab",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/extension-development/adding-a-section-to-a-settings-tab.md",
-          "hash": "400124b03f0d2f53736012100d2be87e77a7bc9c72a5c6af143f62d84321b09d",
+          "hash": "4a6239626d9d680599245a426ac541ccda0b85324bbb2b6880d2a63649f3cd65",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/extension-development/adding-a-section-to-a-settings-tab.md",
-          "id": "a88144dff894408f31a80c96dcee3bd5126ecd28"
+          "id": "a88144dff894408f31a80c96dcee3bd5126ecd28",
+          "links": {
+            "./settings-api.md": "ed56b97b9de350074a302373ebaaa5dcce727e8b"
+          }
         }
       ],
       "categories": []
@@ -1009,7 +1032,7 @@
           "menu_title": "Payment Token API",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/payments/payment-token-api.md",
-          "hash": "ee6753e946e6533dff62a26ece1911442080de12d449c4d5d28fe1e68adc72b7",
+          "hash": "ebbf30a95471cc877a6c5f7c0a9e454e1c875c14dc0e630203b8e27b8eec198a",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/payments/payment-token-api.md",
           "id": "5f345b53875981703d4b80e8d04eae2daafe4c81"
         },
@@ -1026,9 +1049,12 @@
           "menu_title": "Payment Gateway API",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/payments/payment-gateway-api.md",
-          "hash": "7a8441ba0c0aa74aa727209674b5412502232e1bec230c2aee3984f3ff01d610",
+          "hash": "581e12563987918af732bf8a2df7277ba5bec513e944d2c8729ed6a8f6e2b3d0",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/payments/payment-gateway-api.md",
-          "id": "b337203996650b567f91c70306e1010d6f1ae552"
+          "id": "b337203996650b567f91c70306e1010d6f1ae552",
+          "links": {
+            "../cart-and-checkout-blocks/checkout-payment-methods/payment-method-integration.md": "c9a763b6976ecf03aeb961577c17c31f1ac7c420"
+          }
         }
       ],
       "categories": []
@@ -1154,7 +1180,7 @@
           "post_title": "Writing high quality testing instructions",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/quality-and-best-practices/writing-high-quality-testing-instructions.md",
-          "hash": "51fb384f8b1dfcb82fdbad6db08145b2c51dba6227529b8b54e2a281fc4b8ef7",
+          "hash": "5624992fc77063d7ce9a1aee00103f7a67d3acd8147a0f4ec0d4f159d0ac4cad",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/quality-and-best-practices/writing-high-quality-testing-instructions.md",
           "id": "56a8ef0ef0afec9c884f655e7fdd23d9666c9d00"
         },
@@ -1430,7 +1456,7 @@
       "categories": []
     },
     {
-      "content": "\nProperly setting up your test environment and writing tests when contributing to WooCommerce core are essential parts of our development pipeline. The links below are also included in our [Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) on GitHub.\n\nIf you have any questions about testing please reach out to the developer community in our public channels([Developer Blog](https://developer.woocommerce.com/blog/), [GitHub Discussions](https://github.com/woocommerce/woocommerce/discussions), or [Community Slack](https://woocommerce.com/community-slack/)).\n\n## Unit Testing\n\n[End-to-end tests](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw) are powered by `Playwright`. The test site is spun up using `wp-env` ([recommended](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)), but we will continue to support `e2e-environment` in the meantime, and slowly [deprecate](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md) `Puppeteer` testing. \n\n## API Testing\n\n`api-core-tests` is a [package](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/api-core-tests#guide-for-writing-api-tests) that contains automated API tests for WooCommerce, based on `Playwright` and `wp-env`. It supersedes the SuperTest based `api-core-tests` package and `e2e-environment` setup, which we will gradually deprecate.\n\n## Calls for Testing\n\nKeep tabs on calls for testing on our developer blog, and make sure to read our beta testing instructions to help us build new features and enhancements.\n",
+      "content": "\nProperly setting up your test environment and writing tests when contributing to WooCommerce core are essential parts of our development pipeline. The links below are also included in our [Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) on GitHub.\n\nIf you have any questions about testing please reach out to the developer community in our public channels([Developer Blog](https://developer.woocommerce.com/blog/), [GitHub Discussions](https://github.com/woocommerce/woocommerce/discussions), or [Community Slack](https://woocommerce.com/community-slack/)).\n\n## Unit Testing\n\n[End-to-end tests](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw) are powered by `Playwright`. The test site is spun up using `wp-env` ([recommended](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)), but we will continue to support `e2e-environment` in the meantime, and slowly [deprecate](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md) `Puppeteer` testing. \n\n## API Testing\n\n`api-core-tests` is a [package](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/api-core-tests) that contains automated API tests for WooCommerce, based on `Playwright` and `wp-env`. It supersedes the SuperTest based `api-core-tests` package and `e2e-environment` setup, which we will gradually deprecate.\n\n## Calls for Testing\n\nKeep tabs on calls for testing on our developer blog, and make sure to read our beta testing instructions to help us build new features and enhancements.\n",
       "category_slug": "testing",
       "category_title": "Testing",
       "posts": [
@@ -1446,7 +1472,7 @@
       "categories": []
     },
     {
-      "content": "\nLearn to design and integrate custom themes in WooCommerce, focusing on responsive design and ecommerce optimization.\n\nFor blocks themes, see our [block theme documentation](/docs/category/block-theme-development).\n",
+      "content": "\nLearn to design and integrate custom themes in WooCommerce, focusing on responsive design and ecommerce optimization.\n\nFor blocks themes, see our [block theme documentation](../block-theme-development/README.md).\n",
       "category_slug": "theme-development",
       "category_title": "Classic Theme Development",
       "posts": [
@@ -1470,28 +1496,35 @@
         {
           "post_title": "Template structure & Overriding templates via a theme",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/template-structure.md",
-          "hash": "932567a5d398a8624fbb0bf64bd7a913902fe3c4f4933fc434ea2a7915085d45",
+          "hash": "15032a714679dcd7677c6d8a5456ec68fcd5b6d546537b9bdc8f788b02cead62",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/template-structure.md",
-          "id": "34bfebec9fc45e680976814928a7b8a1778af14e"
+          "id": "34bfebec9fc45e680976814928a7b8a1778af14e",
+          "links": {
+            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
+          }
         },
         {
           "post_title": "How to set up and use a child theme",
           "menu_title": "Set up and use a child theme",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/set-up-a-child-theme.md",
-          "hash": "e343a623970fb22db7e109e0623d877ba42d5938885dde99a5701fa42bf7d197",
+          "hash": "7323bec1e33861f2c829bf6fcfaa8785492ef0e26ce0e4237d5c5aca2433dd36",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/set-up-a-child-theme.md",
-          "id": "00b6916595cbde7766f080260a9ea26f53f3271c"
+          "id": "00b6916595cbde7766f080260a9ea26f53f3271c",
+          "links": {
+            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
+          }
         },
         {
           "post_title": "Image sizing for theme developers",
           "menu_title": "Image sizing",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/image-sizes.md",
-          "hash": "94d30b875d0c26b88ebd040a686f802f974f89997a30954fc5bb448de57aefdc",
+          "hash": "32f6a87356b84c0d464bc43787dc186036d8f39ff33f648d494c1f0bde726fde",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/image-sizes.md",
           "id": "3f5301ac3040d38bc449b440733da6a466209df3",
           "links": {
+            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6",
             "./thumbnail-image-regeneration.md": "733e1b16276d64f128ba0e337ca68ec3de0bf68f"
           }
         },
@@ -1500,7 +1533,7 @@
           "menu_title": "Fix outdated templates",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/fixing-outdated-woocommerce-templates.md",
-          "hash": "1b57eba543bb25708fbc4d4ff5802385d06ff2df6f2486f77e6924cb1d44b8d1",
+          "hash": "6ae1db55359ff5ce357f249d24d5a7ef8708b20d54b4f6ec185b4216a35d645e",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/fixing-outdated-woocommerce-templates.md",
           "id": "1fa09bbc2137a65288cc1576c1053224db7187ed"
         },
@@ -1517,15 +1550,18 @@
           "post_title": "Classic theme development handbook",
           "menu_title": "Classic theme development",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/theme-development/classic-theme-developer-handbook.md",
-          "hash": "0a8c8178ad4a83cd3d44f931cc37635e8f8cf26a53f0ee1bc1a0e6a7ca117ece",
+          "hash": "9412e945748544612970da03520eb85d96707ae5bd7e838d2d92e8539ebe7f74",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/theme-development/classic-theme-developer-handbook.md",
-          "id": "c2fde53e1dc3efbded3cfe1fb4df27136a3799a4"
+          "id": "c2fde53e1dc3efbded3cfe1fb4df27136a3799a4",
+          "links": {
+            "../block-theme-development/theming-woo-blocks.md": "90b16f4143d6db728d5ed6dce2ee2c60bdcfdbf6"
+          }
         }
       ],
       "categories": []
     },
     {
-      "content": "\nThis section covers general guidelines, and best practices to follow in order to ensure your product experience aligns with WooCommerce for ease of use, seamless integration, and strong adoption.\n\nWe strongly recommend you review the current [WooCommerce setup experience](https://woocommerce.com/documentation/plugins/woocommerce/getting-started/) to get familiar with the user experience and taxonomy.\n\nWe also recommend you review the [WordPress core guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) to ensure your product isn't breaking any rules, and review [this helpful resource](https://woocommerce.com/document/grammar-punctuation-style-guide/) on content style.\n\n## General\n\nUse existing WordPress/WooCommerce UI, built in components (text fields, checkboxes, etc) and existing menu structures.\n\nPlugins which draw on WordPress' core design aesthetic will benefit from future updates to this design as WordPress continues to evolve. If you need to make an exception for your product, be prepared to provide a valid use case.\n\n- [WordPress Components library](https://wordpress.github.io/gutenberg/?path=/story/docs-introduction--page)\n- [Figma for WordPress](https://make.wordpress.org/design/2018/11/19/figma-for-wordpress/) | ([WordPress Design Library Figma](https://www.figma.com/file/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library))\n- [WooCommerce Component Library](https://woocommerce.github.io/woocommerce-admin/)\n",
+      "content": "\nThis section covers general guidelines, and best practices to follow in order to ensure your product experience aligns with WooCommerce for ease of use, seamless integration, and strong adoption.\n\nWe strongly recommend you review the current [WooCommerce setup experience](https://woocommerce.com/documentation/plugins/woocommerce/getting-started/) to get familiar with the user experience and taxonomy.\n\nWe also recommend you review the [WordPress core guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) to ensure your product isn't breaking any rules, and review [this helpful resource](https://woocommerce.com/document/grammar-punctuation-style-guide/) on content style.\n\n## General\n\nUse existing WordPress/WooCommerce UI, built in components (text fields, checkboxes, etc) and existing menu structures.\n\nPlugins which draw on WordPress' core design aesthetic will benefit from future updates to this design as WordPress continues to evolve. If you need to make an exception for your product, be prepared to provide a valid use case.\n\n- [WordPress Components library](https://wordpress.github.io/gutenberg/?path=/story/docs-introduction--page)\n- [Figma for WordPress](https://make.wordpress.org/design/2018/11/19/figma-for-wordpress/) | ([WordPress Design Library Figma](https://www.figma.com/file/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library))\n- [WooCommerce Component Library](https://woocommerce.github.io/woocommerce/)\n",
       "category_slug": "user-experience-extensions",
       "category_title": "Extension Guidelines",
       "posts": [
@@ -1823,5 +1859,5 @@
       "categories": []
     }
   ],
-  "hash": "927cb05cafccf0bbc4de96489f8e372c14cb05ff48698519eefbdfc92625573f"
+  "hash": "5b316998f4853d5951eb3976cb3adb809a270afa21e027d7816174cc5cf9756c"
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/address-line-2-field.tsx
@@ -3,7 +3,8 @@
  */
 import { ValidatedTextInput } from '@woocommerce/blocks-components';
 import { AddressFormValues, ContactFormValues } from '@woocommerce/settings';
-import { useState, Fragment, useCallback } from '@wordpress/element';
+import { useState, Fragment, useCallback, useEffect } from '@wordpress/element';
+import { usePrevious } from '@woocommerce/base-hooks';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@ariakit/react';
 
@@ -20,11 +21,19 @@ const AddressLine2Field = < T extends AddressFormValues | ContactFormValues >( {
 	value,
 }: AddressLineFieldProps< T > ): JSX.Element => {
 	const isFieldRequired = field?.required ?? false;
+	const previousIsFieldRequired = usePrevious( isFieldRequired );
 
 	// Display the input field if it has a value or if it is required.
 	const [ isFieldVisible, setIsFieldVisible ] = useState(
 		() => Boolean( value ) || isFieldRequired
 	);
+
+	// Re-render if the isFieldVisible prop changes.
+	useEffect( () => {
+		if ( previousIsFieldRequired !== isFieldRequired ) {
+			setIsFieldVisible( Boolean( value ) || isFieldRequired );
+		}
+	}, [ value, previousIsFieldRequired, isFieldRequired ] );
 
 	const handleHiddenInputChange = useCallback(
 		( newValue: string ) => {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -19,11 +19,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { useShallowEqual } from '@woocommerce/base-hooks';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import clsx from 'clsx';
-import {
-	AddressFormValues,
-	ContactFormValues,
-	FormFieldsConfig,
-} from '@woocommerce/settings';
+import { AddressFormValues, ContactFormValues } from '@woocommerce/settings';
 import { objectHasProp } from '@woocommerce/types';
 
 /**
@@ -48,7 +44,6 @@ import { validateState } from './validate-state';
 const Form = < T extends AddressFormValues | ContactFormValues >( {
 	id = '',
 	fields,
-	fieldConfig = {} as FormFieldsConfig,
 	onChange,
 	addressType = 'shipping',
 	values,
@@ -61,7 +56,6 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 
 	// Track incoming props.
 	const currentFields = useShallowEqual( fields );
-	const currentFieldConfig = useShallowEqual( fieldConfig );
 	const currentCountry = useShallowEqual(
 		objectHasProp( values, 'country' ) ? values.country : ''
 	);
@@ -70,7 +64,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 	const addressFormFields = useMemo( (): AddressFormFields => {
 		const preparedFields = prepareFormFields(
 			currentFields,
-			currentFieldConfig,
+			{},
 			currentCountry
 		);
 		return {
@@ -79,7 +73,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 			required: preparedFields.filter( ( field ) => field.required ),
 			hidden: preparedFields.filter( ( field ) => field.hidden ),
 		};
-	}, [ currentFields, currentFieldConfig, currentCountry, addressType ] );
+	}, [ currentFields, currentCountry, addressType ] );
 
 	// Stores refs for rendered fields so we can access them later.
 	const fieldsRef = useRef<

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -14,18 +14,19 @@ import {
 	BillingStateInput,
 	ShippingStateInput,
 } from '@woocommerce/base-components/state-input';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { useShallowEqual } from '@woocommerce/base-hooks';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import clsx from 'clsx';
 import { AddressFormValues, ContactFormValues } from '@woocommerce/settings';
 import { objectHasProp } from '@woocommerce/types';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
  */
-import { AddressFormProps, AddressFormFields } from './types';
+import { AddressFormProps } from './types';
 import prepareFormFields from './prepare-form-fields';
 import validateCountry from './validate-country';
 import customValidationHandler from './custom-validation-handler';
@@ -53,6 +54,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 }: AddressFormProps< T > ): JSX.Element => {
 	const instanceId = useInstanceId( Form );
 	const isFirstRender = useRef( true );
+	const { defaultFields } = useCheckoutBlockContext();
 
 	// Track incoming props.
 	const currentFields = useShallowEqual( fields );
@@ -60,20 +62,14 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 		objectHasProp( values, 'country' ) ? values.country : ''
 	);
 
-	// Memoize the address form fields passed in from the parent component.
-	const addressFormFields = useMemo( (): AddressFormFields => {
-		const preparedFields = prepareFormFields(
-			currentFields,
-			{},
-			currentCountry
-		);
-		return {
-			fields: preparedFields,
-			addressType,
-			required: preparedFields.filter( ( field ) => field.required ),
-			hidden: preparedFields.filter( ( field ) => field.hidden ),
-		};
-	}, [ currentFields, currentCountry, addressType ] );
+	const addressFormFields = prepareFormFields(
+		currentFields,
+		defaultFields,
+		currentCountry
+	);
+	const addressFormFieldsString = JSON.stringify( addressFormFields );
+	const hiddenFields = addressFormFields.filter( ( field ) => field.hidden );
+	const hiddenFieldsString = JSON.stringify( hiddenFields );
 
 	// Stores refs for rendered fields so we can access them later.
 	const fieldsRef = useRef<
@@ -85,13 +81,13 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 		const newValues = {
 			...values,
 			...Object.fromEntries(
-				addressFormFields.hidden.map( ( field ) => [ field.key, '' ] )
+				hiddenFields.map( ( field ) => [ field.key, '' ] )
 			),
 		};
 		if ( ! isShallowEqual( values, newValues ) ) {
 			onChange( newValues );
 		}
-	}, [ onChange, addressFormFields, values ] );
+	}, [ onChange, hiddenFields, hiddenFieldsString, values ] );
 
 	// Maybe validate country and state when other fields change so user is notified that they're required.
 	useEffect( () => {
@@ -100,7 +96,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 		}
 
 		if ( objectHasProp( values, 'state' ) ) {
-			const stateField = addressFormFields.fields.find(
+			const stateField = addressFormFields.find(
 				( f ) => f.key === 'state'
 			);
 
@@ -108,7 +104,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 				validateState( addressType, values, stateField );
 			}
 		}
-	}, [ values, addressType, addressFormFields ] );
+	}, [ values, addressType, addressFormFields, addressFormFieldsString ] );
 
 	// Changing country may change format for postcodes.
 	useEffect( () => {
@@ -120,7 +116,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 		let timeoutId: ReturnType< typeof setTimeout >;
 
 		if ( ! isFirstRender.current && isEditing && fieldsRef.current ) {
-			const firstField = addressFormFields.fields.find(
+			const firstField = addressFormFields.find(
 				( field ) => field.hidden === false
 			);
 
@@ -148,14 +144,21 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 		return () => {
 			clearTimeout( timeoutId );
 		};
-	}, [ isEditing, addressFormFields, id, instanceId, addressType ] );
+	}, [
+		isEditing,
+		addressFormFields,
+		addressFormFieldsString,
+		id,
+		instanceId,
+		addressType,
+	] );
 
 	id = id || `${ instanceId }`;
 
 	return (
 		<div id={ id } className="wc-block-components-address-form">
-			{ addressFormFields.fields.map( ( field ) => {
-				if ( field.hidden ) {
+			{ addressFormFields.map( ( field ) => {
+				if ( !! field.hidden ) {
 					return null;
 				}
 
@@ -188,12 +191,12 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 				if ( field.key === 'address_1' ) {
 					const address1 = getFieldData(
 						'address_1',
-						addressFormFields.fields,
+						addressFormFields,
 						values
 					);
 					const address2 = getFieldData(
 						'address_2',
-						addressFormFields.fields,
+						addressFormFields,
 						values
 					);
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -73,6 +73,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 	// Store previous fields to track changes.
 	const previousFormFields = usePrevious( formFields );
 	const previousIsEditing = usePrevious( isEditing );
+	const previousValues = usePrevious( values );
 
 	// Stores refs for rendered inputs so we can access them later.
 	const inputsRef = useRef<
@@ -151,7 +152,10 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 
 	// Maybe validate country and state when other fields change so user is notified that they're required.
 	useEffect( () => {
-		if ( fastDeepEqual( previousFormFields, formFields ) ) {
+		if (
+			fastDeepEqual( previousFormFields, formFields ) &&
+			fastDeepEqual( previousValues, values )
+		) {
 			return;
 		}
 		if ( objectHasProp( values, 'country' ) ) {
@@ -164,7 +168,13 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 				validateState( addressType, values, stateField );
 			}
 		}
-	}, [ values, addressType, formFields, previousFormFields ] );
+	}, [
+		values,
+		previousValues,
+		addressType,
+		formFields,
+		previousFormFields,
+	] );
 
 	id = id || `${ instanceId }`;
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -21,7 +21,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import clsx from 'clsx';
 import { AddressFormValues, ContactFormValues } from '@woocommerce/settings';
 import { objectHasProp } from '@woocommerce/types';
-import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
+import { useCheckoutAddress } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -54,7 +54,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 }: AddressFormProps< T > ): JSX.Element => {
 	const instanceId = useInstanceId( Form );
 	const isFirstRender = useRef( true );
-	const { defaultFields } = useCheckoutBlockContext();
+	const { defaultFields } = useCheckoutAddress();
 
 	// Track incoming props.
 	const currentFields = useShallowEqual( fields );

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -4,11 +4,9 @@
 import {
 	FormField,
 	FormFields,
-	CountryAddressForm,
-	defaultFields,
+	CountryAddressFields,
 	KeyedFormField,
 	LocaleSpecificFormField,
-	FormFieldsConfig,
 } from '@woocommerce/settings';
 import { __, sprintf } from '@wordpress/i18n';
 import { isNumber, isString } from '@woocommerce/types';
@@ -69,7 +67,9 @@ const getSupportedCoreLocaleProps = (
  *
  * This supports new properties such as optionalLabel which are not used by core (yet).
  */
-const countryAddressForm: CountryAddressForm = Object.entries( COUNTRY_LOCALE )
+const countryAddressFields: CountryAddressFields = Object.entries(
+	COUNTRY_LOCALE
+)
 	.map( ( [ country, countryLocale ] ) => [
 		country,
 		Object.entries( countryLocale )
@@ -93,33 +93,29 @@ const countryAddressForm: CountryAddressForm = Object.entries( COUNTRY_LOCALE )
 
 /**
  * Combines address fields, including fields from the locale, and sorts them by index.
- *
- * @param {Array}  fields         List of field keys--only address fields matching these will be returned.
- * @param {Object} fieldConfigs   Fields config contains field specific overrides at block level which may, for example, hide a field.
- * @param {string} addressCountry Address country code. If unknown, locale fields will not be merged.
- * @return {CountryAddressForm} Object containing address fields.
  */
 const prepareFormFields = (
-	fields: ( keyof FormFields )[],
-	fieldConfigs: FormFieldsConfig,
+	// ist of field keys--only address fields matching these will be returned
+	fieldKeys: ( keyof FormFields )[],
+	// Default fields from settings.
+	defaultFields: FormFields | Record< string, never >,
+	// Address country code. If unknown, locale fields will not be merged.
 	addressCountry = ''
 ): KeyedFormField[] => {
 	const localeConfigs: FormFields =
-		addressCountry && countryAddressForm[ addressCountry ] !== undefined
-			? countryAddressForm[ addressCountry ]
+		addressCountry && countryAddressFields[ addressCountry ] !== undefined
+			? countryAddressFields[ addressCountry ]
 			: ( {} as FormFields );
 
-	return fields
+	return fieldKeys
 		.map( ( field ) => {
 			const defaultConfig = defaultFields[ field ] || {};
 			const localeConfig = localeConfigs[ field ] || {};
-			const fieldConfig = fieldConfigs[ field ] || {};
 
 			return {
 				key: field,
 				...defaultConfig,
 				...localeConfig,
-				...fieldConfig,
 			};
 		} )
 		.sort( ( a, b ) => a.index - b.index );

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/types.ts
@@ -7,7 +7,6 @@ import type {
 	FormFields,
 	FormType,
 	KeyedFormField,
-	FormFieldsConfig,
 } from '@woocommerce/settings';
 
 export type AddressFormFields = {
@@ -31,8 +30,8 @@ export interface AddressFormProps< T > {
 	ariaDescribedBy?: string | undefined;
 	// Array of fields in form.
 	fields: ( keyof FormFields )[];
-	// Field configuration for fields in form.
-	fieldConfig?: FormFieldsConfig;
+	// Default fields for the form as defined on the server.
+	defaultFields: FormFields;
 	// Called with the new address data when the address form changes. This is only called when all required fields are filled and there are no validation errors.
 	onChange: ( newValue: AddressFormValues | ContactFormValues ) => void;
 	// Values for fields.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/types.ts
@@ -30,8 +30,6 @@ export interface AddressFormProps< T > {
 	ariaDescribedBy?: string | undefined;
 	// Array of fields in form.
 	fields: ( keyof FormFields )[];
-	// Default fields for the form as defined on the server.
-	defaultFields: FormFields;
 	// Called with the new address data when the address form changes. This is only called when all required fields are filled and there are no validation errors.
 	onChange: ( newValue: AddressFormValues | ContactFormValues ) => void;
 	// Values for fields.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/utils.ts
@@ -16,7 +16,7 @@ import { AddressFormFields } from './types';
 export interface FieldProps {
 	id: string;
 	errorId: string;
-	label: string | undefined;
+	label: string;
 	autoCapitalize: string | undefined;
 	autoComplete: string | undefined;
 	errorMessage: string | undefined;
@@ -32,7 +32,7 @@ export const createFieldProps = (
 ): FieldProps => ( {
 	id: `${ formId }-${ field?.key }`.replaceAll( '/', '-' ), // Replace all slashes with hyphens to avoid invalid HTML ID.
 	errorId: `${ fieldAddressType }_${ field?.key }`,
-	label: field?.required ? field?.label : field?.optionalLabel,
+	label: ( field?.required ? field?.label : field?.optionalLabel ) || '',
 	autoCapitalize: field?.autocapitalize,
 	autoComplete: field?.autocomplete,
 	errorMessage: field?.errorMessage,

--- a/plugins/woocommerce-blocks/assets/js/base/components/select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/select/index.tsx
@@ -28,8 +28,8 @@ export type SelectProps = Omit<
 	label: string;
 	onChange: ( newVal: string ) => void;
 	errorId?: string;
-	required?: boolean;
-	errorMessage?: string;
+	required?: boolean | undefined;
+	errorMessage?: string | undefined;
 };
 
 export const Select = ( props: SelectProps ) => {

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	defaultFields,
 	ShippingAddress,
 	BillingAddress,
 	getSetting,
@@ -10,13 +11,13 @@ import {
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
-import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
  */
 import { useCustomerData } from './use-customer-data';
 import { useShippingData } from './shipping/use-shipping-data';
+import { useEditorContext } from '../providers/editor-context';
 
 interface CheckoutAddress {
 	defaultFields: FormFields;
@@ -43,6 +44,7 @@ interface CheckoutAddress {
  * Custom hook for exposing address related functionality for the checkout address form.
  */
 export const useCheckoutAddress = (): CheckoutAddress => {
+	const { isEditor, getPreviewData } = useEditorContext();
 	const { needsShipping } = useShippingData();
 	const {
 		useShippingAsBilling,
@@ -69,7 +71,6 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		shippingAddress,
 		setShippingAddress,
 	} = useCustomerData();
-	const { defaultFields } = useCheckoutBlockContext();
 
 	const setEmail = useCallback(
 		( value: string ) =>
@@ -84,7 +85,9 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		false
 	);
 	return {
-		defaultFields,
+		defaultFields: isEditor
+			? ( getPreviewData( 'defaultFields', defaultFields ) as FormFields )
+			: defaultFields,
 		shippingAddress,
 		billingAddress,
 		setShippingAddress,

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import {
-	defaultFields,
-	FormFields,
 	ShippingAddress,
 	BillingAddress,
 	getSetting,
@@ -30,7 +28,6 @@ interface CheckoutAddress {
 	setUseShippingAsBilling: ( useShippingAsBilling: boolean ) => void;
 	setEditingBillingAddress: ( isEditing: boolean ) => void;
 	setEditingShippingAddress: ( isEditing: boolean ) => void;
-	defaultFields: FormFields;
 	showShippingFields: boolean;
 	showBillingFields: boolean;
 	forcedBillingAddress: boolean;
@@ -88,7 +85,6 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		setShippingAddress,
 		setBillingAddress,
 		setEmail,
-		defaultFields,
 		useShippingAsBilling,
 		setUseShippingAsBilling: __internalSetUseShippingAsBilling,
 		editingBillingAddress,

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -3,10 +3,10 @@
  */
 import {
 	defaultFields,
+	FormFields,
 	ShippingAddress,
 	BillingAddress,
 	getSetting,
-	FormFields,
 } from '@woocommerce/settings';
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -20,7 +20,6 @@ import { useShippingData } from './shipping/use-shipping-data';
 import { useEditorContext } from '../providers/editor-context';
 
 interface CheckoutAddress {
-	defaultFields: FormFields;
 	shippingAddress: ShippingAddress;
 	billingAddress: BillingAddress;
 	setShippingAddress: ( data: Partial< ShippingAddress > ) => void;
@@ -32,6 +31,7 @@ interface CheckoutAddress {
 	setUseShippingAsBilling: ( useShippingAsBilling: boolean ) => void;
 	setEditingBillingAddress: ( isEditing: boolean ) => void;
 	setEditingShippingAddress: ( isEditing: boolean ) => void;
+	defaultFields: FormFields;
 	showShippingFields: boolean;
 	showBillingFields: boolean;
 	forcedBillingAddress: boolean;
@@ -85,14 +85,14 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		false
 	);
 	return {
-		defaultFields: isEditor
-			? ( getPreviewData( 'defaultFields', defaultFields ) as FormFields )
-			: defaultFields,
 		shippingAddress,
 		billingAddress,
 		setShippingAddress,
 		setBillingAddress,
 		setEmail,
+		defaultFields: isEditor
+			? ( getPreviewData( 'defaultFields', defaultFields ) as FormFields )
+			: defaultFields,
 		useShippingAsBilling,
 		setUseShippingAsBilling: __internalSetUseShippingAsBilling,
 		editingBillingAddress,

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -5,10 +5,12 @@ import {
 	ShippingAddress,
 	BillingAddress,
 	getSetting,
+	FormFields,
 } from '@woocommerce/settings';
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
  * Internal dependencies
@@ -17,6 +19,7 @@ import { useCustomerData } from './use-customer-data';
 import { useShippingData } from './shipping/use-shipping-data';
 
 interface CheckoutAddress {
+	defaultFields: FormFields;
 	shippingAddress: ShippingAddress;
 	billingAddress: BillingAddress;
 	setShippingAddress: ( data: Partial< ShippingAddress > ) => void;
@@ -66,6 +69,7 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		shippingAddress,
 		setShippingAddress,
 	} = useCustomerData();
+	const { defaultFields } = useCheckoutBlockContext();
 
 	const setEmail = useCallback(
 		( value: string ) =>
@@ -80,6 +84,7 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		false
 	);
 	return {
+		defaultFields,
 		shippingAddress,
 		billingAddress,
 		setShippingAddress,

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/editor-context.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/editor-context.tsx
@@ -18,7 +18,10 @@ interface EditorContextType {
 	previewData: Record< string, unknown >;
 
 	// Get data by name.
-	getPreviewData: ( name: string ) => Record< string, unknown >;
+	getPreviewData: (
+		name: string,
+		fallback?: Record< string, unknown >
+	) => Record< string, unknown >;
 
 	// Indicates whether in the preview context.
 	isPreview?: boolean;
@@ -58,11 +61,14 @@ export const EditorProvider = ( {
 	);
 
 	const getPreviewData = useCallback(
-		( name: string ): Record< string, unknown > => {
+		(
+			name: string,
+			fallback: Record< string, unknown > = {}
+		): Record< string, unknown > => {
 			if ( previewData && name in previewData ) {
 				return previewData[ name ] as Record< string, unknown >;
 			}
-			return {};
+			return fallback;
 		},
 		[ previewData ]
 	);

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/editor-context.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/editor-context.tsx
@@ -43,7 +43,7 @@ export const EditorProvider = ( {
 	currentView = '',
 	isPreview = false,
 }: {
-	children: React.ReactChildren;
+	children: React.ReactNode;
 	currentPostId?: number | undefined;
 	previewData?: Record< string, unknown > | undefined;
 	currentView?: string | undefined;

--- a/plugins/woocommerce-blocks/assets/js/base/utils/address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/utils/address.ts
@@ -14,6 +14,7 @@ import {
 	BillingAddress,
 	CoreAddress,
 	KeyedFormField,
+	defaultFields,
 } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
@@ -98,7 +99,7 @@ export const emptyHiddenAddressFields = <
 ): T => {
 	const addressForm = prepareFormFields(
 		ADDRESS_FORM_KEYS,
-		{},
+		defaultFields,
 		address.country
 	);
 	const newAddress = Object.assign( {}, address ) as T;
@@ -125,7 +126,7 @@ export const emptyAddressFields = <
 ): T => {
 	const addressForm = prepareFormFields(
 		ADDRESS_FORM_KEYS,
-		{},
+		defaultFields,
 		address.country
 	);
 	const newAddress = Object.assign( {}, address ) as T;
@@ -201,7 +202,7 @@ export const isAddressComplete = (
 	}
 	const addressForm = prepareFormFields(
 		ADDRESS_FORM_KEYS,
-		{},
+		defaultFields,
 		address.country
 	);
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/edit.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/edit.js
@@ -88,7 +88,7 @@ export const Edit = ( { clientId, className, attributes, setAttributes } ) => {
 				<EditorProvider
 					previewData={ { previewCart } }
 					currentView={ currentView }
-					isPreview={ isPreview }
+					isPreview={ !! isPreview }
 				>
 					<CartBlockContext.Provider
 						value={ {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -9,7 +9,7 @@ import {
 	objectHasProp,
 	isString,
 } from '@woocommerce/types';
-import { FormFieldsConfig, getSetting } from '@woocommerce/settings';
+import { getSetting } from '@woocommerce/settings';
 import { formatAddress } from '@woocommerce/blocks/checkout/utils';
 import { Button } from '@ariakit/react';
 
@@ -22,13 +22,11 @@ const AddressCard = ( {
 	address,
 	onEdit,
 	target,
-	fieldConfig,
 	isExpanded,
 }: {
 	address: CartShippingAddress | CartBillingAddress;
 	onEdit: () => void;
 	target: string;
-	fieldConfig: FormFieldsConfig;
 	isExpanded: boolean;
 } ): JSX.Element | null => {
 	const countryData = getSetting< Record< string, CountryData > >(
@@ -71,7 +69,7 @@ const AddressCard = ( {
 							<span key={ `address-` + index }>{ field }</span>
 						) ) }
 				</div>
-				{ address.phone && ! fieldConfig.phone.hidden ? (
+				{ address.phone ? (
 					<div
 						key={ `address-phone` }
 						className="wc-block-components-address-card__address-section"

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/attributes.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/attributes.ts
@@ -35,4 +35,28 @@ export const deprecatedAttributes = {
 		type: 'number',
 		default: 0,
 	},
+	showCompanyField: {
+		type: 'boolean',
+		default: false,
+	},
+	requireCompanyField: {
+		type: 'boolean',
+		default: false,
+	},
+	showApartmentField: {
+		type: 'boolean',
+		default: true,
+	},
+	requireApartmentField: {
+		type: 'boolean',
+		default: false,
+	},
+	showPhoneField: {
+		type: 'boolean',
+		default: true,
+	},
+	requirePhoneField: {
+		type: 'boolean',
+		default: false,
+	},
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.json
@@ -26,30 +26,6 @@
 			"default": false,
 			"save": false
 		},
-		"showCompanyField": {
-			"type": "boolean",
-			"default": false
-		},
-		"requireCompanyField": {
-			"type": "boolean",
-			"default": false
-		},
-		"showApartmentField": {
-			"type": "boolean",
-			"default": true
-		},
-		"requireApartmentField": {
-			"type": "boolean",
-			"default": false
-		},
-		"showPhoneField": {
-			"type": "boolean",
-			"default": true
-		},
-		"requirePhoneField": {
-			"type": "boolean",
-			"default": false
-		},
 		"align": {
 			"type": "string",
 			"default": "wide"

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -58,15 +58,7 @@ const Checkout = ( {
 	} );
 	const { cartItems, cartIsLoading } = useStoreCart();
 
-	const {
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-		showFormStepNumbers,
-	} = attributes;
+	const { showFormStepNumbers } = attributes;
 
 	if ( ! cartIsLoading && cartItems.length === 0 ) {
 		return <EmptyCart />;
@@ -92,12 +84,6 @@ const Checkout = ( {
 		<CheckoutBlockContext.Provider
 			value={
 				{
-					showCompanyField,
-					requireCompanyField,
-					showApartmentField,
-					requireApartmentField,
-					showPhoneField,
-					requirePhoneField,
 					showFormStepNumbers,
 				} as Attributes
 			}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -81,13 +81,7 @@ const Checkout = ( {
 	}
 
 	return (
-		<CheckoutBlockContext.Provider
-			value={
-				{
-					showFormStepNumbers,
-				} as Attributes
-			}
-		>
+		<CheckoutBlockContext.Provider value={ { showFormStepNumbers } }>
 			{ children }
 		</CheckoutBlockContext.Provider>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
@@ -1,14 +1,12 @@
 /**
  * External dependencies
  */
-import { defaultFields, FormFields } from '@woocommerce/settings';
 import { createContext, useContext } from '@wordpress/element';
 
 /**
  * Context consumed by inner blocks.
  */
 export type CheckoutBlockContextProps = {
-	defaultFields: FormFields;
 	showOrderNotes: boolean;
 	showPolicyLinks: boolean;
 	showReturnToCart: boolean;
@@ -18,7 +16,6 @@ export type CheckoutBlockContextProps = {
 };
 
 const defaultCheckoutBlockContext = {
-	defaultFields,
 	showOrderNotes: true,
 	showPolicyLinks: true,
 	showReturnToCart: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { defaultFields, FormFields } from '@woocommerce/settings';
 import { createContext, useContext } from '@wordpress/element';
 
 /**
  * Context consumed by inner blocks.
  */
 export type CheckoutBlockContextProps = {
+	defaultFields: FormFields;
 	showOrderNotes: boolean;
 	showPolicyLinks: boolean;
 	showReturnToCart: boolean;
@@ -15,19 +17,23 @@ export type CheckoutBlockContextProps = {
 	showFormStepNumbers: boolean;
 };
 
+const defaultCheckoutBlockContext = {
+	defaultFields,
+	showOrderNotes: true,
+	showPolicyLinks: true,
+	showReturnToCart: true,
+	cartPageId: 0,
+	showRateAfterTaxName: false,
+	showFormStepNumbers: false,
+};
+
 export type CheckoutBlockControlsContextProps = {
 	addressFieldControls: () => JSX.Element | null;
 };
 
-export const CheckoutBlockContext: React.Context< CheckoutBlockContextProps > =
-	createContext< CheckoutBlockContextProps >( {
-		showOrderNotes: true,
-		showPolicyLinks: true,
-		showReturnToCart: true,
-		cartPageId: 0,
-		showRateAfterTaxName: false,
-		showFormStepNumbers: false,
-	} );
+export const CheckoutBlockContext: React.Context<
+	Partial< CheckoutBlockContextProps >
+> = createContext< CheckoutBlockContextProps >( defaultCheckoutBlockContext );
 
 export const CheckoutBlockControlsContext: React.Context< CheckoutBlockControlsContextProps > =
 	createContext< CheckoutBlockControlsContextProps >( {
@@ -35,7 +41,11 @@ export const CheckoutBlockControlsContext: React.Context< CheckoutBlockControlsC
 	} );
 
 export const useCheckoutBlockContext = (): CheckoutBlockContextProps => {
-	return useContext( CheckoutBlockContext );
+	const context = useContext( CheckoutBlockContext );
+	return {
+		...defaultCheckoutBlockContext,
+		...context,
+	};
 };
 
 export const useCheckoutBlockControlsContext =

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/context.ts
@@ -7,12 +7,6 @@ import { createContext, useContext } from '@wordpress/element';
  * Context consumed by inner blocks.
  */
 export type CheckoutBlockContextProps = {
-	showCompanyField: boolean;
-	requireCompanyField: boolean;
-	showApartmentField: boolean;
-	requireApartmentField: boolean;
-	showPhoneField: boolean;
-	requirePhoneField: boolean;
 	showOrderNotes: boolean;
 	showPolicyLinks: boolean;
 	showReturnToCart: boolean;
@@ -27,12 +21,6 @@ export type CheckoutBlockControlsContextProps = {
 
 export const CheckoutBlockContext: React.Context< CheckoutBlockContextProps > =
 	createContext< CheckoutBlockContextProps >( {
-		showCompanyField: false,
-		requireCompanyField: false,
-		showApartmentField: false,
-		requireApartmentField: false,
-		showPhoneField: false,
-		requirePhoneField: false,
 		showOrderNotes: true,
 		showPolicyLinks: true,
 		showReturnToCart: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -21,6 +21,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
 import { dispatch, select, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { defaultFields } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -93,6 +94,18 @@ export const Edit = ( {
 			} );
 		}
 	};
+
+	const editedDefaultFields = {
+		...defaultFields,
+	};
+
+	editedDefaultFields.phone.required = fieldEntities.phone === 'required';
+	editedDefaultFields.company.required = fieldEntities.company === 'required';
+	editedDefaultFields.address_2.required =
+		fieldEntities.apartment === 'required';
+	editedDefaultFields.phone.hidden = fieldEntities.phone === 'hidden';
+	editedDefaultFields.company.hidden = fieldEntities.company === 'hidden';
+	editedDefaultFields.address_2.hidden = fieldEntities.apartment === 'hidden';
 
 	// This focuses on the block when a certain query param is found. This is used on the link from the task list.
 	const focus = useRef( getQueryArg( window.location.href, 'focus' ) );
@@ -261,6 +274,7 @@ export const Edit = ( {
 							>
 								<CheckoutBlockContext.Provider
 									value={ {
+										defaultFields: editedDefaultFields,
 										showOrderNotes,
 										showPolicyLinks,
 										showReturnToCart,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -19,7 +19,7 @@ import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import type { TemplateArray } from '@wordpress/blocks';
 import { useEffect, useRef } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
-import { dispatch, select, useSelect } from '@wordpress/data';
+import { dispatch, select as selectData, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { defaultFields as defaultFieldsSetting } from '@woocommerce/settings';
 
@@ -71,11 +71,11 @@ export const Edit = ( {
 			'site'
 		) as Record< string, string >;
 		const phoneField =
-			settings.woocommerce_checkout_phone_field || 'optional';
+			settings.woocommerce_checkout_phone_field || 'required';
 		const companyField =
 			settings.woocommerce_checkout_company_field || 'optional';
-		const apartmentField =
-			settings.woocommerce_checkout_apartment_field || 'optional';
+		const address2Field =
+			settings.woocommerce_checkout_address_2_field || 'optional';
 		return {
 			...defaultFieldsSetting,
 			phone: {
@@ -90,20 +90,25 @@ export const Edit = ( {
 			},
 			address_2: {
 				...defaultFieldsSetting.address_2,
-				required: apartmentField === 'required',
-				hidden: apartmentField === 'hidden',
+				required: address2Field === 'required',
+				hidden: address2Field === 'hidden',
 			},
 		};
 	} );
 
 	const setFieldEntity = ( field: string, value: string ) => {
 		if (
-			[ 'phone', 'company', 'apartment' ].includes( field ) &&
+			[ 'phone', 'company', 'address_2' ].includes( field ) &&
 			[ 'optional', 'required', 'hidden' ].includes( value )
 		) {
-			dispatch( coreStore ).editEntityRecord( 'root', 'site', undefined, {
-				[ `woocommerce_checkout_${ field }_field` ]: value,
-			} );
+			dispatch( coreStore as unknown as string ).editEntityRecord(
+				'root',
+				'site',
+				undefined,
+				{
+					[ `woocommerce_checkout_${ field }_field` ]: value,
+				}
+			);
 		}
 	};
 
@@ -113,7 +118,7 @@ export const Edit = ( {
 	useEffect( () => {
 		if (
 			focus.current === 'checkout' &&
-			! select( 'core/block-editor' ).hasSelectedBlock()
+			! selectData( 'core/block-editor' ).hasSelectedBlock()
 		) {
 			dispatch( 'core/block-editor' ).selectBlock( clientId );
 			dispatch( 'core/interface' ).enableComplementaryArea(
@@ -189,7 +194,7 @@ export const Edit = ( {
 					checked={ ! defaultFields.address_2.hidden }
 					onChange={ () =>
 						setFieldEntity(
-							'apartment',
+							'address_2',
 							defaultFields.address_2.hidden
 								? 'required'
 								: 'hidden'
@@ -204,11 +209,11 @@ export const Edit = ( {
 						options={ requiredOptions }
 						onChange={ ( value: string ) =>
 							setFieldEntity(
-								'apartment',
+								'address_2',
 								value === 'true' ? 'required' : 'optional'
 							)
 						}
-						className="components-base-control--nested wc-block-components-require-apartment-field"
+						className="components-base-control--nested wc-block-components-require-address_2-field"
 					/>
 				) }
 				<ToggleControl

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -17,7 +17,7 @@ import {
 import { PanelBody, ToggleControl, RadioControl } from '@wordpress/components';
 import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import type { TemplateArray } from '@wordpress/blocks';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
 import { dispatch, select as selectData, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -99,6 +99,36 @@ export const Edit = ( {
 		};
 	} );
 
+	// These state objects are in place so the required toggles remember their last value after being hidden and shown.
+	const [ lastPhoneRequired, setLastPhoneRequired ] = useState(
+		defaultFields.phone.required
+	);
+	const [ lastCompanyRequired, setLastCompanyRequired ] = useState(
+		defaultFields.company.required
+	);
+	const [ lastAddress2Required, setLastAddress2Required ] = useState(
+		defaultFields.address_2.required
+	);
+
+	useEffect( () => {
+		if ( ! defaultFields.phone.hidden ) {
+			setLastPhoneRequired( defaultFields.phone.required );
+		}
+		if ( ! defaultFields.company.hidden ) {
+			setLastCompanyRequired( defaultFields.company.required );
+		}
+		if ( ! defaultFields.address_2.hidden ) {
+			setLastAddress2Required( defaultFields.address_2.required );
+		}
+	}, [
+		defaultFields.phone.hidden,
+		defaultFields.company.hidden,
+		defaultFields.address_2.hidden,
+		defaultFields.phone.required,
+		defaultFields.company.required,
+		defaultFields.address_2.required,
+	] );
+
 	const setFieldEntity = ( field: string, value: string ) => {
 		if (
 			[ 'phone', 'company', 'address_2' ].includes( field ) &&
@@ -170,12 +200,16 @@ export const Edit = ( {
 				<ToggleControl
 					label={ __( 'Company', 'woocommerce' ) }
 					checked={ ! defaultFields.company.hidden }
-					onChange={ () =>
-						setFieldEntity(
-							'company',
-							defaultFields.company.hidden ? 'optional' : 'hidden'
-						)
-					}
+					onChange={ () => {
+						if ( defaultFields.company.hidden ) {
+							setFieldEntity(
+								'company',
+								lastCompanyRequired ? 'required' : 'optional'
+							);
+						} else {
+							setFieldEntity( 'company', 'hidden' );
+						}
+					} }
 				/>
 				{ ! defaultFields.company.hidden && (
 					<RadioControl
@@ -195,14 +229,16 @@ export const Edit = ( {
 				<ToggleControl
 					label={ __( 'Address line 2', 'woocommerce' ) }
 					checked={ ! defaultFields.address_2.hidden }
-					onChange={ () =>
-						setFieldEntity(
-							'address_2',
-							defaultFields.address_2.hidden
-								? 'optional'
-								: 'hidden'
-						)
-					}
+					onChange={ () => {
+						if ( defaultFields.address_2.hidden ) {
+							setFieldEntity(
+								'address_2',
+								lastAddress2Required ? 'required' : 'optional'
+							);
+						} else {
+							setFieldEntity( 'address_2', 'hidden' );
+						}
+					} }
 				/>
 				{ ! defaultFields.address_2.hidden && (
 					<RadioControl
@@ -210,24 +246,28 @@ export const Edit = ( {
 							defaultFields.address_2.required ? 'true' : 'false'
 						}
 						options={ requiredOptions }
-						onChange={ ( value: string ) =>
+						onChange={ ( value: string ) => {
 							setFieldEntity(
 								'address_2',
 								value === 'true' ? 'required' : 'optional'
-							)
-						}
+							);
+						} }
 						className="components-base-control--nested wc-block-components-require-address_2-field"
 					/>
 				) }
 				<ToggleControl
 					label={ __( 'Phone', 'woocommerce' ) }
 					checked={ ! defaultFields.phone.hidden }
-					onChange={ () =>
-						setFieldEntity(
-							'phone',
-							defaultFields.phone.hidden ? 'optional' : 'hidden'
-						)
-					}
+					onChange={ () => {
+						if ( defaultFields.phone.hidden ) {
+							setFieldEntity(
+								'phone',
+								lastPhoneRequired ? 'required' : 'optional'
+							);
+						} else {
+							setFieldEntity( 'phone', 'hidden' );
+						}
+					} }
 				/>
 				{ ! defaultFields.phone.hidden && (
 					<RadioControl
@@ -235,12 +275,12 @@ export const Edit = ( {
 							defaultFields.phone.required ? 'true' : 'false'
 						}
 						options={ requiredOptions }
-						onChange={ ( value: string ) =>
+						onChange={ ( value: string ) => {
 							setFieldEntity(
 								'phone',
 								value === 'true' ? 'required' : 'optional'
-							)
-						}
+							);
+						} }
 						className="components-base-control--nested wc-block-components-require-phone-field"
 					/>
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -202,6 +202,7 @@ export const Edit = ( {
 			</InspectorControls>
 			<EditorProvider
 				isPreview={ isPreview }
+				isPreview={ !! isPreview }
 				previewData={ { previewCart, previewSavedPaymentMethods } }
 			>
 				<SlotFillProvider>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -201,7 +201,6 @@ export const Edit = ( {
 				/>
 			</InspectorControls>
 			<EditorProvider
-				isPreview={ isPreview }
 				isPreview={ !! isPreview }
 				previewData={ { previewCart, previewSavedPaymentMethods } }
 			>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -71,8 +71,8 @@ export const Edit = ( {
 		).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
 
 		const fieldsWithDefaults = {
-			phone: 'required',
-			company: 'optional',
+			phone: 'optional',
+			company: 'hidden',
 			address_2: 'optional',
 		} as const;
 
@@ -173,7 +173,7 @@ export const Edit = ( {
 					onChange={ () =>
 						setFieldEntity(
 							'company',
-							defaultFields.company.hidden ? 'required' : 'hidden'
+							defaultFields.company.hidden ? 'optional' : 'hidden'
 						)
 					}
 				/>
@@ -199,7 +199,7 @@ export const Edit = ( {
 						setFieldEntity(
 							'address_2',
 							defaultFields.address_2.hidden
-								? 'required'
+								? 'optional'
 								: 'hidden'
 						)
 					}
@@ -225,7 +225,7 @@ export const Edit = ( {
 					onChange={ () =>
 						setFieldEntity(
 							'phone',
-							defaultFields.phone.hidden ? 'required' : 'hidden'
+							defaultFields.phone.hidden ? 'optional' : 'hidden'
 						)
 					}
 				/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/edit.tsx
@@ -66,33 +66,36 @@ export const Edit = ( {
 	} = attributes;
 
 	const defaultFields = useSelect( ( select ) => {
-		const settings = select( coreStore ).getEditedEntityRecord(
-			'root',
-			'site'
-		) as Record< string, string >;
-		const phoneField =
-			settings.woocommerce_checkout_phone_field || 'required';
-		const companyField =
-			settings.woocommerce_checkout_company_field || 'optional';
-		const address2Field =
-			settings.woocommerce_checkout_address_2_field || 'optional';
+		const settings = select(
+			coreStore as unknown as string
+		).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
+
+		const fieldsWithDefaults = {
+			phone: 'required',
+			company: 'optional',
+			address_2: 'optional',
+		} as const;
+
 		return {
 			...defaultFieldsSetting,
-			phone: {
-				...defaultFieldsSetting.phone,
-				required: phoneField === 'required',
-				hidden: phoneField === 'hidden',
-			},
-			company: {
-				...defaultFieldsSetting.company,
-				required: companyField === 'required',
-				hidden: companyField === 'hidden',
-			},
-			address_2: {
-				...defaultFieldsSetting.address_2,
-				required: address2Field === 'required',
-				hidden: address2Field === 'hidden',
-			},
+			...Object.fromEntries(
+				Object.entries( fieldsWithDefaults ).map(
+					( [ field, defaultValue ] ) => {
+						const value =
+							settings[
+								`woocommerce_checkout_${ field }_field`
+							] || defaultValue;
+						return [
+							field,
+							{
+								...defaultFieldsSetting[ field ],
+								required: value === 'required',
+								hidden: value === 'hidden',
+							},
+						];
+					}
+				)
+			),
 		};
 	} );
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useMemo, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { useEffectOnce } from 'usehooks-ts';
 import {
 	useCheckoutAddress,
@@ -9,33 +9,23 @@ import {
 	noticeContexts,
 } from '@woocommerce/base-context';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
-import type { ShippingAddress, FormFieldsConfig } from '@woocommerce/settings';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY } from '@woocommerce/block-data';
+import { ShippingAddress } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import CustomerAddress from './customer-address';
 
-const Block = ( {
-	showCompanyField = false,
-	requireCompanyField = false,
-	showApartmentField = false,
-	requireApartmentField = false,
-	showPhoneField = false,
-	requirePhoneField = false,
-}: {
-	showCompanyField: boolean;
-	requireCompanyField: boolean;
-	showApartmentField: boolean;
-	requireApartmentField: boolean;
-	showPhoneField: boolean;
-	requirePhoneField: boolean;
-} ): JSX.Element => {
-	const { billingAddress, setShippingAddress, useBillingAsShipping } =
-		useCheckoutAddress();
+const Block = (): JSX.Element => {
+	const {
+		defaultFields,
+		billingAddress,
+		setShippingAddress,
+		useBillingAsShipping,
+	} = useCheckoutAddress();
 	const { isEditor } = useEditorContext();
 
 	// Syncs shipping address with billing address if "Force shipping to the customer billing address" is enabled.
@@ -46,41 +36,17 @@ const Block = ( {
 				...addressValues,
 			};
 
-			if ( ! showPhoneField ) {
+			if ( ! defaultFields?.phone || defaultFields.phone.hidden ) {
 				delete syncValues.phone;
 			}
 
-			if ( showCompanyField ) {
+			if ( ! defaultFields?.company || defaultFields.company.hidden ) {
 				delete syncValues.company;
 			}
 
 			setShippingAddress( syncValues );
 		}
 	} );
-
-	const addressFieldsConfig = useMemo( () => {
-		return {
-			company: {
-				hidden: ! showCompanyField,
-				required: requireCompanyField,
-			},
-			address_2: {
-				hidden: ! showApartmentField,
-				required: requireApartmentField,
-			},
-			phone: {
-				hidden: ! showPhoneField,
-				required: requirePhoneField,
-			},
-		};
-	}, [
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-	] ) as FormFieldsConfig;
 
 	const WrapperComponent = isEditor ? Noninteractive : Fragment;
 	const noticeContext = useBillingAsShipping
@@ -98,11 +64,7 @@ const Block = ( {
 		<>
 			<StoreNoticesContainer context={ noticeContext } />
 			<WrapperComponent>
-				{ cartDataLoaded ? (
-					<CustomerAddress
-						addressFieldsConfig={ addressFieldsConfig }
-					/>
-				) : null }
+				{ cartDataLoaded ? <CustomerAddress /> : null }
 			</WrapperComponent>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -36,11 +36,11 @@ const Block = (): JSX.Element => {
 				...addressValues,
 			};
 
-			if ( ! defaultFields?.phone || defaultFields.phone.hidden ) {
+			if ( defaultFields?.phone?.hidden ) {
 				delete syncValues.phone;
 			}
 
-			if ( ! defaultFields?.company || defaultFields.company.hidden ) {
+			if ( defaultFields?.company?.hidden ) {
 				delete syncValues.company;
 			}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -4,10 +4,7 @@
 import { useCallback, useEffect } from '@wordpress/element';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
-import type {
-	AddressFormValues,
-	FormFieldsConfig,
-} from '@woocommerce/settings';
+import type { AddressFormValues } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
 import { ADDRESS_FORM_KEYS } from '@woocommerce/block-settings';
@@ -18,11 +15,7 @@ import { ADDRESS_FORM_KEYS } from '@woocommerce/block-settings';
 import AddressWrapper from '../../address-wrapper';
 import AddressCard from '../../address-card';
 
-const CustomerAddress = ( {
-	addressFieldsConfig,
-}: {
-	addressFieldsConfig: FormFieldsConfig;
-} ) => {
+const CustomerAddress = () => {
 	const {
 		billingAddress,
 		setShippingAddress,
@@ -81,11 +74,10 @@ const CustomerAddress = ( {
 				onEdit={ () => {
 					setEditing( true );
 				} }
-				fieldConfig={ addressFieldsConfig }
 				isExpanded={ editing }
 			/>
 		),
-		[ billingAddress, addressFieldsConfig, editing, setEditing ]
+		[ billingAddress, editing, setEditing ]
 	);
 
 	const renderAddressFormComponent = useCallback(
@@ -97,12 +89,11 @@ const CustomerAddress = ( {
 					onChange={ onChangeAddress }
 					values={ billingAddress }
 					fields={ ADDRESS_FORM_KEYS }
-					fieldConfig={ addressFieldsConfig }
 					isEditing={ editing }
 				/>
 			</>
 		),
-		[ addressFieldsConfig, billingAddress, onChangeAddress, editing ]
+		[ billingAddress, onChangeAddress, editing ]
 	);
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/edit.tsx
@@ -14,10 +14,7 @@ import {
 	AdditionalFields,
 	AdditionalFieldsContent,
 } from '../../form-step';
-import {
-	useCheckoutBlockContext,
-	useCheckoutBlockControlsContext,
-} from '../../context';
+import { useCheckoutBlockControlsContext } from '../../context';
 import Block from './block';
 import {
 	getBillingAddresssBlockTitle,
@@ -36,14 +33,6 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: BlockAttributes ) => void;
 } ): JSX.Element | null => {
-	const {
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-	} = useCheckoutBlockContext();
 	const { addressFieldControls: Controls } =
 		useCheckoutBlockControlsContext();
 	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
@@ -61,11 +50,6 @@ export const Edit = ( {
 		forcedBillingAddress
 	);
 
-	// This is needed to force the block to re-render when the requireApartmentField changes.
-	const blockKey = `billing-address-${
-		requireApartmentField ? 'visible' : 'hidden'
-	}-address-2`;
-
 	return (
 		<FormStepBlock
 			setAttributes={ setAttributes }
@@ -76,15 +60,7 @@ export const Edit = ( {
 			) }
 		>
 			<Controls />
-			<Block
-				key={ blockKey }
-				showCompanyField={ showCompanyField }
-				requireCompanyField={ requireCompanyField }
-				showApartmentField={ showApartmentField }
-				requireApartmentField={ requireApartmentField }
-				showPhoneField={ showPhoneField }
-				requirePhoneField={ requirePhoneField }
-			/>
+			<Block />
 			<AdditionalFields block={ innerBlockAreas.BILLING_ADDRESS } />
 		</FormStepBlock>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -34,14 +34,6 @@ const FrontendBlock = ( {
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
-	const {
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-	} = useCheckoutBlockContext();
 	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
 		useCheckoutAddress();
 
@@ -63,14 +55,7 @@ const FrontendBlock = ( {
 			description={ description }
 			showStepNumber={ showFormStepNumbers }
 		>
-			<Block
-				showCompanyField={ showCompanyField }
-				requireCompanyField={ requireCompanyField }
-				showApartmentField={ showApartmentField }
-				requireApartmentField={ requireApartmentField }
-				showPhoneField={ showPhoneField }
-				requirePhoneField={ requirePhoneField }
-			/>
+			<Block />
 			{ children }
 		</FormStep>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { useEffectOnce } from 'usehooks-ts';
 import {
 	useCheckoutAddress,
@@ -14,7 +14,7 @@ import {
 	CheckboxControl,
 } from '@woocommerce/blocks-components';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
-import type { BillingAddress, FormFieldsConfig } from '@woocommerce/settings';
+import type { BillingAddress } from '@woocommerce/settings';
 import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY } from '@woocommerce/block-data';
@@ -26,22 +26,9 @@ import type { CartResponseBillingAddress } from '@woocommerce/types';
  */
 import CustomerAddress from './customer-address';
 
-const Block = ( {
-	showCompanyField = false,
-	requireCompanyField = false,
-	showApartmentField = false,
-	requireApartmentField = false,
-	showPhoneField = false,
-	requirePhoneField = false,
-}: {
-	showCompanyField: boolean;
-	requireCompanyField: boolean;
-	showApartmentField: boolean;
-	requireApartmentField: boolean;
-	showPhoneField: boolean;
-	requirePhoneField: boolean;
-} ): JSX.Element => {
+const Block = (): JSX.Element => {
 	const {
+		defaultFields,
 		setBillingAddress,
 		shippingAddress,
 		billingAddress,
@@ -58,11 +45,11 @@ const Block = ( {
 			...shippingAddress,
 		};
 
-		if ( ! showPhoneField ) {
+		if ( ! defaultFields?.phone || defaultFields.phone.hidden ) {
 			delete syncValues.phone;
 		}
 
-		if ( showCompanyField ) {
+		if ( ! defaultFields?.company || defaultFields.company.hidden ) {
 			delete syncValues.company;
 		}
 
@@ -88,31 +75,6 @@ const Block = ( {
 		}
 	} );
 
-	// Create address fields config from block attributes.
-	const addressFieldsConfig = useMemo( () => {
-		return {
-			company: {
-				hidden: ! showCompanyField,
-				required: requireCompanyField,
-			},
-			address_2: {
-				hidden: ! showApartmentField,
-				required: requireApartmentField,
-			},
-			phone: {
-				hidden: ! showPhoneField,
-				required: requirePhoneField,
-			},
-		};
-	}, [
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-	] ) as FormFieldsConfig;
-
 	const WrapperComponent = isEditor ? Noninteractive : Fragment;
 	const noticeContext = useShippingAsBilling
 		? [ noticeContexts.SHIPPING_ADDRESS, noticeContexts.BILLING_ADDRESS ]
@@ -129,11 +91,7 @@ const Block = ( {
 		<>
 			<StoreNoticesContainer context={ noticeContext } />
 			<WrapperComponent>
-				{ cartDataLoaded ? (
-					<CustomerAddress
-						addressFieldsConfig={ addressFieldsConfig }
-					/>
-				) : null }
+				{ cartDataLoaded ? <CustomerAddress /> : null }
 			</WrapperComponent>
 			<CheckboxControl
 				className="wc-block-checkout__use-address-for-billing"

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -45,11 +45,11 @@ const Block = (): JSX.Element => {
 			...shippingAddress,
 		};
 
-		if ( ! defaultFields?.phone || defaultFields.phone.hidden ) {
+		if ( defaultFields?.phone?.hidden ) {
 			delete syncValues.phone;
 		}
 
-		if ( ! defaultFields?.company || defaultFields.company.hidden ) {
+		if ( defaultFields?.company?.hidden ) {
 			delete syncValues.company;
 		}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -4,10 +4,7 @@
 import { useCallback, useEffect } from '@wordpress/element';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
-import type {
-	FormFieldsConfig,
-	AddressFormValues,
-} from '@woocommerce/settings';
+import type { AddressFormValues } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
 import { ADDRESS_FORM_KEYS } from '@woocommerce/block-settings';

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -18,11 +18,7 @@ import { ADDRESS_FORM_KEYS } from '@woocommerce/block-settings';
 import AddressWrapper from '../../address-wrapper';
 import AddressCard from '../../address-card';
 
-const CustomerAddress = ( {
-	addressFieldsConfig,
-}: {
-	addressFieldsConfig: FormFieldsConfig;
-} ) => {
+const CustomerAddress = () => {
 	const {
 		shippingAddress,
 		setShippingAddress,
@@ -80,11 +76,10 @@ const CustomerAddress = ( {
 				onEdit={ () => {
 					setEditing( true );
 				} }
-				fieldConfig={ addressFieldsConfig }
 				isExpanded={ editing }
 			/>
 		),
-		[ shippingAddress, addressFieldsConfig, editing, setEditing ]
+		[ shippingAddress, editing, setEditing ]
 	);
 
 	const renderAddressFormComponent = useCallback(
@@ -95,11 +90,10 @@ const CustomerAddress = ( {
 				onChange={ onChangeAddress }
 				values={ shippingAddress }
 				fields={ ADDRESS_FORM_KEYS }
-				fieldConfig={ addressFieldsConfig }
 				isEditing={ editing }
 			/>
 		),
-		[ addressFieldsConfig, onChangeAddress, shippingAddress, editing ]
+		[ onChangeAddress, shippingAddress, editing ]
 	);
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
@@ -32,14 +32,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
-	const {
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-	} = useCheckoutBlockContext();
+	const { requireApartmentField } = useCheckoutBlockContext();
 	const { addressFieldControls: Controls } =
 		useCheckoutBlockControlsContext();
 	const { showShippingFields } = useCheckoutAddress();
@@ -63,15 +56,7 @@ export const Edit = ( {
 			) }
 		>
 			<Controls />
-			<Block
-				key={ blockKey }
-				showCompanyField={ showCompanyField }
-				requireCompanyField={ requireCompanyField }
-				showApartmentField={ showApartmentField }
-				requireApartmentField={ requireApartmentField }
-				showPhoneField={ showPhoneField }
-				requirePhoneField={ requirePhoneField }
-			/>
+			<Block key={ blockKey } />
 			<AdditionalFields block={ innerBlockAreas.SHIPPING_ADDRESS } />
 		</FormStepBlock>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
@@ -14,10 +14,7 @@ import {
 	AdditionalFields,
 	AdditionalFieldsContent,
 } from '../../form-step';
-import {
-	useCheckoutBlockContext,
-	useCheckoutBlockControlsContext,
-} from '../../context';
+import { useCheckoutBlockControlsContext } from '../../context';
 import Block from './block';
 
 export const Edit = ( {
@@ -32,7 +29,6 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
-	const { requireApartmentField } = useCheckoutBlockContext();
 	const { addressFieldControls: Controls } =
 		useCheckoutBlockControlsContext();
 	const { showShippingFields } = useCheckoutAddress();
@@ -40,11 +36,6 @@ export const Edit = ( {
 	if ( ! showShippingFields ) {
 		return null;
 	}
-
-	// This is needed to force the block to re-render when the requireApartmentField changes.
-	const blockKey = `shipping-address-${
-		requireApartmentField ? 'visible' : 'hidden'
-	}-address-2`;
 
 	return (
 		<FormStepBlock
@@ -56,7 +47,7 @@ export const Edit = ( {
 			) }
 		>
 			<Controls />
-			<Block key={ blockKey } />
+			<Block />
 			<AdditionalFields block={ innerBlockAreas.SHIPPING_ADDRESS } />
 		</FormStepBlock>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
@@ -29,15 +29,7 @@ const FrontendBlock = ( {
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
 	const { showShippingFields } = useCheckoutAddress();
-	const {
-		showCompanyField,
-		requireCompanyField,
-		showApartmentField,
-		requireApartmentField,
-		showPhoneField,
-		requirePhoneField,
-		showFormStepNumbers,
-	} = useCheckoutBlockContext();
+	const { showFormStepNumbers } = useCheckoutBlockContext();
 
 	if ( ! showShippingFields ) {
 		return null;
@@ -55,14 +47,7 @@ const FrontendBlock = ( {
 			description={ description }
 			showStepNumber={ showFormStepNumbers }
 		>
-			<Block
-				showCompanyField={ showCompanyField }
-				requireCompanyField={ requireCompanyField }
-				showApartmentField={ showApartmentField }
-				requireApartmentField={ requireApartmentField }
-				showPhoneField={ showPhoneField }
-				requirePhoneField={ requirePhoneField }
-			/>
+			<Block />
 			{ children }
 		</FormStep>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -23,12 +23,6 @@ const FrontendBlock = ( {
 }: {
 	title: string;
 	description: string;
-	showCompanyField: boolean;
-	requireCompanyField: boolean;
-	showApartmentField: boolean;
-	requireApartmentField: boolean;
-	showPhoneField: boolean;
-	requirePhoneField: boolean;
 	children: JSX.Element;
 	className?: string;
 } ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/types.ts
@@ -6,12 +6,6 @@ export type InnerBlockTemplate = [
 
 export interface Attributes extends Record< string, boolean | number > {
 	hasDarkControls: boolean;
-	showCompanyField: boolean;
-	requireCompanyField: boolean;
-	showApartmentField: boolean;
-	requireApartmentField: boolean;
-	showPhoneField: boolean;
-	requirePhoneField: boolean;
 	showFormStepNumbers: boolean;
 	// Deprecated.
 	showOrderNotes: boolean;
@@ -19,4 +13,10 @@ export interface Attributes extends Record< string, boolean | number > {
 	showReturnToCart: boolean;
 	showRateAfterTaxName: boolean;
 	cartPageId: number;
+	showCompanyField: boolean;
+	requireCompanyField: boolean;
+	showApartmentField: boolean;
+	requireApartmentField: boolean;
+	showPhoneField: boolean;
+	requirePhoneField: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/shared/default-fields.ts
@@ -107,9 +107,7 @@ export type KeyedFormField = FormField & {
 	errorMessage?: string;
 };
 
-export type CountryAddressForm = Record< string, FormFields >;
-
-export type FormFieldsConfig = Record< keyof FormFields, Partial< FormField > >;
+export type CountryAddressFields = Record< string, FormFields >;
 
 /**
  * Default field properties.

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -539,10 +539,6 @@ test.describe( 'Merchant → Checkout', () => {
 					}
 				);
 
-				const billingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-address_2-field >> text="Optional"'
-				);
-
 				const billingApartmentRequiredToggle = editor.page.locator(
 					'.wc-block-components-require-address_2-field >> text="Required"'
 				);

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -377,6 +377,9 @@ test.describe( 'Merchant → Checkout', () => {
 
 				// Verify that the company field is required.
 				await expect( shippingCompanyRequiredToggle ).toBeChecked();
+				await expect( shippingCompanyInput ).toHaveAttribute(
+					'required'
+				);
 
 				// Disable the company field.
 				await shippingCompanyToggle.uncheck();
@@ -420,21 +423,19 @@ test.describe( 'Merchant → Checkout', () => {
 				// Enable the company field.
 				await billingCompanyToggle.check();
 
-				// Verify that the company field is visible.
+				// Verify that the company field is visible and the field is optional.
 				await expect( billingCompanyInput ).toBeVisible();
-
-				// Verify that the company field is currently required.
-				await expect( billingCompanyRequiredToggle ).toBeChecked();
-				await expect( billingCompanyInput ).toHaveAttribute(
+				await expect( billingCompanyOptionalToggle ).toBeChecked();
+				await expect( billingCompanyInput ).not.toHaveAttribute(
 					'required'
 				);
 
-				// Make the company field optional.
-				await billingCompanyOptionalToggle.check();
+				// Make the company field required.
+				await billingCompanyRequiredToggle.check();
 
-				// Verify that the company field is optional.
-				await expect( billingCompanyOptionalToggle ).toBeChecked();
-				await expect( billingCompanyInput ).not.toHaveAttribute(
+				// Verify that the company field is required.
+				await expect( billingCompanyRequiredToggle ).toBeChecked();
+				await expect( billingCompanyInput ).toHaveAttribute(
 					'required'
 				);
 
@@ -476,11 +477,11 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const shippingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Optional"'
+					'.wc-block-components-require-address_2-field >> text="Optional"'
 				);
 
 				const shippingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Required"'
+					'.wc-block-components-require-address_2-field >> text="Required"'
 				);
 
 				// Verify that the apartment link is visible by default.
@@ -539,11 +540,11 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const billingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Optional"'
+					'.wc-block-components-require-address_2-field >> text="Optional"'
 				);
 
 				const billingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Required"'
+					'.wc-block-components-require-address_2-field >> text="Required"'
 				);
 
 				// Enable the apartment field.
@@ -662,21 +663,19 @@ test.describe( 'Merchant → Checkout', () => {
 				// Enable the phone field.
 				await billingPhoneToggle.check();
 
-				// Verify that the phone field is visible.
+				// Verify that the phone field is visible by default and the field is optional.
 				await expect( billingPhoneInput ).toBeVisible();
-
-				// Verify that the phone field is currently required.
-				await expect( billingPhoneRequiredToggle ).toBeChecked();
-				await expect( billingPhoneInput ).toHaveAttribute( 'required' );
-
-				// Make the phone field optional.
-				await billingPhoneOptionalToggle.check();
-
-				// Verify that the phone field is optional.
 				await expect( billingPhoneOptionalToggle ).toBeChecked();
 				await expect( billingPhoneInput ).not.toHaveAttribute(
 					'required'
 				);
+
+				// Make the phone number required.
+				await billingPhoneRequiredToggle.check();
+
+				// Verify that the phone field is required.
+				await expect( billingPhoneRequiredToggle ).toBeChecked();
+				await expect( billingPhoneInput ).toHaveAttribute( 'required' );
 
 				// Disable the phone field.
 				await billingPhoneToggle.uncheck();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -550,27 +550,29 @@ test.describe( 'Merchant → Checkout', () => {
 				// Enable the apartment field.
 				await billingApartmentToggle.check();
 
-				// Verify that the apartment link is hidden.
-				await expect( billingApartmentLink ).toBeHidden();
-
-				// Verify that the apartment field is visible.
-				await expect( billingApartmentInput ).toBeVisible();
-
-				// Verify that the apartment field is currently required.
-				await expect( billingApartmentRequiredToggle ).toBeChecked();
-				await expect( billingApartmentInput ).toHaveAttribute(
-					'required'
-				);
-
-				// Make the apartment field optional.
-				await billingApartmentOptionalToggle.check();
-
 				// Verify that the apartment link is visible.
 				await expect( billingApartmentLink ).toBeVisible();
 
-				// Verify that the apartment field is hidden and optional.
+				// Verify that the apartment field is hidden.
 				await expect( billingApartmentInput ).not.toBeInViewport();
-				await expect( billingApartmentOptionalToggle ).toBeChecked();
+
+				// Verify that the apartment field is currently not required.
+				await expect(
+					billingApartmentRequiredToggle
+				).not.toBeChecked();
+				await expect( billingApartmentInput ).not.toHaveAttribute(
+					'required'
+				);
+
+				// Make the apartment field required.
+				await billingApartmentRequiredToggle.check();
+
+				// Verify that the apartment link is hidden.
+				await expect( billingApartmentLink ).toBeHidden();
+
+				// Verify that the apartment field is required.
+				await expect( billingApartmentInput ).toBeInViewport();
+				await expect( billingApartmentRequiredToggle ).toBeChecked();
 
 				// Disable the apartment field.
 				await billingApartmentToggle.uncheck();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -476,11 +476,11 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const shippingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Optional"'
+					'.wc-block-components-require-address_2-field >> text="Optional"'
 				);
 
 				const shippingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Required"'
+					'.wc-block-components-require-address_2-field >> text="Required"'
 				);
 
 				// Verify that the apartment link is visible by default.
@@ -539,11 +539,11 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const billingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Optional"'
+					'.wc-block-components-require-address_2-field >> text="Optional"'
 				);
 
 				const billingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-apartment-field >> text="Required"'
+					'.wc-block-components-require-address_2-field >> text="Required"'
 				);
 
 				// Enable the apartment field.

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -567,7 +567,7 @@ test.describe( 'Merchant → Checkout', () => {
 				await expect( billingApartmentLink ).toBeHidden();
 
 				// Verify that the apartment field is required.
-				await expect( billingApartmentInput ).toBeInViewport();
+				await expect( billingApartmentInput ).toBeVisible();
 				await expect( billingApartmentRequiredToggle ).toBeChecked();
 
 				// Disable the apartment field.

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -377,9 +377,6 @@ test.describe( 'Merchant → Checkout', () => {
 
 				// Verify that the company field is required.
 				await expect( shippingCompanyRequiredToggle ).toBeChecked();
-				await expect( shippingCompanyInput ).toHaveAttribute(
-					'required'
-				);
 
 				// Disable the company field.
 				await shippingCompanyToggle.uncheck();
@@ -423,19 +420,21 @@ test.describe( 'Merchant → Checkout', () => {
 				// Enable the company field.
 				await billingCompanyToggle.check();
 
-				// Verify that the company field is visible and the field is optional.
+				// Verify that the company field is visible.
 				await expect( billingCompanyInput ).toBeVisible();
-				await expect( billingCompanyOptionalToggle ).toBeChecked();
-				await expect( billingCompanyInput ).not.toHaveAttribute(
+
+				// Verify that the company field is currently required.
+				await expect( billingCompanyRequiredToggle ).toBeChecked();
+				await expect( billingCompanyInput ).toHaveAttribute(
 					'required'
 				);
 
-				// Make the company field required.
-				await billingCompanyRequiredToggle.check();
+				// Make the company field optional.
+				await billingCompanyOptionalToggle.check();
 
-				// Verify that the company field is required.
-				await expect( billingCompanyRequiredToggle ).toBeChecked();
-				await expect( billingCompanyInput ).toHaveAttribute(
+				// Verify that the company field is optional.
+				await expect( billingCompanyOptionalToggle ).toBeChecked();
+				await expect( billingCompanyInput ).not.toHaveAttribute(
 					'required'
 				);
 
@@ -477,11 +476,11 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const shippingApartmentOptionalToggle = editor.page.locator(
-					'.wc-block-components-require-address_2-field >> text="Optional"'
+					'.wc-block-components-require-apartment-field >> text="Optional"'
 				);
 
 				const shippingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-address_2-field >> text="Required"'
+					'.wc-block-components-require-apartment-field >> text="Required"'
 				);
 
 				// Verify that the apartment link is visible by default.
@@ -539,36 +538,38 @@ test.describe( 'Merchant → Checkout', () => {
 					}
 				);
 
+				const billingApartmentOptionalToggle = editor.page.locator(
+					'.wc-block-components-require-apartment-field >> text="Optional"'
+				);
+
 				const billingApartmentRequiredToggle = editor.page.locator(
-					'.wc-block-components-require-address_2-field >> text="Required"'
+					'.wc-block-components-require-apartment-field >> text="Required"'
 				);
 
 				// Enable the apartment field.
 				await billingApartmentToggle.check();
 
-				// Verify that the apartment link is visible.
-				await expect( billingApartmentLink ).toBeVisible();
-
-				// Verify that the apartment field is hidden.
-				await expect( billingApartmentInput ).not.toBeInViewport();
-
-				// Verify that the apartment field is currently not required.
-				await expect(
-					billingApartmentRequiredToggle
-				).not.toBeChecked();
-				await expect( billingApartmentInput ).not.toHaveAttribute(
-					'required'
-				);
-
-				// Make the apartment field required.
-				await billingApartmentRequiredToggle.check();
-
 				// Verify that the apartment link is hidden.
 				await expect( billingApartmentLink ).toBeHidden();
 
-				// Verify that the apartment field is required.
+				// Verify that the apartment field is visible.
 				await expect( billingApartmentInput ).toBeVisible();
+
+				// Verify that the apartment field is currently required.
 				await expect( billingApartmentRequiredToggle ).toBeChecked();
+				await expect( billingApartmentInput ).toHaveAttribute(
+					'required'
+				);
+
+				// Make the apartment field optional.
+				await billingApartmentOptionalToggle.check();
+
+				// Verify that the apartment link is visible.
+				await expect( billingApartmentLink ).toBeVisible();
+
+				// Verify that the apartment field is hidden and optional.
+				await expect( billingApartmentInput ).not.toBeInViewport();
+				await expect( billingApartmentOptionalToggle ).toBeChecked();
 
 				// Disable the apartment field.
 				await billingApartmentToggle.uncheck();
@@ -661,19 +662,21 @@ test.describe( 'Merchant → Checkout', () => {
 				// Enable the phone field.
 				await billingPhoneToggle.check();
 
-				// Verify that the phone field is visible by default and the field is optional.
+				// Verify that the phone field is visible.
 				await expect( billingPhoneInput ).toBeVisible();
+
+				// Verify that the phone field is currently required.
+				await expect( billingPhoneRequiredToggle ).toBeChecked();
+				await expect( billingPhoneInput ).toHaveAttribute( 'required' );
+
+				// Make the phone field optional.
+				await billingPhoneOptionalToggle.check();
+
+				// Verify that the phone field is optional.
 				await expect( billingPhoneOptionalToggle ).toBeChecked();
 				await expect( billingPhoneInput ).not.toHaveAttribute(
 					'required'
 				);
-
-				// Make the phone number required.
-				await billingPhoneRequiredToggle.check();
-
-				// Verify that the phone field is required.
-				await expect( billingPhoneRequiredToggle ).toBeChecked();
-				await expect( billingPhoneInput ).toHaveAttribute( 'required' );
 
 				// Disable the phone field.
 				await billingPhoneToggle.uncheck();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -458,7 +458,7 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const shippingApartmentInput =
-					shippingAddressBlock.getByLabel( 'Apartment' );
+					shippingAddressBlock.getByLabel( 'Address Line 2' );
 
 				const shippingApartmentLink = shippingAddressBlock.getByRole(
 					'button',
@@ -521,7 +521,7 @@ test.describe( 'Merchant → Checkout', () => {
 				);
 
 				const billingApartmentInput =
-					billingAddressBlock.getByLabel( 'Apartment' );
+					billingAddressBlock.getByLabel( 'Address Line 2' );
 
 				const billingApartmentLink = billingAddressBlock.getByRole(
 					'button',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -521,8 +521,9 @@ test.describe( 'Merchant → Checkout', () => {
 					'woocommerce/checkout-billing-address-block'
 				);
 
-				const billingApartmentInput =
-					billingAddressBlock.getByLabel( 'Address Line 2' );
+				const billingApartmentInput = billingAddressBlock.getByLabel(
+					'Apartment, suite, etc.'
+				);
 
 				const billingApartmentLink = billingAddressBlock.getByRole(
 					'button',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -457,8 +457,9 @@ test.describe( 'Merchant → Checkout', () => {
 					'woocommerce/checkout-shipping-address-block'
 				);
 
-				const shippingApartmentInput =
-					shippingAddressBlock.getByLabel( 'Address Line 2' );
+				const shippingApartmentInput = shippingAddressBlock.getByLabel(
+					'Apartment, suite, etc.'
+				);
 
 				const shippingApartmentLink = shippingAddressBlock.getByRole(
 					'button',

--- a/plugins/woocommerce/changelog/add-checkout-field-entities-42773
+++ b/plugins/woocommerce/changelog/add-checkout-field-entities-42773
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Checkout fields (phone, compaony, address_2) that can be toggled on and off now sync across all blocks globally.

--- a/plugins/woocommerce/changelog/add-checkout-field-entities-42773
+++ b/plugins/woocommerce/changelog/add-checkout-field-entities-42773
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Checkout fields (phone, compaony, address_2) that can be toggled on and off now sync across all blocks globally.
+Checkout fields (phone, company, address_2) that can be toggled on and off now sync across all blocks globally.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -8,6 +8,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+
 /**
  * The WooCommerce countries class stores country/state data.
  */
@@ -721,6 +723,33 @@ class WC_Countries {
 	}
 
 	/**
+	 * Get the default visibility for the address_2 field.
+	 *
+	 * @return string
+	 */
+	public function get_company_field_visibility() {
+		return get_option( 'woocommerce_checkout_company_field', CartCheckoutUtils::is_checkout_block_default() ? 'hidden' : 'optional' );
+	}
+
+	/**
+	 * Get the default visibility for the address_2 field.
+	 *
+	 * @return string
+	 */
+	public function get_address_2_field_visibility() {
+		return get_option( 'woocommerce_checkout_address_2_field', 'optional' );
+	}
+
+	/**
+	 * Get the default visibility for the address_2 field.
+	 *
+	 * @return string
+	 */
+	public function get_phone_field_visibility() {
+		return get_option( 'woocommerce_checkout_phone_field', CartCheckoutUtils::is_checkout_block_default() ? 'optional' : 'required' );
+	}
+
+	/**
 	 * Returns the fields we show by default. This can be filtered later on.
 	 *
 	 * @return array
@@ -730,7 +759,7 @@ class WC_Countries {
 
 		// If necessary, append '(optional)' to the placeholder: we don't need to worry about the
 		// label, though, as woocommerce_form_field() takes care of that.
-		if ( 'optional' === get_option( 'woocommerce_checkout_address_2_field', 'optional' ) ) {
+		if ( 'optional' === $this->get_address_2_field_visibility() ) {
 			$address_2_placeholder = __( 'Apartment, suite, unit, etc. (optional)', 'woocommerce' );
 		} else {
 			$address_2_placeholder = $address_2_label;
@@ -756,7 +785,7 @@ class WC_Countries {
 				'class'        => array( 'form-row-wide' ),
 				'autocomplete' => 'organization',
 				'priority'     => 30,
-				'required'     => 'required' === get_option( 'woocommerce_checkout_company_field', 'optional' ),
+				'required'     => 'required' === $this->get_company_field_visibility(),
 			),
 			'country'    => array(
 				'type'         => 'country',
@@ -782,7 +811,7 @@ class WC_Countries {
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line2',
 				'priority'     => 60,
-				'required'     => 'required' === get_option( 'woocommerce_checkout_address_2_field', 'optional' ),
+				'required'     => 'required' === $this->get_address_2_field_visibility(),
 			),
 			'city'       => array(
 				'label'        => __( 'Town / City', 'woocommerce' ),
@@ -810,11 +839,11 @@ class WC_Countries {
 			),
 		);
 
-		if ( 'hidden' === get_option( 'woocommerce_checkout_company_field', 'optional' ) ) {
+		if ( 'hidden' === $this->get_company_field_visibility() ) {
 			unset( $fields['company'] );
 		}
 
-		if ( 'hidden' === get_option( 'woocommerce_checkout_address_2_field', 'optional' ) ) {
+		if ( 'hidden' === $this->get_address_2_field_visibility() ) {
 			unset( $fields['address_2'] );
 		}
 
@@ -1696,10 +1725,10 @@ class WC_Countries {
 
 		// Add email and phone fields.
 		if ( 'billing_' === $type ) {
-			if ( 'hidden' !== get_option( 'woocommerce_checkout_phone_field', 'required' ) ) {
+			if ( 'hidden' !== $this->get_phone_field_visibility() ) {
 				$address_fields['billing_phone'] = array(
 					'label'        => __( 'Phone', 'woocommerce' ),
-					'required'     => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
+					'required'     => 'required' === $this->get_phone_field_visibility(),
 					'type'         => 'tel',
 					'class'        => array( 'form-row-wide' ),
 					'validate'     => array( 'phone' ),

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -723,33 +723,6 @@ class WC_Countries {
 	}
 
 	/**
-	 * Get the default visibility for the address_2 field.
-	 *
-	 * @return string
-	 */
-	public function get_company_field_visibility() {
-		return get_option( 'woocommerce_checkout_company_field', CartCheckoutUtils::is_checkout_block_default() ? 'hidden' : 'optional' );
-	}
-
-	/**
-	 * Get the default visibility for the address_2 field.
-	 *
-	 * @return string
-	 */
-	public function get_address_2_field_visibility() {
-		return get_option( 'woocommerce_checkout_address_2_field', 'optional' );
-	}
-
-	/**
-	 * Get the default visibility for the address_2 field.
-	 *
-	 * @return string
-	 */
-	public function get_phone_field_visibility() {
-		return get_option( 'woocommerce_checkout_phone_field', CartCheckoutUtils::is_checkout_block_default() ? 'optional' : 'required' );
-	}
-
-	/**
 	 * Returns the fields we show by default. This can be filtered later on.
 	 *
 	 * @return array
@@ -759,7 +732,7 @@ class WC_Countries {
 
 		// If necessary, append '(optional)' to the placeholder: we don't need to worry about the
 		// label, though, as woocommerce_form_field() takes care of that.
-		if ( 'optional' === $this->get_address_2_field_visibility() ) {
+		if ( 'optional' === CartCheckoutUtils::get_address_2_field_visibility() ) {
 			$address_2_placeholder = __( 'Apartment, suite, unit, etc. (optional)', 'woocommerce' );
 		} else {
 			$address_2_placeholder = $address_2_label;
@@ -785,7 +758,7 @@ class WC_Countries {
 				'class'        => array( 'form-row-wide' ),
 				'autocomplete' => 'organization',
 				'priority'     => 30,
-				'required'     => 'required' === $this->get_company_field_visibility(),
+				'required'     => 'required' === CartCheckoutUtils::get_company_field_visibility(),
 			),
 			'country'    => array(
 				'type'         => 'country',
@@ -811,7 +784,7 @@ class WC_Countries {
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line2',
 				'priority'     => 60,
-				'required'     => 'required' === $this->get_address_2_field_visibility(),
+				'required'     => 'required' === CartCheckoutUtils::get_address_2_field_visibility(),
 			),
 			'city'       => array(
 				'label'        => __( 'Town / City', 'woocommerce' ),
@@ -839,11 +812,11 @@ class WC_Countries {
 			),
 		);
 
-		if ( 'hidden' === $this->get_company_field_visibility() ) {
+		if ( 'hidden' === CartCheckoutUtils::get_company_field_visibility() ) {
 			unset( $fields['company'] );
 		}
 
-		if ( 'hidden' === $this->get_address_2_field_visibility() ) {
+		if ( 'hidden' === CartCheckoutUtils::get_address_2_field_visibility() ) {
 			unset( $fields['address_2'] );
 		}
 
@@ -1725,10 +1698,10 @@ class WC_Countries {
 
 		// Add email and phone fields.
 		if ( 'billing_' === $type ) {
-			if ( 'hidden' !== $this->get_phone_field_visibility() ) {
+			if ( 'hidden' !== CartCheckoutUtils::get_phone_field_visibility() ) {
 				$address_fields['billing_phone'] = array(
 					'label'        => __( 'Phone', 'woocommerce' ),
-					'required'     => 'required' === $this->get_phone_field_visibility(),
+					'required'     => 'required' === CartCheckoutUtils::get_phone_field_visibility(),
 					'type'         => 'tel',
 					'class'        => array( 'form-row-wide' ),
 					'validate'     => array( 'phone' ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -32,6 +32,7 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
+		add_action( 'rest_api_init', array( $this, 'register_settings' ) );
 		add_action( 'wp_loaded', array( $this, 'register_patterns' ) );
 		// This prevents the page redirecting when the cart is empty. This is so the editor still loads the page preview.
 		add_filter(
@@ -55,6 +56,63 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_script( 'wc-password-strength-meter' );
 		wp_dequeue_script( 'selectWoo' );
 		wp_dequeue_style( 'select2' );
+	}
+
+	/**
+	 * Exposes settings exposed by the checkout block.
+	 */
+	public function register_settings() {
+		register_setting(
+			'options',
+			'woocommerce_checkout_phone_field',
+			array(
+				'type'         => 'object',
+				'description'  => __( 'Controls the display of the phone field in checkout.', 'woocommerce' ),
+				'label'        => __( 'Phone number', 'woocommerce' ),
+				'show_in_rest' => array(
+					'name'   => 'woocommerce_checkout_phone_field',
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( 'optional', 'required', 'hidden' ),
+					),
+				),
+				'default'      => get_option( 'woocommerce_checkout_phone_field', 'optional' ),
+			)
+		);
+		register_setting(
+			'options',
+			'woocommerce_checkout_company_field',
+			array(
+				'type'         => 'object',
+				'description'  => __( 'Controls the display of the company field in checkout.', 'woocommerce' ),
+				'label'        => __( 'Company', 'woocommerce' ),
+				'show_in_rest' => array(
+					'name'   => 'woocommerce_checkout_company_field',
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( 'optional', 'required', 'hidden' ),
+					),
+				),
+				'default'      => get_option( 'woocommerce_checkout_company_field', 'optional' ),
+			)
+		);
+		register_setting(
+			'options',
+			'woocommerce_checkout_apartment_field',
+			array(
+				'type'         => 'object',
+				'description'  => __( 'Controls the display of the apartment field in checkout.', 'woocommerce' ),
+				'label'        => __( 'Apartment', 'woocommerce' ),
+				'show_in_rest' => array(
+					'name'   => 'woocommerce_checkout_apartment_field',
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( 'optional', 'required', 'hidden' ),
+					),
+				),
+				'default'      => get_option( 'woocommerce_checkout_apartment_field', 'optional' ),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -76,7 +76,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => get_option( 'woocommerce_checkout_phone_field', 'required' ),
+				'default'      => WC()->countries->get_phone_field_visibility(),
 			)
 		);
 		register_setting(
@@ -93,7 +93,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => get_option( 'woocommerce_checkout_company_field', 'optional' ),
+				'default'      => WC()->countries->get_company_field_visibility(),
 			)
 		);
 		register_setting(
@@ -110,7 +110,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => get_option( 'woocommerce_checkout_address_2_field', 'optional' ),
+				'default'      => WC()->countries->get_address_2_field_visibility(),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -76,7 +76,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => WC()->countries->get_phone_field_visibility(),
+				'default'      => CartCheckoutUtils::get_phone_field_visibility(),
 			)
 		);
 		register_setting(
@@ -93,7 +93,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => WC()->countries->get_company_field_visibility(),
+				'default'      => CartCheckoutUtils::get_company_field_visibility(),
 			)
 		);
 		register_setting(
@@ -110,7 +110,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => WC()->countries->get_address_2_field_visibility(),
+				'default'      => CartCheckoutUtils::get_address_2_field_visibility(),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -76,7 +76,7 @@ class Checkout extends AbstractBlock {
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => get_option( 'woocommerce_checkout_phone_field', 'optional' ),
+				'default'      => get_option( 'woocommerce_checkout_phone_field', 'required' ),
 			)
 		);
 		register_setting(
@@ -98,19 +98,19 @@ class Checkout extends AbstractBlock {
 		);
 		register_setting(
 			'options',
-			'woocommerce_checkout_apartment_field',
+			'woocommerce_checkout_address_2_field',
 			array(
 				'type'         => 'object',
-				'description'  => __( 'Controls the display of the apartment field in checkout.', 'woocommerce' ),
+				'description'  => __( 'Controls the display of the apartment (address_2) field in checkout.', 'woocommerce' ),
 				'label'        => __( 'Apartment', 'woocommerce' ),
 				'show_in_rest' => array(
-					'name'   => 'woocommerce_checkout_apartment_field',
+					'name'   => 'woocommerce_checkout_address_2_field',
 					'schema' => array(
 						'type' => 'string',
 						'enum' => array( 'optional', 'required', 'hidden' ),
 					),
 				),
-				'default'      => get_option( 'woocommerce_checkout_apartment_field', 'optional' ),
+				'default'      => get_option( 'woocommerce_checkout_address_2_field', 'optional' ),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -102,7 +102,7 @@ class Checkout extends AbstractBlock {
 			array(
 				'type'         => 'object',
 				'description'  => __( 'Controls the display of the apartment (address_2) field in checkout.', 'woocommerce' ),
-				'label'        => __( 'Apartment', 'woocommerce' ),
+				'label'        => __( 'Address Line 2', 'woocommerce' ),
 				'show_in_rest' => array(
 					'name'   => 'woocommerce_checkout_address_2_field',
 					'schema' => array(

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -497,7 +497,7 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	public function get_core_fields() {
-		return [
+		$fields = [
 			'email'      => [
 				'label'          => __( 'Email address', 'woocommerce' ),
 				'optionalLabel'  => __(
@@ -632,6 +632,16 @@ class CheckoutFields {
 				'index'          => 100,
 			],
 		];
+
+		$fields_with_config = [ 'phone', 'company', 'address_2' ];
+
+		foreach ( $fields_with_config as $field_key ) {
+			$field_config                     = get_option( 'woocommerce_checkout_' . $field_key . '_field', 'optional' );
+			$fields[ $field_key ]['required'] = 'required' === $field_config;
+			$fields[ $field_key ]['hidden']   = 'hidden' === $field_config;
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use WC_Customer;
 use WC_Data;
@@ -552,8 +553,8 @@ class CheckoutFields {
 					'Company (optional)',
 					'woocommerce'
 				),
-				'required'       => 'required' === WC()->countries->get_company_field_visibility(),
-				'hidden'         => 'hidden' === WC()->countries->get_company_field_visibility(),
+				'required'       => 'required' === CartCheckoutUtils::get_company_field_visibility(),
+				'hidden'         => 'hidden' === CartCheckoutUtils::get_company_field_visibility(),
 				'autocomplete'   => 'organization',
 				'autocapitalize' => 'sentences',
 				'index'          => 30,
@@ -576,8 +577,8 @@ class CheckoutFields {
 					'Apartment, suite, etc. (optional)',
 					'woocommerce'
 				),
-				'required'       => 'required' === WC()->countries->get_address_2_field_visibility(),
-				'hidden'         => 'hidden' === WC()->countries->get_address_2_field_visibility(),
+				'required'       => 'required' === CartCheckoutUtils::get_address_2_field_visibility(),
+				'hidden'         => 'hidden' === CartCheckoutUtils::get_address_2_field_visibility(),
 				'autocomplete'   => 'address-line2',
 				'autocapitalize' => 'sentences',
 				'index'          => 50,
@@ -624,8 +625,8 @@ class CheckoutFields {
 					'Phone (optional)',
 					'woocommerce'
 				),
-				'required'       => 'required' === WC()->countries->get_phone_field_visibility(),
-				'hidden'         => 'hidden' === WC()->countries->get_phone_field_visibility(),
+				'required'       => 'required' === CartCheckoutUtils::get_phone_field_visibility(),
+				'hidden'         => 'hidden' === CartCheckoutUtils::get_phone_field_visibility(),
 				'type'           => 'tel',
 				'autocomplete'   => 'tel',
 				'autocapitalize' => 'characters',

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -497,7 +497,7 @@ class CheckoutFields {
 	 * @return array An array of fields.
 	 */
 	public function get_core_fields() {
-		$fields = [
+		return [
 			'email'      => [
 				'label'          => __( 'Email address', 'woocommerce' ),
 				'optionalLabel'  => __(
@@ -552,8 +552,8 @@ class CheckoutFields {
 					'Company (optional)',
 					'woocommerce'
 				),
-				'required'       => false,
-				'hidden'         => false,
+				'required'       => 'required' === WC()->countries->get_company_field_visibility(),
+				'hidden'         => 'hidden' === WC()->countries->get_company_field_visibility(),
 				'autocomplete'   => 'organization',
 				'autocapitalize' => 'sentences',
 				'index'          => 30,
@@ -576,8 +576,8 @@ class CheckoutFields {
 					'Apartment, suite, etc. (optional)',
 					'woocommerce'
 				),
-				'required'       => false,
-				'hidden'         => false,
+				'required'       => 'required' === WC()->countries->get_address_2_field_visibility(),
+				'hidden'         => 'hidden' === WC()->countries->get_address_2_field_visibility(),
 				'autocomplete'   => 'address-line2',
 				'autocapitalize' => 'sentences',
 				'index'          => 50,
@@ -624,24 +624,14 @@ class CheckoutFields {
 					'Phone (optional)',
 					'woocommerce'
 				),
-				'required'       => false,
-				'hidden'         => false,
+				'required'       => 'required' === WC()->countries->get_phone_field_visibility(),
+				'hidden'         => 'hidden' === WC()->countries->get_phone_field_visibility(),
 				'type'           => 'tel',
 				'autocomplete'   => 'tel',
 				'autocapitalize' => 'characters',
 				'index'          => 100,
 			],
 		];
-
-		$fields_with_config = [ 'phone', 'company', 'address_2' ];
-
-		foreach ( $fields_with_config as $field_key ) {
-			$field_config                     = get_option( 'woocommerce_checkout_' . $field_key . '_field', 'optional' );
-			$fields[ $field_key ]['required'] = 'required' === $field_config;
-			$fields[ $field_key ]['hidden']   = 'hidden' === $field_config;
-		}
-
-		return $fields;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
 namespace Automattic\WooCommerce\Blocks\Utils;
 
 /**
@@ -44,6 +44,112 @@ class CartCheckoutUtils {
 		return $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
 	}
 
+	/**
+	 * Migrate checkout block field visibility attributes to settings.
+	 */
+	protected static function migrate_checkout_block_field_visibility_attributes() {
+		// Before migrating attributes, migrate the "default" options checkout block uses into the settings.
+		update_option( 'woocommerce_checkout_phone_field', 'optional' );
+		update_option( 'woocommerce_checkout_company_field', 'hidden' );
+		update_option( 'woocommerce_checkout_address_2_field', 'optional' );
+
+		// Parse the block from the checkout page.
+		$checkout_blocks = \WC_Blocks_Utils::get_blocks_from_page( 'woocommerce/checkout', 'checkout' );
+
+		if ( empty( $checkout_blocks ) ) {
+			return;
+		}
+
+		$checkout_block = $checkout_blocks[0];
+
+		if ( ! isset( $checkout_block['attrs'] ) ) {
+			return;
+		}
+
+		if ( isset( $checkout_block['attrs']['showPhoneField'], $checkout_block['attrs']['requirePhoneField'] ) ) {
+			if ( $checkout_block['attrs']['showPhoneField'] ) {
+				update_option( 'woocommerce_checkout_phone_field', $checkout_block['attrs']['requirePhoneField'] ? 'required' : 'optional' );
+			} else {
+				update_option( 'woocommerce_checkout_phone_field', 'hidden' );
+			}
+		}
+
+		if ( isset( $checkout_block['attrs']['showCompanyField'], $checkout_block['attrs']['requireCompanyField'] ) ) {
+			if ( $checkout_block['attrs']['showCompanyField'] ) {
+				update_option( 'woocommerce_checkout_company_field', $checkout_block['attrs']['requireCompanyField'] ? 'required' : 'optional' );
+			} else {
+				update_option( 'woocommerce_checkout_company_field', 'hidden' );
+			}
+		}
+
+		if ( isset( $checkout_block['attrs']['showApartmentField'], $checkout_block['attrs']['requireApartmentField'] ) ) {
+			if ( $checkout_block['attrs']['showApartmentField'] ) {
+				update_option( 'woocommerce_checkout_address_2_field', $checkout_block['attrs']['requireApartmentField'] ? 'required' : 'optional' );
+			} else {
+				update_option( 'woocommerce_checkout_address_2_field', 'hidden' );
+			}
+		}
+	}
+
+	/**
+	 * Get the default visibility for the address_2 field.
+	 *
+	 * @return string
+	 */
+	public static function get_company_field_visibility() {
+		$option_value = get_option( 'woocommerce_checkout_company_field' );
+
+		if ( $option_value ) {
+			return $option_value;
+		}
+
+		if ( self::is_checkout_block_default() ) {
+			self::migrate_checkout_block_field_visibility_attributes();
+			return get_option( 'woocommerce_checkout_company_field', 'hidden' );
+		}
+
+		return 'optional';
+	}
+
+	/**
+	 * Get the default visibility for the address_2 field.
+	 *
+	 * @return string
+	 */
+	public static function get_address_2_field_visibility() {
+		$option_value = get_option( 'woocommerce_checkout_address_2_field' );
+
+		if ( $option_value ) {
+			return $option_value;
+		}
+
+		if ( self::is_checkout_block_default() ) {
+			self::migrate_checkout_block_field_visibility_attributes();
+			return get_option( 'woocommerce_checkout_address_2_field', 'optional' );
+		}
+
+		return 'optional';
+	}
+
+	/**
+	 * Get the default visibility for the address_2 field.
+	 *
+	 * @return string
+	 */
+	public static function get_phone_field_visibility() {
+		$option_value = get_option( 'woocommerce_checkout_phone_field' );
+
+		if ( $option_value ) {
+			return $option_value;
+		}
+
+		if ( self::is_checkout_block_default() ) {
+			self::migrate_checkout_block_field_visibility_attributes();
+			return get_option( 'woocommerce_checkout_phone_field', 'optional' );
+		}
+
+		return 'required';
+	}
 
 	/**
 	 * Checks if the template overriding the page loads the page content or not.

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -1,7 +1,8 @@
-const { test, expect } = require( '@playwright/test' );
+const { test, expect, request } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { customer } = require( '../../test-data/data' );
 const { random } = require( '../../utils/helpers' );
+const { setOption } = require( '../../utils/options' );
 
 /**
  * External dependencies
@@ -47,11 +48,11 @@ test.describe.serial(
 			await api.put( 'settings/general/woocommerce_calc_taxes', {
 				value: 'yes',
 			} );
-			await api.put(
-				'settings/general/woocommerce_phone_field_visibility',
-				{
-					value: 'required',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_phone_field',
+				'required'
 			);
 		} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -47,6 +47,12 @@ test.describe.serial(
 			await api.put( 'settings/general/woocommerce_calc_taxes', {
 				value: 'yes',
 			} );
+			await api.put(
+				'settings/general/woocommerce_phone_field_visibility',
+				{
+					value: 'required',
+				}
+			);
 		} );
 
 		test.afterAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -68,6 +68,25 @@ test.describe(
 				consumerSecret: process.env.CONSUMER_SECRET,
 				version: 'wc/v3',
 			} );
+			// Set field visibility options
+			await api.put(
+				'settings/general/woocommerce_phone_field_visibility',
+				{
+					value: 'optional',
+				}
+			);
+			await api.put(
+				'settings/general/woocommerce_company_field_visibility',
+				{
+					value: 'optional',
+				}
+			);
+			await api.put(
+				'settings/general/woocommerce_address_2_field_visibility',
+				{
+					value: 'optional',
+				}
+			);
 			// make sure the currency is USD
 			await api.put( 'settings/general/woocommerce_currency', {
 				value: 'USD',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -1,10 +1,12 @@
 const { fillPageTitle } = require( '../../utils/editor' );
+const { request } = require( '@playwright/test' );
 const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
 
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin, customer } = require( '../../test-data/data' );
 const { logIn } = require( '../../utils/login' );
 const { setFilterValue, clearFilters } = require( '../../utils/filters' );
+const { setOption } = require( '../../utils/options' );
 
 /**
  * External dependencies
@@ -69,23 +71,23 @@ test.describe(
 				version: 'wc/v3',
 			} );
 			// Set field visibility options
-			await api.put(
-				'settings/general/woocommerce_phone_field_visibility',
-				{
-					value: 'optional',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_phone_field',
+				'optional'
 			);
-			await api.put(
-				'settings/general/woocommerce_company_field_visibility',
-				{
-					value: 'optional',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_company_field',
+				'optional'
 			);
-			await api.put(
-				'settings/general/woocommerce_address_2_field_visibility',
-				{
-					value: 'optional',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_address_2_field',
+				'optional'
 			);
 			// make sure the currency is USD
 			await api.put( 'settings/general/woocommerce_currency', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -32,6 +32,25 @@ test.describe(
 				consumerSecret: process.env.CONSUMER_SECRET,
 				version: 'wc/v3',
 			} );
+			// Set field visibility options
+			await api.put(
+				'settings/general/woocommerce_phone_field_visibility',
+				{
+					value: 'required',
+				}
+			);
+			await api.put(
+				'settings/general/woocommerce_company_field_visibility',
+				{
+					value: 'optional',
+				}
+			);
+			await api.put(
+				'settings/general/woocommerce_address_2_field_visibility',
+				{
+					value: 'optional',
+				}
+			);
 			// ensure store address is US
 			await api.post( 'settings/general/batch', {
 				update: [

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -1,7 +1,8 @@
-const { test, expect } = require( '@playwright/test' );
+const { test, expect, request } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin, customer } = require( '../../test-data/data' );
 const { setFilterValue, clearFilters } = require( '../../utils/filters' );
+const { setOption } = require( '../../utils/options' );
 
 /**
  * External dependencies
@@ -33,23 +34,23 @@ test.describe(
 				version: 'wc/v3',
 			} );
 			// Set field visibility options
-			await api.put(
-				'settings/general/woocommerce_phone_field_visibility',
-				{
-					value: 'required',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_phone_field',
+				'required'
 			);
-			await api.put(
-				'settings/general/woocommerce_company_field_visibility',
-				{
-					value: 'optional',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_phone_field',
+				'optional'
 			);
-			await api.put(
-				'settings/general/woocommerce_address_2_field_visibility',
-				{
-					value: 'optional',
-				}
+			await setOption(
+				request,
+				baseURL,
+				'woocommerce_checkout_phone_field',
+				'optional'
 			);
 			// ensure store address is US
 			await api.post( 'settings/general/batch', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -43,13 +43,13 @@ test.describe(
 			await setOption(
 				request,
 				baseURL,
-				'woocommerce_checkout_phone_field',
+				'woocommerce_checkout_company_field',
 				'optional'
 			);
 			await setOption(
 				request,
 				baseURL,
-				'woocommerce_checkout_phone_field',
+				'woocommerce_checkout_address_2_field',
 				'optional'
 			);
 			// ensure store address is US

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/CartCheckoutUtilsMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/CartCheckoutUtilsMock.php
@@ -17,4 +17,11 @@ class CartCheckoutUtilsMock extends CartCheckoutUtils {
 	public static function deep_sort_test( $array_to_sort ) {
 		return self::deep_sort_with_accents( $array_to_sort );
 	}
+
+	/**
+	 * Protected test wrapper for migrate_checkout_block_field_visibility_attributes.
+	 */
+	public static function migrate_checkout_block_field_visibility_attributes_test() {
+		return self::migrate_checkout_block_field_visibility_attributes();
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -1,0 +1,79 @@
+<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+
+namespace Automattic\WooCommerce\Tests\Blocks\Utils;
+
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\CartCheckoutUtilsMock;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the CartCheckoutUtils class.
+ */
+class CartCheckoutUtilsTest extends WP_UnitTestCase {
+
+	/**
+	 * Holds an instance of the dependency injection container.
+	 *
+	 * @var Container
+	 */
+	private $container;
+
+	/**
+	 * Setup test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		delete_option( 'woocommerce_checkout_phone_field' );
+		delete_option( 'woocommerce_checkout_company_field' );
+		delete_option( 'woocommerce_checkout_address_2_field' );
+	}
+
+	/**
+	 * Test migrate_checkout_block_field_visibility_attributes() function.
+	 */
+	public function test_migrate_checkout_block_field_visibility_attributes() {
+		// Default migration without checkout page.
+		delete_option( 'woocommerce_checkout_page_id' );
+
+		CartCheckoutUtilsMock::migrate_checkout_block_field_visibility_attributes_test();
+		$this->assertEquals( 'optional', get_option( 'woocommerce_checkout_phone_field' ) );
+		$this->assertEquals( 'hidden', get_option( 'woocommerce_checkout_company_field' ) );
+		$this->assertEquals( 'optional', get_option( 'woocommerce_checkout_address_2_field' ) );
+
+		// Populate checkout page.
+		$page = array(
+			'name'    => 'blocks-page',
+			'title'   => 'Checkout',
+			'content' => '',
+		);
+
+		$page_id         = wc_create_page( $page['name'], 'woocommerce_checkout_page_id', $page['title'], $page['content'] );
+		$updated_content = '<!-- wp:woocommerce/checkout {"showApartmentField":false,"showCompanyField":false,"showPhoneField":false,"requireApartmentField":false,"requireCompanyField":false,"requirePhoneField":false} --> <div class="wp-block-woocommerce-checkout is-loading"></div> <!-- /wp:woocommerce/checkout -->';
+		wp_update_post(
+			[
+				'ID'           => $page_id,
+				'post_content' => $updated_content,
+			]
+		);
+
+		CartCheckoutUtilsMock::migrate_checkout_block_field_visibility_attributes_test();
+		$this->assertEquals( 'hidden', get_option( 'woocommerce_checkout_phone_field' ) );
+		$this->assertEquals( 'hidden', get_option( 'woocommerce_checkout_company_field' ) );
+		$this->assertEquals( 'hidden', get_option( 'woocommerce_checkout_address_2_field' ) );
+
+		// Repeat with different settings.
+		$updated_content = '<!-- wp:woocommerce/checkout {"showApartmentField":true,"showCompanyField":true,"showPhoneField":true,"requireApartmentField":true,"requireCompanyField":true,"requirePhoneField":true} --> <div class="wp-block-woocommerce-checkout is-loading"></div> <!-- /wp:woocommerce/checkout -->';
+		wp_update_post(
+			[
+				'ID'           => $page_id,
+				'post_content' => $updated_content,
+			]
+		);
+
+		CartCheckoutUtilsMock::migrate_checkout_block_field_visibility_attributes_test();
+		$this->assertEquals( 'required', get_option( 'woocommerce_checkout_phone_field' ) );
+		$this->assertEquals( 'required', get_option( 'woocommerce_checkout_company_field' ) );
+		$this->assertEquals( 'required', get_option( 'woocommerce_checkout_address_2_field' ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the visibility settings (hidden and required) for phone, company, and address 2 inputs to global settings instead of block attributes.

This allows the settings to be visible globally across all blocks as well as via the Store API. This approach has several benefits since we know at store level which fields are enabled. The main drawback is you can no longer have different settings per checkout block, but multiple checkout blocks is an edge use case.

Attributes from the checkout block are migrated to the global settings on access if the main checkout page is the checkout block, and the settings are blank. **We could look into migrating even if the settings are not blank, TBD**.

These global settings were already in place:

- `woocommerce_checkout_company_field`
- `woocommerce_checkout_address_2_field`
- `woocommerce_checkout_phone_field`

I believe these are used in the customizer (see `WC_Shop_Customizer::add_checkout_section` and contain values `hidden`, `required`, and `optional`. We match this in the API and the blocks.

In the editor, instead of the field settings being saved to attributes we use entities linked to wp settings. To handle the preview, this PR uses the existing `previewData` to populate the core fields combined with `getEditedEntityRecord` for said fields. On the frontend, this is not needed.

~There is once big caveat with this PR and that is the previously used attributes are discarded. Because they live at block level, I cannot see a good way to persist these globally. Therefore on upgrade, some fields on checkout may change behaviour until the merchant edits the block. This shouldn't be breaking for customers since we'll use the defaults (phone optional, address optional, company hidden).~

Closes #42773

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the page containing the checkout block
2. Focus on the address block
3. Try toggling on/off phone/company/apartment fields, as well as the required/optional checkbox and ensure the preview output matches your selections
4. Save changes
5. Go to the frontend block checkout
6. Confirm the changes made in the editor are reflected on the checkout
7. Go to the frontend legacy shortcode checkout
8. The phone/address 2/company fields should also match the changes you made when editing the checkout block

To test the migration process (this is also covered by tests):

1. On a clean install setup the checkout block before using this PR. The checkout block must be on the main checkout page.
2. Change some field settings e.g. make phone required, hide address 2, etc. Save.
3. Use this PR.
4. Confirm the block settings were persisted.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
