### PR TITLE
Dont register Add To Cart with Option when the feature flag is False

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -4,6 +4,8 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+import { getSettingWithCoercion } from '@woocommerce/settings';
+import { isBoolean } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -12,7 +14,14 @@ import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import './style.scss';
 
-if ( isExperimentalBlocksEnabled() ) {
+// Pick the value of the "blockify add to cart flag"
+const isBlockifiedAddToCart = getSettingWithCoercion(
+	'isBlockifiedAddToCart',
+	false,
+	isBoolean
+);
+
+if ( isExperimentalBlocksEnabled() && isBlockifiedAddToCart ) {
 	registerBlockType( metadata, {
 		icon: <Icon icon={ button } />,
 		edit: AddToCartOptionsEdit,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -21,7 +21,10 @@ const isBlockifiedAddToCart = getSettingWithCoercion(
 	isBoolean
 );
 
-if ( isExperimentalBlocksEnabled() && isBlockifiedAddToCart ) {
+export const shouldRegisterBlock =
+	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
+
+if ( shouldRegisterBlock ) {
 	registerBlockType( metadata, {
 		icon: <Icon icon={ button } />,
 		edit: AddToCartOptionsEdit,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
@@ -3,7 +3,6 @@
  */
 import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
 import { Icon, button } from '@wordpress/icons';
-import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
@@ -10,9 +10,10 @@ import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
  */
 import metadata from './block.json';
 import AddToCartWithOptionsQuantitySelectorEdit from './edit';
+import { shouldRegisterBlock } from '..';
+import '../../../base/components/quantity-selector/style.scss';
 import './style.scss';
 import './editor.scss';
-import '../../../base/components/quantity-selector/style.scss';
 
 const blockSettings = {
 	edit: AddToCartWithOptionsQuantitySelectorEdit,
@@ -31,7 +32,7 @@ const blockSettings = {
 	},
 };
 
-if ( isExperimentalBlocksEnabled() ) {
+if ( shouldRegisterBlock ) {
 	registerBlockSingleProductTemplate( {
 		blockName: metadata.name,
 		blockMetadata: metadata,

--- a/plugins/woocommerce/changelog/update-add-to-cart-not-register-behind-flag
+++ b/plugins/woocommerce/changelog/update-add-to-cart-not-register-behind-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Comment: do not register Add To Cart with Option when the feature flag is False


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure install and activate the `WooCommerce Beta Tester` plugin
<img width="563" alt="image" src="https://github.com/user-attachments/assets/14f63f24-2b4e-4d90-a8a8-6dbe2d4c8014">

2. Go to the `WooCommerce Admin Test Helper` -> `Features` page

<img width="379" alt="image" src="https://github.com/user-attachments/assets/d87d815c-3528-4635-9cf1-6e0d93030f2f">

3. Enable the `experimental-blocks` and `blockified-add-to-cart` flags

<img width="585" alt="Screenshot 2024-12-02 at 12 40 34 PM" src="https://github.com/user-attachments/assets/e9ca7c72-b423-402a-af6f-9b8cb8fad346">

4. Edit the `Single Product` template
5. Confirm the `Add to Cart with Options (Experimental)` block is available

<img width="874" alt="image" src="https://github.com/user-attachments/assets/7074a589-abb3-4a4a-a022-5c72d7486d58">

7. Confirm when `experimental-blocks` or `blockified-add-to-cart` flags are disabled, the block is not available

<img width="434" alt="image" src="https://github.com/user-attachments/assets/c8e1f2da-71f4-452a-9a14-d335ebe50248">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
