### PR TITLE
Add the `exclude_types` param to the `/products` endpoint

### DIFF
--- a/plugins/woocommerce/changelog/53184-52998-add-exclude-types-param
+++ b/plugins/woocommerce/changelog/53184-52998-add-exclude-types-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new "exclude_types" filter on the "/products" endpoint.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -251,6 +251,16 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			);
 		}
 
+		// Add exclude types filter.
+		if ( ! empty( $request['exclude_types'] ) ) {
+			$tax_query[] = array(
+				'taxonomy' => 'product_type',
+				'field'    => 'slug',
+				'terms'    => $request['exclude_types'],
+				'operator' => 'NOT IN',
+			);
+		}
+
 		// Filter by attribute and term.
 		if ( ! empty( $request['attribute'] ) && ! empty( $request['attribute_term'] ) ) {
 			if ( in_array( $request['attribute'], wc_get_attribute_taxonomy_names(), true ) ) {
@@ -1709,6 +1719,17 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		$params['include_types'] = array(
 			'description'       => __( 'Limit result set to products with any of the types.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+				'enum' => array_keys( wc_get_product_types() ),
+			),
+			'sanitize_callback' => 'wp_parse_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['exclude_types'] = array(
+			'description'       => __( 'Exclude products with any of the types from result set.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'string',

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -1014,6 +1014,177 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that `exclude_types` parameter correctly excludes a single type.
+	 */
+	public function test_products_filter_with_single_exclude_types() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+		WC_Helper_Product::create_grouped_product();
+		WC_Helper_Product::create_external_product();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'exclude_types' => array( 'simple' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$types = array_unique( array_column( $data, 'type' ) );
+
+		$this->assertNotContains( 'simple', $types );
+	}
+
+	/**
+	 * Test that `exclude_types` parameter correctly excludes multiple types.
+	 */
+	public function test_products_filter_with_multiple_exclude_types() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+		WC_Helper_Product::create_grouped_product();
+		WC_Helper_Product::create_external_product();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'exclude_types' => array( 'simple', 'grouped' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$types = array_unique( wp_list_pluck( $data, 'type' ) );
+
+		$this->assertEqualsCanonicalizing(
+			array( 'variable', 'external' ),
+			$types
+		);
+
+		$this->assertNotContains( 'simple', $types );
+		$this->assertNotContains( 'grouped', $types );
+	}
+
+	/**
+	 * Test that empty `exclude_types` parameter returns all products.
+	 */
+	public function test_products_filter_with_empty_exclude_types() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+		WC_Helper_Product::create_grouped_product();
+		WC_Helper_Product::create_external_product();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'exclude_types' => array(),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$types = array_unique( wp_list_pluck( $data, 'type' ) );
+
+		$this->assertEqualsCanonicalizing(
+			array_keys( wc_get_product_types() ),
+			$types
+		);
+	}
+
+	/**
+	 * Test that `exclude_types` parameter validation handles invalid values.
+	 */
+	public function test_products_filter_with_invalid_exclude_types() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'exclude_types' => array( 'simple', 'invalid_type' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test that `exclude_types` with all types returns empty result.
+	 */
+	public function test_products_filter_exclude_types_with_all_types_returns_empty() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+		WC_Helper_Product::create_grouped_product();
+		WC_Helper_Product::create_external_product();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'exclude_types' => array_keys( wc_get_product_types() ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEmpty( $response->get_data() );
+	}
+
+	/**
+	 * Test that `exclude_types` parameter takes precedence over `include_types`.
+	 */
+	public function test_products_filter_exclude_types_precedence_over_include() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+		WC_Helper_Product::create_grouped_product();
+		WC_Helper_Product::create_external_product();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'include_types' => array( 'simple', 'grouped' ),
+				'exclude_types' => array( 'grouped' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$types = array_unique( wp_list_pluck( $response->get_data(), 'type' ) );
+
+		$this->assertContains( 'simple', $types );
+		$this->assertNotContains( 'grouped', $types );
+		$this->assertEquals( 1, count( $types ) );
+	}
+
+	/**
+	 * Test that `exclude_types` works correctly with the `type` param.
+	 */
+	public function test_products_filter_exclude_types_with_type_param() {
+		WC_Helper_Product::create_simple_product();
+		WC_Helper_Product::create_variation_product();
+		WC_Helper_Product::create_grouped_product();
+		WC_Helper_Product::create_external_product();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params(
+			array(
+				'type'          => 'simple',
+				'exclude_types' => array( 'simple' ),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEmpty( $data, 'Should return no products when type is excluded' );
+	}
+
+	/**
 	 * Test `downloadable` filter returns only downloadable products.
 	 */
 	public function test_downloadable_filter_returns_only_downloadable_products() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR introduces the new `exclude_types` parameter to the `/products` endpoint.
It allows filtering out products by multiple types simultaneously: `simple`, `variable`, `grouped`, and `external`.

With this implementation, `exclude_types` takes precedence over `type` and `include_types` if any of them is present in the same request.

Closes https://github.com/woocommerce/woocommerce/issues/52998
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have multiple products in different types (`simple`, `variable`, `grouped`, and `external`).
2. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys` and add a new key with `Read/Write` permissions.
3. Make the following request using the consumer key and secret generated in the previous step, adding the `exclude_types` param:
```bash
curl --insecure -u [KEY]:[SECRET] --request GET --url 'https://[STORE_URL]/wp-json/wc/v3/products?exclude_types=simple
```
4. Ensure the result returns only products with types different than `simple`.
5. Repeat the request with multiple types (comma-separated) and check the response makes sense.
6. Try with a non-existing type, it should return a 400 response.
7. Try any other combinations you can think of, and check that the response is consistent.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add new "exclude_types" filter on the "/products" endpoint.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
