### PR TITLE
[dev] Abort building zip if the picked PRs are left open either by bots or humans

### DIFF
--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -10,6 +10,54 @@ on:
 permissions: {}
 
 jobs:
+  verify:
+        name: 'Verify if any PR is left open by author:app/github-actions'
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Verify if any PR is left open by author:app/github-actions
+              id: verify-prs
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+                      const prs = await github.rest.pulls.list({ owner, repo, state: 'open', author: 'app/github-actions' });
+                      if (prs.data.length > 0) {
+                          core.setOutput('prs-left-open-count', prs.data.length);
+                          core.setFailed(`Found ${prs.data.length} open PRs from github-actions bot. Please close them before proceeding.`);
+                      }
+
+            - name: Notify Slack on failure
+              if: ${{ failure() }}
+              uses: archive/github-actions-slack@v2.0.0
+              with:
+                  slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+                  slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
+                  slack-text: |
+                      :ice_cube: Code Freeze workflow failed.
+                      :warning-8c: There are `${{ steps.verify-prs.outputs.prs-left-open-count }}` PRs left open by `app/github-actions` bot. Please merge them and re-run the workflow. Merging them is essential to maintain the integrity of code across all branches. Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            - name: Verify if any PR has a title that includes "cherry" in it
+              id: verify-prs-title
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+                    const prs = await github.rest.pulls.list({ owner, repo, state: 'open', title: 'cherry' });
+                    if (prs.data.length > 0) {
+                        core.setOutput('prs-left-open-count', prs.data.length);
+                        core.setFailed(`Found ${prs.data.length} open PRs with "cherry" in the title. Please close them before proceeding.`);
+                    }
+
+            - name: Notify Slack on failure
+              if: ${{ failure() }}
+              uses: archive/github-actions-slack@v2.0.0
+              with:
+                  slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+                  slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
+                  slack-text: |
+                      :ice_cube: Code Freeze workflow failed.
+                      :warning-8c: There are `${{ steps.verify-prs-title.outputs.prs-left-open-count }}` PRs left open with "cherry" in the title. Please close them before proceeding. Merging them is essential to maintain the integrity of code across all branches. Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   build:
     name: Build release zip file
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -28,6 +28,7 @@ jobs:
               script: |
                   let runBuildZipJob = true;
                   const event = context.payload;
+
                   if (event.inputs.skip_verify !== 'false') {
                     core.setOutput('runBuildZipJob', runBuildZipJob);
                     console.log('Skipping verification step');
@@ -42,7 +43,7 @@ jobs:
                   // Function to handle API call with retry logic
                   const searchPRs = async (query) => {
                     let attempts = 0;
-                    while (attempts < 3) {
+                    while (attempts < 5) {
                       try {
                         return await github.rest.search.issuesAndPullRequests({ q: query });
                       } catch (error) {
@@ -93,7 +94,7 @@ jobs:
           uses: archive/github-actions-slack@v2.0.0
           with:
               slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-              slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
+              slack-channel: ${{ secrets.TEST_WOO_CORE_RELEASE_NOTIFICATION_SLACK_CHANNEL }}
               slack-text: |
                   :x: WooCommerce release zip build failed.
                   :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -6,61 +6,105 @@ on:
         description: 'By default the zip file is generated from the branch the workflow runs from, but you can specify an explicit reference to use instead here (e.g. refs/tags/tag_name or refs/heads/release/x.x). The resulting file will be available as an artifact on the workflow run.'
         required: false
         default: ''
+      skip_verify:
+        description: 'Skip the PR verification step (default: false) pass true to skip'
+        required: false
+        default: 'false'
 
 permissions: {}
 
 jobs:
   verify:
-        name: 'Verify if any PR is left open by author:app/github-actions'
-        runs-on: ubuntu-20.04
-        steps:
-            - name: Verify if any PR is left open by author:app/github-actions
-              id: verify-prs
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-                      const prs = await github.rest.pulls.list({ owner, repo, state: 'open', author: 'app/github-actions' });
-                      if (prs.data.length > 0) {
-                          core.setOutput('prs-left-open-count', prs.data.length);
-                          core.setFailed(`Found ${prs.data.length} open PRs from github-actions bot. Please close them before proceeding.`);
+    name: 'Verify if any PR is left open by author:app/github-actions or with "cherry" in the title'
+    outputs:
+      runBuildZipJob: ${{ steps.verify-prs.outputs.runBuildZipJob }}
+    runs-on: ubuntu-20.04
+    steps:
+        - name: Verify if any PR is left open by author:app/github-actions or with "cherry" in the title
+          id: verify-prs
+          uses: actions/github-script@v6
+          with:
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              script: |
+                  let runBuildZipJob = true;
+                  const event = context.payload;
+                  if (event.inputs.skip_verify !== 'false') {
+                    core.setOutput('runBuildZipJob', runBuildZipJob);
+                    console.log('Skipping verification step');
+                    return;
+                  }
+
+                  const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+
+                  // Helper function to add delay between API calls
+                  const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+                  // Function to handle API call with retry logic
+                  const searchPRs = async (query) => {
+                    let attempts = 0;
+                    while (attempts < 3) {
+                      try {
+                        return await github.rest.search.issuesAndPullRequests({ q: query });
+                      } catch (error) {
+                        if (error.status === 403 && error.message.includes('secondary rate limit')) {
+                          console.log('Rate limit hit, retrying...');
+                          await delay(31000); // 31 second delay before retry
+                          attempts++;
+                        } else {
+                          throw error;
+                        }
+                      }
+                    }
+                    throw new Error('Failed to fetch PRs after multiple attempts');
+                  };
+
+                  // Search for PRs from github-actions bot
+                  const githubActionsPRsQuery = await searchPRs(`repo:${owner}/${repo} is:pr is:open author:app/github-actions`);
+                  const prsOpenByGithubActions = githubActionsPRsQuery.data.items;
+
+                  // Add delay before next API call to avoid rate limiting
+                  await delay(31000); // 31 second delay
+
+                  // Search for PRs with "cherry" in title
+                  const cherryPRsSearch = await searchPRs(`repo:${owner}/${repo} is:pr is:open cherry in:title -author:app/github-actions`);
+                  const prsWithCherryInTitle = cherryPRsSearch.data.items;
+
+                  let failureMessage = ``;
+
+                  if (prsOpenByGithubActions.length > 0 || prsWithCherryInTitle.length > 0) {
+                      runBuildZipJob = false;
+                      if (prsOpenByGithubActions.length > 0) {
+                        failureMessage += `Found \`${prsOpenByGithubActions.length}\` open PRs from github-actions bot which should be merged or closed before proceeding. `;
                       }
 
-            - name: Notify Slack on failure
-              if: ${{ failure() }}
-              uses: archive/github-actions-slack@v2.0.0
-              with:
-                  slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-                  slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
-                  slack-text: |
-                      :ice_cube: Code Freeze workflow failed.
-                      :warning-8c: There are `${{ steps.verify-prs.outputs.prs-left-open-count }}` PRs left open by `app/github-actions` bot. Please merge them and re-run the workflow. Merging them is essential to maintain the integrity of code across all branches. Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                      if (prsWithCherryInTitle.length > 0) {
+                        failureMessage += `Found \`${prsWithCherryInTitle.length}\` open PRs with "cherry" in the title which maybe opened by a human, please verify if they are relevant. `;
+                      }
 
-            - name: Verify if any PR has a title that includes "cherry" in it
-              id: verify-prs-title
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-                    const prs = await github.rest.pulls.list({ owner, repo, state: 'open', title: 'cherry' });
-                    if (prs.data.length > 0) {
-                        core.setOutput('prs-left-open-count', prs.data.length);
-                        core.setFailed(`Found ${prs.data.length} open PRs with "cherry" in the title. Please close them before proceeding.`);
-                    }
+                      failureMessage += 'This step maintains the code integrity and is critical to avoid regression in future releases. Please merge them or close them before proceeding or set skip_verify to true to skip this step if you are confident that the PRs are irrelevant.';
 
-            - name: Notify Slack on failure
-              if: ${{ failure() }}
-              uses: archive/github-actions-slack@v2.0.0
-              with:
-                  slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-                  slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
-                  slack-text: |
-                      :ice_cube: Code Freeze workflow failed.
-                      :warning-8c: There are `${{ steps.verify-prs-title.outputs.prs-left-open-count }}` PRs left open with "cherry" in the title. Please close them before proceeding. Merging them is essential to maintain the integrity of code across all branches. Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                      console.error(failureMessage);
+                      core.setOutput('failureMessage', failureMessage);
+                  }
+                  core.setOutput('runBuildZipJob', runBuildZipJob);
+
+        - name: Notify Slack on failure
+          if: ${{ steps.verify-prs.outputs.failureMessage != '' }}
+          uses: archive/github-actions-slack@v2.0.0
+          with:
+              slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+              slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
+              slack-text: |
+                  :x: Building release zip file workflow failed.
+                  :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}
+                  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>
+
 
   build:
     name: Build release zip file
     runs-on: ubuntu-20.04
+    if: ${{ needs.verify.outputs.runBuildZipJob == 'true' }}
+    needs: verify
     permissions:
       contents: read
     steps:

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -74,14 +74,14 @@ jobs:
                   if (prsOpenByGithubActions.length > 0 || prsWithCherryInTitle.length > 0) {
                       runBuildZipJob = false;
                       if (prsOpenByGithubActions.length > 0) {
-                        failureMessage += `Found \`${prsOpenByGithubActions.length}\` open PRs from github-actions bot which should be merged or closed before proceeding. `;
+                        failureMessage += `Found \`${prsOpenByGithubActions.length}\` open PR(s) from \`github-actions\` bot which should be merged or closed before proceeding. `;
                       }
 
                       if (prsWithCherryInTitle.length > 0) {
-                        failureMessage += `Found \`${prsWithCherryInTitle.length}\` open PRs with "cherry" in the title which maybe opened by a human, please verify if they are relevant. `;
+                        failureMessage += `Found \`${prsWithCherryInTitle.length}\` open PR(s) with \`cherry\` in the title which maybe opened by a human, please verify if they are relevant. `;
                       }
 
-                      failureMessage += 'This step maintains the code integrity and is critical to avoid regression in future releases. Please merge them or close them before proceeding or set skip_verify to true to skip this step if you are confident that the PRs are irrelevant.';
+                      failureMessage += '\n\nThis step maintains the code integrity and is critical to avoid regression in future releases. Please merge them or close them before proceeding or set \`skip_verify\` to \`true\` before running the workflow to skip this step if you are confident that the PRs are irrelevant.';
 
                       console.error(failureMessage);
                       core.setOutput('failureMessage', failureMessage);

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -94,11 +94,14 @@ jobs:
           uses: archive/github-actions-slack@v2.0.0
           with:
               slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-              slack-channel: ${{ secrets.TEST_WOO_CORE_RELEASE_NOTIFICATION_SLACK_CHANNEL }}
+              slack-channel: ${{ secrets.TEST_WOO_CORE_RELEASE_NOTIFICATIONS_SLACK_CHANNEL }}
               slack-text: |
                   :x: WooCommerce release zip build failed.
                   :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}
                   <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>
+              slack-optional-unfurl_links: false
+              slack-optional-unfurl_media: false
+          continue-on-error: true
 
 
   build:

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -95,7 +95,7 @@ jobs:
               slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
               slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
               slack-text: |
-                  :x: Building release zip file workflow failed.
+                  :x: WooCommerce release zip build failed.
                   :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}
                   <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>
 

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -75,11 +75,11 @@ jobs:
                   if (prsOpenByGithubActions.length > 0 || prsWithCherryInTitle.length > 0) {
                       runBuildZipJob = false;
                       if (prsOpenByGithubActions.length > 0) {
-                        failureMessage += `Found \`${prsOpenByGithubActions.length}\` open PR(s) from \`github-actions\` bot which should be merged or closed before proceeding. `;
+                        failureMessage += `Identified \`${prsOpenByGithubActions.length}\` open PR(s) from \`github-actions\` bot which should be merged or closed before proceeding. `;
                       }
 
                       if (prsWithCherryInTitle.length > 0) {
-                        failureMessage += `Found \`${prsWithCherryInTitle.length}\` open PR(s) with \`cherry\` in the title which maybe opened by a human, please verify if they are relevant. `;
+                        failureMessage += `Identified \`${prsWithCherryInTitle.length}\` open PR(s) with \`cherry\` in the title which maybe opened by a human, please verify if they are relevant. `;
                       }
 
                       failureMessage += '\n\nThis step maintains the code integrity and is critical to avoid regression in future releases. Please merge them or close them before proceeding or set \`skip_verify\` to \`true\` before running the workflow to skip this step if you are confident that the PRs are irrelevant.';
@@ -96,7 +96,7 @@ jobs:
               slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
               slack-channel: ${{ secrets.TEST_WOO_CORE_RELEASE_NOTIFICATIONS_SLACK_CHANNEL }}
               slack-text: |
-                  :x: WooCommerce release zip build failed.
+                  :x: Oops we may have missed a cherry pick PR left open. WooCommerce release zip build failed.
                   :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}
                   <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>
               slack-optional-unfurl_links: false

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -94,7 +94,7 @@ jobs:
           uses: archive/github-actions-slack@v2.0.0
           with:
               slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-              slack-channel: ${{ secrets.TEST_WOO_CORE_RELEASE_NOTIFICATIONS_SLACK_CHANNEL }}
+              slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
               slack-text: |
                   :x: Oops we may have missed a cherry pick PR left open. WooCommerce release zip build failed.
                   :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}

--- a/plugins/woocommerce/changelog/cherry-pick-fail-safe
+++ b/plugins/woocommerce/changelog/cherry-pick-fail-safe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Abort building zip if the cherry-picked PRs are open either by bot or humans


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We are introducing a check in Build release zip file [workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml) that will check for any PRs left open by the GitHub bot or by a Human. For the latter, it will check for the PRs which have "cherry" in the title (to be extra safe), if it does, it will abort the flow and sends a notification in the release channel.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure some PRs are opened by the github bot (currently there is one [test PR](https://github.com/woocommerce/woocommerce/pulls/app%2Fgithub-actions)), else you can run the changelog compile workflow to create one temporarily (make sure to close it after testing)
2. Make sure there are some PRs that have `cherry` in their title (currently there are [a few](https://github.com/woocommerce/woocommerce/pulls?q=is:pr+is:open+in:title+cherry+))
3. Goto Build release zip file [workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml) in this repository and select`cherry-pick-fail-safe` before running.
4. Check `test-woo-core-release-notifications` for failed notifications after the run, make sure the number of PR mentioned are correct.
5. Workflow shouldn't move to the build step.
6. Close or Merge PRs opened by the github bot.
7. Re-run the same workflow.
8. Check `test-woo-core-release-notifications` for failed notifications after the run, make sure the number of PR mentioned are correct.
9. Workflow shouldn't move to the build step.
10. Close PRs temporarily for testing which have `cherry` in their title for testing (re-open them again after testing).
11. Re-run the same workflow.
12. If we close all PRs opened by the GitHub bot, that includes those with cherry pick in the title, and the workflow will proceed with the build.
14. Goto Build release zip file [workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml) in this repository and select`cherry-pick-fail-safe` before running and pass `Skip the PR verification step` as true before running.
15. Workflow should skip the verification step and move to build step directly (this feature is given in case we know all the open PRs are relevant and doesn't need to be closed)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
