### PR TITLE
Fix janky core profiler UI interactions

### DIFF
--- a/plugins/woocommerce/changelog/fix-53130-janky-core-profiler
+++ b/plugins/woocommerce/changelog/fix-53130-janky-core-profiler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix janky interactions in core profiler

--- a/plugins/woocommerce/client/admin/client/core-profiler/components/choice/choice.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/components/choice/choice.scss
@@ -8,13 +8,13 @@
 	width: 100%;
 	cursor: pointer;
 
-	&[data-selected] {
-		border: 2px solid var(--wp-admin-theme-color);
-		border-radius: 4px;
+	&[data-selected],
+	&:focus-visible {
+		border-color: var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
 	}
 
 	&:focus-visible {
-		border: 2px solid  var(--wp-admin-theme-color);
 		padding: $gap-large $gap;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce/client/admin/client/core-profiler/style.scss
@@ -27,6 +27,7 @@
 	.woocommerce-select-control__control-input,
 	.components-base-control__help {
 		cursor: pointer;
+		line-height: initial;
 	}
 }
 
@@ -267,6 +268,7 @@
 		.woocommerce-select-control__control-input {
 			margin: 0;
 			padding: 0;
+			padding-left: 1px;
 		}
 
 		.woocommerce-select-control.is-searchable
@@ -636,6 +638,7 @@
 		.woocommerce-select-control__control-input {
 			margin: 0;
 			padding: 0;
+			padding-left: 1px;
 		}
 
 		.woocommerce-select-control.is-searchable


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #53130

Fixes the following in core profiler:

- Jumpy radio button when changing state from selecting and de-selecting in user profile screen
- Jumpy input when activating search in industry textbox
- Vertically center caret in industry textbox

#### Before:

https://github.com/user-attachments/assets/06c553d3-4378-4a3d-b8e0-c05eda6b4612

https://github.com/user-attachments/assets/892d3964-56fd-4634-9fac-8d4abfa8ebaa

#### After:

https://github.com/user-attachments/assets/fc37e28f-e2be-40d8-9d62-1a66c7f990e0

https://github.com/user-attachments/assets/f8fbafc3-6556-4e64-a57f-3d7b0629ea84

### How to test the changes in this Pull Request:

1. Go to core profiler
2. In user profile screen, switch between radio buttons and observe the contents do not jump around
3. In business info screen, click on industry and observe the placeholder do not jump around
4. Observe the industry's caret icon is vertically centered

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>