### PR TITLE
Fix grouped product styles for TT5

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -46,6 +46,7 @@
 
 		&.grouped_form {
 			width: fit-content;
+			word-break: normal;
 		}
 	}
 

--- a/plugins/woocommerce/changelog/fix-52700_gropued_products_styles_twenty_twenty_five
+++ b/plugins/woocommerce/changelog/fix-52700_gropued_products_styles_twenty_twenty_five
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix grouped product styles for TT5 #52856


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses styling inconsistencies in the Twenty Twenty-Five theme, specifically for variable products in grouped product lists. It removes default padding from variable product links in grouped products.

**Before**

![Screenshot 2024-11-15 at 11 34 30 AM](https://github.com/user-attachments/assets/562ccc2f-d9d8-4398-bfa2-a4ff562b429b)

![Screenshot 2024-11-26 at 5 13 34 PM](https://github.com/user-attachments/assets/4a0f20ca-9b1a-493b-96d9-c1f0cc478bbe)

**After**

![Screenshot 2024-11-15 at 11 34 09 AM](https://github.com/user-attachments/assets/eef441c1-4154-4054-a4f7-3afd1ee2458c)

![Screenshot 2024-11-26 at 5 11 42 PM](https://github.com/user-attachments/assets/cb29bd0a-69c9-4509-84a8-b4e094cdeeca)

Closes #52700.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the Twenty Twenty-Five theme
2. Create a grouped product that includes variable products as group items
3. View the grouped product page on the frontend
4. Verify that:
   - The buttons are properly aligned within the table cells
   - The overall layout looks clean and consistent
5. Also test using TT4, Storefront, and other themes to confirm the styles look correct.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
