### PR TITLE
Improve email font family and footer settings

### DIFF
--- a/plugins/woocommerce/changelog/52222-email-font-and-footer-settings
+++ b/plugins/woocommerce/changelog/52222-email-font-and-footer-settings
@@ -1,0 +1,3 @@
+Significance: patch
+Type: add
+Comment: This change adds a font family setting and improves the footer text setting in email settings, adding new placeholders.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -96,6 +96,10 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$header_alignment           = null;
 		$font_family                = null;
 
+		/* translators: %s: Available placeholders for use */
+		$footer_text_description = __( 'The text to appear in the footer of all WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url}' );
+		$footer_text_default     = '{site_title} &mdash; Built with {WooCommerce}';
+
 		$base_color_default        = '#7f54b3';
 		$bg_color_default          = '#f7f7f7';
 		$body_bg_color_default     = '#ffffff';
@@ -176,6 +180,10 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					$additional_fonts
 				),
 			);
+
+			/* translators: %s: Available placeholders for use */
+			$footer_text_description = __( 'This text will appear in the footer of all of your WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url} {store_address} {store_email}' );
+			$footer_text_default     = '{site_title}<br />{store_address}';
 
 			$base_color_default        = '#8526ff';
 			$bg_color_default          = '#ffffff';
@@ -377,13 +385,12 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				array(
 					'title'       => __( 'Footer text', 'woocommerce' ),
-					/* translators: %s: Available placeholders for use */
-					'desc'        => __( 'The text to appear in the footer of all WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url}' ),
+					'desc'        => $footer_text_description,
 					'id'          => 'woocommerce_email_footer_text',
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title} &mdash; Built with {WooCommerce}',
+					'default'     => $footer_text_default,
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -20,6 +20,23 @@ if ( class_exists( 'WC_Settings_Emails', false ) ) {
 class WC_Settings_Emails extends WC_Settings_Page {
 
 	/**
+	 * Array of font families supported in email templates
+	 *
+	 * @var string[]
+	 */
+	public static $font = array(
+		'Arial'           => "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+		'Comic Sans MS'   => "'Comic Sans MS', 'Marker Felt-Thin', Arial, sans-serif",
+		'Courier New'     => "'Courier New', Courier, 'Lucida Sans Typewriter', 'Lucida Typewriter', monospace",
+		'Georgia'         => "Georgia, Times, 'Times New Roman', serif",
+		'Lucida'          => "'Lucida Sans Unicode', 'Lucida Grande', sans-serif",
+		'Tahoma'          => 'Tahoma, Verdana, Segoe, sans-serif',
+		'Times New Roman' => "'Times New Roman', Times, Baskerville, Georgia, serif",
+		'Trebuchet MS'    => "'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif",
+		'Verdana'         => 'Verdana, Geneva, sans-serif',
+	);
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -77,6 +94,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			'desc_tip'    => true,
 		);
 		$header_alignment           = null;
+		$font_family                = null;
 
 		$base_color_default        = '#7f54b3';
 		$bg_color_default          = '#f7f7f7';
@@ -131,6 +149,31 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'left'   => __( 'Left', 'woocommerce' ),
 					'center' => __( 'Center', 'woocommerce' ),
 					'right'  => __( 'Right', 'woocommerce' ),
+				),
+			);
+
+			$additional_fonts = array();
+			if ( wc_current_theme_is_fse_theme() && class_exists( 'WP_Font_Face_Resolver' ) ) {
+				$theme_fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+				if ( count( $theme_fonts ) > 0 ) {
+					foreach ( $theme_fonts as $font ) {
+						if ( ! empty( $font[0]['font-family'] ) ) {
+							$additional_fonts[ $font[0]['font-family'] ] = $font[0]['font-family'];
+						}
+					}
+					ksort( $additional_fonts );
+				}
+			}
+			$font_family = array(
+				'title'    => __( 'Font family', 'woocommerce' ),
+				'id'       => 'woocommerce_email_font_family',
+				'desc_tip' => '',
+				'default'  => 'Arial',
+				'type'     => 'select',
+				'class'    => 'wc-enhanced-select',
+				'options'  => array_merge(
+					array_combine( array_keys( self::$font ), array_keys( self::$font ) ),
+					$additional_fonts
 				),
 			);
 
@@ -321,6 +364,8 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				$logo_image,
 
 				$header_alignment,
+
+				$font_family,
 
 				$base_color_setting_in_template_opts,
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -699,20 +699,20 @@ class WC_Settings_Emails extends WC_Settings_Page {
 						}
 						?>
 					</optgroup>
-			<?php if ( $custom_fonts = $this->get_custom_fonts() ) : ?>
-			<optgroup label="<?php echo esc_attr__( 'Custom fonts', 'woocommerce' ); ?>">
-				<?php
-				foreach ( $custom_fonts as $key => $val ) {
-					?>
-				<option
-					value="<?php echo esc_attr( $key ); ?>"
-					<?php selected( $option_value, (string) $key ); ?>
-				><?php echo esc_html( $val ); ?></option>
-					<?php
-				}
-				?>
-			</optgroup>
-			<?php endif; ?>
+					<?php if ( $custom_fonts = $this->get_custom_fonts() ) : ?>
+						<optgroup label="<?php echo esc_attr__( 'Custom fonts', 'woocommerce' ); ?>">
+							<?php
+							foreach ( $custom_fonts as $key => $val ) {
+								?>
+							<option
+								value="<?php echo esc_attr( $key ); ?>"
+								<?php selected( $option_value, (string) $key ); ?>
+							><?php echo esc_html( $val ); ?></option>
+								<?php
+							}
+							?>
+						</optgroup>
+					<?php endif; ?>
 				</select>
 			</td>
 		</tr>

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -656,6 +656,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 */
 	public function email_font_family( $value ) {
 		$option_value = $value['value'];
+		$custom_fonts = $this->get_custom_fonts();
 
 		?>
 		<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">
@@ -699,7 +700,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 						}
 						?>
 					</optgroup>
-					<?php if ( $custom_fonts = $this->get_custom_fonts() ) : ?>
+					<?php if ( $custom_fonts ) : ?>
 						<optgroup label="<?php echo esc_attr__( 'Custom fonts', 'woocommerce' ); ?>">
 							<?php
 							foreach ( $custom_fonts as $key => $val ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -667,7 +667,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				function renderWithFont( node ) {
 					if ( ! node.element || ! node.element.value ) return node.text;
 					var $wrapper = jQuery( '<span></span>' );
-					$wrapper.css( {'font-family': node.element.dataset['font-family'] || node.element.value, 'font-size': '1.4em'} );
+					$wrapper.css( {'font-family': node.element.dataset['font-family'] || node.element.value} );
 					$wrapper.text( node.text );
 					return $wrapper;
 				}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -35,7 +35,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 			return ( await page.locator( emailPreviewElement ).count() ) > 0;
 		};
 		const iframeContains = async ( text ) => {
-			const iframe = await page.frameLocator( emailPreviewElement );
+			const iframe = page.frameLocator( emailPreviewElement );
 			return iframe.getByText( text );
 		};
 		const getSubject = async () => {
@@ -257,5 +257,74 @@ test.describe( 'WooCommerce Email Settings', () => {
 		await expect(
 			page.getByText( 'Footer text color', { exact: true } )
 		).toHaveCount( 0 );
+	} );
+
+	test( 'See font family setting with a feature flag', async ( {
+		page,
+		baseURL,
+	} ) => {
+		// Disable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'no' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		await expect( page.getByLabel( 'Font family' ) ).toHaveCount( 0 );
+
+		// Enable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.reload();
+
+		const fontFamilyElement = page.getByLabel( 'Font family' );
+		await expect( fontFamilyElement ).toBeVisible();
+
+		// Test standard font selection
+		await fontFamilyElement.selectOption( 'Times New Roman' );
+
+		// Test theme font selection
+		await fontFamilyElement.selectOption( 'Inter' );
+	} );
+
+	test( 'See updated footer text field with a feature flag', async ( {
+		page,
+		baseURL,
+	} ) => {
+		let footerTextLabel;
+
+		// Disable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'no' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		footerTextLabel = page.locator(
+			'css=label[for="woocommerce_email_footer_text"]'
+		);
+		await expect( footerTextLabel ).toBeVisible();
+
+		// Old tooltip text
+		const tooltip = footerTextLabel.locator( 'span.woocommerce-help-tip' );
+		await expect( tooltip ).not.toHaveAttribute(
+			'aria-label',
+			'{store_address}'
+		);
+
+		// Enable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.reload();
+
+		footerTextLabel = page.locator(
+			'css=label[for="woocommerce_email_footer_text"]'
+		);
+		await expect( footerTextLabel ).toBeVisible();
+
+		// New tooltip text
+		const updatedTooltip = footerTextLabel.locator(
+			'span.woocommerce-help-tip'
+		);
+		await expect( updatedTooltip ).toHaveAttribute(
+			'aria-label',
+			expect.stringContaining( '{store_address}' )
+		);
+		await expect( updatedTooltip ).toHaveAttribute(
+			'aria-label',
+			expect.stringContaining( '{store_email}' )
+		);
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the feature flag is enabled, a font family setting is added to email settings. Also, the footer text setting is improved with a new description, a default value and new placeholders: `{store_address}` and `{store_email}`.

Closes #52222.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Settings > Emails` and observe the absence of the font family setting and an old footer text setting.
2. Enable the email_improvements feature flag. It's hidden in the UI, so this needs to be done in the database: set the `woocommerce_feature_email_improvements_enabled` option to `yes`.
3. Reload the email settings page.
4. You should now see the font family setting which allows to select standard fonts as well as fonts from theme.json.
5. You will also see that the email footer text setting is updated with a new description and default value.
5. New placeholders are added to the footer text: `{store_address}` and `{store_email}`. Try using them in an email and see that they are properly expanded.

<!-- End testing instructions -->
