### PR TITLE
Include e2e-utils-playwright package in PR auto label configuration

### DIFF
--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -3,6 +3,9 @@
 
 'package: @woocommerce/e2e-utils':
   - packages/js/e2e-utils/**/*
+    
+'package: @woocommerce/e2e-utils-playwright':
+  - packages/js/e2e-utils-playwright/**/*
 
 'package: @woocommerce/e2e-environment':
   - packages/js/e2e-environment/**/*

--- a/packages/js/e2e-utils-playwright/src/cart.js
+++ b/packages/js/e2e-utils-playwright/src/cart.js
@@ -1,5 +1,5 @@
 /**
- * Adds a specified quantity of a product by ID to the WooCommerce cart
+ * Adds a specified quantity of a product by ID to the WooCommerce cart.
  *
  * @param {import('playwright').Page} page
  * @param {string}                    productId

--- a/packages/js/e2e-utils-playwright/src/cart.js
+++ b/packages/js/e2e-utils-playwright/src/cart.js
@@ -1,5 +1,5 @@
 /**
- * Adds a specified quantity of a product by ID to the WooCommerce cart.
+ * Adds a specified quantity of a product by ID to the WooCommerce cart
  *
  * @param {import('playwright').Page} page
  * @param {string}                    productId


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated the config for the `Label Pull Request Project` workflow to add the `package: @woocommerce/e2e-utils-playwright` label for changes in `packages/js/e2e-utils-playwright/**/*` path.

Part of https://github.com/woocommerce/woocommerce/issues/52939

### How to test the changes in this Pull Request:

Will be tested after merging with a PR that updates files in `packages/js/e2e-utils-playwright/**/*`
