### PR TITLE
[e2e tests] Fix flaky Customize Store Header and Footer tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-gutenberg-customize-store-header-footer
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-gutenberg-customize-store-header-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixed flakiness in the customize store header and footer tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
@@ -80,12 +80,14 @@ test.describe( 'Assembler -> Footers', { tag: '@gutenberg' }, () => {
 		assemblerPage,
 	} ) => {
 		const assembler = await assemblerPage.getAssembler();
-		const footer = assembler
-			.locator( '.block-editor-block-patterns-list__item' )
-			.nth( 2 );
+		const footers = assembler.locator(
+			'.block-editor-block-patterns-list__item'
+		);
 
-		await footer.click();
-		await expect( footer ).toHaveClass( /is-selected/ );
+		await expect( footers ).toHaveCount( 3 );
+		await expect( footers.nth( 2 ) ).toBeVisible();
+		await footers.nth( 2 ).click();
+		await expect( footers.nth( 2 ) ).toHaveClass( /is-selected/ );
 	} );
 
 	test( 'The selected footer should be applied on the frontend', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
@@ -80,12 +80,14 @@ test.describe( 'Assembler -> headers', { tag: '@gutenberg' }, () => {
 		assemblerPage,
 	} ) => {
 		const assembler = await assemblerPage.getAssembler();
-		const header = assembler
-			.locator( '.block-editor-block-patterns-list__item' )
-			.nth( 2 );
+		const headers = assembler.locator(
+			'.block-editor-block-patterns-list__item'
+		);
 
-		await header.click();
-		await expect( header ).toHaveClass( /is-selected/ );
+		await expect( headers ).toHaveCount( 5 );
+		await expect( headers.nth( 4 ) ).toBeVisible();
+		await headers.nth( 2 ).click();
+		await expect( headers.nth( 2 ) ).toHaveClass( /is-selected/ );
 	} );
 
 	test( 'The selected header should be applied on the frontend', async ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53275

I wasn't able to reproduce the flakiness locally and it seems to happen with Gutenberg installed, but according to trace file used from the flaky run, it is obvious that it attempted to click the third header/footer item but it actually clicked the 2nd one due to slowly loading header/footer elements on page (known performance issue).

I added some assertions before clicking the 3rd header/footer on page to avoid this flaky action.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```
pnpm test:e2e tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
```
```
pnpm test:e2e tests/e2e-pw/tests/customize-store/assembler/header.spec.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
