### PR TITLE
[Accessibility] Add aria modal attribute to photoswipe

### DIFF
--- a/plugins/woocommerce/changelog/fix-51926
+++ b/plugins/woocommerce/changelog/fix-51926
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add aria modal attribute to photoswipe

--- a/plugins/woocommerce/templates/single-product/photoswipe.php
+++ b/plugins/woocommerce/templates/single-product/photoswipe.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.0.0
+ * @version 9.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/single-product/photoswipe.php
+++ b/plugins/woocommerce/templates/single-product/photoswipe.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="pswp" tabindex="-1" role="dialog" aria-modal="true" aria-hidden="true">
 	<div class="pswp__bg"></div>
 	<div class="pswp__scroll-wrap">
 		<div class="pswp__container">


### PR DESCRIPTION
### Submission Review Guidelines:

- * I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- * I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- * I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- * Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #51926 .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Browse to a product page on the frontend
2. Open the product image modal

Test Accessibility in using Chrome dev tools.

1. Browse to a product page on the frontend
2. Open Dev Tools
3. Select "Accessibility" under "Elements"
4. Enable "Enable full-page accessibility tree"
5. Reload the page
6. Open the product image modal
8. Ensure only the "dialog" tree is present when the modal is open;

<img width="454" alt="image" src="https://github.com/user-attachments/assets/a7e74f57-e5bf-40e0-8210-2f0d945df67b">

### Changelog entry

- * [ ] Automatically create a changelog entry from the details below.
- * [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance
#### Type

</details>
