### PR TITLE
 Add To Cart with Options: introduce blockified feature flag

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -78,18 +78,14 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 
 	return (
 		<>
-			{ isStepperLayoutFeatureEnabled && (
-				<AddToCartSettings
-					quantitySelectorStyle={
-						props.attributes.quantitySelectorStyle
-					}
-					setAttributes={ setAttributes }
-					features={ {
-						isStepperLayoutFeatureEnabled,
-						isBlockifyAddToCartEnabled,
-					} }
-				/>
-			) }
+			<AddToCartSettings
+				quantitySelectorStyle={ props.attributes.quantitySelectorStyle }
+				setAttributes={ setAttributes }
+				features={ {
+					isStepperLayoutFeatureEnabled,
+					isBlockifyAddToCartEnabled,
+				} }
+			/>
 			<div { ...blockProps }>
 				<Tooltip
 					text="Customer will see product add-to-cart options in this space, dependent on the product type. "

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -25,6 +25,23 @@ export interface Attributes {
 	quantitySelectorStyle: QuantitySelectorStyle;
 }
 
+export type FeaturesKeys =
+	| 'isStepperLayoutFeatureEnabled'
+	| 'isBlockifyAddToCartEnabled';
+
+export type FeaturesProps = {
+	[ key in FeaturesKeys ]?: boolean;
+};
+
+export type UpdateFeaturesType = ( key: FeaturesKeys, value: boolean ) => void;
+
+// Pick the value of the "blockify add to cart flag"
+const isBlockifyAddToCartEnabled = getSettingWithCoercion(
+	'isBlockifyAddToCartEnabled',
+	false,
+	isBoolean
+);
+
 const Edit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
@@ -67,6 +84,10 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 						props.attributes.quantitySelectorStyle
 					}
 					setAttributes={ setAttributes }
+					features={ {
+						isStepperLayoutFeatureEnabled,
+						isBlockifyAddToCartEnabled,
+					} }
 				/>
 			) }
 			<div { ...blockProps }>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -17,7 +17,7 @@ import { isBoolean } from '@woocommerce/types';
  */
 import './editor.scss';
 import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
-import { QuantitySelectorStyle, Settings } from './settings';
+import { QuantitySelectorStyle, AddToCartSettings } from './settings';
 
 export interface Attributes {
 	className?: string;
@@ -42,7 +42,7 @@ const isBlockifyAddToCartEnabled = getSettingWithCoercion(
 	isBoolean
 );
 
-const Edit = ( props: BlockEditProps< Attributes > ) => {
+const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
 	const isStepperLayoutFeatureEnabled = getSettingWithCoercion(
@@ -79,7 +79,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	return (
 		<>
 			{ isStepperLayoutFeatureEnabled && (
-				<Settings
+				<AddToCartSettings
 					quantitySelectorStyle={
 						props.attributes.quantitySelectorStyle
 					}
@@ -187,4 +187,4 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	);
 };
 
-export default Edit;
+export default AddToCartFormEdit;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -27,7 +27,7 @@ export interface Attributes {
 
 export type FeaturesKeys =
 	| 'isStepperLayoutFeatureEnabled'
-	| 'isBlockifyAddToCartEnabled';
+	| 'isBlockifiedAddToCart';
 
 export type FeaturesProps = {
 	[ key in FeaturesKeys ]?: boolean;
@@ -36,8 +36,8 @@ export type FeaturesProps = {
 export type UpdateFeaturesType = ( key: FeaturesKeys, value: boolean ) => void;
 
 // Pick the value of the "blockify add to cart flag"
-const isBlockifyAddToCartEnabled = getSettingWithCoercion(
-	'isBlockifyAddToCartEnabled',
+const isBlockifiedAddToCart = getSettingWithCoercion(
+	'isBlockifiedAddToCart',
 	false,
 	isBoolean
 );
@@ -83,7 +83,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 				setAttributes={ setAttributes }
 				features={ {
 					isStepperLayoutFeatureEnabled,
-					isBlockifyAddToCartEnabled,
+					isBlockifiedAddToCart,
 				} }
 			/>
 			<div { ...blockProps }>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -17,7 +17,7 @@ import { isBoolean } from '@woocommerce/types';
  */
 import './editor.scss';
 import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
-import { QuantitySelectorStyle, AddToCartSettings } from './settings';
+import { QuantitySelectorStyle, AddToCartFormSettings } from './settings';
 
 export interface Attributes {
 	className?: string;
@@ -78,7 +78,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 
 	return (
 		<>
-			<AddToCartSettings
+			<AddToCartFormSettings
 				quantitySelectorStyle={ props.attributes.quantitySelectorStyle }
 				setAttributes={ setAttributes }
 				features={ {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
@@ -8,13 +8,13 @@ import { Icon, button } from '@wordpress/icons';
  * Internal dependencies
  */
 import metadata from './block.json';
-import edit from './edit';
+import AddToCartFormEdit from './edit';
 import './style.scss';
 import './editor.scss';
 import '../../../base/components/quantity-selector/style.scss';
 
 const blockSettings = {
-	edit,
+	edit: AddToCartFormEdit,
 	icon: {
 		src: (
 			<Icon

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -52,7 +52,7 @@ const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
 	}
 };
 
-export const AddToCartSettings = ( {
+export const AddToCartFormSettings = ( {
 	quantitySelectorStyle,
 	setAttributes,
 	features,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -51,7 +51,7 @@ const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
 	}
 };
 
-export const Settings = ( {
+export const AddToCartSettings = ( {
 	quantitySelectorStyle,
 	setAttributes,
 	features: { isBlockifyAddToCartEnabled },

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -28,7 +28,7 @@ export enum QuantitySelectorStyle {
 	Stepper = 'stepper',
 }
 
-type AddToCartFormSettings = {
+type AddToCartFormSettingsProps = {
 	quantitySelectorStyle: QuantitySelectorStyle;
 	setAttributes: ( attributes: {
 		quantitySelectorStyle: QuantitySelectorStyle;
@@ -56,9 +56,8 @@ export const AddToCartFormSettings = ( {
 	quantitySelectorStyle,
 	setAttributes,
 	features,
-}: AddToCartFormSettings ) => {
-	const { isBlockifiedAddToCart, isStepperLayoutFeatureEnabled } =
-		features;
+}: AddToCartFormSettingsProps ) => {
+	const { isBlockifiedAddToCart, isStepperLayoutFeatureEnabled } = features;
 
 	const hasDevFeatures =
 		isStepperLayoutFeatureEnabled || isBlockifiedAddToCart;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -57,11 +57,11 @@ export const AddToCartFormSettings = ( {
 	setAttributes,
 	features,
 }: AddToCartFormSettings ) => {
-	const { isBlockifyAddToCartEnabled, isStepperLayoutFeatureEnabled } =
+	const { isBlockifiedAddToCart, isStepperLayoutFeatureEnabled } =
 		features;
 
 	const hasDevFeatures =
-		isStepperLayoutFeatureEnabled || isBlockifyAddToCartEnabled;
+		isStepperLayoutFeatureEnabled || isBlockifiedAddToCart;
 
 	if ( ! hasDevFeatures ) {
 		return null;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -4,7 +4,9 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
+	Flex,
 	PanelBody,
+	Notice,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore - Ignoring because `__experimentalToggleGroupControl` is not yet in the type definitions.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -14,6 +16,11 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { FeaturesProps } from './edit';
 
 export enum QuantitySelectorStyle {
 	Input = 'input',
@@ -25,6 +32,8 @@ type AddToCartFormSettings = {
 	setAttributes: ( attributes: {
 		quantitySelectorStyle: QuantitySelectorStyle;
 	} ) => void;
+
+	features: FeaturesProps;
 };
 
 const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
@@ -45,9 +54,23 @@ const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
 export const Settings = ( {
 	quantitySelectorStyle,
 	setAttributes,
+	features: { isBlockifyAddToCartEnabled },
 }: AddToCartFormSettings ) => {
 	return (
 		<InspectorControls>
+			{ isBlockifyAddToCartEnabled && (
+				<PanelBody title={ 'Development' }>
+					<Flex>
+						<Notice status="warning" isDismissible={ false }>
+							{ __(
+								'Development features enabled.',
+								'woocommerce'
+							) }
+						</Notice>
+					</Flex>
+				</PanelBody>
+			) }
+
 			<PanelBody title={ __( 'Quantity Selector', 'woocommerce' ) }>
 				<ToggleGroupControl
 					className="wc-block-editor-quantity-selector-style"

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -5,6 +5,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
 	Flex,
+	FlexItem,
 	PanelBody,
 	Notice,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -20,7 +21,7 @@ import {
 /**
  * Internal dependencies
  */
-import type { FeaturesProps } from './edit';
+import type { FeaturesKeys, FeaturesProps } from './edit';
 
 export enum QuantitySelectorStyle {
 	Input = 'input',
@@ -54,47 +55,63 @@ const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
 export const AddToCartSettings = ( {
 	quantitySelectorStyle,
 	setAttributes,
-	features: { isBlockifyAddToCartEnabled },
+	features,
 }: AddToCartFormSettings ) => {
+	const { isBlockifyAddToCartEnabled, isStepperLayoutFeatureEnabled } =
+		features;
+
+	const hasDevFeatures =
+		isStepperLayoutFeatureEnabled || isBlockifyAddToCartEnabled;
+
+	if ( ! hasDevFeatures ) {
+		return null;
+	}
+
+	const featuresList = Object.keys( features ) as FeaturesKeys[];
+	const enabledFeatures = featuresList.filter(
+		( feature ) => features[ feature ]
+	);
+
 	return (
 		<InspectorControls>
-			{ isBlockifyAddToCartEnabled && (
-				<PanelBody title={ 'Development' }>
-					<Flex>
-						<Notice status="warning" isDismissible={ false }>
-							{ __(
-								'Development features enabled.',
-								'woocommerce'
-							) }
-						</Notice>
-					</Flex>
+			<PanelBody title={ 'Development' }>
+				<Flex gap={ 3 } direction="column">
+					<Notice status="warning" isDismissible={ false }>
+						{ __( 'Development features enabled.', 'woocommerce' ) }
+					</Notice>
+
+					{ enabledFeatures.map( ( feature ) => (
+						<FlexItem key={ feature }>{ feature }</FlexItem>
+					) ) }
+				</Flex>
+			</PanelBody>
+
+			{ isStepperLayoutFeatureEnabled && (
+				<PanelBody title={ __( 'Quantity Selector', 'woocommerce' ) }>
+					<ToggleGroupControl
+						className="wc-block-editor-quantity-selector-style"
+						__nextHasNoMarginBottom
+						value={ quantitySelectorStyle }
+						isBlock
+						onChange={ ( value: QuantitySelectorStyle ) => {
+							setAttributes( {
+								quantitySelectorStyle:
+									value as QuantitySelectorStyle,
+							} );
+						} }
+						help={ getHelpText( quantitySelectorStyle ) }
+					>
+						<ToggleGroupControlOption
+							label={ __( 'Input', 'woocommerce' ) }
+							value={ QuantitySelectorStyle.Input }
+						/>
+						<ToggleGroupControlOption
+							label={ __( 'Stepper', 'woocommerce' ) }
+							value={ QuantitySelectorStyle.Stepper }
+						/>
+					</ToggleGroupControl>
 				</PanelBody>
 			) }
-
-			<PanelBody title={ __( 'Quantity Selector', 'woocommerce' ) }>
-				<ToggleGroupControl
-					className="wc-block-editor-quantity-selector-style"
-					__nextHasNoMarginBottom
-					value={ quantitySelectorStyle }
-					isBlock
-					onChange={ ( value: QuantitySelectorStyle ) => {
-						setAttributes( {
-							quantitySelectorStyle:
-								value as QuantitySelectorStyle,
-						} );
-					} }
-					help={ getHelpText( quantitySelectorStyle ) }
-				>
-					<ToggleGroupControlOption
-						label={ __( 'Input', 'woocommerce' ) }
-						value={ QuantitySelectorStyle.Input }
-					/>
-					<ToggleGroupControlOption
-						label={ __( 'Stepper', 'woocommerce' ) }
-						value={ QuantitySelectorStyle.Stepper }
-					/>
-				</ToggleGroupControl>
-			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/plugins/woocommerce/changelog/update-add-feature-flag-for-add-to-cart
+++ b/plugins/woocommerce/changelog/update-add-feature-flag-for-add-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: Add To Cart with Options: introduce blockify feature flag

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -41,6 +41,7 @@
 		"blueprint": false,
 		"reactify-classic-payments-settings": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": false
+		"add-to-cart-with-options-stepper-layout": false,
+		"blockify-add-to-cart": false
 	}
 }

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -42,6 +42,6 @@
 		"reactify-classic-payments-settings": false,
 		"use-wp-horizon": false,
 		"add-to-cart-with-options-stepper-layout": false,
-		"blockify-add-to-cart": false
+		"blockified-add-to-cart": false
 	}
 }

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -42,6 +42,6 @@
 		"reactify-classic-payments-settings": false,
 		"use-wp-horizon": false,
 		"add-to-cart-with-options-stepper-layout": true,
-		"blockify-add-to-cart": true
+		"blockified-add-to-cart": true
 	}
 }

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -41,6 +41,7 @@
 		"blueprint": true,
 		"reactify-classic-payments-settings": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": true
+		"add-to-cart-with-options-stepper-layout": true,
+		"blockify-add-to-cart": true
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -77,7 +77,7 @@ class AddToCartForm extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 		$this->asset_data_registry->add( 'isStepperLayoutFeatureEnabled', Features::is_enabled( 'add-to-cart-with-options-stepper-layout' ) );
-		$this->asset_data_registry->add( 'isBlockifyAddToCartEnabled', Features::is_enabled( 'blockify-add-to-cart' ) );
+		$this->asset_data_registry->add( 'isBlockifiedAddToCart', Features::is_enabled( 'blockified-add-to-cart' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -77,6 +77,7 @@ class AddToCartForm extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 		$this->asset_data_registry->add( 'isStepperLayoutFeatureEnabled', Features::is_enabled( 'add-to-cart-with-options-stepper-layout' ) );
+		$this->asset_data_registry->add( 'isBlockifyAddToCartEnabled', Features::is_enabled( 'blockify-add-to-cart' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the `blockify-add-to-cart` feature flag.
Additionally, it adds a new panel to the block sidebar to show all enabled features.
Let's keep in mind that the stepper mode is also visible depending on a feature flag.

Closes #53007

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure install and activate the `WooCommerce Beta Tester` plugin
<img width="563" alt="image" src="https://github.com/user-attachments/assets/14f63f24-2b4e-4d90-a8a8-6dbe2d4c8014">

2. Go to the `WooCommerce Admin Test Helper` -> `Features` page

<img width="379" alt="image" src="https://github.com/user-attachments/assets/d87d815c-3528-4635-9cf1-6e0d93030f2f">

3. Confirm the `blockify-add-to-cart` is listed there. Also, identify the `add-to-cart-with-options-stepper-layout` feature.
<img width="697" alt="Screenshot 2024-11-26 at 7 17 58 AM" src="https://github.com/user-attachments/assets/d35c1853-1764-41ff-8d28-98509ddcbfce">

4. Enable `blockify-add-to-cart`
5. Edit the `Product individual` template
<img width="682" alt="image" src="https://github.com/user-attachments/assets/defc2a05-befc-408e-bcca-9945a2027d4f">
6. Select the `Add to Cart with Options` block
7. Confirm, that when one of the feature flags is enabled, the sidebar shows the Development panel

<img width="902" alt="image" src="https://github.com/user-attachments/assets/5ac637d2-7892-4d67-8cd2-e5c65ab595b9">

8. Confirm when no one of these feature flags is enabled, the Dev panel isn't shown.
<img width="901" alt="image" src="https://github.com/user-attachments/assets/26965f08-3527-4846-bf87-bc406062c611">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
