### PR TITLE
Hide duplicated header and "Add new _" button in product & coupon editor

### DIFF
--- a/plugins/woocommerce/changelog/update-product-editor-css-remove-add-new
+++ b/plugins/woocommerce/changelog/update-product-editor-css-remove-add-new
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Hide "Add new _" buttons from Product & Coupon editor pages.

--- a/plugins/woocommerce/client/legacy/css/admin/product-editor.scss
+++ b/plugins/woocommerce/client/legacy/css/admin/product-editor.scss
@@ -72,9 +72,32 @@ $break-largeish: 900px; // It's almost $break-large, but kept consistent with th
 		}
 	}
 
+	// Hide duplicated h1 and Add new button.
+	.wrap {
+		h1.wp-heading-inline,
+		.page-title-action {
+			display: none;
+		}
+
+		/*
+		 * Make space for screen meta links.
+		 * We could have clear the floats on .wrap container, which would make margin collapsing easier.
+		 * But, we clear it on hr to still allow extensions to inject something next to the header, or displaying it back again.
+		 */
+		.wp-header-end {
+			padding: 0;
+			margin: 0;
+			border: 0;
+			clear: both;
+		}
+	}
+
 	// Screen meta links.
 	#screen-meta-links {
-		padding: $gap-small 0;
+		padding: 0;
+		margin-top: $gap-small;
+		// There is an invisible, but displayed <hr> below, for float clearance before notices, which prevents margin collapsing.
+		margin-bottom: 0;
 		display: flex;
 		gap: $gap-smaller;
 
@@ -93,6 +116,12 @@ $break-largeish: 900px; // It's almost $break-large, but kept consistent with th
 			bottom: 1px;
 		}
 
+	}
+
+	#poststuff {
+		// Add collapsible gap between post form and notices.
+		margin-top: $gap-small;
+		padding-top: 0;
 	}
 
 	// Gap between title input and generate coupon code.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -63,10 +63,15 @@ test(
 			optionName: 'Add new product',
 		} );
 
-		// Verify that the page has loaded.
+		/*
+		 * Verify that the page has loaded.
+		 * Unfortunatelly, the top heading for product and coupon does not specify what new thing is being added.
+		 * We need to check the input label to make sure.
+		 */
 		await expect(
-			page.getByRole( 'heading', { name: 'Add new product' } )
+			page.getByRole( 'heading', { name: 'Add new' } )
 		).toBeVisible();
+		await expect( page.getByLabel( 'Product name' ) ).toBeVisible();
 	}
 );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-linked-products.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-linked-products.spec.js
@@ -50,7 +50,7 @@ test.describe(
 				// extra click somewhere in the page as a workaround for update button click not always working
 				await page
 					.getByRole( 'heading', {
-						name: 'Edit product',
+						name: 'Edit Product',
 						exact: true,
 					} )
 					.click();


### PR DESCRIPTION
_:warning: This is an addon/ follow up to https://github.com/woocommerce/woocommerce/pull/52632_

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As part of the Product editor UI polish, @j111q proposed to remove the duplicated header and "Add new _" button.
I believe such removal could be a bit more disruptive to extensions tweaking around the header or merchants that got used to this flow. So, I made a separate PR to emphasize it more in git history, added a separate changelog, and gave it a more dedicated review and testing.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout and build this branch
2. Go to 
	1. Edit product page
	2. Edit coupon page 	
4. Check that there is no header and "add new _" button visible and the layout look good and as in jqmi03xIh4d0USEUM6U8jZ-fi-4_166
5. Resize the view port to test responsiveness
6. Open screen options
7. Bring up some notice, or mimic that by `document.querySelector('#lost-connection-notice').style.display = 'block';`


#### Before
![image](https://github.com/user-attachments/assets/fc49fd1d-1c73-4391-a2a5-96f7f025b64d)
#### After
![image](https://github.com/user-attachments/assets/d78abdee-28b0-4ef2-8e68-1d9f85bdfb09)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>