### PR TITLE
Add To Cart with Options: Register store for the product types

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -13,6 +13,7 @@ import { isBoolean } from '@woocommerce/types';
 import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import './style.scss';
+import registerStore from './store';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -25,6 +26,10 @@ export const shouldRegisterBlock =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
 if ( shouldRegisterBlock ) {
+	// Register the store
+	registerStore();
+
+	// Register the block
 	registerBlockType( metadata, {
 		icon: <Icon icon={ button } />,
 		edit: AddToCartOptionsEdit,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/Readme.md
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/Readme.md
@@ -1,0 +1,6 @@
+# WooCommerce Product Types Store
+
+This module defines a custom Redux store for managing WooCommerce product types
+within the WordPress Block Editor.
+It facilitates the retrieval and selection of product types.
+

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/constants.ts
@@ -1,0 +1,7 @@
+export const STORE_NAME = 'woocommerce/template-state';
+
+/**
+ * Actions
+ */
+export const ACTION_SWITCH_PRODUCT_TYPE = 'SWITCH_PRODUCT_TYPE' as const;
+export const ACTION_SET_PRODUCT_TYPES = 'SET_PRODUCT_TYPES' as const;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -45,6 +45,13 @@ const actions = {
 			current: slug,
 		};
 	},
+
+	setProductTypes( productTypes: ProductTypeProps[] ) {
+		return {
+			type: ACTION_SET_PRODUCT_TYPES,
+			productTypes,
+		};
+	},
 };
 
 const reducer = ( state: StoreState = DEFAULT_STATE, action: Actions ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -11,9 +11,8 @@ import {
 	ACTION_SWITCH_PRODUCT_TYPE,
 	STORE_NAME,
 } from './constants';
-import getProductTypeOptions, {
-	type ProductTypeProps,
-} from '../utils/get-product-types';
+import getProductTypeOptions from '../utils/get-product-types';
+import type { ProductTypeProps } from '../types';
 
 const productTypesOptions = getProductTypeOptions();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -11,7 +11,6 @@ import {
 	ACTION_SWITCH_PRODUCT_TYPE,
 	STORE_NAME,
 } from './constants';
-import type { ProductTypeSlug } from '../types';
 import getProductTypeOptions, {
 	type ProductTypeProps,
 } from '../utils/get-product-types';
@@ -21,14 +20,14 @@ const productTypesOptions = getProductTypeOptions();
 type StoreState = {
 	productTypes: {
 		list: ProductTypeProps[];
-		current: ProductTypeSlug | undefined;
+		current: string | undefined;
 	};
 };
 
 type Actions = {
 	type: typeof ACTION_SET_PRODUCT_TYPES | typeof ACTION_SWITCH_PRODUCT_TYPE;
 	productTypes?: ProductTypeProps[];
-	current?: ProductTypeSlug;
+	current?: string;
 };
 
 const DEFAULT_STATE = {
@@ -39,7 +38,7 @@ const DEFAULT_STATE = {
 };
 
 const actions = {
-	switchProductType( slug: ProductTypeSlug ) {
+	switchProductType( slug: string ) {
 		return {
 			type: ACTION_SWITCH_PRODUCT_TYPE,
 			current: slug,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -54,6 +54,15 @@ const actions = {
 	},
 };
 
+const selectors = {
+	getProductTypes( state: StoreState ) {
+		return state.productTypes.list;
+	},
+	getCurrentProductType( state: StoreState ) {
+		return state.productTypes.current;
+	},
+};
+
 const reducer = ( state: StoreState = DEFAULT_STATE, action: Actions ) => {
 	switch ( action.type ) {
 		case ACTION_SET_PRODUCT_TYPES:
@@ -77,15 +86,6 @@ const reducer = ( state: StoreState = DEFAULT_STATE, action: Actions ) => {
 		default:
 			return state;
 	}
-};
-
-const selectors = {
-	getProductTypes( state: StoreState ) {
-		return state.productTypes.list;
-	},
-	getCurrentProductType( state: StoreState ) {
-		return state.productTypes.current;
-	},
 };
 
 const store = createReduxStore( STORE_NAME, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -59,7 +59,9 @@ const selectors = {
 		return state.productTypes.list;
 	},
 	getCurrentProductType( state: StoreState ) {
-		return state.productTypes.current;
+		return state.productTypes.list.find(
+			( productType ) => productType.slug === state.productTypes.current
+		);
 	},
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { createReduxStore, register } from '@wordpress/data';
-import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -13,34 +12,22 @@ import {
 	STORE_NAME,
 } from './constants';
 import type { ProductTypeSlug } from '../types';
+import getProductTypeOptions, {
+	type ProductTypeProps,
+} from '../utils/get-product-types';
 
-const productTypes = getSetting< Record< string, string > >(
-	'productTypes',
-	{}
-);
-
-/**
- * Build options collection for product types.
- */
-export const productTypesOptions = Object.keys( productTypes ).map(
-	( key ) => ( {
-		value: key,
-		label: productTypes[ key ],
-	} )
-);
-
-export type ProductTypesOptions = typeof productTypesOptions;
+const productTypesOptions = getProductTypeOptions();
 
 type StoreState = {
 	productTypes: {
-		list: ProductTypesOptions;
+		list: ProductTypeProps[];
 		current: ProductTypeSlug | undefined;
 	};
 };
 
 type Actions = {
 	type: typeof ACTION_SET_PRODUCT_TYPES | typeof ACTION_SWITCH_PRODUCT_TYPE;
-	productTypes?: ProductTypesOptions;
+	productTypes?: ProductTypeProps[];
 	current?: ProductTypeSlug;
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+import { getSetting } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ACTION_SET_PRODUCT_TYPES,
+	ACTION_SWITCH_PRODUCT_TYPE,
+	STORE_NAME,
+} from './constants';
+import type { ProductTypeSlug } from '../types';
+
+const productTypes = getSetting< Record< string, string > >(
+	'productTypes',
+	{}
+);
+
+/**
+ * Build options collection for product types.
+ */
+export const productTypesOptions = Object.keys( productTypes ).map(
+	( key ) => ( {
+		value: key,
+		label: productTypes[ key ],
+	} )
+);
+
+export type ProductTypesOptions = typeof productTypesOptions;
+
+type StoreState = {
+	productTypes: {
+		list: ProductTypesOptions;
+		current: ProductTypeSlug | undefined;
+	};
+};
+
+type Actions = {
+	type: typeof ACTION_SET_PRODUCT_TYPES | typeof ACTION_SWITCH_PRODUCT_TYPE;
+	productTypes?: ProductTypesOptions;
+	current?: ProductTypeSlug;
+};
+
+const DEFAULT_STATE = {
+	productTypes: {
+		list: productTypesOptions,
+		current: undefined,
+	},
+};
+
+const actions = {
+	switchProductType( slug: ProductTypeSlug ) {
+		return {
+			type: ACTION_SWITCH_PRODUCT_TYPE,
+			current: slug,
+		};
+	},
+};
+
+const reducer = ( state: StoreState = DEFAULT_STATE, action: Actions ) => {
+	switch ( action.type ) {
+		case ACTION_SET_PRODUCT_TYPES:
+			return {
+				...state,
+				productTypes: {
+					...state.productTypes,
+					list: action.productTypes || [],
+				},
+			};
+
+		case ACTION_SWITCH_PRODUCT_TYPE:
+			return {
+				...state,
+				productTypes: {
+					...state.productTypes,
+					current: action.current,
+				},
+			};
+
+		default:
+			return state;
+	}
+};
+
+const selectors = {
+	getProductTypes( state: StoreState ) {
+		return state.productTypes.list;
+	},
+	getCurrentProductType( state: StoreState ) {
+		return state.productTypes.current;
+	},
+};
+
+const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+export default function registerStore() {
+	register( store );
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -1,0 +1,6 @@
+export type ProductTypeSlug = 'single-product';
+
+export type ProductTypeProps = {
+	slug: ProductTypeSlug;
+	type: string;
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -1,6 +1,4 @@
-export type ProductTypeSlug = 'single-product' | string;
-
 export type ProductTypeProps = {
-	slug: ProductTypeSlug;
+	slug: string;
 	type: string;
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -1,4 +1,4 @@
 export type ProductTypeProps = {
 	slug: string;
-	type: string;
+	label: string;
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -1,4 +1,4 @@
-export type ProductTypeSlug = 'single-product';
+export type ProductTypeSlug = 'single-product' | string;
 
 export type ProductTypeProps = {
 	slug: ProductTypeSlug;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
@@ -3,7 +3,7 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
-type ProductTypeProps = {
+export type ProductTypeProps = {
 	value: string;
 	label: string;
 };
@@ -24,5 +24,3 @@ export default function getProductTypeOptions(): ProductTypeProps[] {
 		label: productTypes[ key ],
 	} ) );
 }
-
-export type ProductTypesOptions = typeof getProductTypeOptions;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-product-types/index.ts
@@ -4,7 +4,7 @@
 import { getSetting } from '@woocommerce/settings';
 
 export type ProductTypeProps = {
-	value: string;
+	slug: string;
 	label: string;
 };
 
@@ -20,7 +20,7 @@ const productTypes = getSetting< Record< string, string > >(
  */
 export default function getProductTypeOptions(): ProductTypeProps[] {
 	return Object.keys( productTypes ).map( ( key ) => ( {
-		value: key,
+		slug: key,
 		label: productTypes[ key ],
 	} ) );
 }

--- a/plugins/woocommerce/changelog/update-add-to-cart-introduce-template-state
+++ b/plugins/woocommerce/changelog/update-add-to-cart-introduce-template-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: Register store for the product types


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


This PR introduces the `woocommerce/template-state` store to handle the global product type.
The store could scale to handle other global variables, such as product quantity, and, according to it, change the block representation.

Closes #53365

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

You need to use the Redux Dev Tool ([chrome](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=pt-PT), [firefox](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=pt-PT))

1. Install and activate the WooCommerce Beta Tester plugin
2. Go to WooCommerce Admin Test Helper -> Features and enable `blockified-add-to-cart`
3. Create a new product.
4. Go to Pages > Add New Page.
5. Open the Redux dev tool
6. Filter the store by the `woocommerce/product-template` name

<img width="853" alt="Screenshot 2024-12-03 at 12 25 53 PM" src="https://github.com/user-attachments/assets/2f05024e-1b54-4199-9996-3131a076bcde">

7. Open the dev console
8. Load the product types dispatching the proper action:

```es6
wp.data.dispatch( 'woocommerce/template-state' ).setProductTypes( [
    {
        slug: 'simple',
        label: 'Simple Product',
    },
    {
        slug: 'variable',
        label: 'Variable Product',
    },
    {
        slug: 'grouped',
        label: 'Grouped Product',
    },
] );
```

9. Confirm the store populates

<img width="507" alt="Screenshot 2024-12-03 at 1 07 36 PM" src="https://github.com/user-attachments/assets/59a8f6a3-53c5-4019-a494-46c1395601c0">

11. Select the current type dispatching the following action:

```es6
wp.data.dispatch( 'woocommerce/template-state' ).switchProductType( 'grouped' );
```

12. Confirm it populate the state:

<img width="508" alt="Screenshot 2024-12-03 at 12 29 33 PM" src="https://github.com/user-attachments/assets/65f4580c-a4ae-4dcf-be6e-235c78b09090">

13. Get the current product type by using the following selector:

```es6
wp.data.select( 'woocommerce/template-state' ).getCurrentProductType()
```

<img width="491" alt="image" src="https://github.com/user-attachments/assets/f30bc27f-68cc-4c95-b6c8-8a273ead17bb">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
