### PR TITLE
Scope homescreen overflow tweak to homescreen & extension pages only

### DIFF
--- a/plugins/woocommerce/changelog/52971-fix-52879-analytics-scroll
+++ b/plugins/woocommerce/changelog/52971-fix-52879-analytics-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix horizontal scrolling on Analytics pages.

--- a/plugins/woocommerce/client/admin/client/homescreen/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/style.scss
@@ -1,5 +1,7 @@
 .woocommerce-admin-page__home #wpcontent,
-.woocommerce-admin-page__home.woocommerce_page_wc-admin #wpbody-content {
+.woocommerce-admin-page__home.woocommerce_page_wc-admin #wpbody-content,
+.woocommerce-admin-page__extensions #wpcontent,
+.woocommerce-admin-page__extensions.woocommerce_page_wc-admin #wpbody-content {
 	overflow-x: inherit !important; // Overwriting wc-admin css from elsewhere. Necessary to make the right-hand column 'stick'
 	position: relative;
 }

--- a/plugins/woocommerce/client/admin/client/homescreen/style.scss
+++ b/plugins/woocommerce/client/admin/client/homescreen/style.scss
@@ -1,5 +1,5 @@
-.woocommerce-admin-page #wpcontent,
-.woocommerce-admin-page.woocommerce_page_wc-admin #wpbody-content {
+.woocommerce-admin-page__home #wpcontent,
+.woocommerce-admin-page__home.woocommerce_page_wc-admin #wpbody-content {
 	overflow-x: inherit !important; // Overwriting wc-admin css from elsewhere. Necessary to make the right-hand column 'stick'
 	position: relative;
 }


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce/issues/52879

After https://github.com/woocommerce/woocommerce/pull/48487
The sticky column CSS tweak (https://github.com/woocommerce/woocommerce-admin/pull/4347/) got into Analytics page 
making the the table not scrollable in the horizontal direction.

This PR scopes the sticky column rule to homescreen page only.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout & build this branch
2. Go to `Analytics > Revenue` page `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue`
3. Open it on mobile, or use devtools to shrink the viewport
4. Check that the report table is scrollable horizontally
5. Go to `WooCommerce > Home` page `/wp-admin/admin.php?page=wc-admin`
6. Open it on a wider (but not too tall) viewport
7. check that the right column "sticks" when you scroll down.
8. Smoke test other woocommerce pages for regression

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix horizontal scrolling on Analytics pages.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
