### PR TITLE
 Allow previewing different email types

### DIFF
--- a/plugins/woocommerce/changelog/52227-preview-email-types
+++ b/plugins/woocommerce/changelog/52227-preview-email-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Allow previewing different email types. Still behind a hidden experimental flag, not ready for public use.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -16,6 +16,7 @@ import {
 	DEVICE_TYPE_DESKTOP,
 } from './settings-email-preview-device-type';
 import { EmailPreviewHeader } from './settings-email-preview-header';
+import { EmailPreviewType } from './settings-email-preview-type';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
@@ -30,10 +31,18 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 } ) => {
 	const [ deviceType, setDeviceType ] =
 		useState< string >( DEVICE_TYPE_DESKTOP );
+	const [ emailType, setEmailType ] = useState< string >(
+		'WC_Email_Customer_Processing_Order'
+	);
 	return (
 		<Fill>
 			<div className="wc-settings-email-preview-container">
 				<div className="wc-settings-email-preview-controls">
+					<EmailPreviewType
+						emailTypes={ emailTypes }
+						emailType={ emailType }
+						setEmailType={ setEmailType }
+					/>
 					<EmailPreviewDeviceType
 						deviceType={ deviceType }
 						setDeviceType={ setDeviceType }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -4,7 +4,7 @@
 import { createSlotFill, SelectControl } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -34,6 +34,13 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	const [ emailType, setEmailType ] = useState< string >(
 		'WC_Email_Customer_Processing_Order'
 	);
+	const [ finalPreviewUrl, setFinalPreviewUrl ] =
+		useState< string >( previewUrl );
+
+	useEffect( () => {
+		setFinalPreviewUrl( `${ previewUrl }&type=${ emailType }` );
+	}, [ emailType, previewUrl ] );
+
 	return (
 		<Fill>
 			<div className="wc-settings-email-preview-container">
@@ -53,7 +60,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 				>
 					<EmailPreviewHeader />
 					<iframe
-						src={ previewUrl }
+						src={ finalPreviewUrl }
 						title={ __( 'Email preview frame', 'woocommerce' ) }
 					/>
 				</div>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createSlotFill } from '@wordpress/components';
+import { createSlotFill, SelectControl } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -20,10 +20,12 @@ import { EmailPreviewHeader } from './settings-email-preview-header';
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
 type EmailPreviewFillProps = {
+	emailTypes: SelectControl.Option[];
 	previewUrl: string;
 };
 
 const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
+	emailTypes,
 	previewUrl,
 } ) => {
 	const [ deviceType, setDeviceType ] =
@@ -52,15 +54,29 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 };
 
 export const registerSettingsEmailPreviewFill = () => {
-	const slot_element_id = 'wc_settings_email_preview_slotfill';
-	const slot_element = document.getElementById( slot_element_id );
-	const preview_url = slot_element?.getAttribute( 'data-preview-url' );
-	if ( ! preview_url ) {
+	const slotElementId = 'wc_settings_email_preview_slotfill';
+	const slotElement = document.getElementById( slotElementId );
+	if ( ! slotElement ) {
 		return null;
 	}
+	const previewUrl = slotElement.getAttribute( 'data-preview-url' );
+	if ( ! previewUrl ) {
+		return null;
+	}
+	const emailTypesData = slotElement.getAttribute( 'data-email-types' );
+	let emailTypes: SelectControl.Option[] = [];
+	try {
+		emailTypes = JSON.parse( emailTypesData || '' );
+	} catch ( e ) {}
+
 	registerPlugin( 'woocommerce-admin-settings-email-preview', {
 		// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
 		scope: 'woocommerce-email-preview-settings',
-		render: () => <EmailPreviewFill previewUrl={ preview_url } />,
+		render: () => (
+			<EmailPreviewFill
+				emailTypes={ emailTypes }
+				previewUrl={ previewUrl }
+			/>
+		),
 	} );
 };

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -4,7 +4,7 @@
 import { createSlotFill, SelectControl } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 /**
  * Internal dependencies
@@ -34,12 +34,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	const [ emailType, setEmailType ] = useState< string >(
 		'WC_Email_Customer_Processing_Order'
 	);
-	const [ finalPreviewUrl, setFinalPreviewUrl ] =
-		useState< string >( previewUrl );
-
-	useEffect( () => {
-		setFinalPreviewUrl( `${ previewUrl }&type=${ emailType }` );
-	}, [ emailType, previewUrl ] );
+	const finalPreviewUrl = `${ previewUrl }&type=${ emailType }`;
 
 	return (
 		<Fill>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createSlotFill, SelectControl } from '@wordpress/components';
+import { createSlotFill, SelectControl, Spinner } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -34,6 +34,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	const [ emailType, setEmailType ] = useState< string >(
 		'WC_Email_Customer_Processing_Order'
 	);
+	const [ isLoading, setIsLoading ] = useState< boolean >( false );
 	const finalPreviewUrl = `${ previewUrl }&type=${ emailType }`;
 
 	return (
@@ -43,8 +44,15 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 					<EmailPreviewType
 						emailTypes={ emailTypes }
 						emailType={ emailType }
-						setEmailType={ setEmailType }
+						setEmailType={ ( newEmailType: string ) => {
+							setIsLoading( true );
+							setEmailType( newEmailType );
+						} }
 					/>
+					<div className="wc-settings-email-preview-spinner">
+						{ isLoading && <Spinner /> }
+					</div>
+					<div style={ { flexGrow: 1 } } />
 					<EmailPreviewDeviceType
 						deviceType={ deviceType }
 						setDeviceType={ setDeviceType }
@@ -57,6 +65,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 					<iframe
 						src={ finalPreviewUrl }
 						title={ __( 'Email preview frame', 'woocommerce' ) }
+						onLoad={ () => setIsLoading( false ) }
 					/>
 				</div>
 			</div>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 type EmailPreviewTypeProps = {
 	emailTypes: SelectControl.Option[];
@@ -20,6 +21,7 @@ export const EmailPreviewType: React.FC< EmailPreviewTypeProps > = ( {
 				onChange={ setEmailType }
 				options={ emailTypes }
 				value={ emailType }
+				aria-label={ __( 'Email preview type', 'woocommerce' ) }
 			></SelectControl>
 		</div>
 	);

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+
+type EmailPreviewTypeProps = {
+	emailTypes: SelectControl.Option[];
+	emailType: string;
+	setEmailType: ( emailType: string ) => void;
+};
+
+export const EmailPreviewType: React.FC< EmailPreviewTypeProps > = ( {
+	emailTypes,
+	emailType,
+	setEmailType,
+} ) => {
+	return (
+		<div className="wc-settings-email-preview-order-type">
+			<SelectControl
+				onChange={ setEmailType }
+				options={ emailTypes }
+				value={ emailType }
+			></SelectControl>
+		</div>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
@@ -16,7 +16,7 @@ export const EmailPreviewType: React.FC< EmailPreviewTypeProps > = ( {
 	setEmailType,
 } ) => {
 	return (
-		<div className="wc-settings-email-preview-order-type">
+		<div className="wc-settings-email-preview-type">
 			<SelectControl
 				onChange={ setEmailType }
 				options={ emailTypes }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
@@ -16,7 +16,7 @@ export const EmailPreviewType: React.FC< EmailPreviewTypeProps > = ( {
 	setEmailType,
 } ) => {
 	return (
-		<div className="wc-settings-email-preview-type">
+		<div className="wc-settings-email-preview-type wc-settings-prevent-change-event">
 			<SelectControl
 				onChange={ setEmailType }
 				options={ emailTypes }

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -17,7 +17,7 @@ $wc-setting-email-preview-gap: 16px;
 	justify-content: space-between;
 }
 
-.wc-settings-email-preview-order-type {
+.wc-settings-email-preview-type {
 	width: 200px;
 }
 

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -12,6 +12,15 @@ $wc-setting-email-preview-gap: 16px;
 	width: 652px;
 }
 
+.wc-settings-email-preview-controls {
+	display: flex;
+	justify-content: space-between;
+}
+
+.wc-settings-email-preview-order-type {
+	width: 200px;
+}
+
 .wc-settings-email-preview-device-type {
 	display: grid;
 	grid-gap: 8px;

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -21,6 +21,17 @@ $wc-setting-email-preview-gap: 16px;
 	width: 200px;
 }
 
+.wc-settings-email-preview-spinner {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	width: 40px;
+
+	svg {
+		margin: 0;
+	}
+}
+
 .wc-settings-email-preview-device-type {
 	display: grid;
 	grid-gap: 8px;

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -92,16 +92,17 @@
 		// Edit prompt
 		function editPrompt () {
 			var changed = false;
-			let $check_column = $( '.wp-list-table .check-column' );
+			let $prevent_change_elements = $( '.wp-list-table .check-column, .wc-settings-prevent-change-event' );
 
 			$( 'input, textarea, select, checkbox' ).on( 'change input', function (
 				event
 			) {
-				// Toggling WP List Table checkboxes should not trigger navigation warnings.
-				// Theses checkboxes only select/unselect rows, they don't change the form.
+				// Prevent change event on specific elements, that don't change the form. E.g.:
+				// - WP List Table checkboxes that only (un)select rows
+				// - Changing email type in email preview
 				if (
-					$check_column.length &&
-					$check_column.has( event.target ).length
+					$prevent_change_elements.length &&
+					$prevent_change_elements.has( event.target ).length
 				) {
 					return;
 				}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -434,10 +434,19 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * Creates the React mount point for the email preview.
 	 */
 	public function email_preview() {
+		$emails      = WC()->mailer()->get_emails();
+		$email_types = array();
+		foreach ( $emails as $type => $email ) {
+			$email_types[] = array(
+				'label' => $email->get_title(),
+				'value' => $type,
+			);
+		}
 		?>
 		<div
 			id="wc_settings_email_preview_slotfill"
 			data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
+			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
 		></div>
 		<?php
 	}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview.php
@@ -19,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
  * EmailPreview Class.
  */
 class EmailPreview {
+	const DEFAULT_EMAIL_TYPE = 'WC_Email_Customer_Processing_Order';
+
 	/**
 	 * The single instance of the class.
 	 *
@@ -173,8 +175,20 @@ class EmailPreview {
 	 * @return WC_Email
 	 */
 	private function get_email() {
-		$emails = WC()->mailer()->get_emails();
-		$email  = $emails['WC_Email_Customer_Processing_Order'];
+		$emails     = WC()->mailer()->get_emails();
+		$email_type = self::DEFAULT_EMAIL_TYPE;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// Nonce verification is done in class-wc-admin.php in preview_emails() method.
+		if ( isset( $_GET['type'] ) ) {
+			$type_param = sanitize_text_field( wp_unslash( $_GET['type'] ) );
+			if ( array_key_exists( $type_param, $emails ) ) {
+				$email_type = $type_param;
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$email = $emails[ $email_type ];
 		return $email;
 	}
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -27,6 +27,10 @@ test.describe( 'WooCommerce Email Settings', () => {
 		const hasIframe = async () => {
 			return ( await page.locator( emailPreviewElement ).count() ) > 0;
 		};
+		const iframeContains = async ( text ) => {
+			const iframe = await page.frameLocator( emailPreviewElement );
+			return iframe.getByText( text );
+		};
 
 		// Disable the email_improvements feature flag
 		await setFeatureFlag( baseURL, 'no' );
@@ -37,6 +41,18 @@ test.describe( 'WooCommerce Email Settings', () => {
 		await setFeatureFlag( baseURL, 'yes' );
 		await page.reload();
 		expect( await hasIframe() ).toBeTruthy();
+
+		await expect(
+			await iframeContains( 'Thank you for your order' )
+		).toBeVisible();
+
+		// Select different email type and check that iframe is updated
+		await page
+			.getByLabel( 'Email preview type' )
+			.selectOption( 'Reset password' );
+		await expect(
+			await iframeContains( 'Password Reset Request' )
+		).toBeVisible();
 	} );
 
 	test( 'See email image url field with a feature flag', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -18,6 +18,10 @@ const pickImageFromLibrary = async ( page, imageName ) => {
 test.describe( 'WooCommerce Email Settings', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
+	test.afterAll( async ( { baseURL } ) => {
+		await setFeatureFlag( baseURL, 'no' );
+	} );
+
 	test( 'See email preview with a feature flag', async ( {
 		page,
 		baseURL,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. This PR adds the option to preview any registered email in email settings. 

<img width="882" alt="Screenshot 2024-11-14 at 13 01 14" src="https://github.com/user-attachments/assets/90e14993-8815-4df3-aa84-29a8f0bac1db">

Closes #52227.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. You need to have `email_improvements` experimental flag enabled (in DB, set woocommerce_feature_email_improvements_enabled option to yes).
2. Go to **WooCommerce > Settings > Emails** and check that there is a select box with all registered email types.
3. Check that when you register a new email type (or install an extension that registers new emails, such as [Back in Stock and Price Alert for WooCommerce](https://woocommerce.com/products/back-in-stock-and-price-alert/)) they are listed in the select box.
    - Note, that depending on the extension, the email preview can fail, if it depends on different objects than WooCommerce Order. E.g., WooCommerce Subscriptions emails won't render because they have different data structures - this will be fixed in later PRs before the feature is launched publicly. 
4. Check that when a different email type is selected, the email preview is reloaded without the whole page being reloaded.

<!-- End testing instructions -->