### PR TITLE
Make Add to Cart with Options tooltip string translatable

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -88,7 +88,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 			<div { ...blockProps }>
 				<Tooltip
-					text="Customer will see product add-to-cart options in this space, dependent on the product type. "
+					text={ __( 'Customer will see product add-to-cart options in this space, dependent on the product type.', 'woocommerce' ) }
 					position="bottom right"
 				>
 					<div className="wc-block-editor-add-to-cart-form-container">

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -115,9 +115,9 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 													  }
 													: {}
 											}
-											type={ 'number' }
-											value={ '1' }
-											className={ 'input-text qty text' }
+											type="number"
+											value="1"
+											className="input-text qty text"
 											readOnly
 										/>
 									</div>
@@ -154,11 +154,9 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 														  }
 														: {}
 												}
-												type={ 'number' }
-												value={ '1' }
-												className={
-													'input-text qty text'
-												}
+												type="number"
+												value="1"
+												className="input-text qty text"
 												readOnly
 											/>
 											<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -88,7 +88,10 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 			<div { ...blockProps }>
 				<Tooltip
-					text={ __( 'Customer will see product add-to-cart options in this space, dependent on the product type.', 'woocommerce' ) }
+					text={ __(
+						'Customer will see product add-to-cart options in this space, dependent on the product type.',
+						'woocommerce'
+					) }
 					position="bottom right"
 				>
 					<div className="wc-block-editor-add-to-cart-form-container">

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -14,10 +14,6 @@
 	}
 }
 
-.wc-block-editor-quantity-selector-style {
-	width: 100%;
-}
-
 .quantity .qty {
 	// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
 	width: 3.631em;
@@ -32,10 +28,6 @@ div.product form.cart div.quantity {
 
 input {
 	height: auto;
-}
-
-.wc-block-components-quantity-selector--input {
-	padding: unset;
 }
 
 .wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -88,7 +88,6 @@ export const AddToCartFormSettings = ( {
 			{ isStepperLayoutFeatureEnabled && (
 				<PanelBody title={ __( 'Quantity Selector', 'woocommerce' ) }>
 					<ToggleGroupControl
-						className="wc-block-editor-quantity-selector-style"
 						__nextHasNoMarginBottom
 						value={ quantitySelectorStyle }
 						isBlock

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -100,6 +100,7 @@ div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 
 	.wc-block-components-quantity-selector {
 		display: inline-flex;
+
 		.input-text {
 			font-size: var(--wp--preset--font-size--small);
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -73,20 +73,6 @@ div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 		}
 	}
 
-	input[type="number"].input-text.qty.text {
-		border: unset;
-		text-align: center;
-		order: 1;
-		/**
-		* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
-		*
-		* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
-		*/
-		padding: 0.9rem 0;
-		margin-right: unset;
-		font-size: var(--wp--preset--font-size--small);
-	}
-
 	// Grouped Product
 	table.woocommerce-grouped-product-list.group_table > tbody {
 		td .wc-block-components-quantity-selector {
@@ -124,10 +110,20 @@ div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 			margin: 0;
 		}
 
-		input[type="number"].qty.input-text.text {
-			margin: 0;
+		input[type="number"].input-text.qty.text {
+			-moz-appearance: textfield;
 			border: unset;
+			text-align: center;
 			order: 1;
+			margin: 0;
+			/**
+			* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
+			*
+			* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
+			*/
+			padding: 0.9rem 0;
+			margin-right: unset;
+			font-size: var(--wp--preset--font-size--small);
 		}
 	}
 }

--- a/plugins/woocommerce/changelog/fix-add-to-cart-form-untranslatable-string
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-form-untranslatable-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make Add to Cart with Options tooltip text localizable


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes some minor fixes and improvements to the Add to Cart with Options block that I noticed while working on #53251.

Specifically, it changes:

* Makes the tooltip string localizable (3e443de1ec5afa5efcb72750f04445856237a47c).
* Updates React string props format (acdf3370b83b13bc39ecc681a0a9117928faf114).
* Removes unused CSS rules, merges two duplicate rules into one and add `-moz-appearance: textfield;` to the input button when in _Stepper_ mode (c2114792dc5da11001052b623694e1d6885e20be).

### How to test the changes in this Pull Request:

Testing this PR is mostly focused on making sure there are no regressions:

1. Go to Appearance > Editor > Templates > Single Product.
2. Verify the Add to Cart with Options block is rendered correctly and there are no style regressions.
3. Visit a product page in the frontend and verify there are no visible regressions either.
4. (If you are using a dev build) In the Site Editor, switch the quantity selector type to _Stepper_ and verify there are no visible regressions in the editor or the frontend. In Firefox, verify the default input steppers are not visible.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/515af450-c395-4eba-9ccc-2ca9aa7bb6ae) | ![imatge](https://github.com/user-attachments/assets/0df59bde-2c87-4a4b-8634-f995524d3dd0)