### PR TITLE
Fix the images scroll on Chrome

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -103,12 +103,10 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 	width: 100%;
 	height: fit-content;
 	position: relative;
-	overflow: hidden;
 	flex-grow: 1;
 
 	// Restrict the width of the Large Image when the Next/Previous buttons are outside the image.
 	#{$gallery-next-previous-outside-image} & .wc-block-product-gallery-large-image__image-element {
-		overflow: hidden;
 		margin-right: auto;
 		margin-left: auto;
 		max-width: $outside-image-max-width;
@@ -116,7 +114,7 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 
 	.wc-block-product-gallery-large-image__container {
 		display: flex;
-		overflow-x: hidden;
+		overflow: hidden;
 		scroll-snap-type: x mandatory;
 		scroll-behavior: auto;
 		width: fit-content;

--- a/plugins/woocommerce/changelog/fix-53149-2
+++ b/plugins/woocommerce/changelog/fix-53149-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: fix the incorrect scroll origin in Chrome


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was a bug in Chrome that after second snap scroll, the scroll seemed to be stuck at first image after scroll. It was visible in two ways:
- each next scroll "started" from the "incorrect origin", not from the actual image currently displayed
- when hovering image for zoom, the "incorrect origin" image was zoomed
Please check video below for better explanation. 😅 

It was due to incorrect `overflow` property application.

Closes https://github.com/woocommerce/woocommerce/issues/53149

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Test in Chrome
2. Go to Editor > Single Product Template.
3. Replace Product Image Gallery with Product Gallery (Beta) block
4. Save the template and visit some product on the frontend with at least three images
5. Switch the images by clicking an arrow ">", go back "<"
6. **Expected:** there's always nice transition one by one and animation should not start from the second image (check video below)
7. Hover on images
8. **Expected:** current image is zoomed in, not the second image (check video below)
9. Try other browsers as well (e.g. Firefox, Safari, Arc)

Before | After
-- | --
https://github.com/user-attachments/assets/86519248-4b37-440c-b9c3-5e09c9a2c6a7 |  https://github.com/user-attachments/assets/fecb5768-083f-412f-bd35-bf2f88b4abde

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
