### PR TITLE
Follow-up on cherry-pick #52921, remove changelog from 9.5.x.

### DIFF
--- a/plugins/woocommerce/changelog/cherry-pick-51540-remove-changelog-entry
+++ b/plugins/woocommerce/changelog/cherry-pick-51540-remove-changelog-entry
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: We're removing a changelog entry, because the relevant change was cherry-picked back to 9.4.x.
+
+

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -259,7 +259,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Fix - Make coupon code errors announced by screen readers [#52040](https://github.com/woocommerce/woocommerce/pull/52040)
 * Fix - Make sure session exists before calling its functions in the Cart StoreApi route [#52410](https://github.com/woocommerce/woocommerce/pull/52410)
 * Fix - Modify Product Collection block image alt #52593 [#52593](https://github.com/woocommerce/woocommerce/pull/52593)
-* Fix - Modify product import file check to use the WP filesystem API [#51540](https://github.com/woocommerce/woocommerce/pull/51540)
 * Fix - Patterns: Remove broken Product Hero 2 Column 2 Row pattern [#52624](https://github.com/woocommerce/woocommerce/pull/52624)
 * Fix - Preserve dash when saving Mongolia postcode. [#51674](https://github.com/woocommerce/woocommerce/pull/51674)
 * Fix - Prevent Business Services products from showing pricing information when they're displayed as regular product cards on the Extensions page. [#52118](https://github.com/woocommerce/woocommerce/pull/52118)


### PR DESCRIPTION
- Removes the changelog added via https://github.com/woocommerce/woocommerce/pull/51540
- That same change has been cherry-picked back to `release/9.4` via https://github.com/woocommerce/woocommerce/pull/52921
