### PR TITLE
Preserve unmodified source in get_origin_label() and pass it to the formatted source filter

### DIFF
--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -274,6 +274,9 @@ trait OrderAttributionMeta {
 	 * @return string
 	 */
 	private function get_origin_label( string $source_type, string $source, bool $translated = true ): string {
+		// Store the unmodified source.
+		$source_unmodified = $source;
+		
 		// Set up the label based on the source type.
 		switch ( $source_type ) {
 			case 'utm':
@@ -326,13 +329,15 @@ trait OrderAttributionMeta {
 		 *
 		 * @since 8.5.0
 		 *
-		 * @param string $formatted_source The formatted source.
-		 * @param string $source           The source.
+		 * @param string $formatted_source  The formatted source.
+		 * @param string $source            The source.
+		 * @param string $source_unmodified The unmodified source.
 		 */
 		$formatted_source = apply_filters(
 			'wc_order_attribution_origin_formatted_source',
 			ucfirst( trim( $source, '()' ) ),
-			$source
+			$source,
+			$source_unmodified
 		);
 
 		/**


### PR DESCRIPTION
This PR enhances the `get_origin_label()` method to store the unmodified source value provided as a parameter in a new variable, `$source_unmodified`. The unmodified value is passed to the `wc_order_attribution_origin_formatted_source` filter, enabling developers to filter the formatted source using the raw source value, regardless of modifications made in the method.

This is particularly useful when custom values are saved in the order meta using the `_wc_order_attribution_utm_source` key. The unmodified source allows greater flexibility for developers working with dynamic or custom order attribution sources.

---

### Submission Review Guidelines:

- I have followed the [[WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [[WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [[Pull Requests](https://github.com/woocommerce/woocommerce/pulls)](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [[security best practices](https://developer.wordpress.org/apis/security/)](https://developer.wordpress.org/apis/security/).

---

### Changes proposed in this Pull Request:

- Introduce `$source_unmodified` to retain the original, unaltered source value.
- Pass `$source_unmodified` to the `wc_order_attribution_origin_formatted_source` filter.
- Allow for filtering of the formatted source using the unmodified value, even when custom meta values (e.g., `_wc_order_attribution_utm_source`) are saved or modified during the order lifecycle.

---

### How to test the changes in this Pull Request:

1. Save any custom value in the order meta using the `_wc_order_attribution_utm_source` key.
2. Create a filter for `wc_order_attribution_origin_formatted_source` to customize the formatted source using the unmodified source.
3. Verify that the filter receives the correct unmodified source value, as stored in the order meta.
4. Test with standard source types to ensure backward compatibility.
5. Confirm that the generated label accurately reflects the filtered formatted source.

---

### Changelog entry

- Enhancement: Preserve unmodified source in `get_origin_label()` and pass it to the `wc_order_attribution_origin_formatted_source` filter.