### PR TITLE
Comment: Add product type selector to the add to cart with options block toolbar

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { mediaAndText } from '@wordpress/icons';
+import { eye } from '@woocommerce/icons';
 import type { InnerBlockTemplate } from '@wordpress/blocks';
 import {
 	Icon,
@@ -78,7 +78,7 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarDropdownMenu
-						icon={ <Icon icon={ mediaAndText } /> }
+						icon={ <Icon icon={ eye } /> }
 						label={ __( 'Switch product Type', 'woocommerce' ) }
 						controls={ productTypes.map( ( productType ) => ( {
 							title: productType.label,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -79,7 +79,7 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 				<ToolbarGroup>
 					<ToolbarDropdownMenu
 						icon={ <Icon icon={ mediaAndText } /> }
-						label={ __( 'Switch view', 'woocommerce' ) }
+						label={ __( 'Switch product Type', 'woocommerce' ) }
 						controls={ productTypes.map( ( productType ) => ( {
 							title: productType.label,
 							onClick: () => console.log( productType.value ), // eslint-disable-line no-console

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -2,16 +2,29 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InnerBlocks,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import type { InnerBlockTemplate } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { mediaAndText } from '@wordpress/icons';
+import type { InnerBlockTemplate } from '@wordpress/blocks';
+import {
+	Icon,
+	ToolbarGroup,
+
+	// @ts-expect-error no exported member.
+	ToolbarDropdownMenu,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { useIsDescendentOfSingleProductBlock } from '../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { AddToCartOptionsSettings } from './settings';
+import getProductTypeOptions from './utils/get-product-types';
 export interface Attributes {
 	className?: string;
 	isDescendentOfSingleProductBlock: boolean;
@@ -42,6 +55,9 @@ const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 	],
 ];
 
+// Get product type options.
+const productTypes = getProductTypeOptions();
+
 const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
@@ -59,6 +75,19 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 
 	return (
 		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarDropdownMenu
+						icon={ <Icon icon={ mediaAndText } /> }
+						label={ __( 'Switch view', 'woocommerce' ) }
+						controls={ productTypes.map( ( productType ) => ( {
+							title: productType.label,
+							onClick: () => console.log,
+						} ) ) }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+
 			<AddToCartOptionsSettings
 				features={ {
 					isBlockifiedAddToCart: true,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -82,7 +82,7 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 						label={ __( 'Switch view', 'woocommerce' ) }
 						controls={ productTypes.map( ( productType ) => ( {
 							title: productType.label,
-							onClick: () => console.log,
+							onClick: () => console.log( productType.value ), // eslint-disable-line no-console
 						} ) ) }
 					/>
 				</ToolbarGroup>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+
+const productTypes = getSetting< Record< string, string > >(
+	'productTypes',
+	{}
+);
+
+/**
+ * Build options collection for product types.
+ *
+ * Return a collection of product types with their values and labels.
+ */
+export default function getProductTypeOptions() {
+	return Object.keys( productTypes ).map( ( key ) => ( {
+		value: key,
+		label: productTypes[ key ],
+	} ) );
+}
+
+export type ProductTypesOptions = typeof getProductTypeOptions;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
@@ -3,17 +3,22 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
+type ProductTypeProps = {
+	value: string;
+	label: string;
+};
+
 const productTypes = getSetting< Record< string, string > >(
 	'productTypes',
 	{}
 );
 
 /**
- * Build options collection for product types.
+ * Build product types collection for product types.
  *
- * Return a collection of product types with their values and labels.
+ * @return {ProductTypeProps[]} Product types collection.
  */
-export default function getProductTypeOptions() {
+export default function getProductTypeOptions(): ProductTypeProps[] {
 	return Object.keys( productTypes ).map( ( key ) => ( {
 		value: key,
 		label: productTypes[ key ],

--- a/plugins/woocommerce/changelog/update-impplement-product-type-selector
+++ b/plugins/woocommerce/changelog/update-impplement-product-type-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: Add product type selector to the add to cart with options block toolbar

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -59,6 +59,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 		$this->asset_data_registry->add( 'isBlockifiedAddToCart', Features::is_enabled( 'blockified-add-to-cart' ) );
+		$this->asset_data_registry->add( 'productTypes', wc_get_product_types() );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure install and activate the `WooCommerce Beta Tester` plugin
<img width="563" alt="image" src="https://github.com/user-attachments/assets/14f63f24-2b4e-4d90-a8a8-6dbe2d4c8014">

2. Go to the `WooCommerce Admin Test Helper` -> `Features` page

<img width="379" alt="image" src="https://github.com/user-attachments/assets/d87d815c-3528-4635-9cf1-6e0d93030f2f">

3. Confirm the `experimental-blocks` and `blockified-add-to-cart` flags are enabled

<img width="585" alt="Screenshot 2024-12-02 at 12 40 34 PM" src="https://github.com/user-attachments/assets/e9ca7c72-b423-402a-af6f-9b8cb8fad346">

4. Edit the `Single Product` template
5. Add the `Add To Cart with Options (Experimental)` block

<img width="719" alt="Screenshot 2024-12-02 at 1 16 29 PM" src="https://github.com/user-attachments/assets/d7a21466-f883-4fa8-946c-ece451191a44">

6. Confirm it `Switch product type` button in the toolbar 

<img width="750" alt="image" src="https://github.com/user-attachments/assets/2d3e17b6-1c97-4e07-a03c-92c86f6c57d9">

7. Confirm the dev console logs the product type when clicking on it

<img width="712" alt="Screenshot 2024-12-03 at 9 50 19 AM" src="https://github.com/user-attachments/assets/5c048077-6923-4dc3-bcb1-e2d205f110b3">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
