### PR TITLE
Fix Payments menu item linking to a blank page

### DIFF
--- a/plugins/woocommerce/changelog/fix-52812-payments-menu-item-linking-to-blank-page
+++ b/plugins/woocommerce/changelog/fix-52812-payments-menu-item-linking-to-blank-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Payments main menu item linking to a blank page when onboarding tasks are hidden.

--- a/plugins/woocommerce/client/admin/client/payments-welcome/strings.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/strings.tsx
@@ -95,7 +95,7 @@ export default {
 	survey: {
 		title: __( 'No thanks, I don’t want WooPayments', 'woocommerce' ),
 		intro: __(
-			'Note that the extension hasn’t been installed, this will simply remove WooPayments from the navigation. Please take a moment to tell us why you’d like to dismiss WooPayments.',
+			'Note that the extension hasn’t been installed. This will simply dismiss our limited time offer. Please take a moment to tell us why you’d like to dismiss the WooPayments offer.',
 			'woocommerce'
 		),
 		question: __(

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -149,8 +149,14 @@ class WcPayWelcomePage {
 				call_user_func_array( 'add_menu_page', $menu_with_nav_data );
 			}
 		} else {
-			// Determine the path to the active Payments task page.
-			$menu_path = 'admin.php?page=wc-admin&task=' . $this->get_active_payments_task_slug();
+			// Default to linking to the Payments settings page.
+			$menu_path = 'admin.php?page=wc-settings&tab=checkout';
+
+			// Determine the path to the active Payments task page, if any.
+			$task_slug = $this->get_active_payments_task_slug();
+			if ( ! empty( $task_slug ) ) {
+				$menu_path = 'admin.php?page=wc-admin&task=' . $task_slug;
+			}
 
 			add_menu_page(
 				$menu_title,
@@ -577,22 +583,30 @@ class WcPayWelcomePage {
 	private function get_active_payments_task_slug(): string {
 		$setup_task_list    = TaskLists::get_list( 'setup' );
 		$extended_task_list = TaskLists::get_list( 'extended' );
-		if ( empty( $setup_task_list ) && empty( $extended_task_list ) ) {
+
+		// The task pages are not available if the task lists don't exist or are not visible.
+		if (
+			( empty( $setup_task_list ) || ! $setup_task_list->is_visible() ) &&
+			( empty( $extended_task_list ) || ! $extended_task_list->is_visible() )
+		) {
 			return '';
 		}
 
+		// The Payments task in the setup task list.
 		$payments_task = $setup_task_list->get_task( 'payments' );
-		if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
+		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
 			return 'payments';
 		}
 
+		// The Additional Payments task in the extended task list.
 		$payments_task = $extended_task_list->get_task( 'payments' );
-		if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
+		if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
 			return 'payments';
 		}
 
-		$woopayments_task = $setup_task_list->get_task( 'woocommerce-payments' );
-		if ( ! empty( $woopayments_task ) && $woopayments_task->can_view() ) {
+		// The WooPayments task in the setup task list.
+		$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
+		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
 			return 'woocommerce-payments';
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -594,25 +594,25 @@ class WcPayWelcomePage {
 		}
 
 		// The Payments task in the setup task list.
-		if ( ! empty( $setup_task_list ) ) {
+		if ( ! empty( $setup_task_list ) && $setup_task_list->is_visible() ) {
 			$payments_task = $setup_task_list->get_task( 'payments' );
-			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+			if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
 				return 'payments';
 			}
 		}
 
 		// The Additional Payments task in the extended task list.
-		if ( ! empty( $extended_task_list ) ) {
+		if ( ! empty( $extended_task_list ) && $extended_task_list->is_visible() ) {
 			$payments_task = $extended_task_list->get_task( 'payments' );
-			if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+			if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
 				return 'payments';
 			}
 		}
 
 		// The WooPayments task in the setup task list.
-		if ( ! empty( $setup_task_list ) ) {
+		if ( ! empty( $setup_task_list ) && $setup_task_list->is_visible() ) {
 			$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
-			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+			if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
 				return 'woocommerce-payments';
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -585,6 +585,7 @@ class WcPayWelcomePage {
 		$extended_task_list = TaskLists::get_list( 'extended' );
 
 		// The task pages are not available if the task lists don't exist or are not visible.
+		// Bail early if we have no task to work with.
 		if (
 			( empty( $setup_task_list ) || ! $setup_task_list->is_visible() ) &&
 			( empty( $extended_task_list ) || ! $extended_task_list->is_visible() )
@@ -593,21 +594,27 @@ class WcPayWelcomePage {
 		}
 
 		// The Payments task in the setup task list.
-		$payments_task = $setup_task_list->get_task( 'payments' );
-		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
-			return 'payments';
+		if ( ! empty( $setup_task_list ) ) {
+			$payments_task = $setup_task_list->get_task( 'payments' );
+			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+				return 'payments';
+			}
 		}
 
 		// The Additional Payments task in the extended task list.
-		$payments_task = $extended_task_list->get_task( 'payments' );
-		if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
-			return 'payments';
+		if ( ! empty( $extended_task_list ) ) {
+			$payments_task = $extended_task_list->get_task( 'payments' );
+			if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+				return 'payments';
+			}
 		}
 
 		// The WooPayments task in the setup task list.
-		$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
-		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
-			return 'woocommerce-payments';
+		if ( ! empty( $setup_task_list ) ) {
+			$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
+			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+				return 'woocommerce-payments';
+			}
 		}
 
 		return '';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the WooCommerce onboarding tasks are dismissed or unavailable, their tasks' pages are no longer accessible either. We changed the linking of the Payments menu item to go to the WC Payments settings page by default.

_Update:_ We also fixed a potential fatal PHP error under certain conditions (using the `woocommerce_admin_experimental_onboarding_tasklists` filter to remove the core tasklists).

We have also adjusted the WooPayments incentives dismiss modal copy to make it accurate.

Closes #52812 
Closes #52868
Closes #52901
Closes https://github.com/Automattic/wp-calypso/issues/96499

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a JN store with this PR's live branch (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce=fix/payments-menu-links-to-blank-page))
2. Go through [the original PR's instructions](https://github.com/woocommerce/woocommerce/pull/51541) minus the first one to set up the JN site - you already did that.
3. You should now have WooPayments set up.
4. Go to WooCommerce > Home and hide the WooCommerce setup task list:
![Screenshot 2024-11-15 at 20 22 36](https://github.com/user-attachments/assets/8084e11b-3fe8-4a0f-96b9-76546b333e5f)
5. Go to Plugins and deactivate the WooPayments plugin
6. Click on the "Payments" top-level main menu item and will be taken to the Payments settings page:
![Screenshot 2024-11-15 at 20 29 09](https://github.com/user-attachments/assets/071251e7-0726-4732-8027-52c951b66f3f)
7. Go to Plugins > Add new, search for "stripe woocommerce" and install and activate the "WooCommerce Stripe Payment Gateway"
8. Click on its Settings link:
![Screenshot 2024-11-15 at 20 33 57](https://github.com/user-attachments/assets/61451492-4dd2-4194-9ede-a70d558b901f)
9. Create or connect a test account to set it up (click on "Skip this form" when redirect to Stripe):
![Screenshot 2024-11-15 at 20 34 33](https://github.com/user-attachments/assets/907466a9-745d-4321-a9bf-539f3ee54c12)
10. Click on the "Payments" top-level main menu item and you will be taken to the "Set up additional payment options" task page:
![Screenshot 2024-11-15 at 20 36 51](https://github.com/user-attachments/assets/07bb01f5-e7cf-4761-bf72-e9e93895da79)
11. Go to WooCommerce > Home and hide the "Things to do next" task list:
![Screenshot 2024-11-15 at 20 38 16](https://github.com/user-attachments/assets/f4578e6a-1283-43b2-a571-f7f9dab099c9)
12. Refresh the page, click on the "Payments" top-level main menu item, and you will be taken to the Payments settings page.
13. Activate back WooPayments and when you click on "Payments" top-level main menu item you will be taken to the WooPayments overview page:
![Screenshot 2024-11-15 at 20 41 36](https://github.com/user-attachments/assets/bb676178-2e10-4b16-a773-4db02a134b04)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
