### PR TITLE
Add to Cart with Options - Stepper Layout: trigger change event when stepper buttons are clicked

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/frontend.ts
@@ -4,12 +4,20 @@
 import { store } from '@woocommerce/interactivity';
 import { HTMLElementEvent } from '@woocommerce/types';
 
-const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+const getInputElementFromEvent = (
+	event: HTMLElementEvent< HTMLButtonElement >
+) => {
 	const target = event.target as HTMLButtonElement;
 
 	const inputElement = target.parentElement?.querySelector(
 		'.input-text.qty.text'
 	) as HTMLInputElement | null | undefined;
+
+	return inputElement;
+};
+
+const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+	const inputElement = getInputElementFromEvent( event );
 
 	if ( ! inputElement ) {
 		return;
@@ -34,6 +42,12 @@ const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
 	};
 };
 
+const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
+	const event = new Event( 'change' );
+
+	inputElement.dispatchEvent( event );
+};
+
 store( 'woocommerce/add-to-cart-form', {
 	state: {},
 	actions: {
@@ -47,6 +61,7 @@ store( 'woocommerce/add-to-cart-form', {
 
 			if ( maxValue === undefined || newValue <= maxValue ) {
 				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
 			}
 		},
 		removeQuantity: ( event: HTMLElementEvent< HTMLButtonElement > ) => {
@@ -59,6 +74,7 @@ store( 'woocommerce/add-to-cart-form', {
 
 			if ( newValue >= minValue ) {
 				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
 			}
 		},
 	},

--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -408,7 +408,7 @@ test.describe( `${ blockData.name } Block`, () => {
 
 			expect( eventFired ).toBeUndefined();
 		} );
-		test( 'should trigger input change event when minus stepper button is cliced', async ( {
+		test( 'should trigger input change event when minus stepper button is clicked', async ( {
 			admin,
 			editor,
 			blockUtils,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -22,6 +22,12 @@ const blockData = {
 	},
 };
 
+declare global {
+	interface Window {
+		eventFired: boolean;
+	}
+}
+
 class BlockUtils {
 	editor: Editor;
 	page: Page;
@@ -93,6 +99,21 @@ class BlockUtils {
 			},
 			{ min, max, step }
 		);
+	}
+
+	/**
+	 * Adds an event listener to the quantity input field to check if the change event is fired.
+	 */
+	async addChangeEventListenerToQuantityInput() {
+		await this.page.evaluate( () => {
+			const inputEl = window.document.getElementsByClassName(
+				'wc-block-components-quantity-selector__input'
+			);
+
+			inputEl[ 0 ].addEventListener( 'change', () => {
+				window.eventFired = true;
+			} );
+		} );
 	}
 }
 
@@ -323,6 +344,123 @@ test.describe( `${ blockData.name } Block`, () => {
 			await expect( input ).toHaveValue( '10' );
 			await plusButton.click();
 			await expect( input ).toHaveValue( '10' );
+		} );
+
+		test( 'should trigger input change event when plus stepper button is clicked', async ( {
+			admin,
+			editor,
+			blockUtils,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'woocommerce/single-product' } );
+
+			const productName = 'Hoodie with Logo';
+
+			await blockUtils.configureSingleProductBlock( productName );
+
+			await blockUtils.enableStepperMode();
+			await editor.publishAndVisitPost();
+
+			const plusButton = page.getByLabel( `Increase quantity` );
+
+			await blockUtils.addChangeEventListenerToQuantityInput();
+
+			await plusButton.click();
+
+			const eventFired = await page.evaluate( () => window.eventFired );
+
+			expect( eventFired ).toBe( true );
+		} );
+
+		test( 'should not trigger input change event when plus stepper button is clicked and the value exceeds the maximum limit', async ( {
+			admin,
+			editor,
+			blockUtils,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'woocommerce/single-product' } );
+
+			const productName = 'Hoodie with Logo';
+
+			await blockUtils.configureSingleProductBlock( productName );
+
+			await blockUtils.enableStepperMode();
+			await editor.publishAndVisitPost();
+			await blockUtils.setMinMaxAndStep( {
+				min: 1,
+				max: 4,
+				step: 1,
+			} );
+
+			const plusButton = page.getByLabel( `Increase quantity` );
+
+			for ( let i = 0; i < 5; i++ ) {
+				await plusButton.click();
+			}
+
+			await blockUtils.addChangeEventListenerToQuantityInput();
+
+			await plusButton.click();
+
+			const eventFired = await page.evaluate( () => window.eventFired );
+
+			expect( eventFired ).toBeUndefined();
+		} );
+		test( 'should trigger input change event when minus stepper button is cliced', async ( {
+			admin,
+			editor,
+			blockUtils,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'woocommerce/single-product' } );
+
+			const productName = 'Hoodie with Logo';
+
+			await blockUtils.configureSingleProductBlock( productName );
+
+			await blockUtils.enableStepperMode();
+			await editor.publishAndVisitPost();
+
+			const plusButton = page.getByLabel( `Increase quantity` );
+			await plusButton.click();
+			const minusButton = page.getByLabel( `Reduce quantity` );
+
+			await blockUtils.addChangeEventListenerToQuantityInput();
+
+			await minusButton.click();
+
+			const eventFired = await page.evaluate( () => window.eventFired );
+
+			expect( eventFired ).toBe( true );
+		} );
+		test( 'should not trigger input change event when minus stepper button is clicked and the value goes below the minimum limit', async ( {
+			admin,
+			editor,
+			blockUtils,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'woocommerce/single-product' } );
+
+			const productName = 'Hoodie with Logo';
+
+			await blockUtils.configureSingleProductBlock( productName );
+
+			await blockUtils.enableStepperMode();
+			await editor.publishAndVisitPost();
+
+			const minusButton = page.getByLabel( `Reduce quantity` );
+
+			await blockUtils.addChangeEventListenerToQuantityInput();
+
+			await minusButton.click();
+
+			const eventFired = await page.evaluate( () => window.eventFired );
+
+			expect( eventFired ).toBeUndefined();
 		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/53343-add-trigger-on-change-event-stepper
+++ b/plugins/woocommerce/changelog/53343-add-trigger-on-change-event-stepper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add to Cart with Options - Stepper Layout: trigger change event when stepper button clicked.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses an issue where the change event was not being triggered on the input element when the stepper buttons were clicked. A big thank you to the community for the valuable feedback and suggestions that led to this improvement. 🙇

Closes #53031 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and active WooCommerce Beta Tester Plugin [woocommerce-beta-tester.zip](https://github.com/user-attachments/files/17976002/woocommerce-beta-tester.zip)
2. Visit wp-admin/tools.php?page=woocommerce-admin-test-helper.
3. Enable add-to-cart-with-options-stepper-layout feature.
4. Enable a block theme.
5. Edit the Single Product Template.
6. Ensure that you have the Add To Cart with Options block added.
7. Click on it.
8. Open the block settings.
9. Ensure that you have the Quantity Selector option.
10. Ensure that the default one is Input.
11. Switch the option to Stepper.
12. Save it.
13. Visit a product page. For instance, `/product/beanie-with-logo/`.
14. Open devTools and copy paste this js code:

```js
const inputEl = window.document.getElementsByClassName(
   'wc-block-components-quantity-selector__input'
);

inputEl[0].addEventListener('change', () => {
   alert("clicked")
});
```
<!-- End testing instructions -->
15. Click on the plus stepper button.
16. Ensure that the alert appears.
17. Click on the minus stepper button.
18. Ensure that the alert appears.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add to Cart with Options - Stepper Layout: trigger change event when stepper button clicked.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
