### PR TITLE
Delayed Account Creation: change the "after checkout" setting location

### DIFF
--- a/plugins/woocommerce/changelog/fix-account-settings-order-52985
+++ b/plugins/woocommerce/changelog/fix-account-settings-order-52985
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Moved delayed account setting to top of list in account settings.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -79,17 +79,6 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'      => false,
 			),
 			array(
-				'title'         => __( 'Account creation', 'woocommerce' ),
-				'desc'          => __( 'During checkout', 'woocommerce' ),
-				'desc_tip'      => __( 'Customers can create an account before placing their order.', 'woocommerce' ),
-				'id'            => 'woocommerce_enable_signup_and_login_from_checkout',
-				'default'       => 'no',
-				'type'          => 'checkbox',
-				'checkboxgroup' => 'start',
-				'legend'        => __( 'Allow customers to create an account', 'woocommerce' ),
-				'autoload'      => false,
-			),
-			array(
 				'title'             => __( 'Account creation', 'woocommerce' ),
 				'desc'              => __( 'After checkout (recommended)', 'woocommerce' ),
 				'desc_tip'          => sprintf(
@@ -101,11 +90,22 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'id'                => 'woocommerce_enable_delayed_account_creation',
 				'default'           => 'no',
 				'type'              => 'checkbox',
-				'checkboxgroup'     => '',
+				'checkboxgroup'     => 'start',
 				'autoload'          => false,
 				'custom_attributes' => array(
 					'disabled-tooltip' => __( 'Enable guest checkout to use this feature.', 'woocommerce' ),
 				),
+				'legend'            => __( 'Allow customers to create an account', 'woocommerce' ),
+			),
+			array(
+				'title'         => __( 'Account creation', 'woocommerce' ),
+				'desc'          => __( 'During checkout', 'woocommerce' ),
+				'desc_tip'      => __( 'Customers can create an account before placing their order.', 'woocommerce' ),
+				'id'            => 'woocommerce_enable_signup_and_login_from_checkout',
+				'default'       => 'no',
+				'type'          => 'checkbox',
+				'checkboxgroup' => '',
+				'autoload'      => false,
 			),
 			array(
 				'title'         => __( 'Account creation', 'woocommerce' ),
@@ -271,8 +271,18 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			),
 		);
 
-		// Feature requires a block theme.
+		// Feature requires a block theme. Re-order settings if not using a block theme.
 		if ( ! wc_current_theme_is_fse_theme() ) {
+			$account_settings = array_map(
+				function ( $setting ) {
+					if ( 'woocommerce_enable_signup_and_login_from_checkout' === $setting['id'] ) {
+						$setting['checkboxgroup'] = 'start';
+						$setting['legend']        = __( 'Allow customers to create an account', 'woocommerce' );
+					}
+					return $setting;
+				},
+				$account_settings
+			);
 			$account_settings = array_filter(
 				$account_settings,
 				function ( $setting ) {
@@ -366,7 +376,14 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					});
 				}));
 				checkboxes[0].dispatchEvent(new Event('change')); // Initial state
+			});
+		</script>
+		<?php
 
+		// If the checkout block is not default, delayed account creation is always disabled. Otherwise its based on other settings.
+		if ( CartCheckoutUtils::is_checkout_block_default() ) {
+			?>
+			<script type="text/javascript">
 				// Guest checkout should toggle off some options.
 				const guestCheckout = document.getElementById("woocommerce_enable_guest_checkout");
 
@@ -381,9 +398,9 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					});
 					guestCheckout.dispatchEvent(new Event('change')); // Initial state
 				}
-			});
-		</script>
-		<?php
+			</script>
+			<?php
+		}
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves _account creation after checkout_ option to the top of the list:

![Screenshot 2024-12-03 at 10 50 57](https://github.com/user-attachments/assets/9f239c11-fea2-4ecf-aa70-834ff4fb784a)

Fixes interactions with the "enable guest checkout" option, and adds a tracks event for the customize link. The tracks event is called `wcadmin_delayed_account_creation_customize_link_clicked`.

Closes #52985
Closes #52984

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With block checkout enabled on the main checkout page
   - Go to Settings > Accounts and Privacy
   - Check "After checkout (recommended)" is top of the list
   - Toggle "enable guest checkout". "After checkout (recommended)" should be disabled.
   - Save/toggle settings and confirm working
2. With shortcode checkout enabled on the main checkout page
   - Go to Settings > Accounts and Privacy
   - Check "After checkout (recommended)" is greyed out and says "This feature is only available with the Cart & Checkout blocks."
   - Toggle "enable guest checkout". "After checkout (recommended)" should not toggle.
   - Save/toggle settings and confirm working
3. With a non-block theme enabled such as storefront, "After checkout (recommended)"  is not rendered at all.
4. Back using a block theme, visit the settings page and click the "Customize messaging here" link. It should open in a new tab/window.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
