### PR TITLE
[Accessibility] Update password strength role

### DIFF
--- a/plugins/woocommerce/changelog/fix-51837
+++ b/plugins/woocommerce/changelog/fix-51837
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update password strength role

--- a/plugins/woocommerce/client/legacy/js/frontend/password-strength-meter.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/password-strength-meter.js
@@ -64,7 +64,7 @@ jQuery( function( $ ) {
 			if ( '' === field.val() ) {
 				meter.hide();
 				$( document.body ).trigger( 'wc-password-strength-hide' );
-				field.removeAttr('aria-describedby');
+				field.removeAttr( 'aria-describedby' );
 			} else if ( 0 === meter.length ) {
 				field.after( '<div id="password_strength" class="woocommerce-password-strength" role="alert"></div>' );
 				field.attr( 'aria-describedby', 'password_strength' );

--- a/plugins/woocommerce/client/legacy/js/frontend/password-strength-meter.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/password-strength-meter.js
@@ -64,8 +64,10 @@ jQuery( function( $ ) {
 			if ( '' === field.val() ) {
 				meter.hide();
 				$( document.body ).trigger( 'wc-password-strength-hide' );
+				field.removeAttr('aria-describedby');
 			} else if ( 0 === meter.length ) {
-				field.after( '<div class="woocommerce-password-strength" aria-live="polite"></div>' );
+				field.after( '<div id="password_strength" class="woocommerce-password-strength" role="alert"></div>' );
+				field.attr( 'aria-describedby', 'password_strength' );
 				$( document.body ).trigger( 'wc-password-strength-added' );
 			} else {
 				meter.show();


### PR DESCRIPTION
### Submission Review Guidelines:

- * I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- * I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- * I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- * Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #51837  .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Browse to the My Account Page → Account Details.
2. Enter text for a new Password.
3. When a screen reader is enabled, the screen reader should voice the password strength on each keystroke.
4. The password input field should have `aria-describedby="password_strength"`.
5. The strength indicator should have `role="alert"` and `id="password_strength"`.

### Changelog entry

- * [ ] Automatically create a changelog entry from the details below.
- * [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance
#### Type

</details>
