### PR TITLE
feat: update active filters block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
@@ -39,7 +39,7 @@
 		}
 	},
 	"usesContext": [
-		"filterParams"
+		"activeFilters"
 	],
 	"attributes": {
 		"clearButton": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/frontend.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { store } from '@woocommerce/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import { ProductFilterActiveStore } from '../active-filters/frontend';
+
+store( 'woocommerce/product-filter-removable-chips', {
+	state: {
+		get items() {
+			const productFilterActiveStore = store< ProductFilterActiveStore >(
+				'woocommerce/product-filter-active'
+			);
+			return productFilterActiveStore.state.items;
+		},
+	},
+} );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -21,46 +21,23 @@ final class ProductFilterActive extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$filter_params = $block->context['filterParams'] ?? array();
+		if ( ! isset( $block->context['activeFilters'] ) ) {
+			return $content;
+		}
 
-		/**
-		 * Filters the active filter data provided by filter blocks.
-		 *
-		 * $data = array(
-		 *     <id> => array(
-		 *         'type' => string,
-		 *         'items' => array(
-		 *             array(
-		 *                 'title' => string,
-		 *                 'attributes' => array(
-		 *                     <key> => string
-		 *                 )
-		 *             )
-		 *         )
-		 *     ),
-		 * );
-		 *
-		 * @since 11.7.0
-		 *
-		 * @param array $data   The active filters data
-		 * @param array $params The query param parsed from the URL.
-		 * @return array Active filters data.
-		 */
-		$active_filters = apply_filters( 'collection_active_filters_data', array(), $filter_params );
-
-		$context = array(
-			'hasSelectedFilters' => ! empty( $active_filters ) ?? false,
-		);
+		$active_filters = $block->context['activeFilters'];
 
 		$filter_context = array(
-			'items' => $active_filters,
+			'items'  => $active_filters,
+			'parent' => $this->get_full_block_name(),
 		);
 
 		$wrapper_attributes = array(
 			'data-wc-interactive'  => wp_json_encode( array( 'namespace' => $this->get_full_block_name() ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 			'data-wc-key'          => wp_unique_prefixed_id( $this->get_full_block_name() ),
-			'data-wc-context'      => wp_json_encode( $context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
-			'data-wc-bind--hidden' => '!context.hasSelectedFilters',
+			'data-wc-bind--hidden' => '!state.hasSelectedFilters',
+			/* translators:  {{label}} is the label of the active filter item. */
+			'data-wc-context'      => wp_json_encode( array( 'removeLabelTemplate' => __( 'Remove filter: {{label}}', 'woocommerce' ) ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 		);
 
 		if ( empty( $active_filters ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRemovableChips.php
@@ -24,11 +24,16 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$filters = array();
-
-		if ( ! empty( $block->context['filterData'] ) && ! empty( $block->context['filterData']['items'] ) ) {
-			$filters = $block->context['filterData']['items'];
+		if (
+			empty( $block->context['filterData'] ) ||
+			empty( $block->context['filterData']['parent'] )
+		) {
+			return '';
 		}
+
+		$context      = $block->context['filterData'];
+		$filter_items = $context['items'] ?? array();
+		$parent_block = $context['parent'];
 
 		$style = '';
 
@@ -45,89 +50,51 @@ final class ProductFilterRemovableChips extends AbstractBlock {
 			'style'               => esc_attr( $style ),
 		);
 
-		if ( empty( $filters ) ) {
-			$wrapper_attributes['hidden'] = true;
-		}
-
 		ob_start();
 		?>
 
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<?php if ( ! empty( $filters ) ) : ?>
-				<ul class="wc-block-product-filter-removable-chips__items">
-					<?php foreach ( $filters as $filter ) : ?>
-						<?php foreach ( $filter['items'] as $item ) : ?>
-							<?php $this->render_chip_item( $filter['type'], $item ); ?>
-						<?php endforeach; ?>
-					<?php endforeach; ?>
-				</ul>
-			<?php endif; ?>
+			<ul class="wc-block-product-filter-removable-chips__items">
+				<template
+					data-wc-each="state.items"
+					data-wc-each-key="context.item.uid"
+				>
+					<li class="wc-block-product-filter-removable-chips__item">
+						<span class="wc-block-product-filter-removable-chips__label" data-wc-text="context.item.label"></span>
+						<button
+							type="button"
+							class="wc-block-product-filter-removable-chips__remove"
+							data-wc-bind--aria-label="context.item.removeLabel"
+							data-wc-on--click="<?php echo esc_attr( $parent_block . '::actions.removeFilter' ); ?>"
+							data-wc-bind--data-filter-item="context.item"
+						>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="25" height="25" class="wc-block-product-filter-removable-chips__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
+							<span class="screen-reader-text" data-wc-text="context.item.removeLabel"></span>
+						</button>
+					</li>
+				</template>
+				<?php foreach ( $filter_items as $item ) : ?>
+					<?php $remove_label = sprintf( __( 'Remove filter: %s', 'woocommerce' ), $item['label'] ); ?>
+					<li class="wc-block-product-filter-removable-chips__item" data-wc-each-child>
+						<span class="wc-block-product-filter-removable-chips__label">
+							<?php echo esc_html( $item['label'] ); ?>
+						</span>
+						<button
+							type="button"
+							class="wc-block-product-filter-removable-chips__remove"
+							aria-label="<?php echo esc_attr( $remove_label ); ?>"
+							data-wc-on--click="<?php echo esc_attr( $parent_block . '::actions.removeFilter' ); ?>"
+							data-filter-item="<?php echo esc_attr( wp_json_encode( $item, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) ); ?>"
+						>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="25" height="25" class="wc-block-product-filter-removable-chips__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
+							<span class="screen-reader-text"><?php echo esc_html( $remove_label ); ?></span>
+						</button>
+					</li>
+				<?php endforeach; ?>
+			</ul>
 		</div>
 
 		<?php
 		return ob_get_clean();
-	}
-
-	/**
-	 * Render the chip item of an active filter.
-	 *
-	 * @param string $type Filter type.
-	 * @param array  $item Item data.
-	 * @return string Item HTML.
-	 */
-	private function render_chip_item( $type, $item ) {
-		list ( 'title' => $title, 'attributes' => $attributes ) = wp_parse_args(
-			$item,
-			array(
-				'title'      => '',
-				'attributes' => array(),
-			)
-		);
-
-		if ( ! $title || empty( $attributes ) ) {
-			return;
-		}
-
-		$remove_label = sprintf( 'Remove %s filter', wp_strip_all_tags( $title ) );
-		?>
-		<li class="wc-block-product-filter-removable-chips__item">
-			<span class="wc-block-product-filter-removable-chips__label">
-				<?php printf( '%s: %s', esc_html( $type ), wp_kses_post( $title ) ); ?>
-			</span>
-			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-			<button class="wc-block-product-filter-removable-chips__remove" aria-label="<?php echo esc_attr( $remove_label ); ?>" <?php echo $this->get_html_attributes( $attributes ); ?>>
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="25" height="25" class="wc-block-product-filter-removable-chips__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
-				<span class="screen-reader-text"><?php echo esc_html( $remove_label ); ?></span>
-			</button>
-		</li>
-		<?php
-	}
-
-	/**
-	 * Build HTML attributes string from assoc array.
-	 *
-	 * @param array $attributes Attributes data as an assoc array.
-	 * @return string Escaped HTML attributes string.
-	 */
-	private function get_html_attributes( $attributes ) {
-		return array_reduce(
-			array_keys( $attributes ),
-			function ( $acc, $key ) use ( $attributes ) {
-				$acc .= sprintf( ' %1$s="%2$s"', esc_attr( $key ), esc_attr( $attributes[ $key ] ) );
-				return $acc;
-			},
-			''
-		);
-	}
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @param string $key Data to get, or default to everything.
-	 *
-	 * @return null
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
 	}
 }


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #53021.
Blocked by #53070.

This PR:

- Updates active filters block:
  - uses a flat collection instead of a complex multidimensional array.
  - gets the activeFilters data from the `woocommerce/product-filters` store and decorates it with a remove label for the remove button.
  - adds an action to remove the active filter, removing the need to declare remove action from the inner filter blocks (attribute/price/status/rating).
- Updates removable chips block:
  - uses `wc-each` and `template` to removable chips block for rendering the chips using client-side state.
  - adds `state.items` that is derived from the `woocommerce/product-filter-active::state.items`. We need to do this because the `wc-each` doesn't work with state from other namespace.
  - update the chip markup for the new active filter item data structure.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Testing is done in connected PRs.

<!-- End testing instructions -->
