### PR TITLE
feat: update attribute filter block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/frontend.ts
@@ -6,80 +6,100 @@ import { store, getContext, getElement } from '@woocommerce/interactivity';
 /**
  * Internal dependencies
  */
-import { ProductFiltersContext } from '../../frontend';
+import { ProductFiltersStore } from '../../frontend';
 
-type AttributeFilterContext = {
+type ProductFilterAttributeContext = {
 	attributeSlug: string;
 	queryType: 'or' | 'and';
 	selectType: 'single' | 'multiple';
+	hasFilterOptions: boolean;
+	activeLabelTemplate: string;
 };
 
-store( 'woocommerce/product-filter-attribute', {
+const { state, actions } = store( 'woocommerce/product-filter-attribute', {
+	state: {
+		get selectedFilters() {
+			const context = getContext< ProductFilterAttributeContext >();
+			const productFiltersStore = store< ProductFiltersStore >(
+				'woocommerce/product-filters'
+			);
+			return ( productFiltersStore.state.activeFilters || [] )
+				.filter(
+					( item ) =>
+						item.type === 'attribute' &&
+						item.attribute?.slug === context.attributeSlug
+				)
+				.map( ( item ) => item.value )
+				.filter( Boolean );
+		},
+		get hasSelectedFilters(): boolean {
+			return state.selectedFilters.length > 0;
+		},
+		get isItemSelected(): boolean {
+			const { props } = getElement();
+
+			if ( ! props.value ) return false;
+
+			return state.selectedFilters.includes( props.value );
+		},
+	},
 	actions: {
+		getActiveLabel( label: string ) {
+			const { activeLabelTemplate } =
+				getContext< ProductFilterAttributeContext >();
+			return activeLabelTemplate.replace( '{{label}}', label );
+		},
 		toggleFilter: () => {
-			const { ref } = getElement();
-			const targetAttribute =
-				ref.getAttribute( 'data-target-value' ) ?? 'value';
-			const termSlug = ref.getAttribute( targetAttribute );
+			const { props } = getElement();
+			let filterItem = props[ 'data-filter-item' ];
 
-			if ( ! termSlug ) return;
+			if ( typeof filterItem === 'string' )
+				filterItem = JSON.parse( filterItem );
 
-			const { attributeSlug, queryType } =
-				getContext< AttributeFilterContext >();
-			const productFiltersContext = getContext< ProductFiltersContext >(
+			const { ariaLabel, value } = filterItem;
+
+			if ( ! value || ! ariaLabel ) return;
+
+			const context = getContext< ProductFilterAttributeContext >();
+			const productFiltersStore = store< ProductFiltersStore >(
 				'woocommerce/product-filters'
 			);
 
-			if (
-				! (
-					`filter_${ attributeSlug }` in productFiltersContext.params
-				)
-			) {
-				productFiltersContext.params = {
-					...productFiltersContext.params,
-					[ `filter_${ attributeSlug }` ]: termSlug,
-					[ `query_type_${ attributeSlug }` ]: queryType,
-				};
-				return;
-			}
-
-			const selectedTerms =
-				productFiltersContext.params[
-					`filter_${ attributeSlug }`
-				].split( ',' );
-			if ( selectedTerms.includes( termSlug ) ) {
-				const remainingSelectedTerms = selectedTerms.filter(
-					( term ) => term !== termSlug
+			if ( state.selectedFilters.includes( value ) ) {
+				productFiltersStore.actions.removeActiveFiltersBy(
+					( item ) =>
+						item.value === value &&
+						item.type === 'attribute' &&
+						item.attribute?.slug === context.attributeSlug
 				);
-				if ( remainingSelectedTerms.length > 0 ) {
-					productFiltersContext.params[
-						`filter_${ attributeSlug }`
-					] = remainingSelectedTerms.join( ',' );
-				} else {
-					const updatedParams = productFiltersContext.params;
-
-					delete updatedParams[ `filter_${ attributeSlug }` ];
-					delete updatedParams[ `query_type_${ attributeSlug }` ];
-
-					productFiltersContext.params = updatedParams;
-				}
 			} else {
-				productFiltersContext.params[ `filter_${ attributeSlug }` ] =
-					selectedTerms.concat( termSlug ).join( ',' );
+				productFiltersStore.actions.setActiveFilter( {
+					type: 'attribute',
+					value,
+					label: actions.getActiveLabel( ariaLabel ),
+					attribute: {
+						slug: context.attributeSlug,
+						queryType: 'or',
+					},
+				} );
 			}
+
+			productFiltersStore.actions.navigate();
 		},
 
 		clearFilters: () => {
-			const { attributeSlug } = getContext< AttributeFilterContext >();
-			const productFiltersContext = getContext< ProductFiltersContext >(
+			const context = getContext< ProductFilterAttributeContext >();
+			const productFiltersStore = store< ProductFiltersStore >(
 				'woocommerce/product-filters'
 			);
-			const updatedParams = productFiltersContext.params;
 
-			delete updatedParams[ `filter_${ attributeSlug }` ];
-			delete updatedParams[ `query_type_${ attributeSlug }` ];
+			productFiltersStore.actions.removeActiveFiltersBy(
+				( item ) =>
+					item.type === 'attribute' &&
+					item.attribute?.slug === context.attributeSlug
+			);
 
-			productFiltersContext.params = updatedParams;
+			productFiltersStore.actions.navigate();
 		},
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/frontend.ts
@@ -1,56 +1,17 @@
 /**
  * External dependencies
  */
-import { getContext, getElement, store } from '@woocommerce/interactivity';
-import { HTMLElementEvent } from '@woocommerce/types';
+import { getContext, store } from '@woocommerce/interactivity';
 
-/**
- * Internal dependencies
- */
-
-export type CheckboxListContext = {
-	items: {
-		id: string;
-		label: string;
-		value: string;
-		selected: boolean;
-	}[];
+type CheckboxListContext = {
 	showAll: boolean;
 };
 
 store( 'woocommerce/product-filter-checkbox-list', {
-	state: {
-		get isItemSelected() {
-			const context = getContext< CheckboxListContext >();
-			const { props } = getElement();
-			const result = context.items.find(
-				( item ) => item.value === props.value
-			);
-
-			if ( result ) return result.selected;
-
-			return false;
-		},
-	},
 	actions: {
 		showAllItems: () => {
 			const context = getContext< CheckboxListContext >();
 			context.showAll = true;
-		},
-
-		selectCheckboxItem: ( event: HTMLElementEvent< HTMLInputElement > ) => {
-			const context = getContext< CheckboxListContext >();
-			const value = event.target.value;
-
-			context.items = context.items.map( ( item ) => {
-				if ( item.value.toString() === value ) {
-					return {
-						...item,
-						selected: ! item.selected,
-					};
-				}
-				return item;
-			} );
 		},
 	},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
@@ -6,7 +6,7 @@
 
 :where(.wc-block-product-filter-checkbox-list__label) {
 	align-items: center;
-	display: flex;
+	display: inline-flex;
 	gap: 0.625em;
 }
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/chips/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/chips/frontend.ts
@@ -1,19 +1,13 @@
 /**
  * External dependencies
  */
-import { getElement, getContext, store } from '@woocommerce/interactivity';
+import { getContext, store } from '@woocommerce/interactivity';
 
 /**
  * Internal dependencies
  */
 
 export type ChipsContext = {
-	items: {
-		id: string;
-		label: string;
-		value: string;
-		checked: boolean;
-	}[];
 	showAll: boolean;
 };
 
@@ -22,25 +16,6 @@ store( 'woocommerce/product-filter-chips', {
 		showAllItems: () => {
 			const context = getContext< ChipsContext >();
 			context.showAll = true;
-		},
-
-		selectItem: () => {
-			const { ref } = getElement();
-			const value = ref.getAttribute( 'value' );
-
-			if ( ! value ) return;
-
-			const context = getContext< ChipsContext >();
-
-			context.items = context.items.map( ( item ) => {
-				if ( item.value.toString() === value ) {
-					return {
-						...item,
-						checked: ! item.checked,
-					};
-				}
-				return item;
-			} );
 		},
 	},
 } );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -28,8 +28,8 @@ final class ProductFilterAttribute extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
-		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+		add_filter( 'product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 		add_action( 'deleted_transient', array( $this, 'delete_default_attribute_id_transient' ) );
 		add_action( 'wp_loaded', array( $this, 'register_block_patterns' ) );
 	}
@@ -83,13 +83,13 @@ final class ProductFilterAttribute extends AbstractBlock {
 	}
 
 	/**
-	 * Register the active filters data.
+	 * Prepare the active filter items.
 	 *
-	 * @param array $data   The active filters data.
+	 * @param array $items  The active filter items.
 	 * @param array $params The query param parsed from the URL.
-	 * @return array Active filters data.
+	 * @return array Active filters items.
 	 */
-	public function register_active_filters_data( $data, $params ) {
+	public function prepare_selected_filters( $items, $params ) {
 		$product_attributes_map = array_reduce(
 			wc_get_attribute_taxonomies(),
 			function ( $acc, $attribute_object ) {
@@ -117,40 +117,29 @@ final class ProductFilterAttribute extends AbstractBlock {
 			}
 		);
 
-		$action_namespace = $this->get_full_block_name();
-
 		foreach ( $active_product_attributes as $product_attribute ) {
-			$terms = explode( ',', get_query_var( "filter_{$product_attribute}" ) );
+			if ( empty( $params[ "filter_{$product_attribute}" ] ) ) {
+				continue;
+			}
+			$terms           = explode( ',', $params[ "filter_{$product_attribute}" ] );
+			$attribute_label = wc_attribute_label( "pa_{$product_attribute}" );
 
 			// Get attribute term by slug.
-			$terms = array_map(
-				function ( $term ) use ( $product_attribute, $action_namespace ) {
-					$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
-					return array(
-						'title'      => $term_object->name,
-						'attributes' => array(
-							'value'             => $term,
-							'data-wc-on--click' => "$action_namespace::actions.toggleFilter",
-							'data-wc-context'   => "$action_namespace::" . wp_json_encode(
-								array(
-									'attributeSlug' => $product_attribute,
-									'queryType'     => get_query_var( "query_type_{$product_attribute}" ),
-								),
-								JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-							),
-						),
-					);
-				},
-				$terms
-			);
-
-			$data[ $product_attribute ] = array(
-				'type'  => $product_attributes_map[ $product_attribute ],
-				'items' => $terms,
-			);
+			foreach ( $terms as $term ) {
+				$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
+				$items[]     = array(
+					'type'      => 'attribute',
+					'value'     => $term,
+					'label'     => $attribute_label . ': ' . $term_object->name,
+					'attribute' => array(
+						'slug'      => $product_attribute,
+						'queryType' => 'or',
+					),
+				);
+			}
 		}
 
-		return $data;
+		return $items;
 	}
 
 	/**
@@ -205,33 +194,33 @@ final class ProductFilterAttribute extends AbstractBlock {
 		if ( ! empty( $attribute_counts ) ) {
 			$attribute_options = array_map(
 				function ( $term ) use ( $block_attributes, $attribute_counts, $selected_terms ) {
-					$term             = (array) $term;
-					$term['count']    = $attribute_counts[ $term['term_id'] ] ?? 0;
-					$term['selected'] = in_array( $term['slug'], $selected_terms, true );
+					$term          = (array) $term;
+					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
 					return array(
-						'label'    => $block_attributes['showCounts'] ? sprintf( '%1$s (%2$d)', $term['name'], $term['count'] ) : $term['name'],
-						'value'    => $term['slug'],
-						'selected' => $term['selected'],
-						'rawData'  => $term,
+						'label'     => $block_attributes['showCounts'] ? sprintf( '%1$s (%2$d)', $term['name'], $term['count'] ) : $term['name'],
+						'ariaLabel' => $block_attributes['showCounts'] ? sprintf( '%1$s (%2$d)', $term['name'], $term['count'] ) : $term['name'],
+						'value'     => $term['slug'],
+						'selected'  => in_array( $term['slug'], $selected_terms, true ),
+						'type'      => 'attribute',
+						'data'      => $term,
 					);
 				},
 				$attribute_terms
 			);
 
 			$filter_context = array(
-				'items'   => $attribute_options,
-				'actions' => array(
-					'toggleFilter' => "{$this->get_full_block_name()}::actions.toggleFilter",
-				),
+				'items'  => $attribute_options,
+				'parent' => $this->get_full_block_name(),
 			);
 		}
 
 		$context = array(
-			'attributeSlug'      => str_replace( 'pa_', '', $product_attribute->slug ),
-			'queryType'          => $block_attributes['queryType'],
-			'selectType'         => 'multiple',
-			'hasSelectedFilters' => count( $selected_terms ) > 0,
-			'hasFilterOptions'   => ! empty( $filter_context ),
+			'attributeSlug'       => str_replace( 'pa_', '', $product_attribute->slug ),
+			'queryType'           => $block_attributes['queryType'],
+			'selectType'          => 'multiple',
+			'hasFilterOptions'    => ! empty( $filter_context ),
+			/* translators: {{label}} is the product attribute filter item label. */
+			'activeLabelTemplate' => "{$product_attribute->name}: {{label}}",
 		);
 
 		$wrapper_attributes = array(
@@ -240,6 +229,10 @@ final class ProductFilterAttribute extends AbstractBlock {
 			'data-wc-context'      => wp_json_encode( $context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 			'data-wc-bind--hidden' => '!context.hasFilterOptions',
 		);
+
+		if ( empty( $filter_context ) ) {
+			$wrapper_attributes['hidden'] = true;
+		}
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -24,16 +24,18 @@ final class ProductFilterChips extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( empty( $block->context['filterData'] ) || empty( $block->context['filterData']['items'] ) ) {
+		if (
+			empty( $block->context['filterData'] ) ||
+			empty( $block->context['filterData']['parent'] )
+		) {
 			return '';
 		}
-		$classes               = '';
-		$style                 = '';
-		$context               = $block->context['filterData'];
-		$items                 = $context['items'] ?? array();
-		$checkbox_list_context = array( 'items' => $items );
-		$action                = $context['actions']['toggleFilter'] ?? '';
-		$namespace             = wp_json_encode( array( 'namespace' => 'woocommerce/product-filter-chips' ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
+
+		$block_context = $block->context['filterData'];
+		$parent        = $block_context['parent'];
+		$items         = $block_context['items'] ?? array();
+		$classes       = '';
+		$style         = '';
 
 		$tags = new \WP_HTML_Tag_Processor( $content );
 		if ( $tags->next_tag( array( 'class_name' => 'wc-block-product-filter-chips' ) ) ) {
@@ -52,8 +54,7 @@ final class ProductFilterChips extends AbstractBlock {
 		$count                       = 0;
 
 		$wrapper_attributes = array(
-			'data-wc-interactive' => esc_attr( $namespace ),
-			'data-wc-context'     => wp_json_encode( $checkbox_list_context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
+			'data-wc-interactive' => esc_attr( wp_json_encode( array( 'namespace' => 'woocommerce/product-filter-chips' ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) ),
 			'data-wc-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
 			'class'               => esc_attr( $classes ),
 			'style'               => esc_attr( $style ),
@@ -64,25 +65,31 @@ final class ProductFilterChips extends AbstractBlock {
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wc-block-product-filter-chips__items" aria-label="<?php echo esc_attr__( 'Filter Options', 'woocommerce' ); ?>">
 				<?php foreach ( $items as $item ) { ?>
-					<?php $item['id'] = $item['id'] ?? uniqid( 'chips-' ); ?>
+					<?php
+					$item['id'] = $item['id'] ?? uniqid( 'chips-' );
+					unset( $item['data'] );
+					// translators: %s: item label.
+					$aria_label = sprintf( __( 'Filter item: %s', 'woocommerce' ), $item['ariaLabel'] ?? $item['label'] );
+					?>
 					<button
 						data-wc-key="<?php echo esc_attr( $item['id'] ); ?>"
-						<?php
-						if ( ! $item['selected'] ) :
-							if ( $count >= $remaining_initial_unchecked ) :
-								?>
-								class="wc-block-product-filter-chips__item"
+						id="<?php echo esc_attr( $item['id'] ); ?>"
+						class="wc-block-product-filter-chips__item"
+						type="button"
+						aria-label="<?php echo esc_attr( $aria_label ); ?>"
+						data-wc-on--click--parent-action="<?php echo esc_attr( $parent . '::actions.toggleFilter' ); ?>"
+						value="<?php echo esc_attr( $item['value'] ); ?>"
+						aria-checked="<?php echo $item['selected'] ? 'true' : 'false'; ?>"
+						data-wc-bind--aria-checked="<?php echo esc_attr( $parent . '::state.isItemSelected' ); ?>"
+						data-filter-item="<?php echo esc_attr( wp_json_encode( $item, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) ); ?>"
+						<?php if ( ! $item['selected'] ) : ?>
+							<?php if ( $count >= $remaining_initial_unchecked ) : ?>
 								data-wc-bind--hidden="!context.showAll"
 								hidden
 							<?php else : ?>
 								<?php ++$count; ?>
 							<?php endif; ?>
 						<?php endif; ?>
-						class="wc-block-product-filter-chips__item"
-						data-wc-on--click--select-item="actions.selectItem"
-						data-wc-on--click--parent-action="<?php echo esc_attr( $action ); ?>"
-						value="<?php echo esc_attr( $item['value'] ); ?>"
-						aria-checked="<?php echo $item['selected'] ? 'true' : 'false'; ?>"
 					>
 						<span class="wc-block-product-filter-chips__label">
 							<?php echo wp_kses_post( $item['label'] ); ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #53021.
Blocked by #53070, #53029.

This PR:
- Attribute filter block:
  - updates the filter callback that prepares the active attribute filter following the new active filter item structure.
  - updates the store to use derived state and new actions from the `woocommerce/product-filters` store.
  - replaces some context with state for optimistic updates.
  - passes block namespace through block context for inner blocks to consume.
- Checkbox List block:
  - removes unused context, which reduces the size of returned HTML.
  - updates list item markup in favor of new filter option item data structure.
  - fixes the width issue of checkbox label as reported in https://github.com/woocommerce/woocommerce/issues/52884.
  - passes item data as the whole to `data-filter-item` attribute, so the filter blocks know the shape of the data.
- Chips block:
  - removes unused context, which reduces the size of returned HTML.
  - updates chip item markup in favor of new filter option item data structure.
  - passes item data as the whole to `data-filter-item` attribute, so the filter blocks know the shape of the data.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
1. Add the `Product Filters` block to the `Product Catalog` template.
2. Remove the Status, Price, and Ratings filter blocks as they haven't been updated.
3. Add another Attribute filter block with another attribute, and set the display style to Chips.
4. Save and go to the front end.
5. Interact with filters, confirm:
  - The option is marked as selected **right after** clicking on it.
  - The corresponding item appears in the Active Filters block **right after** selecting the filter option.
  - The page URL is updated.
  - The clear filter button appears after selecting a filter. Clicking on it unselects all selected filter of the current filter block.
  - The product result is updated after the navigation event is finished (There isn't a loading indicator yet for the Product Collection block while the navigation is happening).
6. Enable network throttling to 3G or slow 4G, confirm step 5 is still applied.

<!-- End testing instructions -->