### PR TITLE
Product reviews: improve how reviews are printend on the admin side

### DIFF
--- a/plugins/woocommerce/changelog/53313-improve-hardening-measure-review-comment
+++ b/plugins/woocommerce/changelog/53313-improve-hardening-measure-review-comment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Product reviews: improve how reviews are printend on the admin side.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -957,7 +957,9 @@ class ReviewsListTable extends WP_List_Table {
 			echo $in_reply_to . '<br><br>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
+		echo '<div class="comment-text">';
 		comment_text( $item->comment_ID );
+		echo '</div>';
 
 		if ( $this->current_user_can_edit_review ) {
 			?>

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -957,12 +957,7 @@ class ReviewsListTable extends WP_List_Table {
 			echo $in_reply_to . '<br><br>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		printf(
-			'%1$s%2$s%3$s',
-			'<div class="comment-text">',
-			get_comment_text( $item->comment_ID ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			'</div>'
-		);
+		comment_text( $item->comment_ID );
 
 		if ( $this->current_user_can_edit_review ) {
 			?>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -600,7 +600,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$column_content = ob_get_clean();
 
 		$this->assertStringNotContainsString( 'In reply to', $column_content );
-		$this->assertStringContainsString( '<div class="comment-text">Test review</div>', $column_content );
+		$this->assertStringContainsString( '<div class="comment-text"><p>Test review</p></div>', trim( $column_content ) );
 
 		$reply = $this->factory()->comment->create_and_get(
 			[

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -598,9 +598,15 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->invokeArgs( $list_table, [ $review ] );
 
 		$column_content = ob_get_clean();
-
 		$this->assertStringNotContainsString( 'In reply to', $column_content );
-		$this->assertStringContainsString( '<div class="comment-text"><p>Test review</p></div>', trim( $column_content ) );
+		$this->assertStringContainsString( '<div class="comment-text"><p>Test review</p></div>',
+			str_replace(
+			// Remove new lines from the content to make the comparison easier.
+				PHP_EOL,
+				'',
+				$column_content
+			)
+		);
 
 		$reply = $this->factory()->comment->create_and_get(
 			[
@@ -616,7 +622,14 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$column_content = ob_get_clean();
 
 		$this->assertStringContainsString( 'In reply to', $column_content );
-		$this->assertStringContainsString( '<div class="comment-text">Test reply</div>', $column_content );
+		$this->assertStringContainsString( '<div class="comment-text"><p>Test reply</p></div>',
+			str_replace(
+			// Remove new lines from the content to make the comparison easier.
+				PHP_EOL,
+				'',
+				$column_content
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves how reviews are printed on the admin side replacing `get_comment_text` with `comment_text` function.

Currently, WooCommerce uses get_comment_text to display reviews on the admin side. This function doesn’t strip HTML tags. As a result, users with the unfiltered_html capability can leave comments on product pages that are not correctly rendered in the admin reviews table.

WordPress to render the comments in the admin page uses [the `comment_text` function](https://github.com/WordPress/wordpress-develop/blob/60827f8d2cc880f14da018eaf84ffdc51f1506c2/src/wp-includes/comment-template.php#L1078-L1095) that [strips the HTML](https://github.com/WordPress/wordpress-develop/blob/60827f8d2cc880f14da018eaf84ffdc51f1506c2/src/wp-includes/class-walker-comment.php#L173-L208). 

Kudos to @dinhtungdu for finding it 🙇 


It is worth pointing out that this PR impacts the DOM structure of the page by removing the selector `.comment-text`. I checked on[ wpdirectory](https://wpdirectory.net/search/01JDW6C6CB3TPZKSPGMT8TSFA1), and it looks like that no extension rely on this selector on the editor side.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that you're admin.
2 Visit a Single Product page
3. Leave a review with this text `"><img src=x onerror=alert()>`
4. Visit the reviews page (`wp-admin/edit.php?post_type=product&page=product-reviews&paged=1`)
5. Ensure that NO alert is rendered



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product reviews: improve how reviews are printend on the admin side.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
