### PR TITLE
Live preview email subject and from name/address when changed

### DIFF
--- a/plugins/woocommerce/changelog/52423-email-preview-subject
+++ b/plugins/woocommerce/changelog/52423-email-preview-subject
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Experimental: live preview email subject and from name and address changes in settings

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { date } from '@wordpress/date';
+import { getSetting } from '@woocommerce/settings';
 import { useEffect, useState } from 'react';
 
 /**
@@ -64,7 +66,17 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 		if ( ! email ) {
 			return '';
 		}
-		return email.subject || '';
+		const subject = email.subject || '';
+		const today = date( getSetting( 'dateFormat' ), new Date(), undefined );
+		const placeholders: Record< string, string > = {
+			'{site_title}': getSetting( 'siteTitle' ),
+			'{order_number}': '12345',
+			'{order_date}': today,
+		};
+		return subject.replace(
+			/{\w+}/g,
+			( match ) => placeholders[ match ] ?? match
+		);
 	};
 
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -50,7 +50,7 @@ export const EmailPreviewHeader: React.FC = () => {
 				</div>
 				<div className="wc-settings-email-preview-header-sender">
 					{ fromName }
-					<span>{ fromAddress }</span>
+					<span>&lt;{ fromAddress }&gt;</span>
 				</div>
 			</div>
 		</div>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -8,8 +8,17 @@ import { useEffect, useState } from 'react';
  * Internal dependencies
  */
 import avatarIcon from './icon-avatar.svg';
+import { EmailType } from './settings-email-preview-slotfill';
 
-export const EmailPreviewHeader: React.FC = () => {
+type EmailPreviewHeaderProps = {
+	emailTypes: EmailType[];
+	emailType: string;
+};
+
+export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
+	emailTypes,
+	emailType,
+} ) => {
 	const [ fromName, setFromName ] = useState( '' );
 	const [ fromAddress, setFromAddress ] = useState( '' );
 
@@ -50,10 +59,18 @@ export const EmailPreviewHeader: React.FC = () => {
 		};
 	}, [] );
 
+	const getSubject = () => {
+		const email = emailTypes.find( ( type ) => type.value === emailType );
+		if ( ! email ) {
+			return '';
+		}
+		return email.subject || '';
+	};
+
 	return (
 		<div className="wc-settings-email-preview-header">
 			<h3 className="wc-settings-email-preview-header-subject">
-				Your SampleStore order is now complete
+				{ getSubject() }
 			</h3>
 			<div className="wc-settings-email-preview-header-data">
 				<div className="wc-settings-email-preview-header-icon">

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { __ } from '@wordpress/i18n';
-import { resolveSelect } from '@wordpress/data';
 import { useEffect, useState } from 'react';
 
 /**
@@ -11,29 +9,45 @@ import { useEffect, useState } from 'react';
  */
 import avatarIcon from './icon-avatar.svg';
 
-type FromSettings = {
-	woocommerce_email_from_name?: string;
-	woocommerce_email_from_address?: string;
-};
-
 export const EmailPreviewHeader: React.FC = () => {
 	const [ fromName, setFromName ] = useState( '' );
 	const [ fromAddress, setFromAddress ] = useState( '' );
-	useEffect( () => {
-		const fetchSettings = async () => {
-			const {
-				woocommerce_email_from_name = '',
-				woocommerce_email_from_address = '',
-			} = (
-				await resolveSelect( SETTINGS_STORE_NAME ).getSettings(
-					'email'
-				)
-			 ).email as FromSettings;
 
-			setFromName( woocommerce_email_from_name );
-			setFromAddress( woocommerce_email_from_address );
+	useEffect( () => {
+		const fromNameEl = document.getElementById(
+			'woocommerce_email_from_name'
+		) as HTMLInputElement;
+		const fromAddressEl = document.getElementById(
+			'woocommerce_email_from_address'
+		) as HTMLInputElement;
+
+		if ( ! fromNameEl || ! fromAddressEl ) {
+			return;
+		}
+
+		// Set initial values
+		setFromName( fromNameEl.value || '' );
+		setFromAddress( fromAddressEl.value || '' );
+
+		const handleFromNameChange = ( event: Event ) => {
+			const target = event.target as HTMLInputElement;
+			setFromName( target.value || '' );
 		};
-		fetchSettings();
+		const handleFromAddressChange = ( event: Event ) => {
+			const target = event.target as HTMLInputElement;
+			setFromAddress( target.value || '' );
+		};
+
+		fromNameEl.addEventListener( 'change', handleFromNameChange );
+		fromAddressEl.addEventListener( 'change', handleFromAddressChange );
+
+		return () => {
+			fromNameEl.removeEventListener( 'change', handleFromNameChange );
+			fromAddressEl.removeEventListener(
+				'change',
+				handleFromAddressChange
+			);
+		};
 	}, [] );
 
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -20,8 +20,12 @@ import { EmailPreviewType } from './settings-email-preview-type';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
+export type EmailType = SelectControl.Option & {
+	subject: string;
+};
+
 type EmailPreviewFillProps = {
-	emailTypes: SelectControl.Option[];
+	emailTypes: EmailType[];
 	previewUrl: string;
 };
 
@@ -61,7 +65,10 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 				<div
 					className={ `wc-settings-email-preview wc-settings-email-preview-${ deviceType }` }
 				>
-					<EmailPreviewHeader />
+					<EmailPreviewHeader
+						emailTypes={ emailTypes }
+						emailType={ emailType }
+					/>
 					<iframe
 						src={ finalPreviewUrl }
 						title={ __( 'Email preview frame', 'woocommerce' ) }
@@ -84,7 +91,7 @@ export const registerSettingsEmailPreviewFill = () => {
 		return null;
 	}
 	const emailTypesData = slotElement.getAttribute( 'data-email-types' );
-	let emailTypes: SelectControl.Option[] = [];
+	let emailTypes: EmailType[] = [];
 	try {
 		emailTypes = JSON.parse( emailTypesData || '' );
 	} catch ( e ) {}

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
@@ -4,8 +4,13 @@
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { EmailType } from './settings-email-preview-slotfill';
+
 type EmailPreviewTypeProps = {
-	emailTypes: SelectControl.Option[];
+	emailTypes: EmailType[];
 	emailType: string;
 	setEmailType: ( emailType: string ) => void;
 };

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -438,8 +438,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$email_types = array();
 		foreach ( $emails as $type => $email ) {
 			$email_types[] = array(
-				'label' => $email->get_title(),
-				'value' => $type,
+				'label'   => $email->get_title(),
+				'value'   => $type,
+				'subject' => $email->get_default_subject(),
 			);
 		}
 		?>

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -59,6 +59,49 @@ test.describe( 'WooCommerce Email Settings', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Email sender options live change in email preview', async ( {
+		page,
+		baseURL,
+	} ) => {
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		const fromNameElement = '#woocommerce_email_from_name';
+		const fromAddressElement = '#woocommerce_email_from_address';
+		const senderElement = '.wc-settings-email-preview-header-sender';
+
+		const getSender = async () => {
+			return await page.locator( senderElement ).textContent();
+		};
+
+		// Verify initial sender contains fromName and fromAddress
+		const initialFromName = await page
+			.locator( fromNameElement )
+			.inputValue();
+		const initialFromAddress = await page
+			.locator( fromAddressElement )
+			.inputValue();
+		let sender = await getSender();
+		expect( sender ).toContain( initialFromName );
+		expect( sender ).toContain( initialFromAddress );
+
+		// Change the fromName and verify the sender updates
+		const newFromName = 'New Name';
+		await page.fill( fromNameElement, newFromName );
+		await page.locator( fromNameElement ).blur();
+		sender = await getSender();
+		expect( sender ).toContain( newFromName );
+		expect( sender ).toContain( initialFromAddress );
+
+		// Change the fromAddress and verify the sender updates
+		const newFromAddress = 'new@example.com';
+		await page.fill( fromAddressElement, newFromAddress );
+		await page.locator( fromAddressElement ).blur();
+		sender = await getSender();
+		expect( sender ).toContain( newFromName );
+		expect( sender ).toContain( newFromAddress );
+	} );
+
 	test( 'See email image url field with a feature flag', async ( {
 		page,
 		baseURL,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. Live preview subject when an email type is changed and also live preview from name and address when changed in email settings. 

Closes #52423.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `email_improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
2. Go to **WooCommerce > Settings > Emails**.
3. Check that the from name and address in the email preview are the same as in the `Email sender options` settings section.
    <img width="710" alt="Screenshot 2024-11-26 at 16 28 39" src="https://github.com/user-attachments/assets/f25589f6-a004-404b-b161-01cffa6cf403">

4. Check that email subject placeholders are replaced with actual data (site title, today's date, or order number, which is hardcoded to `12345`).
5. Change the `"From" name` and `"From" address` and observe that they are also changed in the email preview without the need to save settings. 

<!-- End testing instructions -->

