### PR TITLE
[dev] Monorepo: fix bash warning in git post-merge hook.

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -18,7 +18,7 @@ staleWireitDirectories=$(( \
 	$( find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) + \
 	$( find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) \
 ))
-if [[ $staleWireitDirectories -gt 0 ]]; then
+if [ $staleWireitDirectories -gt 0 ]; then
 	echo "Cleaning up stale wireit-cache ($staleWireitDirectories directories)"
 	find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
 	find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes `.husky/post-merge: 21: [[: not found` warning appearing when script executed by git.

### How to test the changes in this Pull Request:

n/a
