### PR TITLE
feat: update price filter block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/frontend.ts
@@ -6,183 +6,31 @@ import { formatPrice, getCurrency } from '@woocommerce/price-format';
 import { HTMLElementEvent } from '@woocommerce/types';
 import { debounce } from '@woocommerce/base-utils';
 
-type PriceSliderContext = {
-	minPrice: number;
-	maxPrice: number;
-	minRange: number;
-	maxRange: number;
-};
-
-function inRange( value: number, min: number, max: number ) {
-	return value >= min && value <= max;
-}
-
-const constrainRangeSliderValues = (
-	/**
-	 * Tuple containing min and max values.
-	 */
-	values: [ number, number ],
-	/**
-	 * Min allowed value for the sliders.
-	 */
-	min?: number | null,
-	/**
-	 * Max allowed value for the sliders.
-	 */
-	max?: number | null,
-	/**
-	 * Step value for the sliders.
-	 */
-	step = 1,
-	/**
-	 * Whether we're currently interacting with the min range slider or not, so we update the correct values.
-	 */
-	isMin = false
-): { minPrice: number; maxPrice: number } => {
-	let [ minValue, maxValue ] = values;
-
-	const isFinite = ( n: number | null | undefined ): n is number =>
-		Number.isFinite( n );
-
-	if ( ! isFinite( minValue ) ) {
-		minValue = min || 0;
-	}
-
-	if ( ! isFinite( maxValue ) ) {
-		maxValue = max || step;
-	}
-
-	if ( isFinite( min ) && min > minValue ) {
-		minValue = min;
-	}
-
-	if ( isFinite( max ) && max <= minValue ) {
-		minValue = max - step;
-	}
-
-	if ( isFinite( min ) && min >= maxValue ) {
-		maxValue = min + step;
-	}
-
-	if ( isFinite( max ) && max < maxValue ) {
-		maxValue = max;
-	}
-
-	if ( ! isMin && minValue >= maxValue ) {
-		minValue = maxValue - step;
-	}
-
-	if ( isMin && maxValue <= minValue ) {
-		maxValue = minValue + step;
-	}
-
-	return { minPrice: minValue, maxPrice: maxValue };
-};
-
-const _updateRange = (
-	event: HTMLElementEvent< HTMLInputElement >,
-	context: PriceSliderContext
-) => {
-	const { minPrice, maxPrice, minRange, maxRange } = context;
-	const isMin = event.target.classList.contains( 'min' );
-	const targetValue = Number( event.target.value );
-	const stepValue = 1;
-	const currentValues: [ number, number ] = isMin
-		? [ Math.round( targetValue / stepValue ) * stepValue, maxPrice ]
-		: [ minPrice, Math.round( targetValue / stepValue ) * stepValue ];
-	const values = constrainRangeSliderValues(
-		currentValues,
-		minRange,
-		maxRange,
-		stepValue,
-		isMin
-	);
-
-	if ( targetValue >= maxPrice ) {
-		context.maxPrice = minPrice + 1;
-	} else if ( targetValue <= minPrice ) {
-		context.minPrice = maxPrice - 1;
-	}
-
-	if ( isMin ) {
-		context.minPrice = values.minPrice;
-	} else {
-		context.maxPrice = values.maxPrice;
-	}
-};
-
-const _debounceUpdateRange = debounce(
-	(
-		event: HTMLElementEvent< HTMLInputElement >,
-		context: PriceSliderContext
-	) => {
-		const isMin = event.target.classList.contains( 'min' );
-		const isMax = event.target.classList.contains( 'max' );
-		const targetValue = Number( event.target.value );
-		if ( isMin ) {
-			if (
-				targetValue &&
-				inRange( targetValue, context.minRange, context.maxRange ) &&
-				targetValue < context.maxPrice
-			) {
-				context.minPrice = targetValue;
-			} else {
-				context.minPrice = context.minRange;
-			}
-			event.target.setAttribute(
-				'data-min-price',
-				context.minPrice.toString()
-			);
-			event.target.value = formatPrice(
-				context.minPrice,
-				getCurrency( { minorUnit: 0 } )
-			);
-		}
-
-		if ( isMax ) {
-			if (
-				targetValue &&
-				inRange( targetValue, context.minRange, context.maxRange ) &&
-				targetValue > context.minPrice
-			) {
-				context.maxPrice = targetValue;
-			} else {
-				context.maxPrice = context.maxRange;
-			}
-			event.target.setAttribute(
-				'data-max-price',
-				context.maxPrice.toString()
-			);
-			event.target.value = formatPrice(
-				context.maxPrice,
-				getCurrency( { minorUnit: 0 } )
-			);
-		}
-
-		event.target.dispatchEvent( new Event( 'change' ) );
-	},
-	1000
-);
+/**
+ * Internal dependencies
+ */
+import {
+	ProductFilterPriceContext,
+	ProductFilterPriceStore,
+} from '../price-filter/frontend';
 
 store( 'woocommerce/product-filter-price-slider', {
 	state: {
 		rangeStyle: () => {
-			const { minPrice, maxPrice, minRange, maxRange } =
-				getContext< PriceSliderContext >();
+			const { minRange, maxRange } =
+				getContext< ProductFilterPriceContext >(
+					'woocommerce/product-filter-price'
+				);
+			const productFilterPriceStore = store< ProductFilterPriceStore >(
+				'woocommerce/product-filter-price'
+			);
+			const { minPrice, maxPrice } = productFilterPriceStore.state;
 
 			return `--low: ${
 				( 100 * ( minPrice - minRange ) ) / ( maxRange - minRange )
 			}%; --high: ${
 				( 100 * ( maxPrice - minRange ) ) / ( maxRange - minRange )
 			}%;`;
-		},
-		formattedMinPrice: () => {
-			const { minPrice } = getContext< PriceSliderContext >();
-			return formatPrice( minPrice, getCurrency( { minorUnit: 0 } ) );
-		},
-		formattedMaxPrice: () => {
-			const { maxPrice } = getContext< PriceSliderContext >();
-			return formatPrice( maxPrice, getCurrency( { minorUnit: 0 } ) );
 		},
 	},
 	actions: {
@@ -192,15 +40,28 @@ store( 'woocommerce/product-filter-price-slider', {
 				element.ref.select();
 			}
 		},
-		updateRange: ( event: HTMLElementEvent< HTMLInputElement > ) => {
-			const context = getContext< PriceSliderContext >();
-			_updateRange( event, context );
-		},
-		debounceUpdateRange: (
-			event: HTMLElementEvent< HTMLInputElement >
-		) => {
-			const context = getContext< PriceSliderContext >();
-			_debounceUpdateRange( event, context );
+		debounceSetPrice: debounce(
+			( e: HTMLElementEvent< HTMLInputElement > ) => {
+				e.target.dispatchEvent( new Event( 'change' ) );
+			},
+			1000
+		),
+		limitRange: ( e: HTMLElementEvent< HTMLInputElement > ) => {
+			const productFilterPriceStore = store< ProductFilterPriceStore >(
+				'woocommerce/product-filter-price'
+			);
+			const { minPrice, maxPrice } = productFilterPriceStore.state;
+			if ( e.target.classList.contains( 'min' ) ) {
+				e.target.value = Math.min(
+					parseInt( e.target.value, 10 ),
+					maxPrice - 1
+				).toString();
+			} else {
+				e.target.value = Math.max(
+					parseInt( e.target.value, 10 ),
+					minPrice + 1
+				).toString();
+			}
 		},
 	},
 } );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -29,8 +29,63 @@ final class ProductFilterPrice extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
-		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+		add_filter( 'product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'product_filters_active_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+	}
+
+	/**
+	 * Prepare the active filter items.
+	 *
+	 * @param array $items  The active filter items.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters items.
+	 */
+	public function prepare_selected_filters( $items, $params ) {
+		$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
+		$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
+		$formatted_min_price = $min_price ? html_entity_decode( wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ) ) : null;
+		$formatted_max_price = $max_price ? html_entity_decode( wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) ) : null;
+
+		if ( ! $formatted_min_price && ! $formatted_max_price ) {
+			return $items;
+		}
+
+		$item = array(
+			'type'  => 'price',
+			'value' => "{$min_price}-{$max_price}",
+			'price' => array(),
+		);
+
+		if ( $min_price ) {
+			$item['price']['min'] = $min_price;
+		}
+
+		if ( $max_price ) {
+			$item['price']['max'] = $max_price;
+		}
+
+		if ( $formatted_min_price && $formatted_max_price ) {
+			$item['label'] = sprintf(
+				/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
+				__( 'Price: %1$s - %2$s', 'woocommerce' ),
+				$formatted_min_price,
+				$formatted_max_price
+			);
+		}
+
+		if ( ! $formatted_min_price ) {
+			/* translators: %s is the formatted maximum price. */
+			$item['label'] = sprintf( __( 'Price: Up to %s', 'woocommerce' ), $formatted_max_price );
+		}
+
+		if ( ! $formatted_max_price ) {
+			/* translators: %s is the formatted minimum price. */
+			$item['label'] = sprintf( __( 'Price: From %s', 'woocommerce' ), $formatted_min_price );
+		}
+
+		$items[] = $item;
+
+		return $items;
 	}
 
 	/**
@@ -56,57 +111,6 @@ final class ProductFilterPrice extends AbstractBlock {
 	}
 
 	/**
-	 * Register the active filters data.
-	 *
-	 * @param array $data   The active filters data.
-	 * @param array $params The query param parsed from the URL.
-	 * @return array Active filters data.
-	 */
-	public function register_active_filters_data( $data, $params ) {
-		$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
-		$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
-		$formatted_min_price = $min_price ? wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ) : null;
-		$formatted_max_price = $max_price ? wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) : null;
-
-		if ( ! $formatted_min_price && ! $formatted_max_price ) {
-			return $data;
-		}
-
-		if ( $formatted_min_price && $formatted_max_price ) {
-			$title = sprintf(
-				/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
-				__( 'Between %1$s and %2$s', 'woocommerce' ),
-				$formatted_min_price,
-				$formatted_max_price
-			);
-		}
-
-		if ( ! $formatted_min_price ) {
-			/* translators: %s is the formatted maximum price. */
-			$title = sprintf( __( 'Up to %s', 'woocommerce' ), $formatted_max_price );
-		}
-
-		if ( ! $formatted_max_price ) {
-			/* translators: %s is the formatted minimum price. */
-			$title = sprintf( __( 'From %s', 'woocommerce' ), $formatted_min_price );
-		}
-
-		$data['price'] = array(
-			'type'  => __( 'Price', 'woocommerce' ),
-			'items' => array(
-				array(
-					'title'      => $title,
-					'attributes' => array(
-						'data-wc-on--click' => "{$this->get_full_block_name()}::actions.clearFilters",
-					),
-				),
-			),
-		);
-
-		return $data;
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -128,15 +132,13 @@ final class ProductFilterPrice extends AbstractBlock {
 		$max_price     = intval( $filter_params[ self::MAX_PRICE_QUERY_VAR ] ?? $max_range );
 
 		$filter_context = array(
-			'price'   => array(
+			'price'  => array(
 				'minPrice' => $min_price,
 				'maxPrice' => $max_price,
 				'minRange' => $min_range,
 				'maxRange' => $max_range,
 			),
-			'actions' => array(
-				'setPrices' => "{$this->get_full_block_name()}::actions.setPrices",
-			),
+			'parent' => $this->get_full_block_name(),
 		);
 
 		$wrapper_attributes = array(
@@ -148,12 +150,17 @@ final class ProductFilterPrice extends AbstractBlock {
 			),
 			'data-wc-context'      => wp_json_encode(
 				array(
-					'minPrice'           => $min_price,
-					'maxPrice'           => $max_price,
-					'minRange'           => $min_range,
-					'maxRange'           => $max_range,
-					'hasFilterOptions'   => $min_range < $max_range && $min_price < $max_price,
-					'hasSelectedFilters' => $min_price !== $min_range || $max_price !== $max_range,
+					'minRange'             => $min_range,
+					'maxRange'             => $max_range,
+					'hasFilterOptions'     => $min_range < $max_range && $min_price < $max_price,
+					'activeLabelTemplates' => array(
+						/* translators: {{min}} and {{max}} are the formatted minimum and maximum prices respectively. */
+						'minAndMax' => __( 'Price: {{min}} - {{max}}', 'woocommerce' ),
+						/* translators: {{max}} is the formatted maximum price. */
+						'maxOnly'   => __( 'Price: Up to {{max}}', 'woocommerce' ),
+						/* translators: {{min}} is the formatted minimum price. */
+						'minOnly'   => __( 'Price: From {{min}}', 'woocommerce' ),
+					),
 				),
 				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP,
 			),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -30,7 +30,7 @@ final class ProductFilterPrice extends AbstractBlock {
 		parent::initialize();
 
 		add_filter( 'product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
-		add_filter( 'product_filters_active_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+		add_filter( 'product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
@@ -34,7 +34,6 @@ class ProductFilterPriceSlider extends AbstractBlock {
 			return '';
 		}
 
-		$actions    = $block->context['filterData']['actions'];
 		$price_data = $block->context['filterData']['price'];
 		$min_price  = $price_data['minPrice'];
 		$max_price  = $price_data['maxPrice'];
@@ -70,7 +69,6 @@ class ProductFilterPriceSlider extends AbstractBlock {
 					),
 					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 				),
-				'data-wc-context'     => wp_json_encode( $price_data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 				'data-wc-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),
 
 			)
@@ -96,15 +94,14 @@ class ProductFilterPriceSlider extends AbstractBlock {
 							class="min"
 							type="text"
 							value="<?php echo esc_attr( wp_strip_all_tags( $formatted_min_price ) ); ?>"
-							data-wc-bind--value="state.formattedMinPrice"
+							data-wc-bind--value="woocommerce/product-filter-price::state.formattedMinPrice"
 							data-wc-on--focus="actions.selectInputContent"
-							data-wc-on--input="actions.debounceUpdateRange"
-							data-wc-on--change="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-							data-min-price="<?php echo esc_attr( $min_price ); ?>"
-							data-wc-bind--data-min-price="context.minPrice"
+							data-wc-on--input="actions.debounceSetPrice"
+							data-wc-on--change--set-price="woocommerce/product-filter-price::actions.setMinPrice"
+							data-wc-on--change--navigate="woocommerce/product-filters::actions.navigate"
 						/>
 					<?php else : ?>
-						<span><?php echo wp_kses_post( $formatted_min_price ); ?></span>
+						<span data-wc-text="woocommerce/product-filter-price::state.formattedMinPrice"><?php echo wp_kses_post( $formatted_min_price ); ?></span>
 					<?php endif; ?>
 				</div>
 				<div
@@ -119,15 +116,14 @@ class ProductFilterPriceSlider extends AbstractBlock {
 						min="<?php echo esc_attr( $min_range ); ?>"
 						max="<?php echo esc_attr( $max_range ); ?>"
 						value="<?php echo esc_attr( $min_price ); ?>"
-						data-wc-bind--value="context.minPrice"
-						data-wc-bind--min="context.minRange"
-						data-wc-bind--max="context.maxRange"
-						data-wc-on--input="actions.updateRange"
-						data-wc-on--mouseup="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-						data-wc-on--keyup="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-						data-wc-on--touchend="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-						data-min-price="<?php echo esc_attr( $min_price ); ?>"
-						data-wc-bind--data-min-price="context.minPrice"
+						data-wc-bind--value="woocommerce/product-filter-price::state.minPrice"
+						data-wc-bind--min="woocommerce/product-filter-price::context.minRange"
+						data-wc-bind--max="woocommerce/product-filter-price::context.maxRange"
+						data-wc-on--input--update-price="woocommerce/product-filter-price::actions.setMinPrice"
+						data-wc-on--input--limit-range="actions.limitRange"
+						data-wc-on--mouseup="woocommerce/product-filters::actions.navigate"
+						data-wc-on--keyup="woocommerce/product-filters::actions.navigate"
+						data-wc-on--touchend="woocommerce/product-filters::actions.navigate"
 					/>
 					<input
 						type="range"
@@ -135,15 +131,14 @@ class ProductFilterPriceSlider extends AbstractBlock {
 						min="<?php echo esc_attr( $min_range ); ?>"
 						max="<?php echo esc_attr( $max_range ); ?>"
 						value="<?php echo esc_attr( $max_price ); ?>"
-						data-wc-bind--value="context.maxPrice"
-						data-wc-bind--min="context.minRange"
-						data-wc-bind--max="context.maxRange"
-						data-wc-on--input="actions.updateRange"
-						data-wc-on--mouseup="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-						data-wc-on--keyup="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-						data-wc-on--touchend="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-						data-max-price="<?php echo esc_attr( $max_price ); ?>"
-						data-wc-bind--data-max-price="context.maxPrice"
+						data-wc-bind--value="woocommerce/product-filter-price::state.maxPrice"
+						data-wc-bind--max="woocommerce/product-filter-price::context.maxRange"
+						data-wc-bind--max="woocommerce/product-filter-price::context.maxRange"
+						data-wc-on--input--update-price="woocommerce/product-filter-price::actions.setMaxPrice"
+						data-wc-on--input--limit-range="actions.limitRange"
+						data-wc-on--mouseup="woocommerce/product-filters::actions.navigate"
+						data-wc-on--keyup="woocommerce/product-filters::actions.navigate"
+						data-wc-on--touchend="woocommerce/product-filters::actions.navigate"
 					/>
 				</div>
 				<div class="wc-block-product-filter-price-slider__right text">
@@ -152,15 +147,14 @@ class ProductFilterPriceSlider extends AbstractBlock {
 							class="max"
 							type="text"
 							value="<?php echo esc_attr( wp_strip_all_tags( $formatted_max_price ) ); ?>"
-							data-wc-bind--value="state.formattedMaxPrice"
+							data-wc-bind--value="woocommerce/product-filter-price::state.formattedMaxPrice"
 							data-wc-on--focus="actions.selectInputContent"
-							data-wc-on--input="actions.debounceUpdateRange"
-							data-wc-on--change="<?php echo esc_attr( $actions['setPrices'] ); ?>"
-							data-max-price="<?php echo esc_attr( $max_price ); ?>"
-							data-wc-bind--data-max-price="context.maxPrice"
+							data-wc-on--input="actions.debounceSetPrice"
+							data-wc-on--change--set-price="woocommerce/product-filter-price::actions.setMaxPrice"
+							data-wc-on--change--navigate="woocommerce/product-filters::actions.navigate"
 						/>
 					<?php else : ?>
-						<span><?php echo wp_kses_post( $formatted_max_price ); ?></span>
+					<span data-wc-text="woocommerce/product-filter-price::state.formattedMaxPrice"><?php echo wp_kses_post( $formatted_max_price ); ?></span>
 					<?php endif; ?>
 				</div>
 			</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #53021.
Blocked by #53070, #53029.

This PR:
- Price filter block:
  - updates the filter callback that prepares the active filter following the new active filter item structure.
  - updates the store to use derived state and new actions from the `woocommerce/product-filters` store.
  - replaces some context with state for optimistic updates.
  - pass block namespace through block context for inner blocks to consume.
- Price Slider block:
  - removes the obsoleted logic.
  - removes unnecessary context, and replaces them with derived state when possible.
  - adds a callback to enforce the min and max thumbs never cross each other.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
1. Add the `Product Filters` block to the `Product Catalog` template.
2. Remove the Status, Attribute, and Ratings filter blocks as they haven't been updated.
4. Save and go to the front end.
5. Interact with price slider, confirm:
  - The slider is working, price is changing as the slider is dragging.
  - The thumb of the minimum price never exceeds the maximum one and vice versa.
  - The input is working and only triggers the navigation event after finishing typing.
  - The price appears in the Active Filters block **right after** setting the price, and updates as the price changes.
  - The page URL is updated.
  - The clear filter button appears after selecting a filter. Clicking on it unselects all selected filter of the current filter block.
  - The product result is updated after the navigation event is finished (There isn't a loading indicator yet for the Product Collection block while the navigation is happening).
6. Enable network throttling to 3G or slow 4G, confirm step 5 is still applied.

<!-- End testing instructions -->