### PR TITLE
Update expected 9.5.0 release date.

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -169,7 +169,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
-= 9.5.0 2024-12-02 =
+= 9.5.0 2024-12-16 =
 
 **WooCommerce**
 


### PR DESCRIPTION
Corrects the changelog header date for 9.5.0 (based on the current release calendar, we expect 9.5.0 to ship on Dec 16).