### PR TITLE
[api-core-tests] Add an extra check for response status on create user

### DIFF
--- a/plugins/woocommerce/changelog/e2e-api-checks-add-extra-check-user-response
+++ b/plugins/woocommerce/changelog/e2e-api-checks-add-extra-check-user-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+API core tests: add an extra check for response code on user create

--- a/plugins/woocommerce/tests/e2e-pw/.eslintrc.js
+++ b/plugins/woocommerce/tests/e2e-pw/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
 		'jest/no-disabled-tests': 'off',
 		'jest/valid-expect': 'off',
 		'jest/expect-expect': 'off',
+		'jest/no-standalone-expect': 'off',
 		'testing-library/await-async-utils': 'off',
 	},
 };

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -47,6 +47,9 @@ test.describe(
 						},
 					}
 				);
+
+				expect( userResponse.status() ).toEqual( 201 );
+
 				const userResponseJSON = await userResponse.json();
 				// set subscriber user id to newly created user
 				subscriberUserId = userResponseJSON.id;
@@ -58,9 +61,7 @@ test.describe(
 				`/wp-json/wc/v3/customers/${ subscriberUserId }`
 			);
 			const responseJSON = await response.json();
-			// eslint-disable-next-line jest/no-standalone-expect
 			expect( response.status() ).toEqual( 200 );
-			// eslint-disable-next-line jest/no-standalone-expect
 			expect( responseJSON.role ).toEqual( 'subscriber' );
 		} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds an extra check of the response code when creating a user in the setup of the customer tests. This adds more clarity and eases debugging in case the user creation fails. 

### How to test the changes in this Pull Request:

Check the api tests in CI. All should pass.
