### PR TITLE
Improve email color settings

### DIFF
--- a/plugins/woocommerce/changelog/52223-email-color-settings
+++ b/plugins/woocommerce/changelog/52223-email-color-settings
@@ -1,0 +1,3 @@
+Significance: patch
+Type: add
+Comment: This change renames and reorders email color setting fields and also adds new default color values for block-based themes which are taken from theme.json.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -104,6 +104,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		/* translators: %s: footer default color */
 		$footer_text_color_desc = sprintf( __( 'The footer text color. Default %s.', 'woocommerce' ), '<code>' . $footer_text_color_default . '</code>' );
 
+		$color_palette_section_header = null;
+		$color_palette_section_end    = null;
+
 		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
 			$email_template_description = __( 'Customize your WooCommerce email template and preview it below.', 'woocommerce' );
 			$logo_image                 = array(
@@ -165,7 +168,89 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			$footer_text_color_title = __( 'Secondary text', 'woocommerce' );
 			/* translators: %s: footer default color */
 			$footer_text_color_desc = sprintf( __( 'Choose a color for your secondary text, such as your footer content. Default %s.', 'woocommerce' ), '<code>' . $footer_text_color_default . '</code>' );
+
+			$color_palette_section_header = array(
+				'title' => __( 'Color palette', 'woocommerce' ),
+				'type'  => 'title',
+				'id'    => 'email_color_palette',
+			);
+
+			$color_palette_section_end = array(
+				'type' => 'sectionend',
+				'id'   => 'email_template_options',
+			);
 		}
+
+		// Reorder email color settings based on the email_improvements feature flag
+
+		$base_color_setting = array(
+			'title'    => $base_color_title,
+			'desc'     => $base_color_desc,
+			'id'       => 'woocommerce_email_base_color',
+			'type'     => 'color',
+			'css'      => 'width:6em;',
+			'default'  => $base_color_default,
+			'autoload' => false,
+			'desc_tip' => true,
+		);
+
+		$bg_color_setting = array(
+			'title'    => $bg_color_title,
+			'desc'     => $bg_color_desc,
+			'id'       => 'woocommerce_email_background_color',
+			'type'     => 'color',
+			'css'      => 'width:6em;',
+			'default'  => $bg_color_default,
+			'autoload' => false,
+			'desc_tip' => true,
+		);
+
+		$body_bg_color_setting = array(
+			'title'    => $body_bg_color_title,
+			'desc'     => $body_bg_color_desc,
+			'id'       => 'woocommerce_email_body_background_color',
+			'type'     => 'color',
+			'css'      => 'width:6em;',
+			'default'  => $body_bg_color_default,
+			'autoload' => false,
+			'desc_tip' => true,
+		);
+
+		$body_text_color_setting = array(
+			'title'    => $body_text_color_title,
+			'desc'     => $body_text_color_desc,
+			'id'       => 'woocommerce_email_text_color',
+			'type'     => 'color',
+			'css'      => 'width:6em;',
+			'default'  => $body_text_color_default,
+			'autoload' => false,
+			'desc_tip' => true,
+		);
+
+		$footer_text_color_setting = array(
+			'title'    => $footer_text_color_title,
+			'desc'     => $footer_text_color_desc,
+			'id'       => 'woocommerce_email_footer_text_color',
+			'type'     => 'color',
+			'css'      => 'width:6em;',
+			'default'  => $footer_text_color_default,
+			'autoload' => false,
+			'desc_tip' => true,
+		);
+
+		$reorder_colors = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+		$base_color_setting_in_template_opts        = $reorder_colors ? null : $base_color_setting;
+		$bg_color_setting_in_template_opts          = $reorder_colors ? null : $bg_color_setting;
+		$body_bg_color_setting_in_template_opts     = $reorder_colors ? null : $body_bg_color_setting;
+		$body_text_color_setting_in_template_opts   = $reorder_colors ? null : $body_text_color_setting;
+		$footer_text_color_setting_in_template_opts = $reorder_colors ? null : $footer_text_color_setting;
+
+		$base_color_setting_in_palette        = $reorder_colors ? $base_color_setting : null;
+		$bg_color_setting_in_palette          = $reorder_colors ? $bg_color_setting : null;
+		$body_bg_color_setting_in_palette     = $reorder_colors ? $body_bg_color_setting : null;
+		$body_text_color_setting_in_palette   = $reorder_colors ? $body_text_color_setting : null;
+		$footer_text_color_setting_in_palette = $reorder_colors ? $footer_text_color_setting : null;
 
 		$settings =
 			array(
@@ -237,49 +322,13 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				$header_alignment,
 
-				array(
-					'title'    => $base_color_title,
-					'desc'     => $base_color_desc,
-					'id'       => 'woocommerce_email_base_color',
-					'type'     => 'color',
-					'css'      => 'width:6em;',
-					'default'  => $base_color_default,
-					'autoload' => false,
-					'desc_tip' => true,
-				),
+				$base_color_setting_in_template_opts,
 
-				array(
-					'title'    => $bg_color_title,
-					'desc'     => $bg_color_desc,
-					'id'       => 'woocommerce_email_background_color',
-					'type'     => 'color',
-					'css'      => 'width:6em;',
-					'default'  => $bg_color_default,
-					'autoload' => false,
-					'desc_tip' => true,
-				),
+				$bg_color_setting_in_template_opts,
 
-				array(
-					'title'    => $body_bg_color_title,
-					'desc'     => $body_bg_color_desc,
-					'id'       => 'woocommerce_email_body_background_color',
-					'type'     => 'color',
-					'css'      => 'width:6em;',
-					'default'  => $body_bg_color_default,
-					'autoload' => false,
-					'desc_tip' => true,
-				),
+				$body_bg_color_setting_in_template_opts,
 
-				array(
-					'title'    => $body_text_color_title,
-					'desc'     => $body_text_color_desc,
-					'id'       => 'woocommerce_email_text_color',
-					'type'     => 'color',
-					'css'      => 'width:6em;',
-					'default'  => $body_text_color_default,
-					'autoload' => false,
-					'desc_tip' => true,
-				),
+				$body_text_color_setting_in_template_opts,
 
 				array(
 					'title'       => __( 'Footer text', 'woocommerce' ),
@@ -294,21 +343,26 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'desc_tip'    => true,
 				),
 
-				array(
-					'title'    => $footer_text_color_title,
-					'desc'     => $footer_text_color_desc,
-					'id'       => 'woocommerce_email_footer_text_color',
-					'type'     => 'color',
-					'css'      => 'width:6em;',
-					'default'  => $footer_text_color_default,
-					'autoload' => false,
-					'desc_tip' => true,
-				),
+				$footer_text_color_setting_in_template_opts,
 
 				array(
 					'type' => 'sectionend',
 					'id'   => 'email_template_options',
 				),
+
+				$color_palette_section_header,
+
+				$base_color_setting_in_palette,
+
+				$bg_color_setting_in_palette,
+
+				$body_bg_color_setting_in_palette,
+
+				$body_text_color_setting_in_palette,
+
+				$footer_text_color_setting_in_palette,
+
+				$color_palette_section_end,
 
 				array( 'type' => 'email_preview' ),
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -78,6 +78,32 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		);
 		$header_alignment           = null;
 
+		$base_color_default        = '#7f54b3';
+		$bg_color_default          = '#f7f7f7';
+		$body_bg_color_default     = '#ffffff';
+		$body_text_color_default   = '#3c3c3c';
+		$footer_text_color_default = '#3c3c3c';
+
+		$base_color_title = __( 'Base color', 'woocommerce' );
+		/* translators: %s: default color */
+		$base_color_desc = sprintf( __( 'The base color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>' . $base_color_default . '</code>' );
+
+		$bg_color_title = __( 'Background color', 'woocommerce' );
+		/* translators: %s: default color */
+		$bg_color_desc = sprintf( __( 'The background color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>' . $bg_color_default . '</code>' );
+
+		$body_bg_color_title = __( 'Body background color', 'woocommerce' );
+		/* translators: %s: default color */
+		$body_bg_color_desc = sprintf( __( 'The main body background color. Default %s.', 'woocommerce' ), '<code>' . $body_bg_color_default . '</code>' );
+
+		$body_text_color_title = __( 'Body text color', 'woocommerce' );
+		/* translators: %s: default color */
+		$body_text_color_desc = sprintf( __( 'The main body text color. Default %s.', 'woocommerce' ), '<code>' . $body_text_color_default . '</code>' );
+
+		$footer_text_color_title = __( 'Footer text color', 'woocommerce' );
+		/* translators: %s: footer default color */
+		$footer_text_color_desc = sprintf( __( 'The footer text color. Default %s.', 'woocommerce' ), '<code>' . $footer_text_color_default . '</code>' );
+
 		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
 			$email_template_description = __( 'Customize your WooCommerce email template and preview it below.', 'woocommerce' );
 			$logo_image                 = array(
@@ -104,6 +130,41 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'right'  => __( 'Right', 'woocommerce' ),
 				),
 			);
+
+			$base_color_default        = '#8526ff';
+			$bg_color_default          = '#ffffff';
+			$body_bg_color_default     = '#ffffff';
+			$body_text_color_default   = '#1e1e1e';
+			$footer_text_color_default = '#787c82';
+
+			if ( wc_current_theme_is_fse_theme() && function_exists( 'wp_get_global_styles' ) ) {
+				$global_styles             = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
+				$base_color_default        = $global_styles['elements']['button']['color']['text'] ?? $base_color_default;
+				$bg_color_default          = $global_styles['color']['background'] ?? $bg_color_default;
+				$body_bg_color_default     = $global_styles['color']['background'] ?? $body_bg_color_default;
+				$body_text_color_default   = $global_styles['color']['text'] ?? $body_text_color_default;
+				$footer_text_color_default = $global_styles['elements']['caption']['color']['text'] ?? $footer_text_color_default;
+			}
+
+			$base_color_title = __( 'Accent', 'woocommerce' );
+			/* translators: %s: default color */
+			$base_color_desc = sprintf( __( 'Customize the color of your buttons and links. Default %s.', 'woocommerce' ), '<code>' . $base_color_default . '</code>' );
+
+			$bg_color_title = __( 'Email background', 'woocommerce' );
+			/* translators: %s: default color */
+			$bg_color_desc = sprintf( __( 'Select a color for the background of your emails. Default %s.', 'woocommerce' ), '<code>' . $bg_color_default . '</code>' );
+
+			$body_bg_color_title = __( 'Content background', 'woocommerce' );
+			/* translators: %s: default color */
+			$body_bg_color_desc = sprintf( __( 'Choose a background color for the content area of your emails. Default %s.', 'woocommerce' ), '<code>' . $body_bg_color_default . '</code>' );
+
+			$body_text_color_title = __( 'Heading & text', 'woocommerce' );
+			/* translators: %s: default color */
+			$body_text_color_desc = sprintf( __( 'Set the color of your headings and text. Default %s.', 'woocommerce' ), '<code>' . $body_text_color_default . '</code>' );
+
+			$footer_text_color_title = __( 'Secondary text', 'woocommerce' );
+			/* translators: %s: footer default color */
+			$footer_text_color_desc = sprintf( __( 'Choose a color for your secondary text, such as your footer content. Default %s.', 'woocommerce' ), '<code>' . $footer_text_color_default . '</code>' );
 		}
 
 		$settings =
@@ -177,49 +238,45 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				$header_alignment,
 
 				array(
-					'title'    => __( 'Base color', 'woocommerce' ),
-					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The base color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#7f54b3</code>' ),
+					'title'    => $base_color_title,
+					'desc'     => $base_color_desc,
 					'id'       => 'woocommerce_email_base_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
-					'default'  => '#7f54b3',
+					'default'  => $base_color_default,
 					'autoload' => false,
 					'desc_tip' => true,
 				),
 
 				array(
-					'title'    => __( 'Background color', 'woocommerce' ),
-					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The background color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#f7f7f7</code>' ),
+					'title'    => $bg_color_title,
+					'desc'     => $bg_color_desc,
 					'id'       => 'woocommerce_email_background_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
-					'default'  => '#f7f7f7',
+					'default'  => $bg_color_default,
 					'autoload' => false,
 					'desc_tip' => true,
 				),
 
 				array(
-					'title'    => __( 'Body background color', 'woocommerce' ),
-					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The main body background color. Default %s.', 'woocommerce' ), '<code>#ffffff</code>' ),
+					'title'    => $body_bg_color_title,
+					'desc'     => $body_bg_color_desc,
 					'id'       => 'woocommerce_email_body_background_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
-					'default'  => '#ffffff',
+					'default'  => $body_bg_color_default,
 					'autoload' => false,
 					'desc_tip' => true,
 				),
 
 				array(
-					'title'    => __( 'Body text color', 'woocommerce' ),
-					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The main body text color. Default %s.', 'woocommerce' ), '<code>#3c3c3c</code>' ),
+					'title'    => $body_text_color_title,
+					'desc'     => $body_text_color_desc,
 					'id'       => 'woocommerce_email_text_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
-					'default'  => '#3c3c3c',
+					'default'  => $body_text_color_default,
 					'autoload' => false,
 					'desc_tip' => true,
 				),
@@ -238,13 +295,12 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				),
 
 				array(
-					'title'    => __( 'Footer text color', 'woocommerce' ),
-					/* translators: %s: footer default color */
-					'desc'     => sprintf( __( 'The footer text color. Default %s.', 'woocommerce' ), '<code>#3c3c3c</code>' ),
+					'title'    => $footer_text_color_title,
+					'desc'     => $footer_text_color_desc,
 					'id'       => 'woocommerce_email_footer_text_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
-					'default'  => '#3c3c3c',
+					'default'  => $footer_text_color_default,
 					'autoload' => false,
 					'desc_tip' => true,
 				),

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -116,4 +116,87 @@ test.describe( 'WooCommerce Email Settings', () => {
 		await expect( page.locator( existingImageElement ) ).toBeHidden();
 		await expect( page.locator( newImageElement ) ).toBeVisible();
 	} );
+
+	test( 'See new color settings with a feature flag', async ( {
+		page,
+		baseURL,
+	} ) => {
+		// Disable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'no' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		await expect(
+			page.getByText( 'Color palette', { exact: true } )
+		).toHaveCount( 0 );
+		await expect( page.getByText( 'Accent', { exact: true } ) ).toHaveCount(
+			0
+		);
+		await expect(
+			page.getByText( 'Email background', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Content background', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Heading & text', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Secondary text', { exact: true } )
+		).toHaveCount( 0 );
+
+		await expect(
+			page.getByText( 'Base color', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Background color', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Body background color', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Body text color', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Footer text color', { exact: true } )
+		).toBeVisible();
+
+		// Enable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.reload();
+
+		await expect(
+			page.getByText( 'Color palette', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Accent', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Email background', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Content background', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Heading & text', { exact: true } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Secondary text', { exact: true } )
+		).toBeVisible();
+
+		await expect(
+			page.getByText( 'Base color', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Background color', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Body background color', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Body text color', { exact: true } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByText( 'Footer text color', { exact: true } )
+		).toHaveCount( 0 );
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the feature flag is enabled, email color settings are renamed, rearranged, and their default values are changed to the ones taken from theme.json for block-based themes or to new hardcoded values for non-block-based themes.

Closes #52223.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Settings > Emails` and observe the existing color setting fields.
2. Enable the email_improvements feature flag. It's hidden in the UI, so this needs to be done in the database: set the `woocommerce_feature_email_improvements_enabled` option to `yes`.
3. Reload the email settings page.
4. You should now see the color fields renamed, reordered, and their default values changed (hover mouse over a tooltip icon).
5. Test that the default values are taken from theme.json for block-based themes as stated in #52223. For non-block-based themes the values should be new as well, but hardcoded.
5. Note that theme.json may have no style for certain elements, in this case a hardcoded value for non-block-based themes is used. Also, theme.json styles have multiple colors for some elements, e.g. text, background, gradient, hover etc. We use the text color in all cases.

<!-- End testing instructions -->