### PR TITLE
Update Action Scheduler to 3.9.0.

### DIFF
--- a/plugins/woocommerce/changelog/dev-bump-action-scheduler-to-3.9.0
+++ b/plugins/woocommerce/changelog/dev-bump-action-scheduler-to-3.9.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Updates the Action Scheduler library to 3.9.0.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -37,7 +37,7 @@
 		"composer/installers": "^1.9",
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
-		"woocommerce/action-scheduler": "3.8.2",
+		"woocommerce/action-scheduler": "3.9.0",
 		"woocommerce/blueprint": "*"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e068848765b4c2df4244eac75f7ea46d",
+    "content-hash": "91228a938c6db8e8394ac6511411d5c0",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1251,20 +1251,20 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.8.2",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "2bc91d88fdbc2c07ab899cbb56b983e11e62cf69"
+                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/2bc91d88fdbc2c07ab899cbb56b983e11e62cf69",
-                "reference": "2bc91d88fdbc2c07ab899cbb56b983e11e62cf69",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/90b98e6fe97d455679b1d288f050cad8f6f79771",
+                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5",
@@ -1288,9 +1288,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.8.2"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.0"
             },
-            "time": "2024-09-12T23:12:58+00:00"
+            "time": "2024-11-15T00:11:39+00:00"
         },
         {
             "name": "woocommerce/blueprint",
@@ -5134,13 +5134,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },


### PR DESCRIPTION
Following the release of [Action Scheduler 3.9.0](https://github.com/woocommerce/action-scheduler/releases/tag/3.9.0), we also want to update the version bundled with WooCommerce. 

## 👷🏼‍♀️ Testing instructions

Using a build of this branch, install and activate WooCommerce on a test site.

1. After you've run through initial setup (onboarding wizard, etc), navigate to **WooCommerce ‣ Status ‣ Scheduled Actions**. You should see a list of scheduled actions.
2. If you see any pending actions, it should be possible to run them via the UI (hover over them, and a *run* action should appear). Often you'll find a `woocommerce_cleanup_draft_orders` action that you can use.
3. Repeat the above, except via the canonical action management screen found at **Tools ‣ Scheduled Actions**.
4. If you need to create additional actions for testing purposes, you may wish to use the following snippet (assuming you have access to WP CLI), which you can repeat as needed:

```sh
wp eval "as_schedule_single_action( time() + rand( 1, 100 ), uniqid( 'test-' ) );"
```

The above is only intended to provide some baseline confidence. If you wish to dig deeper and test other functionalities, please feel free!