### PR TITLE
Product Hero: allow changing displayed product

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
@@ -72,7 +72,7 @@ const Editor = ( {
 			? productPreview[ 0 ]?.id
 			: null;
 
-		// If the product is not set, and we have a preview product, set the product ID.
+		// If the product is set, do not override it with the preview.
 		if ( ! productPreviewId || productId ) {
 			return;
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
@@ -8,7 +8,7 @@ import { withProduct } from '@woocommerce/block-hocs';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { isNull, ProductResponseItem } from '@woocommerce/types';
+import { ProductResponseItem } from '@woocommerce/types';
 import ErrorPlaceholder, {
 	ErrorObject,
 } from '@woocommerce/editor-components/error-placeholder';

--- a/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/single-product/edit/index.tsx
@@ -8,7 +8,7 @@ import { withProduct } from '@woocommerce/block-hocs';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { ProductResponseItem } from '@woocommerce/types';
+import { isNull, ProductResponseItem } from '@woocommerce/types';
 import ErrorPlaceholder, {
 	ErrorObject,
 } from '@woocommerce/editor-components/error-placeholder';
@@ -71,7 +71,9 @@ const Editor = ( {
 		const productPreviewId = productPreview
 			? productPreview[ 0 ]?.id
 			: null;
-		if ( ! productPreviewId ) {
+
+		// If the product is not set, and we have a preview product, set the product ID.
+		if ( ! productPreviewId || productId ) {
 			return;
 		}
 
@@ -80,7 +82,7 @@ const Editor = ( {
 			productId: productPreviewId,
 		} );
 		setIsEditing( false );
-	}, [ attributes, productPreview, setAttributes ] );
+	}, [ attributes, productId, productPreview, setAttributes ] );
 
 	if ( error ) {
 		return (

--- a/plugins/woocommerce/changelog/53090-52999-patterns-unable-to-change-product-being-shown-in-product-hero-pattern
+++ b/plugins/woocommerce/changelog/53090-52999-patterns-unable-to-change-product-being-shown-in-product-hero-pattern
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Product Hero: allow changing displayed product


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR fixes a bug where the user wasn't able to change the product if the `productPreviewId` was defined.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #52999.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Ensure that the tracking is enabled, otherwise enabled it.
3. Open the Post Editor and add the `Product Hero` pattern.
4. Focus on the pattern.
5. Click on the pencil icon:
![image](https://github.com/user-attachments/assets/834702db-41f9-4ed8-b23a-eef5b8722bf2)
6. Select another product.
7. Click done.
8. Ensure that the new product is displayed.
9. Save the post.
10. Ensure that the new product is visible on the frontend.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/eff721b0-a360-4c36-bbe0-e64a12d36696" /> | <video src="https://github.com/user-attachments/assets/720dfd47-fe52-4fac-bf06-ce76c5fab13b" /> | 





<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Hero: allow changing displayed product

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
