### PR TITLE
[Settings] Ensure Modern pages update on url changes

### DIFF
--- a/packages/js/settings-editor/changelog/53016-fix-settings-modern-route-update
+++ b/packages/js/settings-editor/changelog/53016-fix-settings-modern-route-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Ensure Modern settings pages re-render on updated url

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -188,10 +188,8 @@ export const useActiveRoute = (): {
 	const modernRoutes = useModernRoutes();
 
 	return useMemo( () => {
-		const {
-			tab: activePage = 'general',
-			section: activeSection = 'default',
-		} = location.params;
+		const { tab: activePage = 'general', section: activeSection } =
+			location.params;
 		const settingsPage = settingsData?.[ activePage ];
 
 		if ( ! settingsPage ) {
@@ -205,7 +203,7 @@ export const useActiveRoute = (): {
 			return {
 				route: getLegacyRoute(
 					activePage,
-					activeSection,
+					activeSection || 'default',
 					settingsPage,
 					settingsData
 				),

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -138,8 +138,8 @@ const getModernPages = () => {
  *
  * @return {Record<string, Route>} The pages.
  */
-export function useModernRoutes() {
-	const [ routes, setRoutes ] = useState( {} );
+export function useModernRoutes(): Record< string, Route > {
+	const [ routes, setRoutes ] = useState< Record< string, Route > >( {} );
 	const location = useLocation() as Location;
 
 	/*

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -140,6 +140,10 @@ const getModernPages = () => {
  */
 export function useModernRoutes() {
 	const [ routes, setRoutes ] = useState( getModernPages() );
+	const location = useLocation() as Location;
+
+	// console.log( 'updating routes' );
+	// console.log( getModernPages()[ 'shipping' ].paul );
 
 	/*
 	 * Handler for new pages being added after the initial filter has been run,
@@ -166,7 +170,7 @@ export function useModernRoutes() {
 		};
 	}, [] );
 
-	return routes;
+	return getModernPages();
 }
 
 /**

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -142,9 +142,6 @@ export function useModernRoutes() {
 	const [ routes, setRoutes ] = useState( getModernPages() );
 	const location = useLocation() as Location;
 
-	// console.log( 'updating routes' );
-	// console.log( getModernPages()[ 'shipping' ].paul );
-
 	/*
 	 * Handler for new pages being added after the initial filter has been run,
 	 * so that if any routing pages are added later, they can still be rendered
@@ -170,7 +167,12 @@ export function useModernRoutes() {
 		};
 	}, [] );
 
-	return getModernPages();
+	// Update modern when the location changes.
+	useEffect( () => {
+		setRoutes( getModernPages() );
+	}, [ location.params ] );
+
+	return routes;
 }
 
 /**

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -139,7 +139,7 @@ const getModernPages = () => {
  * @return {Record<string, Route>} The pages.
  */
 export function useModernRoutes() {
-	const [ routes, setRoutes ] = useState( getModernPages() );
+	const [ routes, setRoutes ] = useState( {} );
 	const location = useLocation() as Location;
 
 	/*

--- a/plugins/woocommerce/changelog/53016-fix-settings-modern-route-update
+++ b/plugins/woocommerce/changelog/53016-fix-settings-modern-route-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Ensure Modern settings pages re-render on updated url

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -128,10 +128,10 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 					}
 
 					$section_settings_data[] = $section_setting;
-
-					// Replace empty string section ids with 'default'.
-					$section_id = '' === $section_id ? 'default' : $section_id;
 				}
+
+				// Replace empty string section ids with 'default'.
+				$section_id = '' === $section_id ? 'default' : $section_id;
 
 				$sections_data[ $section_id ] = array(
 					'label'    => html_entity_decode( $section_label ),

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -131,12 +131,12 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 
 					// Replace empty string section ids with 'default'.
 					$section_id = '' === $section_id ? 'default' : $section_id;
-
-					$sections_data[ $section_id ] = array(
-						'label'    => html_entity_decode( $section_label ),
-						'settings' => $section_settings_data,
-					);
 				}
+
+				$sections_data[ $section_id ] = array(
+					'label'    => html_entity_decode( $section_label ),
+					'settings' => $section_settings_data,
+				);
 			}
 
 			$pages[ $this->id ] = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When testing out some Modern Pages, the modern page components were not updating as a result of url changes. This PR fixes this plus other cleanups.

* Ensure a re-render of Modern pages when the url changes
* Make sure added sections with no configuration are still represented in the Settings data
* Update the `default` query parameter logic so it only applies to legacy pages. We don't want to force the default parameter for modern pages' first section key.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate/Enable Gutenberg and turn on the `settings` feature flag
2. WooCommerce > Settings > Shipping. There should now be four sections (there were previously two)
<img width="569" alt="image" src="https://github.com/user-attachments/assets/543598ed-a970-4520-bb2c-7e83546c5eb3">

3. Add [woocommerce-settings-migration-tester](https://github.com/woocommerce/woocommerce-settings-migration-tester) by running `npm install && npm run plugin-zip` locally and upload. Note that `trunk` has new commits if you've already cloned the repo locally.
4. WooCommerce > Settings > Modern Settings
5. See the tab content should react as you would expect


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure Modern settings pages re-render on updated url

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
