### PR TITLE
[dev] Monorepo: drop .wireit cache folders older than four weeks

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -21,6 +21,6 @@ staleWireitDirectories=$(( \
 if [[ $staleWireitDirectories -gt 0 ]]; then
 	echo "Cleaning up stale wireit-cache ($staleWireitDirectories directories)"
 	find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
-    find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
-    find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
+	find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
+	find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -14,9 +14,9 @@ fi
 
 # Cleanup .wireit cache that is older than 4 weeks (28 days); otherwise, the repository directory size keeps growing and growing.
 staleWireitDirectories=$(( \
-	$( find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -printf '.' 2>/dev/null | wc -c ) + \
-	$( find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -printf '.' 2>/dev/null | wc -c ) + \
-	$( find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -printf '.' 2>/dev/null | wc -c ) \
+	$( find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) + \
+	$( find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) + \
+	$( find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) \
 ))
 if [[ $staleWireitDirectories -gt 0 ]]; then
 	echo "Cleaning up stale wireit-cache ($staleWireitDirectories directories)"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -3,6 +3,7 @@
 
 # The hook documentation: https://git-scm.com/docs/githooks.html#_post_merge
 
+# Refresh dependencies when pulled changes might change the deps.
 changedManifests=$( ( git diff --name-only HEAD ORIG_HEAD  | grep -E '(package.json|pnpm-lock.yaml|pnpm-workspace.yaml|composer.json|composer.lock)$' ) || echo '' )
 if [ -n "$changedManifests" ]; then
 	printf "It was a change in the following file(s) - refreshing dependencies:\n"
@@ -10,3 +11,8 @@ if [ -n "$changedManifests" ]; then
 
 	pnpm install --frozen-lockfile
 fi
+
+# Cleanup .wireit cache that is older than 4 weeks; otherwise, the repository directory size keeps growing and growing.
+find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \;
+find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \;
+find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \;

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -12,7 +12,15 @@ if [ -n "$changedManifests" ]; then
 	pnpm install --frozen-lockfile
 fi
 
-# Cleanup .wireit cache that is older than 4 weeks; otherwise, the repository directory size keeps growing and growing.
-find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \;
-find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \;
-find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \;
+# Cleanup .wireit cache that is older than 4 weeks (28 days); otherwise, the repository directory size keeps growing and growing.
+staleWireitDirectories=$(( \
+	$( find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -printf '.' 2>/dev/null | wc -c ) + \
+	$( find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -printf '.' 2>/dev/null | wc -c ) + \
+	$( find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -printf '.' 2>/dev/null | wc -c ) \
+))
+if [[ $staleWireitDirectories -gt 0 ]]; then
+	echo "Cleaning up stale wireit-cache ($staleWireitDirectories directories)"
+	find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
+    find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
+    find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
+fi


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: monorepo feedback from eng. teams

- Drop stale cache directories when pulling changes from origin

### How to test the changes in this Pull Request:

- Execute the new commands locally; they should succeed
