### PR TITLE
Use core function to register Add to Cart with Options (experimental) block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/add-to-cart-with-options",
 	"version": "1.0.0",
 	"title": "Add to Cart with Options (Experimental)",
-	"description": "Display a button so the customer can add a product to their cart. Options will also be displayed depending on product type. e.g. quantity, variation.",
+	"description": "Create an \"Add To Cart\" composition by using blocks",
 	"category": "woocommerce-product-elements",
 	"attributes": {
 		"isDescendentOfSingleProductBlock": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/constants.ts
@@ -1,14 +1,3 @@
 /**
- * External dependencies
+ * Constants
  */
-import type { InnerBlockTemplate } from '@wordpress/blocks';
-
-export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
-	[
-		'woocommerce/product-button',
-		{
-			textAlign: 'center',
-			fontSize: 'small',
-		},
-	],
-];

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -4,13 +4,14 @@
 import { useEffect } from '@wordpress/element';
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
+import type { InnerBlockTemplate } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { useIsDescendentOfSingleProductBlock } from '../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { AddToCartOptionsSettings } from './settings';
-import { INNER_BLOCKS_TEMPLATE } from './constants';
 export interface Attributes {
 	className?: string;
 	isDescendentOfSingleProductBlock: boolean;
@@ -23,6 +24,23 @@ export type FeaturesProps = {
 };
 
 export type UpdateFeaturesType = ( key: FeaturesKeys, value: boolean ) => void;
+
+const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
+	[
+		'core/heading',
+		{
+			level: 2,
+			content: __( 'Add to Cart', 'woocommerce' ),
+		},
+	],
+	[
+		'woocommerce/product-button',
+		{
+			textAlign: 'center',
+			fontSize: 'small',
+		},
+	],
+];
 
 const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
+import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
@@ -12,26 +12,10 @@ import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import './style.scss';
 
-const blockSettings = {
-	edit: AddToCartOptionsEdit,
-	icon: {
-		src: (
-			<Icon
-				icon={ button }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
-	save() {
-		return null;
-	},
-};
-
 if ( isExperimentalBlocksEnabled() ) {
-	registerBlockSingleProductTemplate( {
-		blockName: metadata.name,
-		blockMetadata: metadata,
-		blockSettings,
-		isAvailableOnPostEditor: true,
+	registerBlockType( metadata, {
+		icon: <Icon icon={ button } />,
+		edit: AddToCartOptionsEdit,
+		save: () => null,
 	} );
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -22,7 +22,6 @@ const blockSettings = {
 			/>
 		),
 	},
-	ancestor: [ 'woocommerce/single-product' ],
 	save() {
 		return null;
 	},

--- a/plugins/woocommerce/changelog/update-improve-block-tempplate-of-add-to-cart
+++ b/plugins/woocommerce/changelog/update-improve-block-tempplate-of-add-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Comment: use core function to register Add to Cart with Options (experimental) block


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The main change in terms of implementation is using the registerBlockType() function to register the `Add To Cart with Options (Experimental)` block.
Using a custom register diverges from the core and is not aligned with the idea of being Gutenberg-friendly, which has largely talked about recently.

Also:
* It moves the template from the constant to the Edit component function. 
* Tweak a bit the block description (we can update it later)
* Move a block definition to `block.json` file


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

No significant changes here in terms of functionallity


1. Ensure install and activate the `WooCommerce Beta Tester` plugin
<img width="563" alt="image" src="https://github.com/user-attachments/assets/14f63f24-2b4e-4d90-a8a8-6dbe2d4c8014">

2. Go to the `WooCommerce Admin Test Helper` -> `Features` page

<img width="379" alt="image" src="https://github.com/user-attachments/assets/d87d815c-3528-4635-9cf1-6e0d93030f2f">

3. Confirm the `experimental-blocks` and `blockified-add-to-cart` flags are enabled

<img width="585" alt="Screenshot 2024-12-02 at 12 40 34 PM" src="https://github.com/user-attachments/assets/e9ca7c72-b423-402a-af6f-9b8cb8fad346">

4. Edit the `Single Product` template
5. Add the `Add To Cart with Options (Experimental)` block
<img width="719" alt="Screenshot 2024-12-02 at 1 16 29 PM" src="https://github.com/user-attachments/assets/d7a21466-f883-4fa8-946c-ece451191a44">

6. Confirm the block works as expected

<img width="1260" alt="Screenshot 2024-12-02 at 1 14 52 PM" src="https://github.com/user-attachments/assets/cb9b5bef-bde9-4b29-b15f-7c85725c1441">

7. Create/edit a new post
8. Add a Single Product Block
9. Add the `Add To Cart with Options (Experimental)` block
10. Confirm it works as expected

<img width="1257" alt="Screenshot 2024-12-02 at 12 42 57 PM" src="https://github.com/user-attachments/assets/ad8422b7-1d99-4b1f-a74e-cffed15fd6c7">


11. Confirm that removing the feature flags the blocks are not available 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
