### PR TITLE
Fix E2E selector so it works on both WordPress 6.7 and 6.6

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
@@ -37,10 +37,9 @@ export class Admin extends CoreAdmin {
 		};
 
 		const editorLoaded = async () => {
-			// Wait for Editor to load.
 			await this.page
 				.getByRole( 'heading', {
-					name: `${ name } · Pattern`,
+					name: 'pattern',
 				} )
 				.waitFor();
 		};

--- a/plugins/woocommerce/changelog/fix-e2e-tests-wp-6-6
+++ b/plugins/woocommerce/changelog/fix-e2e-tests-wp-6-6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update the E2E selector so it covers WordPress 6.7 and 6.6, not worth mentioning in changelog
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/53077 I added new tests to cover patterns creations. Unfortunately one selector worked only on WordPress 6.7 and failed on 6.6. This PR makes the selector more universal in similar way as it was fixed by @gigitux in this PR: https://github.com/woocommerce/woocommerce/pull/52909.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To be tested ONLY by developers!

1. Build the Blocks E2E test environment with WP 6.7 (default setup): `nvm use && pnpm --filter=@woocommerce/block-library env:start`
2. Run tests regarding patterns: `nvm use && pnpm --filter=@woocommerce/block-library test:e2e --ui tests/e2e/tests/patterns`
3. **Expected:** All four tests pass
4. Destroy the env: `nvm use && pnpm --filter=@woocommerce/block-library wp-env destroy`
5. Change the WordPress version to 6.6.2 in testing environment [in here](https://github.com/woocommerce/woocommerce/blob/ea39de5f6ee6b75c40fb9105639fc4c158039047/plugins/woocommerce-blocks/.wp-env.json#L2): `"core": "https://wordpress.org/wordpress-6.6.2.zip",`
6. Build the Blocks E2E test environment again with WP 6.6: `nvm use && pnpm --filter=@woocommerce/block-library env:start`
7. Run tests regarding patterns: `nvm use && pnpm --filter=@woocommerce/block-library test:e2e --ui tests/e2e/tests/patterns`
8. **Expected:** All four tests pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
