### PR TITLE
[WIP][Accessibility] Update billing email autocomplete to use email only

### DIFF
--- a/plugins/woocommerce/changelog/fix-51831
+++ b/plugins/woocommerce/changelog/fix-51831
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update billing email autocomplete to use email only

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1713,7 +1713,7 @@ class WC_Countries {
 				'type'         => 'email',
 				'class'        => array( 'form-row-wide' ),
 				'validate'     => array( 'email' ),
-				'autocomplete' => 'no' === get_option( 'woocommerce_registration_generate_username' ) ? 'email' : 'email username',
+				'autocomplete' => 'email',
 				'priority'     => 110,
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- * I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- * I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- * I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- * Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #51831 .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Browse to My Account → Edit Address page
2. Add or Edit the Billing Address
3. The Email Address field should have `email` as the autocomplete property value.

### Changelog entry

- * [ ] Automatically create a changelog entry from the details below.
- * [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance
#### Type

</details>
