### PR TITLE
[api-core-tests] Trigger tests on setup and Playwright config changes

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-changes-list-for-api-core-include-setup-files
+++ b/plugins/woocommerce/changelog/e2e-update-changes-list-for-api-core-include-setup-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update CI config for api core tests to be triggered by changes in the setup and configuration files

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -458,6 +458,7 @@
 						"templates/**/*.php",
 						"tests/e2e-pw/tests/api-tests/**",
 						"tests/e2e-pw/*.js",
+						"tests/e2e-pw/*.sh",
 						".wp-env.json",
 						"woocommerce.php",
 						"uninstall.php"

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -457,6 +457,7 @@
 						"src/**/*.php",
 						"templates/**/*.php",
 						"tests/e2e-pw/tests/api-tests/**",
+						"tests/e2e-pw/*.js",
 						".wp-env.json",
 						"woocommerce.php",
 						"uninstall.php"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the CI config so that the Core API test job will run on changes to setup or configuration files in the `e2e-pw` dir. 

### How to test the changes in this Pull Request:

- Create a new branch based on this one
- Make a change in one of the `.js` or `.sh` files in the `e2e-pw` dir
- Run `pnpm utils ci-jobs --base-ref origin/e2e/update-changes-list-for-api-core-include-setup-files` and check the output. It should contain`Core API tests - @woocommerce/plugin-woocommerce [api]` 
