### PR TITLE
Try: Add to Cart with options Button block based on core blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-add-to-cart-with-options",
+	"version": "1.0.0",
+	"title": "Add To Cart with Options (Experimental)",
+	"description": "Create an \"Add To Cart\" composition by using blocks",
+	"category": "woocommerce",
+	"keywords": [
+		"WooCommerce"
+	],
+	"textdomain": "woocommerce",
+	"supports": {
+		"interactivity": true
+	},
+	"example": {}
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/edit.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlockTemplate } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+
+const TEMPLATE: InnerBlockTemplate[] = [
+	[
+		'core/heading',
+		{
+			level: 2,
+			content: __( 'Add to Cart', 'woocommerce' ),
+		},
+	],
+	[
+		'core/buttons',
+		{
+			className: 'wc-block-product-add-to-cart-with-options-buttons',
+			layout: {
+				type: 'flex',
+				verticalAlignment: 'center',
+				justifyContent: 'center',
+			},
+			metadata: {
+				name: __( 'Cart Buttons', 'woocommerce' ),
+			},
+		},
+		[
+			[
+				'core/button',
+				{
+					className:
+						'wc-block-product-add-to-cart-with-options-button',
+					text: __( 'Add to Cart', 'woocommerce' ),
+					withRole: 'add-to-cart-with-options-button',
+					lock: {
+						remove: true,
+						move: true,
+					},
+					metadata: {
+						bindings: {
+							url: {
+								source: 'core/post-meta',
+								args: {
+									key: 'add_to_cart_url',
+								},
+							},
+						},
+					},
+				},
+			],
+		],
+	],
+];
+
+export default function AddToCartWithOptionsEdit() {
+	const blockProps = useBlockProps( {
+		className: clsx( 'wc-block-product-add-to-cart' ),
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks templateLock={ false } template={ TEMPLATE } />
+		</div>
+	);
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/frontend.ts
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { store } from '@woocommerce/interactivity';
+
+store( 'woocommerce/product-add-to-cart-with-options', {
+	actions: {
+		addToCart: () => {
+			console.log( 'Add to cart' ); // eslint-disable-line no-console
+		},
+	},
+} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import AddToCartWithOptionsEdit from './edit';
+import save from './save';
+import './style.scss';
+
+if ( isExperimentalBlocksEnabled() ) {
+	registerBlockType( metadata, {
+		edit: AddToCartWithOptionsEdit,
+		save,
+	} );
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/save.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/save.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import {
+	useBlockProps,
+
+	// @ts-expect-error no exported member.
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+
+export default function save(): JSX.Element {
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <div { ...innerBlocksProps } />;
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-add-to-cart-with-options/style.scss
@@ -1,0 +1,1 @@
+// Block styles

--- a/plugins/woocommerce-blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce-blocks/bin/webpack-entries.js
@@ -88,6 +88,9 @@ const blocks = {
 	},
 	'single-product': {},
 	'stock-filter': {},
+	'product-add-to-cart-with-options': {
+		isExperimental: true,
+	},
 	'product-filters': {
 		isExperimental: true,
 	},

--- a/plugins/woocommerce/changelog/update-atcwo-wrapper-block
+++ b/plugins/woocommerce/changelog/update-atcwo-wrapper-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: Implement Add To Cart with options button based on core blocks

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductAddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductAddToCartWithOptions.php
@@ -85,12 +85,10 @@ class ProductAddToCartWithOptions extends AbstractBlock {
 
 		$processor = new \WP_HTML_Tag_Processor( $content );
 
-		if ( $processor->next_tag(
-			array(
-				'tag_name'   => 'div',
-				'class_name' => 'wp-block-woocommerce-product-add-to-cart-with-options',
-			) )
-		) {
+		if ( $processor->next_tag( array(
+			'tag_name'   => 'div',
+			'class_name' => 'wp-block-woocommerce-product-add-to-cart-with-options',
+		) ) ) {
 			$processor->set_attribute( 'data-wc-interactive', $data_wc_interactive );
 
 			if ( $processor->next_tag( array( 'tag_name' => 'a', 'class_name' => 'wp-element-button' ) ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductAddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductAddToCartWithOptions.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+
+/**
+ * CatalogSorting class.
+ */
+class ProductAddToCartWithOptions extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-add-to-cart-with-options';
+
+	/**
+	 * Initialize the block type
+	 */
+	public function initialize() {
+		parent::initialize();
+		add_filter( 'register_block_type_args', array( $this, 'add_attributes_to_button_blocks' ), 10, 2 );
+	}
+
+	/**
+	 * Add attributes to button blocks.
+	 *
+	 * @param array  $args Block type args.
+	 * @param string $block_name Block name.
+	 * @return array
+	 */
+	public function add_attributes_to_button_blocks( $args, $block_name ) {
+		if ( 'core/button' === $block_name ) {
+			if ( ! isset( $args['attributes'] ) ) {
+				$args['attributes'] = array();
+			}
+	
+			$args['attributes']['withRole'] = array(
+				'type'    => 'string',
+			);
+
+			if ( ! isset( $args['variations'] ) ) {
+				$args['variations'] = array();
+			}
+
+			$args['variations'][] = array(
+				'name'        => 'woocommerce/product-add-to-cart-with-options-button',
+				'title'       => __( 'Add To Cart Button (Experimental)', 'woocommerce' ),
+				'description' => __( 'Add a Button block to add product quantity to cart.', 'woocommerce' ),
+				'attributes'  => array(
+					'className' => 'wc-block-product-add-to-cart-with-options-button',
+					'withRole'  => 'add-to-cart-with-options-button',
+					'text'      => __( 'Add to Cart', 'woocommerce' ),
+				),
+				'scope'        => array(
+					'block',
+				),
+				'isActive'     => [ 'withRole' ],
+				'isDefault'    => false,
+			);
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    - $attributes Block attributes.
+	 * @param string   - $content Block content.
+	 * @param WP_Block - $block Block instance.
+	 *
+	 * @return string | void Rendered block output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		// Interactivity API - Namespace and Context
+		$i_api_namespace     = $this->get_full_block_name();
+		$data_wc_interactive = wp_json_encode( array( 'namespace' => $i_api_namespace ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
+
+		// Interactivity API - Add to Cart Button / Actions
+		$data_wc_add_to_cart_action = $i_api_namespace . '::actions.addToCart';
+
+		$processor = new \WP_HTML_Tag_Processor( $content );
+
+		if ( $processor->next_tag( array( 'tag_name' => 'div', 'class_name' => 'wp-block-woocommerce-product-add-to-cart-with-options' ) ) ) {
+			$processor->set_attribute( 'data-wc-interactive', $data_wc_interactive );
+
+			if ( $processor->next_tag( array( 'tag_name' => 'a', 'class_name' => 'wp-element-button' ) ) ) {
+				$processor->set_attribute( 'data-wc-on--click', $data_wc_add_to_cart_action );
+			}
+        }
+
+		return $processor->get_updated_html();
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductAddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductAddToCartWithOptions.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
@@ -36,9 +37,9 @@ class ProductAddToCartWithOptions extends AbstractBlock {
 			if ( ! isset( $args['attributes'] ) ) {
 				$args['attributes'] = array();
 			}
-	
+
 			$args['attributes']['withRole'] = array(
-				'type'    => 'string',
+				'type' => 'string',
 			);
 
 			if ( ! isset( $args['variations'] ) ) {
@@ -54,11 +55,11 @@ class ProductAddToCartWithOptions extends AbstractBlock {
 					'withRole'  => 'add-to-cart-with-options-button',
 					'text'      => __( 'Add to Cart', 'woocommerce' ),
 				),
-				'scope'        => array(
+				'scope'       => array(
 					'block',
 				),
-				'isActive'     => [ 'withRole' ],
-				'isDefault'    => false,
+				'isActive'    => [ 'withRole' ],
+				'isDefault'   => false,
 			);
 		}
 
@@ -75,22 +76,27 @@ class ProductAddToCartWithOptions extends AbstractBlock {
 	 * @return string | void Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		// Interactivity API - Namespace and Context
+		// Interactivity API - Namespace and Context.
 		$i_api_namespace     = $this->get_full_block_name();
 		$data_wc_interactive = wp_json_encode( array( 'namespace' => $i_api_namespace ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
 
-		// Interactivity API - Add to Cart Button / Actions
+		// Interactivity API - Add to Cart Button / Actions.
 		$data_wc_add_to_cart_action = $i_api_namespace . '::actions.addToCart';
 
 		$processor = new \WP_HTML_Tag_Processor( $content );
 
-		if ( $processor->next_tag( array( 'tag_name' => 'div', 'class_name' => 'wp-block-woocommerce-product-add-to-cart-with-options' ) ) ) {
+		if ( $processor->next_tag(
+			array(
+				'tag_name'   => 'div',
+				'class_name' => 'wp-block-woocommerce-product-add-to-cart-with-options',
+			) )
+		) {
 			$processor->set_attribute( 'data-wc-interactive', $data_wc_interactive );
 
 			if ( $processor->next_tag( array( 'tag_name' => 'a', 'class_name' => 'wp-element-button' ) ) ) {
 				$processor->set_attribute( 'data-wc-on--click', $data_wc_add_to_cart_action );
 			}
-        }
+		}
 
 		return $processor->get_updated_html();
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -453,6 +453,8 @@ final class BlockTypesController {
 		// Update plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
 		// when modifying this list.
 		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$block_types[] = 'ProductAddToCartWithOptions';
+
 			$block_types[] = 'ProductFilters';
 			$block_types[] = 'ProductFilterStatus';
 			$block_types[] = 'ProductFilterPrice';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a research PR to implement the `Add To Cart with options Button` using core blocks.

## Approach 

### Introduce `core/button` variation

To get more control over the `core/block,` this PR introduces the `woocommerce/product-add-to-cart-with-options-button` variation.
Also, it extends the `core/button` block, adding the new `whole` string attribute. It detects the variation (via the `isActive`) property.

### Interactivity API integration

To integrate the block with the Interactivity API, this PR tweaks the render method of the block, populating the markup with the proper attributes. 
This super basic block version handles the event when the user clicks on the button, showing a log in the dev console.

### Remove `Link` toolbar button

This has been handled (maybe) with a workaround. We use the Binding API to bind the `URL` block attribute with an external source. With this, the block gets bound, disabling the ability to edit the attribute, which fits appropriately with our requirements, if I'm not wrong.
In some cases, we could also use it to set up a valid URL.

## Limitations and considerations

* **We cannot extend the styles panel for these variations.**
It isn't a big deal, but we'll probably have to handle the `Link` button mode.

* A core button instance requires a `core/buttons` parent block instance. 

Closes #53206

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the feature flags
2. Edit the Single Product template

https://github.com/user-attachments/assets/1650604e-cedd-4964-938b-3825ce774751

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
