### PR TITLE
[e2e tests] Skip consumer token setup if environment variable is set

### DIFF
--- a/plugins/woocommerce/changelog/e2e-skip-api-key-setup
+++ b/plugins/woocommerce/changelog/e2e-skip-api-key-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: support consumer key from env variable

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -16,7 +16,6 @@ module.exports = async ( config ) => {
 
 	// Clean up the consumer keys
 	const keysRetries = 5;
-	console.log( 'Clearing consumer token...', process.env.API_KEY_NAME );
 	if ( process.env.API_KEY_NAME ) {
 		for ( let i = 0; i < keysRetries; i++ ) {
 			try {

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -16,78 +16,42 @@ module.exports = async ( config ) => {
 
 	// Clean up the consumer keys
 	const keysRetries = 5;
-
-	for ( let i = 0; i < keysRetries; i++ ) {
-		try {
-			console.log( 'Trying to clear consumer token... Try:' + i );
-			await adminPage.goto( `/wp-admin` );
-			await logIn( adminPage, admin.username, admin.password );
-			await adminPage.goto(
-				`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
-			);
-			await adminPage
-				.getByRole( 'link', { name: 'Revoke', includeHidden: true } )
-				.first()
-				.dispatchEvent( 'click' );
-			console.log( 'Cleared up consumer token successfully.' );
-			consumerTokenCleared = true;
-
-			console.log( 'Clearing pages...' );
-			// clear pages created
-			await adminPage.goto(
-				'/wp-admin/edit.php?s=page-&post_status=all&post_type=page'
-			);
-			if ( ! adminPage.getByText( 'No pages found.' ) ) {
-				await adminPage.locator( '#cb-select-all-1' ).check();
+	console.log( 'Clearing consumer token...', process.env.API_KEY_NAME );
+	if ( process.env.API_KEY_NAME ) {
+		for ( let i = 0; i < keysRetries; i++ ) {
+			try {
+				console.log(
+					`Trying to clear consumer token ${ process.env.API_KEY_NAME }... Try:` +
+						i
+				);
+				await adminPage.goto( `./wp-admin` );
+				await logIn( adminPage, admin.username, admin.password );
+				await adminPage.goto(
+					`./wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
+				);
 				await adminPage
-					.locator( '#bulk-action-selector-top' )
-					.selectOption( 'Move to Trash' );
-				await adminPage.locator( '#doaction' ).click();
+					.getByRole( 'cell', {
+						name: process.env.API_KEY_NAME,
+					} )
+					.getByRole( 'link', {
+						name: 'Revoke',
+						includeHidden: true,
+					} )
+					.dispatchEvent( 'click' );
+				consumerTokenCleared = true;
+				console.log(
+					`Cleared up consumer token  ${ process.env.API_KEY_NAME } successfully.`
+				);
+				break;
+			} catch ( e ) {
+				console.log(
+					`Failed to clear consumer token  ${ process.env.API_KEY_NAME }. Retrying...`
+				);
+				console.log( e );
 			}
-
-			// clear mini cart pages
-			await adminPage.goto(
-				'/wp-admin/edit.php?s=Mini+Cart&post_status=all&post_type=page'
-			);
-			if ( ! adminPage.getByText( 'No pages found.' ) ) {
-				await adminPage.locator( '#cb-select-all-1' ).check();
-				await adminPage
-					.locator( '#bulk-action-selector-top' )
-					.selectOption( 'Move to Trash' );
-				await adminPage.locator( '#doaction' ).click();
-			}
-
-			// clear product showcase pages
-			await adminPage.goto(
-				'/wp-admin/edit.php?s=Product+Showcase&post_status=all&post_type=page'
-			);
-			if ( ! adminPage.getByText( 'No pages found.' ) ) {
-				await adminPage.locator( '#cb-select-all-1' ).check();
-				await adminPage
-					.locator( '#bulk-action-selector-top' )
-					.selectOption( 'Move to Trash' );
-				await adminPage.locator( '#doaction' ).click();
-			}
-
-			console.log( 'Clearing posts...' );
-			// clear posts
-			await adminPage.goto(
-				'/wp-admin/edit.php?s=Post-&post_status=all&post_type=post'
-			);
-			if ( ! adminPage.getByText( 'No posts found.' ) ) {
-				await adminPage.locator( '#cb-select-all-1' ).check();
-				await adminPage
-					.locator( '#bulk-action-selector-top' )
-					.selectOption( 'Move to Trash' );
-				await adminPage.locator( '#doaction' ).click();
-			}
-
-			break;
-		} catch ( e ) {
-			console.log( 'Failed to clear consumer token. Retrying...' );
-			console.log( e );
 		}
+		await expect( consumerTokenCleared ).toBe( true );
+	} else {
+		console.log( 'No consumer token to clear.' );
 	}
-
-	await expect( consumerTokenCleared ).toBe( true );
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update setup and teardown to skip managing consumer key and secret if they're set via environment variables. This is mostly useful for external sites especially when running the tests multiple times.
It also ensures only the key that was created by the setup is cleared, so that other keys that we may want to keep are not removed.

I also removed part of the teardown that are not longer necessary.


### How to test the changes in this Pull Request:

Run test tests normally and check the log output. A consumer key is created in the setup phase and then cleared in the teardown phase.

```
pnpm test:api hello.test.js
```

Run the test using the `CONSUMER_KEY` and `CONSUMER_SECRET` and check the log output. No key is generated in the setup and no key is cleared in the teardown.

```
CONSUMER_KEY=your_key CONSUMER_SECRET=your_secret pnpm test:api hello.test.js
```
