### PR TITLE
fix: update clear button block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/block.json
@@ -19,6 +19,9 @@
 		"woocommerce/product-filter-status",
 		"woocommerce/product-filter-active"
 	],
+	"usesContext": [
+		"filterData"
+	],
 	"attributes": {
 		"clearType": {
 			"type": "string",

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
@@ -43,13 +43,19 @@ final class ProductFilterClearButton extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		// don't render if its admin, or ajax in progress.
-		if ( is_admin() || wp_doing_ajax() ) {
+		if (
+			is_admin() ||
+			wp_doing_ajax() ||
+			empty( $block->context['filterData'] ) ||
+			empty( $block->context['filterData']['parent'] )
+		) {
 			return '';
 		}
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'data-wc-bind--hidden' => '!context.hasSelectedFilters',
+				'data-wc-bind--hidden' => '!state.hasSelectedFilters',
+				'data-wc-interactive'  => wp_json_encode( array( 'namespace' => $block->context['filterData']['parent'] ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 			)
 		);
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #53021.

This PR update the clear button block to use `state.hasSelectedFiters` from its parent block instead of rely on the context that come from server, after navigation. This add optimistic update to the clear button block.

Besides, there is a bug with the current runtime of the Interactivity API that Woo is using, which causes the clear button (when placed below the filter option block) to lose its original state/context. This PR fixes that issue by declaring the interactive namespace for the clear button block to ensure it uses the original state/context.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing is done in connected PRs.

<!-- End testing instructions -->


