### PR TITLE
[e2e tests] Fix flaky create grouped product test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-grouped-products-tests
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-grouped-products-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixed flaky test for creating a grouped product

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-grouped-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-grouped-product-block-editor.spec.js
@@ -51,6 +51,11 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 		test( 'can create a grouped product', async ( { page } ) => {
 			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
 			await clickOnTab( 'General', page );
+			const waitForProductResponse = page.waitForResponse(
+				( response ) =>
+					response.url().includes( '/wp-json/wc/v3/products/' ) &&
+					response.status() === 200
+			);
 			await page
 				.getByPlaceholder( 'e.g. 12 oz Coffee Mug' )
 				.fill( productData.name );
@@ -72,11 +77,11 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 				.getByText( 'Grouped product' )
 				.click();
 
-			await page.waitForResponse(
-				( response ) =>
-					response.url().includes( '/wp-json/wc/v3/products/' ) &&
-					response.status() === 200
-			);
+			await expect(
+				page.getByLabel( 'Dismiss this notice' )
+			).toContainText( 'Product type changed.' );
+
+			await waitForProductResponse;
 
 			await page
 				.locator( '[data-title="Product section"]' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50820

These tests were pretty non flaky but sometimes flaky. As Buildkite says, over 98% reliability score.

The flaky part was waiting for a response. I added a regression step instead of waiting for a response to fix the flakiness and increase coverage. It worked well locally, both with and without Gutenberg—100% success.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```
pnpm test:e2e tests/e2e-pw/tests/merchant/products/block-editor/create-grouped-product-block-editor.spec.js --repeat-each=10
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
