### PR TITLE
[dev] Monorepo: update pr-highlight-changes.yml and pass base reference into linting

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -30,10 +30,9 @@ jobs:
         env:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
-          HEAD_REF=$(git rev-parse HEAD)
           exclude="plugins/woocommerce/tests"
-          version=$(pnpm analyzer major-minor "$HEAD_REF" "plugins/woocommerce/woocommerce.php" | tail -n 1)
-          pnpm analyzer "$HEAD_REF" $version --outputStyle "github" --exclude $exclude
+          version=$(pnpm analyzer major-minor "${{ github.event.pull_request.head.sha }}" "plugins/woocommerce/woocommerce.php" | tail -n 1)
+          pnpm analyzer "${{ github.event.pull_request.head.sha }}" $version --base "${{ github.event.pull_request.base.sha }}" --outputStyle "github" --exclude $exclude
       - uses: 'actions/github-script@v6'
         name: 'Validate'
         with:

--- a/plugins/woocommerce/templates/single-product/related.php
+++ b/plugins/woocommerce/templates/single-product/related.php
@@ -30,6 +30,7 @@ if ( $related_products ) : ?>
 			?>
 			<h2><?php echo esc_html( $heading ); ?></h2>
 		<?php endif; ?>
+
 		<?php woocommerce_product_loop_start(); ?>
 
 			<?php foreach ( $related_products as $related_product ) : ?>

--- a/plugins/woocommerce/templates/single-product/related.php
+++ b/plugins/woocommerce/templates/single-product/related.php
@@ -30,7 +30,6 @@ if ( $related_products ) : ?>
 			?>
 			<h2><?php echo esc_html( $heading ); ?></h2>
 		<?php endif; ?>
-
 		<?php woocommerce_product_loop_start(); ?>
 
 			<?php foreach ( $related_products as $related_product ) : ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1732810917576789-slack-C03CPM3UXDJ

With this change, we are passing base sha1 into linter so it correctly recognizes the diff for different target branches.

### How to test the changes in this Pull Request:

CI-checks shall pass. Test run for a failing check: [here](https://github.com/woocommerce/woocommerce/actions/runs/12081143883/job/33689695251?pr=53297).