### PR TITLE
[dev] CI: revert Proton team auto-assignment as a reviewer.

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -25,14 +25,6 @@ when:
         - flux
   - author:
       teamIs:
-        - proton
-      ignore:
-        nameIs:
-    assign:
-      teams:
-        - proton
-  - author:
-      teamIs:
         - mailpoet
       ignore:
         nameIs:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1732062805081309-slack-C0E1AV8T0

Remove the team from reviewers auto-assignment config.

### How to test the changes in this Pull Request:

CI-checks shall pass