### PR TITLE
Refactor merged packages activation

### DIFF
--- a/plugins/woocommerce/changelog/53192-update-refactor-merged-packages-activation
+++ b/plugins/woocommerce/changelog/53192-update-refactor-merged-packages-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: A fix related to enable Brands to 5%, which hasn't been released.
+

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -271,7 +271,6 @@ class WC_Install {
 			'wc_update_940_remove_help_panel_highlight_shown',
 		),
 		'9.5.0' => array(
-			'wc_update_950_add_brands_enabled_option',
 			'wc_update_950_tracking_option_autoload',
 		),
 	);

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2922,13 +2922,6 @@ function wc_update_940_remove_help_panel_highlight_shown() {
 }
 
 /**
- * Add wc_feature_woocommerce_brands_enabled.
- */
-function wc_update_950_add_brands_enabled_option() {
-	add_option( 'wc_feature_woocommerce_brands_enabled', 'yes' );
-}
-
-/**
  * Autoloads woocommerce_allow_tracking option.
  */
 function wc_update_950_tracking_option_autoload() {

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -122,7 +122,21 @@ class Packages {
 
 		foreach ( self::$merged_packages as $merged_package_name => $package_class ) {
 
-			// For gradual rollouts, ensure that a package is enabled for user's remote variant number.
+			$option       = 'wc_feature_' . str_replace( '-', '_', $merged_package_name ) . '_enabled';
+			$option_value = get_option( $option, '' );
+
+			// Opt out from the feature.
+			if ( 'no' === $option_value ) {
+				continue;
+			}
+
+			// Force enable feature -- mainly for testing purpose.
+			if ( 'yes' === $option_value ) {
+				$enabled_packages[ $merged_package_name ] = $package_class;
+				continue;
+			}
+
+			// If an option is not set, ensure that a package is enabled for user's remote variant number. Mainly for gradual releases.
 			$experimental_package_enabled = method_exists( $package_class, 'is_enabled' ) ?
 				call_user_func( array( $package_class, 'is_enabled' ) ) :
 				false;
@@ -131,10 +145,7 @@ class Packages {
 				continue;
 			}
 
-			$option = 'wc_feature_' . str_replace( '-', '_', $merged_package_name ) . '_enabled';
-			if ( 'yes' === get_option( $option, 'no' ) ) {
-				$enabled_packages[ $merged_package_name ] = $package_class;
-			}
+			$enabled_packages[ $merged_package_name ] = $package_class;
 		}
 
 		return array_merge( $enabled_packages, self::$base_packages );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR refactors the way merged, optional packages are activated to prevent WooCommerce from storing one option the database for every package that gets enabled. Instead, a new option will be created only for users, who would like to disable the feature. 

**Before:**
Before the change, if the `wc_feature_[feature name]_enabled` option was not set, then the feature was considered disabled. The option would have to be set to `yes` _and_ the remote variation assignment should be within specific limits in order for the feature to be enabled. This required a database migration.

**After:**
After the change, if the `wc_feature_[feature name]_enabled` option is not set, then the activation logic falls back to the remote variant assignment. If the feature has been enabled to all users, then if the `wc_feature_[feature name]_enabled` option is not set, the feature will be enabled.

If the `wc_feature_[feature name]_enabled` option is set to `no`, then the feature will be disabled. 

If the `wc_feature_[feature name]_enabled` option is set to `yes`, then the feature will be enabled always, regardless of the remote assignment. This will also help with testing during the experimental phase, as testers won't have to set up the remote variant as well.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new site with WooCommerce 9.5.
2. In the WP CLI, run `wp option update woocommerce_remote_variant_assignment 2`.
3. Ensure that you see the Products > Brands tab. 
4. In the WP CLI, run `wp option update woocommerce_remote_variant_assignment 20`.
5. Ensure that the Products > Brands tab is hidden.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

A fix related to enable Brands to 5%, which hasn't been released.

</details>
