### PR TITLE
Remove unnecessary setState() from <DesignWithNoAiController>

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-unnecessary-set-state
+++ b/plugins/woocommerce/changelog/fix-remove-unnecessary-set-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Remove unnecessary setState() from <DesignWithNoAiController>

--- a/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/index.tsx
@@ -3,7 +3,6 @@
  */
 import { useMachine, useSelector } from '@xstate/react';
 import { AnyInterpreter, Sender } from 'xstate';
-import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -68,14 +67,7 @@ export const DesignWithNoAiController = ( {
 		)
 	);
 
-	const [ CurrentComponent, setCurrentComponent ] =
-		useState< DesignWithoutAiComponent | null >( null );
-
-	useEffect( () => {
-		if ( currentNodeMeta?.component ) {
-			setCurrentComponent( () => currentNodeMeta?.component );
-		}
-	}, [ CurrentComponent, currentNodeMeta?.component ] );
+	const CurrentComponent = currentNodeMeta?.component;
 
 	return (
 		<div className={ `woocommerce-design-without-ai__container` }>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While working on https://github.com/woocommerce/woocommerce/pull/53352, I noticed that in `<DesignWithNoAiController>` we had a state which, I think, can be derived on render. Saving us a call to `useState()` and `useEffect()`. I didn't want to include these changes in #53352 because that PR will belong to a Point Release Request, so I wanted to keep its changes to the minimum.

### How to test the changes in this Pull Request:

1. Install the latest [Gutenberg Nightly](https://github.com/Automattic/gutenberg-nightlies/releases).
2. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
3. Go to WooCommerce > Customize Your Store. Verify there are no errors displayed on the screen.
4. Smoke test the CYS functionality: change the logo, fonts, colors, some patterns, etc. and save it.
5. Verify at no moment you see an error.
