### PR TITLE
[WIP][Accessibility] Update product link display prop to support focus ring

### DIFF
--- a/plugins/woocommerce/changelog/fix-51923
+++ b/plugins/woocommerce/changelog/fix-51923
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update product link display prop to support focus ring

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -526,6 +526,10 @@ p.demo_store,
 			font-size: 1em;
 		}
 
+		.woocommerce-loop-product__link {
+			display: inline-block;
+		}
+
 		a {
 			text-decoration: none;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #51923 .


### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit a product and add upsell products in the admin page
2. Browse to the frontend of the product page
3. Tab through the page until you reach upsell products
4. When focusing on an upsell product, the focus ring should display correctly

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Details</summary>
<summary>Changelog Entry Comment</summary>
</details>
