### PR TITLE
[Settings] Avoid brief flash of Page Not Found

### DIFF
--- a/packages/js/settings-editor/changelog/53232-fix-settings-flash-modern-screens
+++ b/packages/js/settings-editor/changelog/53232-fix-settings-flash-modern-screens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Make sure Modern settings screens are available on first run.
+

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -139,7 +139,9 @@ const getModernPages = () => {
  * @return {Record<string, Route>} The pages.
  */
 export function useModernRoutes(): Record< string, Route > {
-	const [ routes, setRoutes ] = useState< Record< string, Route > >( {} );
+	const [ routes, setRoutes ] = useState< Record< string, Route > >(
+		getModernPages()
+	);
 	const location = useLocation() as Location;
 
 	/*
@@ -167,7 +169,7 @@ export function useModernRoutes(): Record< string, Route > {
 		};
 	}, [] );
 
-	// Update modern when the location changes.
+	// Update modern pages when the location changes.
 	useEffect( () => {
 		setRoutes( getModernPages() );
 	}, [ location.params ] );

--- a/packages/js/settings-editor/src/tests/route.test.tsx
+++ b/packages/js/settings-editor/src/tests/route.test.tsx
@@ -181,7 +181,7 @@ describe( 'route.tsx', () => {
 				.calls[ 0 ][ 2 ];
 			hookAddedCallback( 'unrelated_hook' );
 
-			expect( applyFilters ).toHaveBeenCalledTimes( 1 ); // Only initial call
+			expect( applyFilters ).toHaveBeenCalledTimes( 2 ); // Only initial call
 		} );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53168

When viewing Modern pages, there is a flash of "Page Not Found" because the modern routes have not yet been gathered on the first run.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add/Enable Gutenberg and turn on the `settings` feature flag
2. Use the [Settings Tester](https://github.com/woocommerce/woocommerce-settings-migration-tester) to test Modern screens. Clone it locally and `npm install && npm run plugin-zip`
3. WooCommerce > Settings > Modern Settings

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Make sure Modern settings screens are available on first run.

</details>
