### PR TITLE
Fix `woocommerce_reports_charts` filter

### DIFF
--- a/plugins/woocommerce/changelog/53126-fix-52910-reports_charts-filter
+++ b/plugins/woocommerce/changelog/53126-fix-52910-reports_charts-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `woocommerce_reports_charts` filter

--- a/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-reports.php
@@ -217,13 +217,14 @@ class WC_Admin_Reports {
 		$reports = apply_filters( 'woocommerce_reports_charts', $reports ); // Backwards compatibility.
 
 		foreach ( $reports as $key => &$report_group ) {
+			if ( isset( $report_group['charts'] ) ) {
+				$report_group['reports'] = $report_group['charts'];
+			}
+
 			// Silently ignore reports given for the filter in Automattic\WooCommerce\Admin\API\Reports\Controller.
 			if ( ! isset( $report_group['reports'] ) ) {
 				unset( $reports[ $key ] );
 				continue;
-			}
-			if ( isset( $report_group['charts'] ) ) {
-				$report_group['reports'] = $report_group['charts'];
 			}
 
 			foreach ( $report_group['reports'] as &$report ) {


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

https://github.com/woocommerce/woocommerce/pull/51592 accidentally broke `woocommerce_reports_charts` as stated in  https://github.com/woocommerce/woocommerce/issues/52910

This PR brings it back to function.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Use WC.9.4
1. Place the place the following snippet in the theme's functions.php file:
```php
add_filter( 'woocommerce_reports_charts', function ( $reports ) {
	$reports['tickets'] = array(
		'title'  =>  __( 'Tickets', 'textdomain' ),
		'charts' => array(
			array(
				'title'       => __( 'Sales by Product', 'textdomain' ),
				'description' => '',
				'hide_title'  => true,
				'function'    => function () {
					return [];
				}
			),
		)
	);
	return $reports;
} );
```
2. Navigate to _WooCommerce > Reports_ and verify that the "Tickets" tab is visible on the reports page.
3. Upgrade to WC 9.5-Beta-1.
4. Go to _WooCommerce > Reports_ again and observe that the "Tickets" tab is no longer visible.

<!-- End testing instructions -->

### Aditional details
1. `woocommerce_reports_charts` was already a legacy filter replaced by `woocommerce_admin_reports` in WooCommerce Reports which also a deprecated legacy, soon to be removed. So we could consider removing `woocommerce_reports_charts` completely, instead of bringing it back.
   However, as long as we still have `woocommerce_admin_reports` in Reports, which has a colliding name with another filter used by Analytics, `woocommerce_reports_charts` acts as a handy disambiguate solution, so may be worth keeping alive.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix `woocommerce_reports_charts` filter

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
