### PR TITLE
Include Blocks e2e with WP L-1 in the daily and release checks

### DIFF
--- a/plugins/woocommerce/changelog/ci-add-daily-checks-for-blocks-e2e-with-wp-l-1
+++ b/plugins/woocommerce/changelog/ci-add-daily-checks-for-blocks-e2e-with-wp-l-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI config: include blocks e2e with wp L-1 in the daily checks

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -626,6 +626,39 @@
 					}
 				},
 				{
+					"name": "Blocks e2e tests - WP latest-1",
+					"testType": "e2e",
+					"command": "test:e2e:blocks",
+					"shardingArguments": [
+						"--shard=1/10",
+						"--shard=2/10",
+						"--shard=3/10",
+						"--shard=4/10",
+						"--shard=5/10",
+						"--shard=6/10",
+						"--shard=7/10",
+						"--shard=8/10",
+						"--shard=9/10",
+						"--shard=10/10"
+					],
+					"changes": [],
+					"testEnv": {
+						"start": "env:start:blocks",
+						"config": {
+							"wpVersion": "prerelease"
+						}
+					},
+					"events": [
+						"daily-checks",
+						"release-checks"
+					],
+					"report": {
+						"resultsBlobName": "blocks-e2e-report-wp-latest-1",
+						"resultsPath": "../woocommerce-blocks/tests/e2e/artifacts/test-results",
+						"allure": true
+					}
+				},
+				{
 					"name": "Core e2e tests - default Pressable site",
 					"testType": "e2e",
 					"command": "test:e2e:with-env default-pressable",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -645,7 +645,7 @@
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {
-							"wpVersion": "prerelease"
+							"wpVersion": "latest-1"
 						}
 					},
 					"events": [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add new jobs to the daily and release checks for Blocks e2e with WP latest-1 (currently 6.6.2).

### How to test the changes in this Pull Request:

See [this daily checks workflow run](https://github.com/woocommerce/woocommerce/actions/runs/11971284327/job/33375792992), manually triggered from this branch. 10 new jobs `Blocks e2e tests - WP latest-1 [WP 6.6.2] n/10` ran.