### PR TITLE
[dev] Remove the bot check from CFE and PRR flow

### DIFF
--- a/.github/workflows/new-cfe-cherry-pick.yml
+++ b/.github/workflows/new-cfe-cherry-pick.yml
@@ -62,7 +62,7 @@ jobs:
                       console.log("isBot:", isBot);
                       console.log("baseRef.startsWith('release/'):", baseRef.startsWith('release/'));
 
-                      if ( !isBot && baseRef.startsWith( 'release/' ) ) {
+                      if ( baseRef.startsWith( 'release/' ) ) {
                         core.setOutput( 'run', 'true' );
                       } else {
                         core.setOutput( 'run', 'false' );

--- a/.github/workflows/new-prr-cherry-pick.yml
+++ b/.github/workflows/new-prr-cherry-pick.yml
@@ -62,7 +62,7 @@ jobs:
                       console.log("isBot:", isBot);
                       console.log("baseRef.startsWith('release/'):", baseRef.startsWith('release/'));
 
-                      if ( !isBot && baseRef.startsWith( 'release/' ) ) {
+                      if ( baseRef.startsWith( 'release/' ) ) {
                         core.setOutput( 'run', 'true' );
                       } else {
                         core.setOutput( 'run', 'false' );


### PR DESCRIPTION
We remove the bot check, so that any PR created by bot with the help of milestone change can also be picked to frozen release branch.