### PR TITLE
feat: update status filter block

### DIFF
--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -30,7 +30,7 @@ final class ProductFilterStatus extends AbstractBlock {
 		parent::initialize();
 
 		add_filter( 'product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
-		add_filter( 'product_filters_active_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+		add_filter( 'product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -29,8 +29,8 @@ final class ProductFilterStatus extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
-		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+		add_filter( 'product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
+		add_filter( 'product_filters_active_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
 	/**
@@ -56,48 +56,42 @@ final class ProductFilterStatus extends AbstractBlock {
 	}
 
 	/**
-	 * Register the active filters data.
+	 * Prepare the active filter items.
 	 *
-	 * @param array $data   The active filters data.
+	 * @param array $items  The active filter items.
 	 * @param array $params The query param parsed from the URL.
-	 * @return array Active filters data.
+	 * @return array Active filters items.
 	 */
-	public function register_active_filters_data( $data, $params ) {
-		$stock_status_options = wc_get_product_stock_status_options();
+	public function prepare_selected_filters( $items, $params ) {
+		$status_options = array_merge(
+			wc_get_product_stock_status_options(),
+			// On sale and Featured status are declared here.
+			array()
+		);
 
 		if ( empty( $params[ self::STOCK_STATUS_QUERY_VAR ] ) ) {
-			return $data;
+			return $items;
 		}
 
-		$active_stock_statuses = array_filter(
+		$active_statuses = array_filter(
 			explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] )
 		);
 
-		if ( empty( $active_stock_statuses ) ) {
-			return $data;
+		if ( empty( $active_statuses ) ) {
+			return $items;
 		}
 
 		$action_namespace = $this->get_full_block_name();
 
-		$active_stock_statuses = array_map(
-			function ( $status ) use ( $stock_status_options, $action_namespace ) {
-				return array(
-					'title'      => $stock_status_options[ $status ],
-					'attributes' => array(
-						'value'             => $status,
-						'data-wc-on--click' => "$action_namespace::actions.toggleFilter",
-					),
-				);
-			},
-			$active_stock_statuses
-		);
+		foreach ( $active_statuses as $status ) {
+			$items[] = array(
+				'type'  => 'status',
+				'value' => $status,
+				'label' => sprintf( __( 'Status: %s', 'woocommerce' ), $status_options[ $status ] ),
+			);
+		}
 
-		$data['stock'] = array(
-			'type'  => __( 'Status', 'woocommerce' ),
-			'items' => $active_stock_statuses,
-		);
-
-		return $data;
+		return $items;
 	}
 
 	/**
@@ -122,6 +116,10 @@ final class ProductFilterStatus extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		// don't render if its admin, or ajax in progress.
+		if ( is_admin() || wp_doing_ajax() ) {
+			return '';
+		}
 
 		$stock_status_data       = $this->get_stock_status_counts( $block );
 		$stock_statuses          = wc_get_product_stock_status_options();
@@ -133,31 +131,29 @@ final class ProductFilterStatus extends AbstractBlock {
 			function ( $item ) use ( $stock_statuses, $selected_stock_statuses, $attributes ) {
 				$label = $stock_statuses[ $item['status'] ] . ( $attributes['showCounts'] ? ' (' . $item['count'] . ')' : '' );
 				return array(
-					'label'    => $label,
-					'value'    => $item['status'],
-					'selected' => in_array( $item['status'], $selected_stock_statuses, true ),
-					'rawData'  => $item,
+					'label'     => $label,
+					'ariaLabel' => $label,
+					'value'     => $item['status'],
+					'selected'  => in_array( $item['status'], $selected_stock_statuses, true ),
+					'type'      => 'status',
+					'data'      => $item,
 				);
 			},
 			$stock_status_data
 		);
 
 		$filter_context = array(
-			'filterData'         => array(
-				'items'   => $filter_options,
-				'actions' => array(
-					'toggleFilter' => "{$this->get_full_block_name()}::actions.toggleFilter",
-				),
-			),
-			'hasSelectedFilters' => ! empty( $selected_stock_statuses ),
+			'items'  => array_values( $filter_options ),
+			'parent' => $this->get_full_block_name(),
 		);
 
 		$wrapper_attributes = array(
 			'data-wc-interactive'  => wp_json_encode( array( 'namespace' => $this->get_full_block_name() ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ),
 			'data-wc-context'      => wp_json_encode(
 				array(
-					'hasSelectedFilters' => $filter_context['hasSelectedFilters'],
-					'hasFilterOptions'   => ! empty( $filter_options ),
+					'hasFilterOptions'    => ! empty( $filter_options ),
+					/* translators: {{label}} is the status filter item label. */
+					'activeLabelTemplate' => __( 'Status: {{label}}', 'woocommerce' ),
 				),
 				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 			),
@@ -176,7 +172,7 @@ final class ProductFilterStatus extends AbstractBlock {
 			array_reduce(
 				$block->parsed_block['innerBlocks'],
 				function ( $carry, $parsed_block ) use ( $filter_context ) {
-					$carry .= ( new \WP_Block( $parsed_block, array( 'filterData' => $filter_context['filterData'] ) ) )->render();
+					$carry .= ( new \WP_Block( $parsed_block, array( 'filterData' => $filter_context ) ) )->render();
 					return $carry;
 				},
 				''


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #53021.
Blocked by #53070, #53029, #53092.

This PR updates the Status filter block to:

- update the filter callback that prepares the active filter following the new active filter item structure.
- update the store to use derived state and new actions from the `woocommerce/product-filters` store.
- replace some context with the derived state for optimistic updates.
- pass block namespace through block context for inner blocks to consume.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Ensure the experimental blocks are enabled:
    - If you use the WooCommerce Beta Tester plugin, you can enable the experimental blocks in Tools > WCA Test Helper > Features. Toggle the `experimental-blocks` option.
    - If you build this PR locally, build the branch with `pnpm --filter='@woocommerce/plugin-woocommerce' watch:build` command to have experimental blocks available.
1. Add the `Product Filters` block to the `Product Catalog` template.
2. Remove the Price and Ratings filter blocks as they haven't been updated.
4. Save and go to the front end.
5. Interact with stock filter block, confirm:
  - The option is marked as selected **right after** clicking on it.
  - The corresponding item appears in the Active Filters block **right after** selecting the filter option.
  - The page URL is updated.
  - The clear filter button appears after selecting a filter. Clicking on it unselects all selected filter of the current filter block.
  - The product result is updated after the navigation event is finished (There isn't a loading indicator yet for the Product Collection block while the navigation is happening).
6. Enable network throttling to 3G or slow 4G, confirm step 5 is still applied.

<!-- End testing instructions -->