### PR TITLE
[Settings] Add transformer for grouping settings elements into sections and checkbox groups

### DIFF
--- a/packages/js/settings-editor/changelog/add-transform-settings-data
+++ b/packages/js/settings-editor/changelog/add-transform-settings-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update SettingsField types

--- a/packages/js/settings-editor/typings/global.d.ts
+++ b/packages/js/settings-editor/typings/global.d.ts
@@ -1,27 +1,47 @@
 declare global {
-	interface SettingsField {
-		title?: string;
-		type: string;
-		id?: string;
-		desc?: string;
-		desc_tip?: boolean | string;
-		default?: string | number | boolean | object;
-		value: string | number | boolean | object;
-		placeholder?: string;
-		custom_attributes?: {
-			[ key: string ]: string | number;
-		};
-		options?: {
-			[ key: string ]: string;
-		};
-		css?: string;
-		class?: string;
-		checkboxgroup?: 'start' | 'end' | '';
-		autoload?: boolean;
-		show_if_checked?: string;
-		content?: string;
-		[ key: string ]: any;
-	}
+    interface BaseSettingsField {
+        title?: string;
+        type: string;
+        id?: string;
+        desc?: string;
+        desc_tip?: boolean | string;
+        default?: string | number | boolean | object;
+        value: string | number | boolean | object;
+        placeholder?: string;
+        custom_attributes?: {
+            [key: string]: string | number;
+        };
+        options?: {
+            [key: string]: string;
+        };
+        css?: string;
+        class?: string;
+        autoload?: boolean;
+        show_if_checked?: string;
+        content?: string;
+        [key: string]: any;
+    }
+
+    interface GroupSettingsField extends BaseSettingsField {
+        type: 'group';
+        settings: SettingsField[];
+    }
+    interface CheckboxSettingsField extends BaseSettingsField {
+        type: 'checkbox';
+        checkboxgroup?: 'start' | 'end' | '';
+    }
+
+    interface CheckboxGroupSettingsField extends BaseSettingsField {
+        type: 'checkboxgroup';
+        settings: CheckboxSettingsField[];
+    }
+
+    type SettingsField = BaseSettingsField | GroupSettingsField | CheckboxGroupSettingsField | CheckboxSettingsField;
+
+    interface SettingsSection {
+        label: string;
+        settings: SettingsField[];
+    }
 
 	interface SettingsSection {
 		label: string;

--- a/packages/js/settings-editor/typings/global.d.ts
+++ b/packages/js/settings-editor/typings/global.d.ts
@@ -38,11 +38,6 @@ declare global {
 
     type SettingsField = BaseSettingsField | GroupSettingsField | CheckboxGroupSettingsField | CheckboxSettingsField;
 
-    interface SettingsSection {
-        label: string;
-        settings: SettingsField[];
-    }
-
 	interface SettingsSection {
 		label: string;
 		settings: SettingField[];

--- a/plugins/woocommerce/changelog/add-transform-settings-data
+++ b/plugins/woocommerce/changelog/add-transform-settings-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Transform SettingsSection data for layout

--- a/plugins/woocommerce/src/Admin/Features/Settings/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Init.php
@@ -16,7 +16,7 @@ class Init {
 	/**
 	 * Class instance.
 	 *
-	 * @var transform instance
+	 * @var Init instance
 	 */
 	protected static $instance = null;
 

--- a/plugins/woocommerce/src/Admin/Features/Settings/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Init.php
@@ -147,8 +147,8 @@ class Init {
 		foreach ( $setting_pages as $setting_page ) {
 			$pages = $setting_page->add_settings_page_data( $pages );
 		}
-
-		$settings['settingsData'] = Transformer::transform( $pages );
+		$transformer              = new Transformer();
+		$settings['settingsData'] = $transformer->transform( $pages );
 
 		return $settings;
 	}

--- a/plugins/woocommerce/src/Admin/Features/Settings/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Init.php
@@ -1,20 +1,22 @@
-<?php //phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+<?php
 /**
  * WooCommerce Settings.
  */
 
-namespace Automattic\WooCommerce\Admin\Features;
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\Settings;
 
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 
 /**
  * Contains backend logic for the Settings feature.
  */
-class Settings {
+class Init {
 	/**
 	 * Class instance.
 	 *
-	 * @var Settings instance
+	 * @var transform instance
 	 */
 	protected static $instance = null;
 
@@ -146,7 +148,7 @@ class Settings {
 			$pages = $setting_page->add_settings_page_data( $pages );
 		}
 
-		$settings['settingsData'] = $pages;
+		$settings['settingsData'] = Transformer::transform( $pages );
 
 		return $settings;
 	}

--- a/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * WooCommerce Settings Data Transformer.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Features\Settings;
+
+/**
+ * Transforms WooCommerce settings data into a structured format with logical groupings.
+ */
+class Transformer {
+	/**
+	 * Current group being processed.
+	 *
+	 * @var array|null
+	 */
+	private static ?array $current_group = null;
+
+	/**
+	 * Current checkbox group being processed.
+	 *
+	 * @var array|null
+	 */
+	private static ?array $current_checkbox_group = null;
+
+	/**
+	 * Transform settings data.
+	 *
+	 * @param array $raw_settings Raw settings data.
+	 *
+	 * @return array Transformed settings data.
+	 */
+	public static function transform( array $raw_settings ): array {
+		$transformed = array();
+
+		foreach ( $raw_settings as $tab_id => $tab ) {
+			// If the tab doesn't have sections, or the sections aren't an array, skip it.
+			if ( ! isset( $tab['sections'] ) || ! is_array( $tab['sections'] ) ) {
+				$transformed[ $tab_id ] = $tab;
+				continue;
+			}
+
+			$transformed[ $tab_id ] = array_merge(
+				$tab,
+				array( 'sections' => self::transform_sections( $tab['sections'] ) )
+			);
+		}
+
+		return $transformed;
+	}
+
+	/**
+	 * Transform sections within a tab.
+	 *
+	 * @param array $sections Sections to transform.
+	 *
+	 * @return array Transformed sections.
+	 */
+	private static function transform_sections( array $sections ): array {
+		$transformed_sections = array();
+
+		foreach ( $sections as $section_id => $section ) {
+			// If the section doesn't have settings, or the settings aren't an array, skip it.
+			if ( ! isset( $section['settings'] ) || ! is_array( $section['settings'] ) ) {
+				$transformed_sections[ $section_id ] = $section;
+				continue;
+			}
+
+			$transformed_sections[ $section_id ] = array_merge(
+				$section,
+				array( 'settings' => self::transform_section_settings( $section['settings'] ) )
+			);
+		}
+
+		return $transformed_sections;
+	}
+
+	/**
+	 * Transform settings within a section.
+	 *
+	 * @param array $settings Settings to transform.
+	 *
+	 * @return array Transformed settings.
+	 */
+	private static function transform_section_settings( array $settings ): array {
+		self::reset_state();
+		$transformed_settings = array();
+
+		foreach ( $settings as $setting ) {
+			self::process_setting( $setting, $transformed_settings );
+		}
+		self::finalize_transformation( $transformed_settings );
+
+		return $transformed_settings;
+	}
+
+	/**
+	 * Process individual setting.
+	 *
+	 * @param array $setting Setting to process.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function process_setting( array $setting, array &$transformed_settings ): void {
+		$type = $setting['type'] ?? '';
+
+		if ( self::$current_checkbox_group && 'checkbox' !== $type ) {
+			// It's expected that a checkbox group will always be closed before a non-checkbox setting.
+			self::flush_current_checkbox_group( $transformed_settings );
+		}
+
+		switch ( $type ) {
+			case 'title':
+				self::handle_group_start( $setting, $transformed_settings );
+				break;
+
+			case 'sectionend':
+				self::handle_group_end( $setting, $transformed_settings );
+				break;
+
+			case 'checkbox':
+				self::handle_checkbox_setting( $setting, $transformed_settings );
+				break;
+
+			default:
+				self::add_setting( $setting, $transformed_settings );
+				break;
+		}
+	}
+
+	/**
+	 * Handle the start of a new group.
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function handle_group_start( array $setting, array &$transformed_settings ): void {
+		// If we already have a group, flush it to settings before starting a new one.
+		if ( self::$current_group ) {
+			self::flush_current_group( $transformed_settings );
+		}
+
+		// If setting doesn't have an ID, add it as-is since we will be unable to match it with a sectionend.
+		if ( ! isset( $setting['id'] ) ) {
+			self::add_setting( $setting, $transformed_settings );
+			return;
+		}
+
+		self::$current_group = array( $setting );
+	}
+
+	/**
+	 * Handle the end of a group.
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function handle_group_end( array $setting, array &$transformed_settings ): void {
+		$ids_match = self::$current_group &&
+			isset( self::$current_group[0]['id'] ) &&
+			isset( $setting['id'] ) &&
+			self::$current_group[0]['id'] === $setting['id'];
+
+		// If IDs match, add the group and close it.
+		if ( $ids_match ) {
+			// pop first element from current group.
+			$title_setting = array_shift( self::$current_group );
+
+			$transformed_settings[] = array_merge(
+				$title_setting,
+				array(
+					'type'     => 'group',
+					'settings' => self::$current_group,
+				)
+			);
+			self::$current_group    = null;
+			return;
+		}
+
+		// If IDs don't match, we don't need to transform anything so flush the current group.
+		self::flush_current_group( $transformed_settings );
+		self::add_setting( $setting, $transformed_settings );
+	}
+
+	/**
+	 * Flush current group to transformed settings.
+	 *
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function flush_current_group( array &$transformed_settings ): void {
+		if ( self::$current_group ) {
+			$transformed_settings = array_merge( $transformed_settings, self::$current_group );
+			self::$current_group  = null;
+		}
+	}
+
+	/**
+	 * Handle checkbox setting and grouping.
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function handle_checkbox_setting( array $setting, array &$transformed_settings ): void {
+		$checkboxgroup = $setting['checkboxgroup'] ?? '';
+
+		switch ( $checkboxgroup ) {
+			case 'start':
+				self::start_checkbox_group( $setting, $transformed_settings );
+				break;
+			case 'end':
+				self::end_checkbox_group( $setting, $transformed_settings );
+				break;
+
+			default:
+				self::handle_checkbox_group_item( $setting, $transformed_settings );
+				break;
+		}
+	}
+
+	/**
+	 * Start a new checkbox group.
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function start_checkbox_group( array $setting, array &$transformed_settings ): void {
+		// If we already have an open checkbox group, flush it to settings before starting a new one.
+		if ( self::$current_checkbox_group ) {
+			self::flush_current_checkbox_group( $transformed_settings );
+		}
+
+		self::$current_checkbox_group = array( $setting );
+	}
+
+	/**
+	 * End current checkbox group.
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function end_checkbox_group( array $setting, array &$transformed_settings ): void {
+		if ( ! self::$current_checkbox_group ) {
+			// If we don't have an open checkbox group, add the setting as-is.
+			self::flush_current_checkbox_group( $transformed_settings );
+			self::add_setting( $setting, $transformed_settings );
+			return;
+		}
+
+		self::$current_checkbox_group[] = $setting;
+		$first_setting                  = self::$current_checkbox_group[0];
+
+		$checkbox_group_setting = array(
+			'type'     => 'checkboxgroup',
+			'title'    => $first_setting['title'] ?? '',
+			'settings' => self::$current_checkbox_group,
+		);
+
+		self::add_setting( $checkbox_group_setting, $transformed_settings );
+		self::$current_checkbox_group = null;
+	}
+
+	/**
+	 * Handle checkbox within a group.
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function handle_checkbox_group_item( array $setting, array &$transformed_settings ): void {
+		if ( self::$current_checkbox_group ) {
+			self::$current_checkbox_group[] = $setting;
+			return;
+		}
+
+		// If we don't have an open checkbox group, add the setting as-is.
+		self::add_setting( $setting, $transformed_settings );
+	}
+
+	/**
+	 * Flush current checkbox group to transformed settings.
+	 *
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function flush_current_checkbox_group( array &$transformed_settings ): void {
+		if ( self::$current_checkbox_group ) {
+			$transformed_settings         = array_merge( $transformed_settings, self::$current_checkbox_group );
+			self::$current_checkbox_group = null;
+		}
+	}
+
+	/**
+	 * Add setting to current context (group or root).
+	 *
+	 * @param array $setting Setting to add.
+	 * @param array $transformed_settings Transformed settings array.
+	 */
+	private static function add_setting( array $setting, array &$transformed_settings ): void {
+		if ( self::$current_group ) {
+			self::$current_group[] = $setting;
+			return;
+		}
+
+		$transformed_settings[] = $setting;
+	}
+
+	/**
+	 * Finalize the transformation process.
+	 *
+	 * @param array &$transformed_settings Transformed settings array.
+	 */
+	private static function finalize_transformation( array &$transformed_settings ): void {
+		if ( self::$current_group ) {
+			self::flush_current_group( $transformed_settings );
+		}
+
+		if ( self::$current_checkbox_group ) {
+			self::flush_current_checkbox_group( $transformed_settings );
+		}
+	}
+
+
+	/**
+	 * Reset the state to its initial values.
+	 */
+	public static function reset_state(): void {
+		self::$current_group          = null;
+		self::$current_checkbox_group = null;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
@@ -16,14 +16,14 @@ class Transformer {
 	 *
 	 * @var array|null
 	 */
-	private static ?array $current_group = null;
+	private ?array $current_group = null;
 
 	/**
 	 * Current checkbox group being processed.
 	 *
 	 * @var array|null
 	 */
-	private static ?array $current_checkbox_group = null;
+	private ?array $current_checkbox_group = null;
 
 	/**
 	 * Transform settings data.
@@ -32,7 +32,7 @@ class Transformer {
 	 *
 	 * @return array Transformed settings data.
 	 */
-	public static function transform( array $raw_settings ): array {
+	public function transform( array $raw_settings ): array {
 		$transformed = array();
 
 		foreach ( $raw_settings as $tab_id => $tab ) {
@@ -43,7 +43,7 @@ class Transformer {
 			}
 
 			$transformed[ $tab_id ]             = $tab;
-			$transformed[ $tab_id ]['sections'] = self::transform_sections( $tab['sections'] );
+			$transformed[ $tab_id ]['sections'] = $this->transform_sections( $tab['sections'] );
 		}
 
 		return $transformed;
@@ -56,7 +56,7 @@ class Transformer {
 	 *
 	 * @return array Transformed sections.
 	 */
-	private static function transform_sections( array $sections ): array {
+	private function transform_sections( array $sections ): array {
 		$transformed_sections = array();
 
 		foreach ( $sections as $section_id => $section ) {
@@ -67,7 +67,7 @@ class Transformer {
 			}
 
 			$transformed_sections[ $section_id ]             = $section;
-			$transformed_sections[ $section_id ]['settings'] = self::transform_section_settings( $section['settings'] );
+			$transformed_sections[ $section_id ]['settings'] = $this->transform_section_settings( $section['settings'] );
 		}
 
 		return $transformed_sections;
@@ -80,14 +80,14 @@ class Transformer {
 	 *
 	 * @return array Transformed settings.
 	 */
-	private static function transform_section_settings( array $settings ): array {
-		self::reset_state();
+	private function transform_section_settings( array $settings ): array {
+		$this->reset_state();
 		$transformed_settings = array();
 
 		foreach ( $settings as $setting ) {
-			self::process_setting( $setting, $transformed_settings );
+			$this->process_setting( $setting, $transformed_settings );
 		}
-		self::finalize_transformation( $transformed_settings );
+		$this->finalize_transformation( $transformed_settings );
 
 		return $transformed_settings;
 	}
@@ -98,30 +98,30 @@ class Transformer {
 	 * @param array $setting Setting to process.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function process_setting( array $setting, array &$transformed_settings ): void {
+	private function process_setting( array $setting, array &$transformed_settings ): void {
 		$type = $setting['type'] ?? '';
 
-		if ( self::$current_checkbox_group && 'checkbox' !== $type ) {
+		if ( $this->current_checkbox_group && 'checkbox' !== $type ) {
 			// It's expected that a checkbox group will always be closed before a non-checkbox setting.
 			// If not, it's likely a checkbox group was not closed properly so we flush the current checkbox group and add the setting as-is.
-			self::flush_current_checkbox_group( $transformed_settings );
+			$this->flush_current_checkbox_group( $transformed_settings );
 		}
 
 		switch ( $type ) {
 			case 'title':
-				self::handle_group_start( $setting, $transformed_settings );
+				$this->handle_group_start( $setting, $transformed_settings );
 				break;
 
 			case 'sectionend':
-				self::handle_group_end( $setting, $transformed_settings );
+				$this->handle_group_end( $setting, $transformed_settings );
 				break;
 
 			case 'checkbox':
-				self::handle_checkbox_setting( $setting, $transformed_settings );
+				$this->handle_checkbox_setting( $setting, $transformed_settings );
 				break;
 
 			default:
-				self::add_setting( $setting, $transformed_settings );
+				$this->add_setting( $setting, $transformed_settings );
 				break;
 		}
 	}
@@ -132,19 +132,19 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function handle_group_start( array $setting, array &$transformed_settings ): void {
+	private function handle_group_start( array $setting, array &$transformed_settings ): void {
 		// If setting doesn't have an ID, add it as-is since we will be unable to match it with a sectionend.
 		if ( ! isset( $setting['id'] ) ) {
-			self::add_setting( $setting, $transformed_settings );
+			$this->add_setting( $setting, $transformed_settings );
 			return;
 		}
 
 		// If we already have a group, flush it to settings before starting a new one.
-		if ( self::$current_group ) {
-			self::flush_current_group( $transformed_settings );
+		if ( $this->current_group ) {
+			$this->flush_current_group( $transformed_settings );
 		}
 
-		self::$current_group = array( $setting );
+		$this->current_group = array( $setting );
 	}
 
 	/**
@@ -153,30 +153,30 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function handle_group_end( array $setting, array &$transformed_settings ): void {
-		$ids_match = self::$current_group &&
-			isset( self::$current_group[0]['id'] ) &&
+	private function handle_group_end( array $setting, array &$transformed_settings ): void {
+		$ids_match = $this->current_group &&
+			isset( $this->current_group[0]['id'] ) &&
 			isset( $setting['id'] ) &&
-			self::$current_group[0]['id'] === $setting['id'];
+			$this->current_group[0]['id'] === $setting['id'];
 
 		// If IDs match, add the group and close it.
 		if ( $ids_match ) {
 			// Compose the group setting.
-			$title_setting          = array_shift( self::$current_group );
+			$title_setting          = array_shift( $this->current_group );
 			$transformed_settings[] = array_merge(
 				$title_setting,
 				array(
 					'type'     => 'group',
-					'settings' => self::$current_group,
+					'settings' => $this->current_group,
 				)
 			);
-			self::$current_group    = null;
+			$this->current_group    = null;
 			return;
 		}
 
 		// If IDs don't match, we don't need to transform anything so flush the current group.
-		self::flush_current_group( $transformed_settings );
-		self::add_setting( $setting, $transformed_settings );
+		$this->flush_current_group( $transformed_settings );
+		$this->add_setting( $setting, $transformed_settings );
 	}
 
 	/**
@@ -184,10 +184,10 @@ class Transformer {
 	 *
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function flush_current_group( array &$transformed_settings ): void {
-		if ( is_array( self::$current_group ) ) {
-			$transformed_settings = array_merge( $transformed_settings, self::$current_group );
-			self::$current_group  = null;
+	private function flush_current_group( array &$transformed_settings ): void {
+		if ( is_array( $this->current_group ) ) {
+			$transformed_settings = array_merge( $transformed_settings, $this->current_group );
+			$this->current_group  = null;
 		}
 	}
 
@@ -197,20 +197,20 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function handle_checkbox_setting( array $setting, array &$transformed_settings ): void {
+	private function handle_checkbox_setting( array $setting, array &$transformed_settings ): void {
 		$checkboxgroup = $setting['checkboxgroup'] ?? '';
 
 		switch ( $checkboxgroup ) {
 			case 'start':
-				self::start_checkbox_group( $setting, $transformed_settings );
+				$this->start_checkbox_group( $setting, $transformed_settings );
 				break;
 
 			case 'end':
-				self::end_checkbox_group( $setting, $transformed_settings );
+				$this->end_checkbox_group( $setting, $transformed_settings );
 				break;
 
 			default:
-				self::handle_checkbox_group_item( $setting, $transformed_settings );
+				$this->handle_checkbox_group_item( $setting, $transformed_settings );
 				break;
 		}
 	}
@@ -221,13 +221,13 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function start_checkbox_group( array $setting, array &$transformed_settings ): void {
+	private function start_checkbox_group( array $setting, array &$transformed_settings ): void {
 		// If we already have an open checkbox group, flush it to settings before starting a new one.
-		if ( is_array( self::$current_checkbox_group ) ) {
-			self::flush_current_checkbox_group( $transformed_settings );
+		if ( is_array( $this->current_checkbox_group ) ) {
+			$this->flush_current_checkbox_group( $transformed_settings );
 		}
 
-		self::$current_checkbox_group = array( $setting );
+		$this->current_checkbox_group = array( $setting );
 	}
 
 	/**
@@ -236,24 +236,24 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function end_checkbox_group( array $setting, array &$transformed_settings ): void {
-		if ( empty( self::$current_checkbox_group ) ) {
+	private function end_checkbox_group( array $setting, array &$transformed_settings ): void {
+		if ( empty( $this->current_checkbox_group ) ) {
 			// If we don't have an open checkbox group, add the setting as-is.
-			self::add_setting( $setting, $transformed_settings );
+			$this->add_setting( $setting, $transformed_settings );
 			return;
 		}
 
-		self::$current_checkbox_group[] = $setting;
-		$first_setting                  = self::$current_checkbox_group[0];
+		$this->current_checkbox_group[] = $setting;
+		$first_setting                  = $this->current_checkbox_group[0];
 
 		$checkbox_group_setting = array(
 			'type'     => 'checkboxgroup',
 			'title'    => $first_setting['title'] ?? '',
-			'settings' => self::$current_checkbox_group,
+			'settings' => $this->current_checkbox_group,
 		);
 
-		self::add_setting( $checkbox_group_setting, $transformed_settings );
-		self::$current_checkbox_group = null;
+		$this->add_setting( $checkbox_group_setting, $transformed_settings );
+		$this->current_checkbox_group = null;
 	}
 
 	/**
@@ -262,14 +262,14 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function handle_checkbox_group_item( array $setting, array &$transformed_settings ): void {
-		if ( is_array( self::$current_checkbox_group ) ) {
-			self::$current_checkbox_group[] = $setting;
+	private function handle_checkbox_group_item( array $setting, array &$transformed_settings ): void {
+		if ( is_array( $this->current_checkbox_group ) ) {
+			$this->current_checkbox_group[] = $setting;
 			return;
 		}
 
 		// If we don't have an open checkbox group, add the setting as-is.
-		self::add_setting( $setting, $transformed_settings );
+		$this->add_setting( $setting, $transformed_settings );
 	}
 
 	/**
@@ -277,10 +277,10 @@ class Transformer {
 	 *
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function flush_current_checkbox_group( array &$transformed_settings ): void {
-		if ( is_array( self::$current_checkbox_group ) ) {
-			$transformed_settings         = array_merge( $transformed_settings, self::$current_checkbox_group );
-			self::$current_checkbox_group = null;
+	private function flush_current_checkbox_group( array &$transformed_settings ): void {
+		if ( is_array( $this->current_checkbox_group ) ) {
+			$transformed_settings         = array_merge( $transformed_settings, $this->current_checkbox_group );
+			$this->current_checkbox_group = null;
 		}
 	}
 
@@ -290,9 +290,9 @@ class Transformer {
 	 * @param array $setting Setting to add.
 	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private static function add_setting( array $setting, array &$transformed_settings ): void {
-		if ( is_array( self::$current_group ) ) {
-			self::$current_group[] = $setting;
+	private function add_setting( array $setting, array &$transformed_settings ): void {
+		if ( is_array( $this->current_group ) ) {
+			$this->current_group[] = $setting;
 			return;
 		}
 
@@ -304,16 +304,16 @@ class Transformer {
 	 *
 	 * @param array &$transformed_settings Transformed settings array.
 	 */
-	private static function finalize_transformation( array &$transformed_settings ): void {
-		self::flush_current_group( $transformed_settings );
-		self::flush_current_checkbox_group( $transformed_settings );
+	private function finalize_transformation( array &$transformed_settings ): void {
+		$this->flush_current_group( $transformed_settings );
+		$this->flush_current_checkbox_group( $transformed_settings );
 	}
 
 	/**
 	 * Reset the state to its initial values.
 	 */
-	public static function reset_state(): void {
-		self::$current_group          = null;
-		self::$current_checkbox_group = null;
+	public function reset_state(): void {
+		$this->current_group          = null;
+		$this->current_checkbox_group = null;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
@@ -42,10 +42,8 @@ class Transformer {
 				continue;
 			}
 
-			$transformed[ $tab_id ] = array_merge(
-				$tab,
-				array( 'sections' => self::transform_sections( $tab['sections'] ) )
-			);
+			$transformed[ $tab_id ]             = $tab;
+			$transformed[ $tab_id ]['sections'] = self::transform_sections( $tab['sections'] );
 		}
 
 		return $transformed;
@@ -68,10 +66,8 @@ class Transformer {
 				continue;
 			}
 
-			$transformed_sections[ $section_id ] = array_merge(
-				$section,
-				array( 'settings' => self::transform_section_settings( $section['settings'] ) )
-			);
+			$transformed_sections[ $section_id ]             = $section;
+			$transformed_sections[ $section_id ]['settings'] = self::transform_section_settings( $section['settings'] );
 		}
 
 		return $transformed_sections;

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
@@ -1,0 +1,605 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Admin\Features\Settings;
+
+use Automattic\WooCommerce\Admin\Features\Settings\Transformer;
+use WC_Unit_Test_Case;
+
+/**
+ * Unit tests for Settings Data Transformer.
+ *
+ * @covers \Automattic\WooCommerce\Admin\Features\Settings\Transformer
+ */
+class TransformerTest extends WC_Unit_Test_Case {
+	/**
+	 * Set things up before each test case.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Transformer::reset_state();
+	}
+
+	/**
+	 * Test basic transformation with no sections.
+	 */
+	public function test_transform_with_no_sections(): void {
+		$input = array(
+			'tab1' => array(
+				'label' => 'Tab 1',
+				'icon'  => 'icon1',
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'label' => 'Tab 1',
+				'icon'  => 'icon1',
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected no sections to be transformed' );
+	}
+
+	/**
+	 * Test transformation with empty sections.
+	 */
+	public function test_transform_with_empty_sections(): void {
+		$input = array(
+			'tab1' => array(
+				'label'    => 'Tab 1',
+				'sections' => array(),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'label'    => 'Tab 1',
+				'sections' => array(),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected empty sections to remain untransformed' );
+	}
+
+	/**
+	 * Test group grouping.
+	 */
+	public function test_group_grouping(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'id'    => 'group_1',
+								'title' => 'group 1',
+								'desc'  => 'Description 1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting2',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'group_1',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'     => 'group',
+								'id'       => 'group_1',
+								'title'    => 'group 1',
+								'desc'     => 'Description 1',
+								'settings' => array(
+									array(
+										'type' => 'text',
+										'id'   => 'setting1',
+									),
+									array(
+										'type' => 'text',
+										'id'   => 'setting2',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected group to be transformed' );
+	}
+
+	/**
+	 * Test checkbox group transformation.
+	 */
+	public function test_checkbox_group_transformation(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check1',
+								'title'         => 'Checkbox Group',
+								'checkboxgroup' => 'start',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check2',
+								'checkboxgroup' => '',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check3',
+								'checkboxgroup' => 'end',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'     => 'checkboxgroup',
+								'title'    => 'Checkbox Group',
+								'settings' => array(
+									array(
+										'type'          => 'checkbox',
+										'id'            => 'check1',
+										'title'         => 'Checkbox Group',
+										'checkboxgroup' => 'start',
+									),
+									array(
+										'type'          => 'checkbox',
+										'id'            => 'check2',
+										'checkboxgroup' => '',
+									),
+									array(
+										'type'          => 'checkbox',
+										'id'            => 'check3',
+										'checkboxgroup' => 'end',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected checkbox group to be transformed' );
+	}
+
+	/**
+	 * Test nested sectionend and checkboxgroup.
+	 */
+	public function test_nested_sectionend_and_checkboxgroup(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'id'    => 'group_1',
+								'title' => 'group 1',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check1',
+								'title'         => 'Checkbox Group',
+								'checkboxgroup' => 'start',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check2',
+								'checkboxgroup' => 'end',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'group_1',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'     => 'group',
+								'id'       => 'group_1',
+								'title'    => 'group 1',
+								'settings' => array(
+									array(
+										'type'     => 'checkboxgroup',
+										'title'    => 'Checkbox Group',
+										'settings' => array(
+											array(
+												'type'  => 'checkbox',
+												'id'    => 'check1',
+												'title' => 'Checkbox Group',
+												'checkboxgroup' => 'start',
+											),
+											array(
+												'type' => 'checkbox',
+												'id'   => 'check2',
+												'checkboxgroup' => 'end',
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected nested sectionend and checkboxgroup to be transformed' );
+	}
+
+	/**
+	 * Test that unmatched title and sectionend are left as is.
+	 */
+	public function test_unmatched_title_and_sectionend(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'id'    => 'group_1',
+								'title' => 'group 1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'different_id', // Mismatched ID.
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'id'    => 'group_1',
+								'title' => 'group 1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'different_id',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected unmatched title and sectionend to remain untransformed' );
+	}
+
+	/**
+	 * Test that incomplete checkbox groups are left as is.
+	 */
+	public function test_incomplete_checkbox_group(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check1',
+								'title'         => 'Checkbox 1',
+								'checkboxgroup' => 'start',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check2',
+								'checkboxgroup' => '',
+							),
+							// Missing 'end' checkbox.
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = $input;
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected incomplete checkbox group to remain untransformed' );
+	}
+
+	/**
+	 * Test orphaned end checkbox.
+	 */
+	public function test_orphaned_end_checkbox(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check1',
+								'checkboxgroup' => 'end', // Orphaned end.
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = $input;
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected orphaned end checkbox to remain untransformed' );
+	}
+
+	/**
+	 * Test multiple independent checkboxes.
+	 */
+	public function test_independent_checkboxes(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type' => 'checkbox',
+								'id'   => 'check1',
+							),
+							array(
+								'type' => 'checkbox',
+								'id'   => 'check2',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type' => 'checkbox',
+								'id'   => 'check1',
+							),
+							array(
+								'type' => 'checkbox',
+								'id'   => 'check2',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected independent checkboxes to remain untransformed' );
+	}
+
+	/**
+	 * Test mixed valid and invalid groups.
+	 */
+	public function test_mixed_valid_and_invalid_groups(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							// Valid group.
+							array(
+								'type'  => 'title',
+								'id'    => 'valid_group',
+								'title' => 'Valid group',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'valid_group',
+							),
+							// Invalid group.
+							array(
+								'type'  => 'title',
+								'id'    => 'invalid_group',
+								'title' => 'Invalid group',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting2',
+							),
+							// No matching sectionend
+							// Valid checkbox group.
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check1',
+								'title'         => 'Valid Group',
+								'checkboxgroup' => 'start',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check2',
+								'checkboxgroup' => 'end',
+							),
+							// Invalid checkbox group.
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check3',
+								'title'         => 'Invalid Group',
+								'checkboxgroup' => 'start',
+							),
+							// No matching end.
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							// Valid group gets transformed.
+							array(
+								'type'     => 'group',
+								'id'       => 'valid_group',
+								'title'    => 'Valid group',
+								'settings' => array(
+									array(
+										'type' => 'text',
+										'id'   => 'setting1',
+									),
+								),
+							),
+							// Invalid group remains untransformed.
+							array(
+								'type'  => 'title',
+								'id'    => 'invalid_group',
+								'title' => 'Invalid group',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting2',
+							),
+							// Valid checkbox group gets transformed.
+							array(
+								'type'     => 'checkboxgroup',
+								'title'    => 'Valid Group',
+								'settings' => array(
+									array(
+										'type'          => 'checkbox',
+										'id'            => 'check1',
+										'title'         => 'Valid Group',
+										'checkboxgroup' => 'start',
+									),
+									array(
+										'type'          => 'checkbox',
+										'id'            => 'check2',
+										'checkboxgroup' => 'end',
+									),
+								),
+							),
+							// Invalid checkbox group remains untransformed.
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check3',
+								'title'         => 'Invalid Group',
+								'checkboxgroup' => 'start',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, Transformer::transform( $input ) );
+	}
+
+	/**
+	 * Test multiple groups in a section.
+	 */
+	public function test_multiple_groups(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'id'    => 'group_1',
+								'title' => 'group 1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'group_1',
+							),
+							array(
+								'type'  => 'title',
+								'id'    => 'group_2',
+								'title' => 'group 2',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting2',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'group_2',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$transformed = Transformer::transform( $input );
+		$settings    = $transformed['tab1']['sections']['section1']['settings'];
+
+		$this->assertCount( 2, $settings );
+		$this->assertEquals( 'group_1', $settings[0]['id'] );
+		$this->assertEquals( 'group_2', $settings[1]['id'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
@@ -14,13 +14,20 @@ use WC_Unit_Test_Case;
  */
 class TransformerTest extends WC_Unit_Test_Case {
 	/**
+	 * Transformer instance.
+	 *
+	 * @var Transformer
+	 */
+	private Transformer $transformer;
+
+	/**
 	 * Set things up before each test case.
 	 *
 	 * @return void
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		Transformer::reset_state();
+		$this->transformer = new Transformer();
 	}
 
 	/**
@@ -28,7 +35,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 	 * @param array $input Input data.
 	 */
 	public function test_basic_transformations( array $input ): void {
-		$this->assertEquals( $input, Transformer::transform( $input ) );
+		$this->assertEquals( $input, $this->transformer->transform( $input ) );
 	}
 
 	/**
@@ -67,7 +74,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 	public function test_malformed_input( array $input, string $message ): void {
 		$this->assertEquals(
 			$input,
-			Transformer::transform( $input ),
+			$this->transformer->transform( $input ),
 			$message
 		);
 	}
@@ -166,7 +173,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected group to be transformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected group to be transformed' );
 	}
 
 
@@ -211,7 +218,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$transformed = Transformer::transform( $input );
+		$transformed = $this->transformer->transform( $input );
 		$settings    = $transformed['tab1']['sections']['section1']['settings'];
 
 		$expected = array(
@@ -361,7 +368,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected, Transformer::transform( $input ) );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ) );
 	}
 
 	/**
@@ -428,7 +435,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected checkbox group to be transformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected checkbox group to be transformed' );
 	}
 
 
@@ -474,7 +481,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected independent checkboxes to remain untransformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected independent checkboxes to remain untransformed' );
 	}
 
 	/**
@@ -529,7 +536,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected unmatched title and sectionend to remain untransformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected unmatched title and sectionend to remain untransformed' );
 	}
 
 	/**
@@ -565,7 +572,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 
 		$expected = $input;
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected incomplete checkbox group to remain untransformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected incomplete checkbox group to remain untransformed' );
 	}
 
 	/**
@@ -594,7 +601,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 
 		$expected = $input;
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected orphaned end checkbox to remain untransformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected orphaned end checkbox to remain untransformed' );
 	}
 
 		/**
@@ -667,6 +674,6 @@ class TransformerTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected, Transformer::transform( $input ), 'Expected nested sectionend and checkboxgroup to be transformed' );
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected nested sectionend and checkboxgroup to be transformed' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
@@ -110,6 +110,20 @@ class TransformerTest extends WC_Unit_Test_Case {
 				),
 				'Invalid section format should remain unchanged',
 			),
+			'null_sections'           => array(
+				array(
+					'tab1' => array(
+						'sections' => null,
+					),
+				),
+				'Null sections should remain unchanged',
+			),
+			'null_tab_content'        => array(
+				array(
+					'tab1' => null,
+				),
+				'Null tab content should remain unchanged',
+			),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52798

This PR introduces a transformer class that organizes settings data into logical groups while maintaining the original structure and order of settings by:

- Grouping settings between `title` and `sectionend` into logical groups
- Grouping consecutive checkboxes marked with `checkboxgroup` attributes
- Preserving original settings when grouping conditions aren't met
- Maintaining the order of settings within sections

For simplicity, this transformer does not handle nested groups since we don't have any use cases for it yet.

I implemented it in PHP because we can cache the transformed data on server side to improve performance instead of transforming the data on-the-fly in JS, which delays the initial page load. But this PR doesn't include that to keep this PR focused on the main task.

Changes:
- Added `Transformer` class for settings data transformation. 
- Update `global.d.ts`
- Add unit tests

Input example:

```php
[
    'tab_id' => [
        'sections' => [
            'section_id' => [
                'settings' => [
                    ['type' => 'title', 'id' => 'group_1', ...],
                    ['type' => 'text', ...],
                    ['type' => 'sectionend', 'id' => 'group_1']
                ]
            ]
        ]
    ]
]
```

Output example:

```php
[
    'tab_id' => [
        'sections' => [
            'section_id' => [
                'settings' => [
                    [
                        'type' => 'group',
                        'id' => 'group_1',
                        'settings' => [
                            ['type' => 'text', ...]
                        ]
                    ]
                ]
            ]
        ]
    ]
]
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review the code changes and confirm unit tests cover all possible cases.
2. Create a fresh site with `settings` feature flag enabled.
3. Go to the settings page and open dev tools.
4. Run `window.wcSettings.admin.settingsData` in the console and confirm the structure is as expected.


See that Products settings for example is grouped as expected.

![Screenshot 2024-11-19 at 10 28 23](https://github.com/user-attachments/assets/6e6e9f4d-fac7-4d6b-8b0a-d05ca731b891)
![Screenshot 2024-11-19 at 10 30 01](https://github.com/user-attachments/assets/d94423ed-3d8d-423c-aab4-1a7465cef124)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
