### PR TITLE
Fix WordPress 6.7 internalization-related warnings in Brands

### DIFF
--- a/plugins/woocommerce/changelog/fix-wp-i10n-warning-brands
+++ b/plugins/woocommerce/changelog/fix-wp-i10n-warning-brands
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevented a i10n-related warning when using WordPress 6.7 with Brands

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -18,11 +18,18 @@ use Automattic\Jetpack\Constants;
 class WC_Brands_Admin {
 
 	/**
-	 * Settings array.
+	 * Settings array (Deprecated).
 	 *
 	 * @var array
 	 */
 	public $settings_tabs;
+
+	/**
+	 * Settings form fields (Deprecated).
+	 *
+	 * @var array
+	 */
+	private $settings;
 
 	/**
 	 * Admin fields.
@@ -55,17 +62,17 @@ class WC_Brands_Admin {
 			}
 		);
 
-		add_action( 'before_woocommerce_init', function() {
-			$this->settings_tabs = array(
-				'brands' => __( 'Brands', 'woocommerce' ),
-			);
-		} );
-
 		// Hiding setting for future depreciation. Only users who have touched this settings should see it.
 		$setting_value = get_option( 'wc_brands_show_description' );
 		if ( is_string( $setting_value ) ) {
+
 			// Add the settings fields to each tab.
-			$this->init_form_fields();
+			add_action( 'before_woocommerce_init', function() {
+				$this->init_form_fields();
+				$this->settings_tabs = array(
+						'brands' => __( 'Brands', 'woocommerce' ),
+				);
+			} );
 			add_action( 'woocommerce_get_sections_products', array( $this, 'add_settings_tab' ) );
 			add_action( 'woocommerce_get_settings_products', array( $this, 'add_settings_section' ), null, 2 );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -55,9 +55,11 @@ class WC_Brands_Admin {
 			}
 		);
 
-		$this->settings_tabs = array(
-			'brands' => __( 'Brands', 'woocommerce' ),
-		);
+		add_action( 'before_woocommerce_init', function() {
+			$this->settings_tabs = array(
+				'brands' => __( 'Brands', 'woocommerce' ),
+			);
+		} );
 
 		// Hiding setting for future depreciation. Only users who have touched this settings should see it.
 		$setting_value = get_option( 'wc_brands_show_description' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -69,7 +69,7 @@ class WC_Brands_Admin {
 			// Add the settings fields to each tab.
 			add_action(
 				'before_woocommerce_init',
-				function() {
+				function () {
 					$this->init_form_fields();
 					$this->settings_tabs = array(
 						'brands' => __( 'Brands', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -67,12 +67,15 @@ class WC_Brands_Admin {
 		if ( is_string( $setting_value ) ) {
 
 			// Add the settings fields to each tab.
-			add_action( 'before_woocommerce_init', function() {
-				$this->init_form_fields();
-				$this->settings_tabs = array(
+			add_action(
+				'before_woocommerce_init',
+				function() {
+					$this->init_form_fields();
+					$this->settings_tabs = array(
 						'brands' => __( 'Brands', 'woocommerce' ),
-				);
-			} );
+					);
+				}
+			);
 			add_action( 'woocommerce_get_sections_products', array( $this, 'add_settings_tab' ) );
 			add_action( 'woocommerce_get_settings_products', array( $this, 'add_settings_section' ), null, 2 );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request addresses a warning encountered when using the brands feature in WordPress 6.7. The warning states: `Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the woocommerce domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. (This message was added in version 6.7.0.)`. 

It resolves the issue by moving the assignment of the settings array from `plugins_loaded` at priority 100 to `before_woocommerce_init` at priority 10.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with the `trunk` branch.
2. Use a store with WordPress 6.7.
3. Switch the user's /admin's locale to a locale that's not `en_US`.
4. Set the `wc_brands_show_description` option to `no` using your favorite DB manager (or wp-cli option set)
5. Navigate to WooCommerce > Products.
6. Notice the _doing_it_wrong_ warning in the console.
7. Checkout this branch.
8. Notice the "Brands" tab. 
9. Click on "Brands" and notice the expected setting fields.
10. Ensure that there is no warning.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
