### PR TITLE
Fix "missing 'price' property in 'offers'" error in Google Search Console

### DIFF
--- a/plugins/woocommerce/changelog/fix-offer-metadata-missing-price
+++ b/plugins/woocommerce/changelog/fix-offer-metadata-missing-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "missing 'price' property in 'offers'" error in Google Search Console

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -370,10 +370,10 @@ class WC_Structured_Data {
 			}
 
 			$markup_offer += array(
-				'priceCurrency' => $currency,
-				'availability'  => 'http://schema.org/' . $stock_status_schema,
-				'url'           => $permalink,
-				'seller'        => array(
+				'priceValidUntil' => $sale_price_valid_until ?? $price_valid_until,
+				'availability'    => 'http://schema.org/' . $stock_status_schema,
+				'url'             => $permalink,
+				'seller'          => array(
 					'@type' => 'Organization',
 					'name'  => $shop_name,
 					'url'   => $shop_url,

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -244,10 +244,11 @@ class WC_Structured_Data {
 					);
 				} else {
 					$markup_offer = array(
-						'@type'      => 'AggregateOffer',
-						'lowPrice'   => wc_format_decimal( $lowest, wc_get_price_decimals() ),
-						'highPrice'  => wc_format_decimal( $highest, wc_get_price_decimals() ),
-						'offerCount' => count( $product->get_children() ),
+						'@type'         => 'AggregateOffer',
+						'lowPrice'      => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'highPrice'     => wc_format_decimal( $highest, wc_get_price_decimals() ),
+						'priceCurrency' => $currency,
+						'offerCount'    => count( $product->get_children() ),
 					);
 
 					if ( $product->is_on_sale() ) {

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -231,8 +231,6 @@ class WC_Structured_Data {
 				if ( $lowest === $highest ) {
 					$markup_offer = array(
 						'@type'              => 'Offer',
-						'price'              => wc_format_decimal( $lowest, wc_get_price_decimals() ),
-						'priceValidUntil'    => $price_valid_until,
 						'priceSpecification' => array(
 							array(
 								'@type'                 => 'UnitPriceSpecification',
@@ -246,10 +244,11 @@ class WC_Structured_Data {
 					);
 				} else {
 					$markup_offer = array(
-						'@type'      => 'AggregateOffer',
-						'lowPrice'   => wc_format_decimal( $lowest, wc_get_price_decimals() ),
-						'highPrice'  => wc_format_decimal( $highest, wc_get_price_decimals() ),
-						'offerCount' => count( $product->get_children() ),
+						'@type'         => 'AggregateOffer',
+						'lowPrice'      => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'highPrice'     => wc_format_decimal( $highest, wc_get_price_decimals() ),
+						'priceCurrency' => $currency,
+						'offerCount'    => count( $product->get_children() ),
 					);
 
 					if ( $product->is_on_sale() ) {
@@ -308,8 +307,6 @@ class WC_Structured_Data {
 
 				$markup_offer = array(
 					'@type'              => 'Offer',
-					'price'              => wc_format_decimal( $min_price, wc_get_price_decimals() ),
-					'priceValidUntil'    => $price_valid_until,
 					'priceSpecification' => array(
 						array(
 							'@type'                 => 'UnitPriceSpecification',
@@ -339,8 +336,6 @@ class WC_Structured_Data {
 			} else {
 				$markup_offer = array(
 					'@type'              => 'Offer',
-					'price'              => wc_format_decimal( $product->get_price(), wc_get_price_decimals() ),
-					'priceValidUntil'    => $price_valid_until,
 					'priceSpecification' => array(
 						array(
 							'@type'                 => 'UnitPriceSpecification',
@@ -376,10 +371,10 @@ class WC_Structured_Data {
 			}
 
 			$markup_offer += array(
-				'priceCurrency' => $currency,
-				'availability'  => 'http://schema.org/' . $stock_status_schema,
-				'url'           => $permalink,
-				'seller'        => array(
+				'priceValidUntil' => $sale_price_valid_until ?? $price_valid_until,
+				'availability'    => 'http://schema.org/' . $stock_status_schema,
+				'url'             => $permalink,
+				'seller'          => array(
 					'@type' => 'Organization',
 					'name'  => $shop_name,
 					'url'   => $shop_url,

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -234,7 +234,6 @@ class WC_Structured_Data {
 						'priceSpecification' => array(
 							array(
 								'@type'                 => 'UnitPriceSpecification',
-								'priceType'             => 'https://schema.org/ListPrice',
 								'price'                 => wc_format_decimal( $lowest, wc_get_price_decimals() ),
 								'priceCurrency'         => $currency,
 								'valueAddedTaxIncluded' => wc_prices_include_tax(),
@@ -244,11 +243,10 @@ class WC_Structured_Data {
 					);
 				} else {
 					$markup_offer = array(
-						'@type'         => 'AggregateOffer',
-						'lowPrice'      => wc_format_decimal( $lowest, wc_get_price_decimals() ),
-						'highPrice'     => wc_format_decimal( $highest, wc_get_price_decimals() ),
-						'priceCurrency' => $currency,
-						'offerCount'    => count( $product->get_children() ),
+						'@type'      => 'AggregateOffer',
+						'lowPrice'   => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'highPrice'  => wc_format_decimal( $highest, wc_get_price_decimals() ),
+						'offerCount' => count( $product->get_children() ),
 					);
 
 					if ( $product->is_on_sale() ) {
@@ -305,28 +303,32 @@ class WC_Structured_Data {
 					$min_sale_price = min( $child_sale_prices );
 				}
 
+				$unit_price_specification = array(
+					'@type'                 => 'UnitPriceSpecification',
+					'price'                 => wc_format_decimal( $min_price, wc_get_price_decimals() ),
+					'priceCurrency'         => $currency,
+					'valueAddedTaxIncluded' => wc_prices_include_tax(),
+					'validThrough'          => $price_valid_until,
+				);
+				if ( $product->is_on_sale() && $min_price !== $min_sale_price ) {
+					// `priceType` should only be specified in prices which are not the current offer.
+					// https://developers.google.com/search/docs/appearance/structured-data/merchant-listing#sale-pricing-example
+					$unit_price_specification['priceType'] = 'https://schema.org/ListPrice';
+				}
 				$markup_offer = array(
 					'@type'              => 'Offer',
 					'priceSpecification' => array(
-						array(
-							'@type'                 => 'UnitPriceSpecification',
-							'priceType'             => 'https://schema.org/ListPrice',
-							'price'                 => wc_format_decimal( $min_price, wc_get_price_decimals() ),
-							'priceCurrency'         => $currency,
-							'valueAddedTaxIncluded' => wc_prices_include_tax(),
-							'validThrough'          => $price_valid_until,
-						),
+						$unit_price_specification,
 					),
 				);
 
-				if ( $product->is_on_sale() ) {
+				if ( $product->is_on_sale() && $min_price !== $min_sale_price ) {
 					if ( $product->get_date_on_sale_to() ) {
 						$sale_price_valid_until = gmdate( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
 					}
 
 					$markup_offer['priceSpecification'][] = array(
 						'@type'                 => 'UnitPriceSpecification',
-						'priceType'             => 'https://schema.org/SalePrice',
 						'price'                 => wc_format_decimal( $min_sale_price, wc_get_price_decimals() ),
 						'priceCurrency'         => $currency,
 						'valueAddedTaxIncluded' => wc_prices_include_tax(),
@@ -334,17 +336,22 @@ class WC_Structured_Data {
 					);
 				}
 			} else {
+				$unit_price_specification = array(
+					'@type'                 => 'UnitPriceSpecification',
+					'price'                 => wc_format_decimal( $product->get_regular_price(), wc_get_price_decimals() ),
+					'priceCurrency'         => $currency,
+					'valueAddedTaxIncluded' => wc_prices_include_tax(),
+					'validThrough'          => $price_valid_until,
+				);
+				if ( $product->is_on_sale() ) {
+					// `priceType` should only be specified in prices which are not the current offer.
+					// https://developers.google.com/search/docs/appearance/structured-data/merchant-listing#sale-pricing-example
+					$unit_price_specification['priceType'] = 'https://schema.org/ListPrice';
+				}
 				$markup_offer = array(
 					'@type'              => 'Offer',
 					'priceSpecification' => array(
-						array(
-							'@type'                 => 'UnitPriceSpecification',
-							'priceType'             => 'https://schema.org/ListPrice',
-							'price'                 => wc_format_decimal( $product->get_regular_price(), wc_get_price_decimals() ),
-							'priceCurrency'         => $currency,
-							'valueAddedTaxIncluded' => wc_prices_include_tax(),
-							'validThrough'          => $price_valid_until,
-						),
+						$unit_price_specification,
 					),
 				);
 
@@ -355,7 +362,6 @@ class WC_Structured_Data {
 
 					$markup_offer['priceSpecification'][] = array(
 						'@type'                 => 'UnitPriceSpecification',
-						'priceType'             => 'https://schema.org/SalePrice',
 						'price'                 => wc_format_decimal( $product->get_sale_price(), wc_get_price_decimals() ),
 						'priceCurrency'         => $currency,
 						'valueAddedTaxIncluded' => wc_prices_include_tax(),
@@ -380,6 +386,14 @@ class WC_Structured_Data {
 					'url'   => $shop_url,
 				),
 			);
+			if (
+				( ! empty( $markup_offer['price'] ) ||
+					! empty( $markup_offer['lowPrice'] ) ||
+					! empty( $markup_offer['highPrice'] )
+				) && empty( $markup_offer['priceCurrency'] )
+			) {
+				$markup_offer['priceCurrency'] = $currency;
+			}
 
 			$markup['offers'] = array( apply_filters( 'woocommerce_structured_data_product_offer', $markup_offer, $product ) );
 		}

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -231,6 +231,8 @@ class WC_Structured_Data {
 				if ( $lowest === $highest ) {
 					$markup_offer = array(
 						'@type'              => 'Offer',
+						'price'              => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'priceValidUntil'    => $price_valid_until,
 						'priceSpecification' => array(
 							array(
 								'@type'                 => 'UnitPriceSpecification',
@@ -244,11 +246,10 @@ class WC_Structured_Data {
 					);
 				} else {
 					$markup_offer = array(
-						'@type'         => 'AggregateOffer',
-						'lowPrice'      => wc_format_decimal( $lowest, wc_get_price_decimals() ),
-						'highPrice'     => wc_format_decimal( $highest, wc_get_price_decimals() ),
-						'priceCurrency' => $currency,
-						'offerCount'    => count( $product->get_children() ),
+						'@type'      => 'AggregateOffer',
+						'lowPrice'   => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'highPrice'  => wc_format_decimal( $highest, wc_get_price_decimals() ),
+						'offerCount' => count( $product->get_children() ),
 					);
 
 					if ( $product->is_on_sale() ) {
@@ -307,6 +308,8 @@ class WC_Structured_Data {
 
 				$markup_offer = array(
 					'@type'              => 'Offer',
+					'price'              => wc_format_decimal( $min_price, wc_get_price_decimals() ),
+					'priceValidUntil'    => $price_valid_until,
 					'priceSpecification' => array(
 						array(
 							'@type'                 => 'UnitPriceSpecification',
@@ -336,6 +339,8 @@ class WC_Structured_Data {
 			} else {
 				$markup_offer = array(
 					'@type'              => 'Offer',
+					'price'              => wc_format_decimal( $product->get_price(), wc_get_price_decimals() ),
+					'priceValidUntil'    => $price_valid_until,
 					'priceSpecification' => array(
 						array(
 							'@type'                 => 'UnitPriceSpecification',
@@ -371,10 +376,10 @@ class WC_Structured_Data {
 			}
 
 			$markup_offer += array(
-				'priceValidUntil' => $sale_price_valid_until ?? $price_valid_until,
-				'availability'    => 'http://schema.org/' . $stock_status_schema,
-				'url'             => $permalink,
-				'seller'          => array(
+				'priceCurrency' => $currency,
+				'availability'  => 'http://schema.org/' . $stock_status_schema,
+				'url'           => $permalink,
+				'seller'        => array(
 					'@type' => 'Organization',
 					'name'  => $shop_name,
 					'url'   => $shop_url,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/52105 we updated the structured data of sale prices. That was done by moving the sale price and the regular price under `priceSpecification`, which allowed for both prices to be listed in the metadata. That was an SEO enhancement.

Even though the code from that PR passed the validator checks, after testing it in an online store, it caused Google Search Console to output an error and a warning:

Missing 'price' in 'offers' | Missing 'priceValidUntil' in 'offers'
--- | ---
![Captura de pantalla de 2024-11-15 11-02-52](https://github.com/user-attachments/assets/ed0e6996-39ff-477d-a70c-e073417c64a0) | ![Captura de pantalla de 2024-11-15 11-02-44](https://github.com/user-attachments/assets/5fd7058b-6998-4f32-87a8-087c4da7f874)

The first one is specially serious, as it might cause the products to be delisted from Google enriched results.

To be honest, I'm not 100% sure why the errors appear, but I think:

* The first one was caused by `priceCurrency` still being under `offers`. I think in some way Google expects that if there is a `priceCurrency` property, there must be a `price` property at the same level. I made it so `priceCurrency` is only added if we detect a `price`, `lowPrice` or `highPrice` properties.
*  The second one seems to indicate that even though we added `validThrough` to the specific `priceSpecification`s, we still needed to keep `priceValidUntil` in the parent `offers`. I added it back.

I also made sure that we don't include `priceType` in the current offer. As this is what's advised by Google. And also made sure that in Grouped products there is no chance that the sale and regular price is the same. (I left comments inline explaining everything).

I tested it in a live store and Google Search Console seems to be fine again.

cc @zhyian in case you also want to take a look. :slightly_smiling_face: 

Note: I'm targeting `release/9.5` as I think this deserves a CFE so we don't ship a regression in WC 9.5.

### How to test the changes in this Pull Request:

1. Create an online store that can be crawled by Google Search Console. Create several products: simple, variable, grouped, on sale, etc.
2. Inspect all product pages using the Search Console URL [Inspector Tool](https://support.google.com/webmasters/answer/9012289?hl=en).
3. Verify there are no errors in any of them.