### PR TITLE
[Settings] Remove GlobalStylesProvider

### DIFF
--- a/packages/js/settings-editor/changelog/53231-fix-settings-global-styles
+++ b/packages/js/settings-editor/changelog/53231-fix-settings-global-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Remove GlobalStylesProvider because its not required.
+

--- a/packages/js/settings-editor/src/index.tsx
+++ b/packages/js/settings-editor/src/index.tsx
@@ -8,10 +8,6 @@ import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 // @ts-ignore No types for this exist yet.
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
-import {
-	// @ts-expect-error No types for this exist yet.
-	privateApis as editorPrivateApis,
-} from '@wordpress/editor';
 /* eslint-enable @woocommerce/dependency-group */
 
 /**
@@ -22,7 +18,6 @@ import { Layout } from './layout';
 import { useActiveRoute } from './route';
 
 const { RouterProvider } = unlock( routerPrivateApis );
-const { GlobalStylesProvider } = unlock( editorPrivateApis );
 
 const SettingsLayout = () => {
 	const { route, settingsPage, tabs, activeSection } = useActiveRoute();
@@ -53,11 +48,9 @@ export const SettingsEditor = () => {
 	}
 
 	return (
-		<GlobalStylesProvider>
-			<RouterProvider>
-				<SettingsLayout />
-			</RouterProvider>
-		</GlobalStylesProvider>
+		<RouterProvider>
+			<SettingsLayout />
+		</RouterProvider>
 	);
 };
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53168

`<GlobalStylesProvider />` uses several round trips to the server to get styles unique to the user and site theme before painting the screen. These are used for blocks and don't have styles pertaining to the admin UI, so this PR removes the provider for better performance.

Before and after removing GlobalStylesProvider.

<img width="317" alt="Screenshot 2024-11-27 at 3 10 41 PM" src="https://github.com/user-attachments/assets/0f230c3a-9a5f-48a9-9e7e-b82436bce9ea">
<img width="322" alt="Screenshot 2024-11-27 at 3 10 03 PM" src="https://github.com/user-attachments/assets/84f11567-e0c3-4f2e-82d9-8fde57a440cd">

@louwie17 the Product Editor has the same situation. Customize Your Store uses this functionality because it previews the site, so data like color palette is useful. If you wish to keep this, its possible to preload this data to avoid several round trips.

https://github.com/woocommerce/woocommerce/blob/930f7a9272cac95f5ffaa58d88608a9ec74a80f4/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php#L187-L201

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add/Enable Gutenberg and turn on the `settings` feature flag
2. WooCommerce > Settings and see the page loads without error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Remove GlobalStylesProvider because its not required.

</details>
