### PR TITLE
[Accessibility] Update the checkout page order summary product title to use h3

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -171,7 +171,7 @@ const OrderSummaryItem = ( {
 					disabled={ true }
 					name={ name }
 					permalink={ permalink }
-					disabledTagName='h3'
+					disabledTagName="h3"
 				/>
 				<ProductPrice
 					currency={ priceCurrency }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -171,6 +171,7 @@ const OrderSummaryItem = ( {
 					disabled={ true }
 					name={ name }
 					permalink={ permalink }
+					disabledTagName='h3'
 				/>
 				<ProductPrice
 					currency={ priceCurrency }

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-name/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-name/index.tsx
@@ -58,7 +58,9 @@ export const ProductName = ( {
 	const classes = clsx( 'wc-block-components-product-name', className );
 	const DisabledTagName = disabledTagName as DisabledTagNameType;
 	if ( disabled ) {
-		const disabledProps = props as HTMLAttributes< HTMLHeadingElement | HTMLSpanElement >;
+		const disabledProps = props as HTMLAttributes<
+			HTMLHeadingElement | HTMLSpanElement
+		>;
 		return (
 			<DisabledTagName
 				className={ classes }

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-name/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-name/index.tsx
@@ -10,6 +10,8 @@ import type { AnchorHTMLAttributes, HTMLAttributes } from 'react';
  */
 import './style.scss';
 
+type DisabledTagNameType = 'span' | 'h3';
+
 export interface ProductNameProps
 	extends AnchorHTMLAttributes< HTMLAnchorElement > {
 	/**
@@ -30,6 +32,10 @@ export interface ProductNameProps
 	 * Link for the product
 	 */
 	permalink?: string;
+	/*
+	 * Disabled tag for the product name
+	 */
+	disabledTagName?: DisabledTagNameType;
 }
 
 /**
@@ -46,14 +52,15 @@ export const ProductName = ( {
 	rel,
 	style,
 	onClick,
+	disabledTagName = 'span',
 	...props
 }: ProductNameProps ): JSX.Element => {
 	const classes = clsx( 'wc-block-components-product-name', className );
+	const DisabledTagName = disabledTagName as DisabledTagNameType;
 	if ( disabled ) {
-		// Cast the props as type HTMLSpanElement.
-		const disabledProps = props as HTMLAttributes< HTMLSpanElement >;
+		const disabledProps = props as HTMLAttributes< HTMLHeadingElement | HTMLSpanElement >;
 		return (
-			<span
+			<DisabledTagName
 				className={ classes }
 				{ ...disabledProps }
 				dangerouslySetInnerHTML={ {

--- a/plugins/woocommerce-blocks/assets/js/base/components/product-name/stories/index.stories.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/product-name/stories/index.stories.tsx
@@ -15,6 +15,7 @@ export default {
 		name: 'Test product',
 		permalink: '#',
 	},
+	disabledTagName: 'span',
 } as Meta< ProductNameProps >;
 
 const Template: Story< ProductNameProps > = ( args ) => (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/style.scss
@@ -1,8 +1,12 @@
 .wc-block-checkout__sidebar {
 	.wc-block-components-product-name {
-		display: block;
 		color: inherit;
+		display: block;
 		flex-grow: 1;
+		font-family: inherit;
+		font-weight: inherit;
+		line-height: inherit;
+		margin: 0;
 	}
 	.wc-block-components-totals-footer-item {
 		margin: 0;

--- a/plugins/woocommerce/changelog/fix-51799
+++ b/plugins/woocommerce/changelog/fix-51799
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update the checkout page order summary product title to use h3


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #51799 .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add products to your cart and browse to the checkout page.
2. Check that the tag type for product title under "Order summary" is `<h3>`.

Noting: this has been tested on themes 2017-current. The style updates are required to avoid regressions on older themes. If we prefer to default to the h3 styles for each, we can remove the properties using `inherit`. 

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
<summary>Changelog Entry Details</summary>
<summary>Changelog Entry Comment</summary>
</details>
