### PR TITLE
Use payment method directly, rather than through a payment intent

### DIFF
--- a/plugins/woocommerce/changelog/53051-fix-52990-use-payment-method-instead-of-intent
+++ b/plugins/woocommerce/changelog/53051-fix-52990-use-payment-method-instead-of-intent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This PR does not require a changelog entry, as it is an alteration of https://github.com/woocommerce/woocommerce/pull/52173, a PR that has not been released yet.
+

--- a/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
+++ b/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
@@ -112,24 +112,22 @@ class PaymentInfo {
 				return array();
 			}
 
-			$intent_id = $order->get_meta( '_intent_id' );
-			if ( ! $intent_id ) {
+			$payment_method_id = $order->get_meta( '_payment_method_id' );
+			if ( ! $payment_method_id ) {
 				return array();
 			}
 
 			try {
 				$payment_details = \WC_Payments::get_payments_api_client()
-					->get_intent( $intent_id )
-					->get_charge()
-					->get_payment_method_details();
+					->get_payment_method( $payment_method_id );
 			} catch ( Exception $ex ) {
 				$order_id = $order->get_id();
 				$message  = $ex->getMessage();
 				wc_get_logger()->error(
 					sprintf(
-						'%s - retrieving info for charge %s for order %s: %s',
+						'%s - retrieving info for payment method %s for order %s: %s',
 						StringUtil::class_name_without_namespace( static::class ),
-						$intent_id,
+						$payment_method_id,
 						$order_id,
 						$message
 					),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/52173 introduced the `PaymentInfo` class. The class loads WooPayments payment method details by getting the Payment Intent, associated with an order, and then using the nested charge and payment method objects.

This PR circumvents the Payment Intent, and loads the Payment Method directly. This is not only more efficient, but also works with orders that have a Setup Intent associated with them, rather than a Payment Intent:

1. Payment Intents are used for orders that actually require payment, which is most cases.
2. Setup Intents are used for orders that do not require payment (zero amount), or whenever the payment method is changed for a subscription. This case was not supported until now, thus introducing a bug.

With this PR, it does not matter what type of intent is used, as the payment method is always stored anyway.

Closes #52990.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing instructions for the changes in this PR can be also found in https://github.com/woocommerce/woocommerce/issues/52990.

0. Check out `trunk`.
1. Install WooPayments and WooCommerce Subscriptions. Setup the former, add a basic subscription product for the latter.
4. Sign up for the subscription (add to cart and check out).
5. Navigate to My Account > My Subscription. Observe that the page looks alright.
6. Click "Change Payment", and enter a new payment method (`4242 4242 4242 4242` and any CVC + expiration date work). Using an existing payment method would not trigger failure.
7. Observe the error.
8. Check out this PR and refresh. The error should be gone.

<!-- End testing instructions -->

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR does not require a changelog entry, as it is an alteration of https://github.com/woocommerce/woocommerce/pull/52173, a PR that has not been released yet.

</details>
