### PR TITLE
Update E2E tests to work with WP 6.7

### DIFF
--- a/plugins/woocommerce-blocks/.wp-env.json
+++ b/plugins/woocommerce-blocks/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-6.7-RC2.zip",
+	"core": "https://wordpress.org/wordpress-latest.zip",
 	"phpVersion": "7.4",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",

--- a/plugins/woocommerce/changelog/52867-update-use-wp-6.7-for-e2e-tests
+++ b/plugins/woocommerce/changelog/52867-update-use-wp-6.7-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: A changelog entry is not required for this update as it solely impacts the testing architecture and has no effect on the user-facing features.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #52447, @kmanijak changed the WordPress version for the e2e tests from `wordpress-latest` to `wordpress-6.7-RC2` to test the plugin against the release candidate. As [WordPress 6.7 had been released meanwhile](https://wordpress.org/news/2024/11/rollins/), this PR changes the version back to `wordpress-latest`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify that all CI checks are passing.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

A changelog entry is not required for this update as it solely impacts the testing architecture and has no effect on the user-facing features.

</details>
