### PR TITLE
fix: jetpack connection screen for jetpack pre-installed

### DIFF
--- a/plugins/woocommerce/changelog/fix-core-profiler-jetpack-pre-installed
+++ b/plugins/woocommerce/changelog/fix-core-profiler-jetpack-pre-installed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Reinstate Jetpack connection screen for sites with Jetpack pre-installed

--- a/plugins/woocommerce/client/admin/client/core-profiler/events.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/events.tsx
@@ -92,6 +92,10 @@ export type PluginsPageSkippedEvent = {
 	type: 'PLUGINS_PAGE_SKIPPED';
 };
 
+export type PluginsPageCompletedWithoutSelectingPluginsEvent = {
+	type: 'PLUGINS_PAGE_COMPLETED_WITHOUT_SELECTING_PLUGINS';
+};
+
 export type PluginInstalledAndActivatedEvent = {
 	type: 'PLUGIN_INSTALLED_AND_ACTIVATED';
 	payload: {
@@ -134,6 +138,7 @@ export type CoreProfilerEvents =
 	| PluginsInstallationRequestedEvent
 	| PluginsLearnMoreLinkClickedEvent
 	| PluginsPageSkippedEvent
+	| PluginsPageCompletedWithoutSelectingPluginsEvent
 	| PluginInstalledAndActivatedEvent
 	| PluginsInstallationCompletedEvent
 	| PluginsInstallationCompletedWithErrorsEvent

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -1431,6 +1431,9 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							],
 							target: 'pluginsSkipped',
 						},
+						PLUGINS_PAGE_COMPLETED_WITHOUT_SELECTING_PLUGINS: {
+							target: 'postPluginInstallation.noPluginsSelected',
+						},
 						PLUGINS_LEARN_MORE_LINK_CLICKED: {
 							actions: [
 								{
@@ -1449,33 +1452,70 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					},
 				},
 				postPluginInstallation: {
-					invoke: {
-						input: ( { event } ) => {
-							assertEvent(
-								event,
-								'PLUGINS_INSTALLATION_COMPLETED'
-							);
-							return event;
-						},
-						src: fromPromise( async ( { input: event } ) => {
-							return await dispatch(
-								ONBOARDING_STORE_NAME
-							).updateProfileItems( {
-								business_extensions:
-									event.payload.installationCompletedResult.installedPlugins.map(
-										( extension: InstalledPlugin ) =>
-											extension.plugin
-									),
-								completed: true,
-							} );
-						} ),
-						onDone: [
-							{
-								target: 'isJetpackConnected',
-								guard: 'hasJetpackSelectedForInstallation',
+					initial: 'noPluginsSelected',
+					states: {
+						withPluginsSelected: {
+							invoke: {
+								input: ( { event } ) => {
+									assertEvent(
+										event,
+										'PLUGINS_INSTALLATION_COMPLETED'
+									);
+									return event;
+								},
+								src: fromPromise(
+									async ( { input: event } ) => {
+										return await dispatch(
+											ONBOARDING_STORE_NAME
+										).updateProfileItems( {
+											business_extensions:
+												event.payload.installationCompletedResult.installedPlugins.map(
+													(
+														extension: InstalledPlugin
+													) => extension.plugin
+												),
+											completed: true,
+										} );
+									}
+								),
+								onDone: [
+									{
+										target: '#isJetpackConnected',
+										guard: 'hasJetpackSelectedForInstallation',
+									},
+									{ actions: 'redirectToWooHome' },
+								],
+								onError: {
+									actions: 'redirectToWooHome',
+								},
 							},
-							{ actions: 'redirectToWooHome' },
-						],
+						},
+						noPluginsSelected: {
+							entry: assign( {
+								loader: {
+									progress: 80,
+								},
+							} ),
+							invoke: {
+								src: fromPromise( () =>
+									dispatch(
+										ONBOARDING_STORE_NAME
+									).updateProfileItems( {
+										completed: true,
+									} )
+								),
+								onDone: [
+									{
+										target: '#isJetpackConnected',
+										guard: 'hasJetpackActivated',
+									},
+									{ actions: 'redirectToWooHome' },
+								],
+								onError: {
+									actions: 'redirectToWooHome',
+								},
+							},
+						},
 					},
 					meta: {
 						component: CoreProfilerLoader,
@@ -1483,6 +1523,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					},
 				},
 				isJetpackConnected: {
+					id: 'isJetpackConnected',
 					invoke: {
 						src: 'getJetpackIsConnected',
 						onDone: [
@@ -1566,7 +1607,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							],
 						},
 						PLUGINS_INSTALLATION_COMPLETED: {
-							target: 'postPluginInstallation',
+							target: 'postPluginInstallation.withPluginsSelected',
 							actions: [
 								{
 									type: 'recordSuccessfulPluginInstallation',

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -1481,7 +1481,10 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 								onDone: [
 									{
 										target: '#isJetpackConnected',
-										guard: 'hasJetpackSelectedForInstallation',
+										guard: or( [
+											'hasJetpackSelectedForInstallation',
+											'hasJetpackActivated',
+										] ),
 									},
 									{ actions: 'redirectToWooHome' },
 								],

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
@@ -15,6 +15,7 @@ import {
 	PluginsLearnMoreLinkClickedEvent,
 	PluginsInstallationRequestedEvent,
 	PluginsPageSkippedEvent,
+	PluginsPageCompletedWithoutSelectingPluginsEvent,
 } from '../../events';
 import { Heading } from '../../components/heading/heading';
 import { Navigation } from '../../components/navigation/navigation';
@@ -83,6 +84,7 @@ export const Plugins = ( {
 		payload:
 			| PluginsInstallationRequestedEvent
 			| PluginsPageSkippedEvent
+			| PluginsPageCompletedWithoutSelectingPluginsEvent
 			| PluginsLearnMoreLinkClickedEvent
 	) => void;
 	navigationProgress: number;
@@ -112,6 +114,12 @@ export const Plugins = ( {
 	const skipPluginsPage = () => {
 		return sendEvent( {
 			type: 'PLUGINS_PAGE_SKIPPED',
+		} );
+	};
+
+	const completedPluginsPageWithoutSelectingPlugins = () => {
+		return sendEvent( {
+			type: 'PLUGINS_PAGE_COMPLETED_WITHOUT_SELECTING_PLUGINS',
 		} );
 	};
 
@@ -217,7 +225,7 @@ export const Plugins = ( {
 							onClick={
 								selectedPlugins.size > 0
 									? submitInstallationRequest
-									: skipPluginsPage
+									: completedPluginsPageWithoutSelectingPlugins
 							}
 						>
 							{ __( 'Continue', 'woocommerce' ) }

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
@@ -143,7 +143,7 @@ describe( 'Plugins Component', () => {
 		const continueButton = screen.getByText( 'Continue' );
 		fireEvent.click( continueButton );
 		expect( mockSendEvent ).toHaveBeenCalledWith( {
-			type: 'PLUGINS_PAGE_SKIPPED',
+			type: 'PLUGINS_PAGE_COMPLETED_WITHOUT_SELECTING_PLUGINS',
 		} );
 	} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #52810.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Scenarios:
1. Jetpack pre-installed and some plugins selected for installation, continue clicked
2. Jetpack pre-installed and all plugins deselected for installation, continue clicked
3. Jetpack not pre-installed and Jetpack selected for installation, continue clicked
4. Jetpack not pre-installed and Jetpack not selected for installation, with other plugins selected, continue clicked
5. Jetpack pre-installed and skip link clicked
6. Jetpack not pre-installed and skip link clicked
7. Jetpack installed and connected, no other plugins selected, continue clicked (you can reuse scenarios 1/2/3 for this)
8. Jetpack installed and connected, some other plugins selected, continue clicked (you can reuse scenarios 1/2/3 for this)

(3 and 4 are identical code paths so it's not really necessary to test them both)

Testing instructions:
1. Spin up a JN site with Jetpack pre-installed or not, depending on the scenario you are testing
2. Go through the Core Profiler, until the Plugin installation screen
3. Execute according to the scenarios above
4. Scenarios 1, 2, 3 should see the Jetpack connection screen, but not in 4, 5, 6, 7, 8


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
