### PR TITLE
Cherry-pick #52900 to `release/9.4`

### DIFF
--- a/plugins/woocommerce-admin/client/payments-welcome/strings.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/strings.tsx
@@ -95,7 +95,7 @@ export default {
 	survey: {
 		title: __( 'No thanks, I don’t want WooPayments', 'woocommerce' ),
 		intro: __(
-			'Note that the extension hasn’t been installed, this will simply remove WooPayments from the navigation. Please take a moment to tell us why you’d like to dismiss WooPayments.',
+			'Note that the extension hasn’t been installed. This will simply dismiss our limited time offer. Please take a moment to tell us why you’d like to dismiss the WooPayments offer.',
 			'woocommerce'
 		),
 		question: __(

--- a/plugins/woocommerce/changelog/fix-52812-payments-menu-item-linking-to-blank-page
+++ b/plugins/woocommerce/changelog/fix-52812-payments-menu-item-linking-to-blank-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Payments main menu item linking to a blank page when onboarding tasks are hidden.

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -600,25 +600,25 @@ class WcPayWelcomePage {
 		}
 
 		// The Payments task in the setup task list.
-		if ( ! empty( $setup_task_list ) ) {
+		if ( ! empty( $setup_task_list ) && $setup_task_list->is_visible() ) {
 			$payments_task = $setup_task_list->get_task( 'payments' );
-			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+			if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
 				return 'payments';
 			}
 		}
 
 		// The Additional Payments task in the extended task list.
-		if ( ! empty( $extended_task_list ) ) {
+		if ( ! empty( $extended_task_list ) && $extended_task_list->is_visible() ) {
 			$payments_task = $extended_task_list->get_task( 'payments' );
-			if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+			if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
 				return 'payments';
 			}
 		}
 
 		// The WooPayments task in the setup task list.
-		if ( ! empty( $setup_task_list ) ) {
+		if ( ! empty( $setup_task_list ) && $setup_task_list->is_visible() ) {
 			$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
-			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+			if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
 				return 'woocommerce-payments';
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -591,6 +591,7 @@ class WcPayWelcomePage {
 		$extended_task_list = TaskLists::get_list( 'extended' );
 
 		// The task pages are not available if the task lists don't exist or are not visible.
+		// Bail early if we have no task to work with.
 		if (
 			( empty( $setup_task_list ) || ! $setup_task_list->is_visible() ) &&
 			( empty( $extended_task_list ) || ! $extended_task_list->is_visible() )
@@ -599,21 +600,27 @@ class WcPayWelcomePage {
 		}
 
 		// The Payments task in the setup task list.
-		$payments_task = $setup_task_list->get_task( 'payments' );
-		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
-			return 'payments';
+		if ( ! empty( $setup_task_list ) ) {
+			$payments_task = $setup_task_list->get_task( 'payments' );
+			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+				return 'payments';
+			}
 		}
 
 		// The Additional Payments task in the extended task list.
-		$payments_task = $extended_task_list->get_task( 'payments' );
-		if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
-			return 'payments';
+		if ( ! empty( $extended_task_list ) ) {
+			$payments_task = $extended_task_list->get_task( 'payments' );
+			if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+				return 'payments';
+			}
 		}
 
 		// The WooPayments task in the setup task list.
-		$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
-		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
-			return 'woocommerce-payments';
+		if ( ! empty( $setup_task_list ) ) {
+			$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
+			if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
+				return 'woocommerce-payments';
+			}
 		}
 
 		return '';

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -155,8 +155,14 @@ class WcPayWelcomePage {
 				call_user_func_array( 'add_menu_page', $menu_with_nav_data );
 			}
 		} else {
-			// Determine the path to the active Payments task page.
-			$menu_path = 'admin.php?page=wc-admin&task=' . $this->get_active_payments_task_slug();
+			// Default to linking to the Payments settings page.
+			$menu_path = 'admin.php?page=wc-settings&tab=checkout';
+
+			// Determine the path to the active Payments task page, if any.
+			$task_slug = $this->get_active_payments_task_slug();
+			if ( ! empty( $task_slug ) ) {
+				$menu_path = 'admin.php?page=wc-admin&task=' . $task_slug;
+			}
 
 			add_menu_page(
 				$menu_title,
@@ -583,22 +589,30 @@ class WcPayWelcomePage {
 	private function get_active_payments_task_slug(): string {
 		$setup_task_list    = TaskLists::get_list( 'setup' );
 		$extended_task_list = TaskLists::get_list( 'extended' );
-		if ( empty( $setup_task_list ) && empty( $extended_task_list ) ) {
+
+		// The task pages are not available if the task lists don't exist or are not visible.
+		if (
+			( empty( $setup_task_list ) || ! $setup_task_list->is_visible() ) &&
+			( empty( $extended_task_list ) || ! $extended_task_list->is_visible() )
+		) {
 			return '';
 		}
 
+		// The Payments task in the setup task list.
 		$payments_task = $setup_task_list->get_task( 'payments' );
-		if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
+		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
 			return 'payments';
 		}
 
+		// The Additional Payments task in the extended task list.
 		$payments_task = $extended_task_list->get_task( 'payments' );
-		if ( ! empty( $payments_task ) && $payments_task->can_view() ) {
+		if ( $extended_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
 			return 'payments';
 		}
 
-		$woopayments_task = $setup_task_list->get_task( 'woocommerce-payments' );
-		if ( ! empty( $woopayments_task ) && $woopayments_task->can_view() ) {
+		// The WooPayments task in the setup task list.
+		$payments_task = $setup_task_list->get_task( 'woocommerce-payments' );
+		if ( $setup_task_list->is_visible() && ! empty( $payments_task ) && $payments_task->can_view() ) {
 			return 'woocommerce-payments';
 		}
 


### PR DESCRIPTION
- Please see https://github.com/woocommerce/woocommerce/pull/52900 for testing instructions.
- This PR cherry-picks the same range of commits, and targets `release/9.4`.