### PR TITLE
Make blocks registered through `registerBlockSingleProductTemplate` available in patterns

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -54,9 +54,8 @@ export const registerBlockSingleProductTemplate = ( {
 			editSiteStore?.getEditedPostId< string | number | undefined >()
 		);
 		const hasChangedTemplate = previousTemplateId !== currentTemplateId;
-		const hasTemplateId = Boolean( currentTemplateId );
 
-		if ( ! hasChangedTemplate || ! hasTemplateId || ! blockName ) {
+		if ( ! hasChangedTemplate || ! blockName ) {
 			return;
 		}
 
@@ -106,6 +105,7 @@ export const registerBlockSingleProductTemplate = ( {
 		const isBlockRegistered = Boolean( variationName )
 			? blocksRegistered.has( variationName )
 			: blocksRegistered.has( blockName );
+
 		// This subscribe callback could be invoked with the core/blocks store
 		// which would cause infinite registration loops because of the `registerBlockType` call.
 		// This local cache helps prevent that.

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -53,6 +53,7 @@ export const registerBlockSingleProductTemplate = ( {
 		currentTemplateId = parseTemplateId(
 			editSiteStore?.getEditedPostId< string | number | undefined >()
 		);
+
 		const hasChangedTemplate = previousTemplateId !== currentTemplateId;
 
 		if ( ! hasChangedTemplate || ! blockName ) {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.block_theme.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+
+test.describe( 'Patterns in block theme', () => {
+	test( 'Synced Pattern can be created with basic blocks', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPattern( 'Woo Blocks Synced Pattern' );
+
+		// Add testing blocks
+		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
+		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
+		await editor.canvas.getByText( 'Album' ).click();
+		await editor.canvas.getByText( 'Done' ).click();
+
+		// Product Collection optimizes rendering products so 2nd+ products
+		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
+		// hence CSS selectors and condition to be visible.
+		const productTitles = editor.canvas
+			.locator( '.wp-block-post-title' )
+			.locator( 'visible=true' );
+		const productPrices = editor.canvas
+			.getByLabel( 'Block: Product Price' )
+			.locator( 'visible=true' );
+
+		await expect( productTitles ).toHaveText( [
+			// Product Collection
+			'Beanie',
+			'Beanie with Logo',
+			'Belt',
+			'Cap',
+			'Hoodie',
+			// Single Product
+			'Album',
+		] );
+		await expect( productPrices ).toHaveText( [
+			// Product Collection
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$65.00Discounted price:$55.00',
+			'Previous price:$18.00Discounted price:$16.00',
+			'Previous price:$45.00Discounted price:$42.00',
+			// Single Product
+			'$15.00',
+		] );
+	} );
+
+	test( 'Unsynced Pattern can be created with basic blocks', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPattern( 'Woo Blocks Unsynced Pattern', false );
+
+		// Add testing blocks
+		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
+		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
+		await editor.canvas.getByText( 'Album' ).click();
+		await editor.canvas.getByText( 'Done' ).click();
+
+		// Product Collection optimizes rendering products so 2nd+ products
+		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
+		// hence CSS selectors and condition to be visible.
+		const productTitles = editor.canvas
+			.locator( '.wp-block-post-title' )
+			.locator( 'visible=true' );
+		const productPrices = editor.canvas
+			.getByLabel( 'Block: Product Price' )
+			.locator( 'visible=true' );
+
+		await expect( productTitles ).toHaveText( [
+			// Product Collection
+			'Beanie',
+			'Beanie with Logo',
+			'Belt',
+			'Cap',
+			'Hoodie',
+			// Single Product
+			'Album',
+		] );
+		await expect( productPrices ).toHaveText( [
+			// Product Collection
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$65.00Discounted price:$55.00',
+			'Previous price:$18.00Discounted price:$16.00',
+			'Previous price:$45.00Discounted price:$42.00',
+			// Single Product
+			'$15.00',
+		] );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.block_theme.spec.ts
@@ -6,6 +6,7 @@ import { test, expect } from '@woocommerce/e2e-utils';
 /**
  * Internal dependencies
  */
+import { addTestingBlocks, expectedTitles, expectedPrices } from './utils';
 
 test.describe( 'Patterns in block theme', () => {
 	test( 'Synced Pattern can be created with basic blocks', async ( {
@@ -13,43 +14,12 @@ test.describe( 'Patterns in block theme', () => {
 		editor,
 	} ) => {
 		await admin.createNewPattern( 'Woo Blocks Synced Pattern' );
+		const { productTitles, productPrices } = await addTestingBlocks(
+			editor
+		);
 
-		// Add testing blocks
-		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
-		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
-		await editor.canvas.getByText( 'Album' ).click();
-		await editor.canvas.getByText( 'Done' ).click();
-
-		// Product Collection optimizes rendering products so 2nd+ products
-		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
-		// hence CSS selectors and condition to be visible.
-		const productTitles = editor.canvas
-			.locator( '.wp-block-post-title' )
-			.locator( 'visible=true' );
-		const productPrices = editor.canvas
-			.getByLabel( 'Block: Product Price' )
-			.locator( 'visible=true' );
-
-		await expect( productTitles ).toHaveText( [
-			// Product Collection
-			'Beanie',
-			'Beanie with Logo',
-			'Belt',
-			'Cap',
-			'Hoodie',
-			// Single Product
-			'Album',
-		] );
-		await expect( productPrices ).toHaveText( [
-			// Product Collection
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$65.00Discounted price:$55.00',
-			'Previous price:$18.00Discounted price:$16.00',
-			'Previous price:$45.00Discounted price:$42.00',
-			// Single Product
-			'$15.00',
-		] );
+		await expect( productTitles ).toHaveText( expectedTitles );
+		await expect( productPrices ).toHaveText( expectedPrices );
 	} );
 
 	test( 'Unsynced Pattern can be created with basic blocks', async ( {
@@ -58,41 +28,11 @@ test.describe( 'Patterns in block theme', () => {
 	} ) => {
 		await admin.createNewPattern( 'Woo Blocks Unsynced Pattern', false );
 
-		// Add testing blocks
-		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
-		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
-		await editor.canvas.getByText( 'Album' ).click();
-		await editor.canvas.getByText( 'Done' ).click();
+		const { productTitles, productPrices } = await addTestingBlocks(
+			editor
+		);
 
-		// Product Collection optimizes rendering products so 2nd+ products
-		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
-		// hence CSS selectors and condition to be visible.
-		const productTitles = editor.canvas
-			.locator( '.wp-block-post-title' )
-			.locator( 'visible=true' );
-		const productPrices = editor.canvas
-			.getByLabel( 'Block: Product Price' )
-			.locator( 'visible=true' );
-
-		await expect( productTitles ).toHaveText( [
-			// Product Collection
-			'Beanie',
-			'Beanie with Logo',
-			'Belt',
-			'Cap',
-			'Hoodie',
-			// Single Product
-			'Album',
-		] );
-		await expect( productPrices ).toHaveText( [
-			// Product Collection
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$65.00Discounted price:$55.00',
-			'Previous price:$18.00Discounted price:$16.00',
-			'Previous price:$45.00Discounted price:$42.00',
-			// Single Product
-			'$15.00',
-		] );
+		await expect( productTitles ).toHaveText( expectedTitles );
+		await expect( productPrices ).toHaveText( expectedPrices );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.classic_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.classic_theme.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { test, expect, CLASSIC_THEME_SLUG } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+
+test.describe( 'Patterns in classic theme', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
+	} );
+
+	test( 'Synced Pattern can be created with basic blocks', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPattern( 'Woo Blocks Unsynced Pattern' );
+
+		// Add testing blocks
+		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
+		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
+		await editor.canvas.getByText( 'Album' ).click();
+		await editor.canvas.getByText( 'Done' ).click();
+
+		// Product Collection optimizes rendering products so 2nd+ products
+		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
+		// hence CSS selectors and condition to be visible.
+		const productTitles = editor.canvas
+			.locator( '.wp-block-post-title' )
+			.locator( 'visible=true' );
+		const productPrices = editor.canvas
+			.getByLabel( 'Block: Product Price' )
+			.locator( 'visible=true' );
+
+		await expect( productTitles ).toHaveText( [
+			// Product Collection
+			'Beanie',
+			'Beanie with Logo',
+			'Belt',
+			'Cap',
+			'Hoodie',
+			// Single Product
+			'Album',
+		] );
+		await expect( productPrices ).toHaveText( [
+			// Product Collection
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$65.00Discounted price:$55.00',
+			'Previous price:$18.00Discounted price:$16.00',
+			'Previous price:$45.00Discounted price:$42.00',
+			// Single Product
+			'$15.00',
+		] );
+	} );
+
+	test( 'Unsynced Pattern can be created with basic blocks', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPattern( 'Woo Blocks Unsynced Pattern', false );
+
+		// Add testing blocks
+		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
+		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
+		await editor.canvas.getByText( 'Album' ).click();
+		await editor.canvas.getByText( 'Done' ).click();
+
+		// Product Collection optimizes rendering products so 2nd+ products
+		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
+		// hence CSS selectors and condition to be visible.
+		const productTitles = editor.canvas
+			.locator( '.wp-block-post-title' )
+			.locator( 'visible=true' );
+		const productPrices = editor.canvas
+			.getByLabel( 'Block: Product Price' )
+			.locator( 'visible=true' );
+
+		await expect( productTitles ).toHaveText( [
+			// Product Collection
+			'Beanie',
+			'Beanie with Logo',
+			'Belt',
+			'Cap',
+			'Hoodie',
+			// Single Product
+			'Album',
+		] );
+		await expect( productPrices ).toHaveText( [
+			// Product Collection
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$20.00Discounted price:$18.00',
+			'Previous price:$65.00Discounted price:$55.00',
+			'Previous price:$18.00Discounted price:$16.00',
+			'Previous price:$45.00Discounted price:$42.00',
+			// Single Product
+			'$15.00',
+		] );
+	} );
+} );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.classic_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/patterns/add-new-pattern.classic_theme.spec.ts
@@ -6,6 +6,7 @@ import { test, expect, CLASSIC_THEME_SLUG } from '@woocommerce/e2e-utils';
 /**
  * Internal dependencies
  */
+import { addTestingBlocks, expectedTitles, expectedPrices } from './utils';
 
 test.describe( 'Patterns in classic theme', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
@@ -18,42 +19,12 @@ test.describe( 'Patterns in classic theme', () => {
 	} ) => {
 		await admin.createNewPattern( 'Woo Blocks Unsynced Pattern' );
 
-		// Add testing blocks
-		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
-		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
-		await editor.canvas.getByText( 'Album' ).click();
-		await editor.canvas.getByText( 'Done' ).click();
+		const { productTitles, productPrices } = await addTestingBlocks(
+			editor
+		);
 
-		// Product Collection optimizes rendering products so 2nd+ products
-		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
-		// hence CSS selectors and condition to be visible.
-		const productTitles = editor.canvas
-			.locator( '.wp-block-post-title' )
-			.locator( 'visible=true' );
-		const productPrices = editor.canvas
-			.getByLabel( 'Block: Product Price' )
-			.locator( 'visible=true' );
-
-		await expect( productTitles ).toHaveText( [
-			// Product Collection
-			'Beanie',
-			'Beanie with Logo',
-			'Belt',
-			'Cap',
-			'Hoodie',
-			// Single Product
-			'Album',
-		] );
-		await expect( productPrices ).toHaveText( [
-			// Product Collection
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$65.00Discounted price:$55.00',
-			'Previous price:$18.00Discounted price:$16.00',
-			'Previous price:$45.00Discounted price:$42.00',
-			// Single Product
-			'$15.00',
-		] );
+		await expect( productTitles ).toHaveText( expectedTitles );
+		await expect( productPrices ).toHaveText( expectedPrices );
 	} );
 
 	test( 'Unsynced Pattern can be created with basic blocks', async ( {
@@ -62,41 +33,11 @@ test.describe( 'Patterns in classic theme', () => {
 	} ) => {
 		await admin.createNewPattern( 'Woo Blocks Unsynced Pattern', false );
 
-		// Add testing blocks
-		await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
-		await editor.insertBlockUsingGlobalInserter( 'Single Product' );
-		await editor.canvas.getByText( 'Album' ).click();
-		await editor.canvas.getByText( 'Done' ).click();
+		const { productTitles, productPrices } = await addTestingBlocks(
+			editor
+		);
 
-		// Product Collection optimizes rendering products so 2nd+ products
-		// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
-		// hence CSS selectors and condition to be visible.
-		const productTitles = editor.canvas
-			.locator( '.wp-block-post-title' )
-			.locator( 'visible=true' );
-		const productPrices = editor.canvas
-			.getByLabel( 'Block: Product Price' )
-			.locator( 'visible=true' );
-
-		await expect( productTitles ).toHaveText( [
-			// Product Collection
-			'Beanie',
-			'Beanie with Logo',
-			'Belt',
-			'Cap',
-			'Hoodie',
-			// Single Product
-			'Album',
-		] );
-		await expect( productPrices ).toHaveText( [
-			// Product Collection
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$20.00Discounted price:$18.00',
-			'Previous price:$65.00Discounted price:$55.00',
-			'Previous price:$18.00Discounted price:$16.00',
-			'Previous price:$45.00Discounted price:$42.00',
-			// Single Product
-			'$15.00',
-		] );
+		await expect( productTitles ).toHaveText( expectedTitles );
+		await expect( productPrices ).toHaveText( expectedPrices );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/patterns/utils.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/patterns/utils.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import type { Editor } from '@woocommerce/e2e-utils';
+
+export const addTestingBlocks = async ( editor: Editor ) => {
+	// Add testing blocks
+	await editor.insertBlockUsingGlobalInserter( 'On Sale Products' );
+	await editor.insertBlockUsingGlobalInserter( 'Single Product' );
+	await editor.canvas.getByText( 'Album' ).click();
+	await editor.canvas.getByText( 'Done' ).click();
+
+	// Product Collection optimizes rendering products so 2nd+ products
+	// are not accessible through block selectors like getByLabel( 'Block: Product Title' )
+	// hence CSS selectors and condition to be visible.
+	const productTitles = editor.canvas
+		.locator( '.wp-block-post-title' )
+		.locator( 'visible=true' );
+	const productPrices = editor.canvas
+		.getByLabel( 'Block: Product Price' )
+		.locator( 'visible=true' );
+
+	return {
+		productTitles,
+		productPrices,
+	};
+};
+
+export const expectedTitles = [
+	// Product Collection
+	'Beanie',
+	'Beanie with Logo',
+	'Belt',
+	'Cap',
+	'Hoodie',
+	// Single Product
+	'Album',
+];
+
+export const expectedPrices = [
+	// Product Collection
+	'Previous price:$20.00Discounted price:$18.00',
+	'Previous price:$20.00Discounted price:$18.00',
+	'Previous price:$65.00Discounted price:$55.00',
+	'Previous price:$18.00Discounted price:$16.00',
+	'Previous price:$45.00Discounted price:$42.00',
+	// Single Product
+	'$15.00',
+];

--- a/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -17,15 +17,13 @@ const blockData: BlockData = {
 test.describe( `${ blockData.name } Block`, () => {
 	test( "can't be added in the Post Editor", async ( { admin, editor } ) => {
 		await admin.createNewPost();
-
+		await editor.insertBlock( { name: blockData.slug } );
 		await expect(
-			editor.insertBlock( { name: blockData.slug } )
-		).rejects.toThrow(
-			new RegExp( `Block type '${ blockData.slug }' is not registered.` )
-		);
+			await editor.getBlockByName( blockData.slug )
+		).toBeHidden();
 	} );
 
-	test( "can't be added in the Post Editor - Product Catalog Template", async ( {
+	test( "can't be added in the Product Catalog Template", async ( {
 		admin,
 		editor,
 	} ) => {
@@ -48,7 +46,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		).toBeHidden();
 	} );
 
-	test( "can't be added in the Post Editor - Single Product Template", async ( {
+	test( "can't be added in the Single Product Template", async ( {
 		admin,
 		editor,
 	} ) => {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -18,11 +18,10 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 	} ) => {
 		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.slug } );
 		await expect(
-			editor.insertBlock( { name: blockData.slug } )
-		).rejects.toThrow(
-			new RegExp( `Block type '${ blockData.slug }' is not registered.` )
-		);
+			await editor.getBlockByName( blockData.slug )
+		).toBeHidden();
 	} );
 
 	test( 'block can be inserted in the Site Editor', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
@@ -11,4 +11,27 @@ export class Admin extends CoreAdmin {
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
 	}
+
+	async createNewPattern( name: string, synced = true ) {
+		await this.page.goto( '/wp-admin/site-editor.php?postType=wp_block' );
+		await this.page.getByRole( 'button', { name: 'Patterns' } ).click();
+		await this.page.getByLabel( 'Add New Pattern' ).click();
+		await this.page
+			.getByRole( 'menuitem', { name: 'Add New Pattern' } )
+			.click();
+		await this.page.getByLabel( 'Name' ).fill( name );
+
+		if ( ! synced ) {
+			// Synced toggle is enabled by default.
+			await this.page.getByLabel( 'Synced' ).click();
+		}
+
+		await this.page.getByRole( 'button', { name: 'Add' } ).click();
+		// Wait for Editor to load.
+		await this.page
+			.getByRole( 'heading', {
+				name: `${ name } · Pattern`,
+			} )
+			.waitFor();
+	}
 }

--- a/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
@@ -27,11 +27,24 @@ export class Admin extends CoreAdmin {
 		}
 
 		await this.page.getByRole( 'button', { name: 'Add' } ).click();
-		// Wait for Editor to load.
-		await this.page
-			.getByRole( 'heading', {
-				name: `${ name } · Pattern`,
-			} )
-			.waitFor();
+
+		const welcomePopUp = async () => {
+			await this.page
+				.getByRole( 'button', {
+					name: 'Get started',
+				} )
+				.click();
+		};
+
+		const editorLoaded = async () => {
+			// Wait for Editor to load.
+			await this.page
+				.getByRole( 'heading', {
+					name: `${ name } · Pattern`,
+				} )
+				.waitFor();
+		};
+
+		await Promise.any( [ welcomePopUp(), editorLoaded() ] );
 	}
 }

--- a/plugins/woocommerce/changelog/fix-52699
+++ b/plugins/woocommerce/changelog/fix-52699
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Elements: fix the issue that some product elements like price or rating were not available in Patterns


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Created in collaboration with @gigitux 🙏 

For some time already blocks registered through `registerBlockSingleProductTemplate` were not available in the Patterns due to error in the function logic. When in patterns, these blocks were never initially registered.

For Single Product block it occurred as "Product not registered" error and was raised by a user in https://github.com/woocommerce/woocommerce/issues/51138 after Product Price was migrated to use the `registerBlockSingleProductTemplate` function https://github.com/woocommerce/woocommerce/pull/49906.

Recently I exposed Product Collection collections to the inserter in https://github.com/woocommerce/woocommerce/pull/52209. They use a `createBlocksFromInnerBlocksTemplate` method which internally has additional check for blocks and it throws an error when the block is not registered. After this, when opening an inserter, the Editor crashed. So even though the issue was there for some time (and even raised by a user) already it was "exposed" as destructive by https://github.com/woocommerce/woocommerce/pull/52209.

Closes https://github.com/woocommerce/woocommerce/issues/52699
Closes https://github.com/woocommerce/woocommerce/issues/51138
Closes https://github.com/woocommerce/woocommerce/issues/46781


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Blocks registered by `registerBlockSingleProductTemplate` should follow this logic:

1. Be available "globally" in Single Product template
2. Follow `ancestors` in
    - other templates (e.g. Product Catalog)
    - posts/pages
    - patterns

#### Single Product template

1. Go to Editor > Single Product template
2. Try to insert Product Price and Product Rating in couple of places
3. **Expected:** They should be available in the inserter

#### Other templates

1. Go to Editor > Product Catalog template
2. Try to insert Product Price and Product Rating within Product Collection block
3. **Expected:** They should be available in the inserter
4. Try to insert Product Price and Product Rating outside of Product Collection block
3. **Expected:** They should NOT be available in the inserter

#### Posts/Pages

1. Create new post
2. Insert Single Product block
3. Try to insert Product Price and Product Rating within Single Product block
4. **Expected:** They should be available in the inserter
5. Try to insert Product Price and Product Rating outside of Single Product block
3. **Expected:** They should NOT be available in the inserter

#### Patterns

1. Go to Editor > Patterns > Add new pattern
2. Create synced pattern
3. Insert Single Product block
4. Try to insert Product Price and Product Rating within Single Product block
5. **Expected:** They should be available in the inserter
6. Try to insert Product Price and Product Rating outside of Single Product block
3. **Expected:** They should NOT be available in the inserter

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
