### PR TITLE
[dev] Fix failing merchant tests affected by recent changes in Gutenberg Nightly 

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-fix-gutenberg-nightly-page-title
+++ b/plugins/woocommerce/changelog/dev-e2e-fix-gutenberg-nightly-page-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update the page title locator to be compatible with both Gutenberg stable and nightly.

--- a/plugins/woocommerce/changelog/dev-e2e-fix-gutenberg-nightly-page-title
+++ b/plugins/woocommerce/changelog/dev-e2e-fix-gutenberg-nightly-page-title
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Update the page title locator to be compatible with both Gutenberg stable and nightly.
+Update affected tests to be compatible with both Gutenberg stable and nightly.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
@@ -23,8 +23,12 @@ test.describe(
 
 			const canvas = await getCanvas( page );
 
+			// TODO (Gutenberg 19.9): Remove this click() step.
+			// Current stable version of Gutenberg (19.7) doesn't show the "Empty block" element right away, you need to click on the "Add default block" element first before it appears.
+			// Upcoming Gutenberg nightly (version 19.9) no longer shows the "Add default block" element, but rather displays the "Empty block" right away.
+			// There's no need for this click() step anymore when GB 19.9 comes out.
 			await canvas
-				.getByRole( 'button', { name: 'Add default block' } )
+				.getByLabel( /(Add default block|Empty block)/ )
 				.click();
 
 			await canvas

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -180,17 +180,28 @@ test.describe(
 								exact: true,
 							} )
 							.click();
+						// Click on the Reviews by Product block to show the Block Tools to be used later.
+						await canvas
+							.getByLabel( 'Block: Reviews by Product' )
+							.click();
 					}
 
 					// verify added blocks into page
 					await expect(
-						canvas
+						await canvas
 							.getByRole( 'document', {
 								name: `Block: ${ blocks[ i ] }`,
 								exact: true,
 							} )
 							.first()
 					).toBeVisible();
+
+					// Add a new empty block to insert the next block into.
+					await page
+						.getByLabel( 'Block tools' )
+						.getByLabel( 'Options' )
+						.click();
+					await page.getByText( 'Add after' ).click();
 				} );
 			}
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -169,10 +169,13 @@ test.describe(
 
 					// eslint-disable-next-line playwright/no-conditional-in-test
 					if ( blocks[ i ] === 'Reviews by Product' ) {
+						// Use click() instead of check().
+						// check() causes occasional flakiness:
+						//     - "Error: locator.check: Clicking the checkbox did not change its state"
 						await canvas
 							.locator( '.wc-block-reviews-by-product' )
 							.getByLabel( simpleProductName )
-							.check();
+							.click();
 						await canvas
 							.locator( '.wc-block-reviews-by-product' )
 							.getByRole( 'button', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -191,7 +191,7 @@ test.describe(
 
 					// verify added blocks into page
 					await expect(
-						await canvas
+						canvas
 							.getByRole( 'document', {
 								name: `Block: ${ blocks[ i ] }`,
 								exact: true,

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -50,6 +50,9 @@ const goToPostEditor = async ( { page } ) => {
 };
 
 const fillPageTitle = async ( page, title ) => {
+	// TODO (Gutenberg 19.9): Keep only the "Block: Title" label locator.
+	// Current stable version of Gutenberg (19.7) uses the "Add title" label locator.
+	// Upcoming Gutenberg 19.9 uses the "Block: Title" one. We should use it instead when GB 19.9 comes out.
 	await ( await getCanvas( page ) )
 		.getByLabel( /(Add title|Block: Title)/ )
 		.click();
@@ -59,6 +62,7 @@ const fillPageTitle = async ( page, title ) => {
 };
 
 const insertBlock = async ( page, blockName, wpVersion = null ) => {
+	await ( await getCanvas( page ) ).getByLabel( 'Empty block' ).click();
 	// With Gutenberg active we have Block Inserter name
 	await page
 		.getByRole( 'button', {

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -50,8 +50,12 @@ const goToPostEditor = async ( { page } ) => {
 };
 
 const fillPageTitle = async ( page, title ) => {
-	await ( await getCanvas( page ) ).getByLabel( 'Add title' ).click();
-	await ( await getCanvas( page ) ).getByLabel( 'Add title' ).fill( title );
+	await ( await getCanvas( page ) )
+		.getByLabel( /(Add title|Block: Title)/ )
+		.click();
+	await ( await getCanvas( page ) )
+		.getByLabel( /(Add title|Block: Title)/ )
+		.fill( title );
 };
 
 const insertBlock = async ( page, blockName, wpVersion = null ) => {

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -62,6 +62,13 @@ const fillPageTitle = async ( page, title ) => {
 };
 
 const insertBlock = async ( page, blockName, wpVersion = null ) => {
+	// Focus on "Empty block" element before inserting a new block.
+	// Otherwise Gutenberg nightly (v19.9-nightly) would display "{Block name} can't be inserted."
+	const emptyBlock = ( await getCanvas( page ) ).getByLabel( 'Empty block' );
+	if ( await emptyBlock.isVisible() ) {
+		await emptyBlock.click();
+	}
+
 	// With Gutenberg active we have Block Inserter name
 	await page
 		.getByRole( 'button', {
@@ -69,17 +76,6 @@ const insertBlock = async ( page, blockName, wpVersion = null ) => {
 			expanded: false,
 		} )
 		.click();
-
-	// Make sure there's an Empty block in the canvas and click on it.
-	// Unlike Gutenberg stable, Gutenberg nightly doesn't automatically add an empty block.
-	// Also, GB nightly gives off an error when you try to insert a block without clicking on the empty block first.
-	const emptyBlock = ( await getCanvas( page ) ).getByLabel( 'Empty block' );
-	if ( ! ( await emptyBlock.isVisible() ) ) {
-		await page
-			.getByRole( 'option', { name: 'Paragraph', exact: true } )
-			.click();
-	}
-	await emptyBlock.click();
 
 	await page.getByPlaceholder( 'Search', { exact: true } ).fill( blockName );
 	await page.getByRole( 'option', { name: blockName, exact: true } ).click();

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -62,7 +62,6 @@ const fillPageTitle = async ( page, title ) => {
 };
 
 const insertBlock = async ( page, blockName, wpVersion = null ) => {
-	await ( await getCanvas( page ) ).getByLabel( 'Empty block' ).click();
 	// With Gutenberg active we have Block Inserter name
 	await page
 		.getByRole( 'button', {
@@ -70,6 +69,18 @@ const insertBlock = async ( page, blockName, wpVersion = null ) => {
 			expanded: false,
 		} )
 		.click();
+
+	// Make sure there's an Empty block in the canvas and click on it.
+	// Unlike Gutenberg stable, Gutenberg nightly doesn't automatically add an empty block.
+	// Also, GB nightly gives off an error when you try to insert a block without clicking on the empty block first.
+	const emptyBlock = ( await getCanvas( page ) ).getByLabel( 'Empty block' );
+	if ( ! ( await emptyBlock.isVisible() ) ) {
+		await page
+			.getByRole( 'option', { name: 'Paragraph', exact: true } )
+			.click();
+	}
+	await emptyBlock.click();
+
 	await page.getByPlaceholder( 'Search', { exact: true } ).fill( blockName );
 	await page.getByRole( 'option', { name: blockName, exact: true } ).click();
 

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -54,10 +54,10 @@ const fillPageTitle = async ( page, title ) => {
 	// Current stable version of Gutenberg (19.7) uses the "Add title" label locator.
 	// Upcoming Gutenberg 19.9 uses the "Block: Title" one. We should use it instead when GB 19.9 comes out.
 	await ( await getCanvas( page ) )
-		.getByLabel( /(Add title|Block: Title)/ )
+		.getByLabel( /^(Add title|Block: Title)$/ )
 		.click();
 	await ( await getCanvas( page ) )
-		.getByLabel( /(Add title|Block: Title)/ )
+		.getByLabel( /^(Add title|Block: Title)$/ )
 		.fill( title );
 };
 

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -53,12 +53,12 @@ const fillPageTitle = async ( page, title ) => {
 	// TODO (Gutenberg 19.9): Keep only the "Block: Title" label locator.
 	// Current stable version of Gutenberg (19.7) uses the "Add title" label locator.
 	// Upcoming Gutenberg 19.9 uses the "Block: Title" one. We should use it instead when GB 19.9 comes out.
-	await ( await getCanvas( page ) )
-		.getByLabel( /^(Add title|Block: Title)$/ )
-		.click();
-	await ( await getCanvas( page ) )
-		.getByLabel( /^(Add title|Block: Title)$/ )
-		.fill( title );
+	const canvas = await getCanvas( page );
+	const block_title = canvas
+		.getByLabel( 'Add title' )
+		.or( canvas.getByLabel( 'Block: Title' ) );
+	await block_title.click();
+	await block_title.fill( title );
 };
 
 const insertBlock = async ( page, blockName, wpVersion = null ) => {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the recently failing Gutenberg Nightly merchant E2E tests in mentioned in #53064 by:

1. Updating the page title locator to work with both GB stable and GB nightly.
2. Adding a step to add and then click on the "Type / to choose a block" empty block before opening the block inserter. Otherwise, GB nightly would show the error _"Block "Classic Shortcode" can't be inserted."_ GB stable doesn't have this problem. I think it is a bug on GB nightly itself because I can replicate this error even on a WP Core block like the Image block. It seems that GB nightly couldn't automatically look for the next empty block to insert on. I'll raise this on GB's repo after working on this PR.

<img width="335" alt="Screenshot 2024-11-23 at 1 32 20 AM" src="https://github.com/user-attachments/assets/f2e02e45-74dd-429e-bfb5-75b03ceab6ca">


This PR is intentionally targeting the `release/9.4` branch. I wrote instructions below on how to proceed after this PR is approved.

Closes #53064.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure that the following E2E tests are passing the `daily-checks` with this branch:
 
```
merchant/create-cart-block.spec.js
    > Transform Classic Cart To Cart Block
    > can transform classic cart to cart block

merchant/create-checkout-block.spec.js
    > Transform Classic Checkout To Checkout Block
    > can transform classic checkout to checkout block

merchant/create-page.spec.js
    > Can create a new page
    > can create new page

merchant/create-woocommerce-blocks.spec.js
    > Add WooCommerce Blocks Into Page
    > can insert all WooCommerce blocks into page

merchant/create-woocommerce-patterns.spec.js
    > Add WooCommerce Patterns Into Page
    > can insert WooCommerce patterns into page
```

    Other tests might still fail due to other reasons unrelated to the scope of this PR. For example, the `customize-store/assembler` tests.

----

### Instructions to reviewer/merger after this PR is approved

As per the new CFE & PRR process, follow these steps after this PR is approved:

1. DO NOT merge this PR yet.
5. Apply both the `cherry pick to trunk` and `cherry pick to frozen release` labels to this PR. This will trigger the new workflow that will automatically create 2 additional PRs: one targeting `release/9.5` and the other targeting `trunk`.
6. Merge all these 3 PRs into their respective target branches.
