### PR TITLE
Set current stable tag

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: online store, ecommerce, shop, shopping cart, sell online
 Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 9.3.3
+Stable tag: 9.4.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
Stable tag (for the 9.5 release branch) should match the actual current stable tag.