### PR TITLE
[Experimental] Add to Cart with Options Quantity Selector Stepper Layout: trigger change event when stepper buttons are clicked

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -4,12 +4,20 @@
 import { store } from '@woocommerce/interactivity';
 import { HTMLElementEvent } from '@woocommerce/types';
 
-const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+const getInputElementFromEvent = (
+	event: HTMLElementEvent< HTMLButtonElement >
+) => {
 	const target = event.target as HTMLButtonElement;
 
 	const inputElement = target.parentElement?.querySelector(
 		'.input-text.qty.text'
 	) as HTMLInputElement | null | undefined;
+
+	return inputElement;
+};
+
+const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+	const inputElement = getInputElementFromEvent( event );
 
 	if ( ! inputElement ) {
 		return;
@@ -34,6 +42,12 @@ const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
 	};
 };
 
+const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
+	const event = new Event( 'change' );
+
+	inputElement.dispatchEvent( event );
+};
+
 store( 'woocommerce/add-to-cart-with-options', {
 	state: {},
 	actions: {
@@ -47,6 +61,7 @@ store( 'woocommerce/add-to-cart-with-options', {
 
 			if ( maxValue === undefined || newValue <= maxValue ) {
 				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
 			}
 		},
 		removeQuantity: ( event: HTMLElementEvent< HTMLButtonElement > ) => {
@@ -59,6 +74,7 @@ store( 'woocommerce/add-to-cart-with-options', {
 
 			if ( newValue >= minValue ) {
 				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
 			}
 		},
 	},

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -2,80 +2,8 @@
  * External dependencies
  */
 import { store } from '@woocommerce/interactivity';
-import { HTMLElementEvent } from '@woocommerce/types';
-
-const getInputElementFromEvent = (
-	event: HTMLElementEvent< HTMLButtonElement >
-) => {
-	const target = event.target as HTMLButtonElement;
-
-	const inputElement = target.parentElement?.querySelector(
-		'.input-text.qty.text'
-	) as HTMLInputElement | null | undefined;
-
-	return inputElement;
-};
-
-const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
-	const inputElement = getInputElementFromEvent( event );
-
-	if ( ! inputElement ) {
-		return;
-	}
-
-	const parsedValue = parseInt( inputElement.value, 10 );
-	const parsedMinValue = parseInt( inputElement.min, 10 );
-	const parsedMaxValue = parseInt( inputElement.max, 10 );
-	const parsedStep = parseInt( inputElement.step, 10 );
-
-	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
-	const minValue = isNaN( parsedMinValue ) ? 1 : parsedMinValue;
-	const maxValue = isNaN( parsedMaxValue ) ? undefined : parsedMaxValue;
-	const step = isNaN( parsedStep ) ? 1 : parsedStep;
-
-	return {
-		currentValue,
-		minValue,
-		maxValue,
-		step,
-		inputElement,
-	};
-};
-
-const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
-	const event = new Event( 'change' );
-
-	inputElement.dispatchEvent( event );
-};
 
 store( 'woocommerce/add-to-cart-with-options', {
 	state: {},
-	actions: {
-		addQuantity: ( event: HTMLElementEvent< HTMLButtonElement > ) => {
-			const inputData = getInputData( event );
-			if ( ! inputData ) {
-				return;
-			}
-			const { currentValue, maxValue, step, inputElement } = inputData;
-			const newValue = currentValue + step;
-
-			if ( maxValue === undefined || newValue <= maxValue ) {
-				inputElement.value = newValue.toString();
-				dispatchChangeEvent( inputElement );
-			}
-		},
-		removeQuantity: ( event: HTMLElementEvent< HTMLButtonElement > ) => {
-			const inputData = getInputData( event );
-			if ( ! inputData ) {
-				return;
-			}
-			const { currentValue, minValue, step, inputElement } = inputData;
-			const newValue = currentValue - step;
-
-			if ( newValue >= minValue ) {
-				inputElement.value = newValue.toString();
-				dispatchChangeEvent( inputElement );
-			}
-		},
-	},
+	actions: {},
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/frontend.ts
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { store } from '@woocommerce/interactivity';
+import { HTMLElementEvent } from '@woocommerce/types';
+
+const getInputElementFromEvent = (
+	event: HTMLElementEvent< HTMLButtonElement >
+) => {
+	const target = event.target as HTMLButtonElement;
+
+	const inputElement = target.parentElement?.querySelector(
+		'.input-text.qty.text'
+	) as HTMLInputElement | null | undefined;
+
+	return inputElement;
+};
+
+const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+	const inputElement = getInputElementFromEvent( event );
+
+	if ( ! inputElement ) {
+		return;
+	}
+
+	const parsedValue = parseInt( inputElement.value, 10 );
+	const parsedMinValue = parseInt( inputElement.min, 10 );
+	const parsedMaxValue = parseInt( inputElement.max, 10 );
+	const parsedStep = parseInt( inputElement.step, 10 );
+
+	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
+	const minValue = isNaN( parsedMinValue ) ? 1 : parsedMinValue;
+	const maxValue = isNaN( parsedMaxValue ) ? undefined : parsedMaxValue;
+	const step = isNaN( parsedStep ) ? 1 : parsedStep;
+
+	return {
+		currentValue,
+		minValue,
+		maxValue,
+		step,
+		inputElement,
+	};
+};
+
+const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
+	const event = new Event( 'change' );
+
+	inputElement.dispatchEvent( event );
+};
+
+store( 'woocommerce/add-to-cart-with-options', {
+	state: {},
+	actions: {
+		addQuantity: ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+			const inputData = getInputData( event );
+			if ( ! inputData ) {
+				return;
+			}
+			const { currentValue, maxValue, step, inputElement } = inputData;
+			const newValue = currentValue + step;
+
+			if ( maxValue === undefined || newValue <= maxValue ) {
+				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
+			}
+		},
+		removeQuantity: ( event: HTMLElementEvent< HTMLButtonElement > ) => {
+			const inputData = getInputData( event );
+			if ( ! inputData ) {
+				return;
+			}
+			const { currentValue, minValue, step, inputElement } = inputData;
+			const newValue = currentValue - step;
+
+			if ( newValue >= minValue ) {
+				inputElement.value = newValue.toString();
+				dispatchChangeEvent( inputElement );
+			}
+		},
+	},
+} );

--- a/plugins/woocommerce/changelog/add-trigger-on-change-event-stepper-quantity-selector
+++ b/plugins/woocommerce/changelog/add-trigger-on-change-event-stepper-quantity-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add to Cart with Options Quantity Selector Stepper Layout: trigger change event when stepper buttons are clicked
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
@@ -18,16 +18,6 @@ class AddToCartWithOptionsQuantitySelector extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-quantity-selector';
 
 	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @param string $key Data to get, or default to everything.
-	 * @return null
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
-	}
-
-	/**
 	 * Get the block's attributes.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.


### PR DESCRIPTION
Same as https://github.com/woocommerce/woocommerce/pull/53343 but for the new block.

### How to test the changes in this Pull Request:

1. Install and activate the `WooCommerce Beta Tester` plugin
2. Go to `WooCommerce Admin Test Helper` -> `Features` and enable `add-to-cart-with-options-stepper-layout` and `blockified-add-to-cart`.
3. Create a new product.
4. Go to Pages > Add New Page.
5. Add a `Single product` block and select the product you just created.
6. Remove the current _Add to Cart with Options_ block.
7. Go to the block inserter and add a _Quantity Selector (Experimental)_ block and a _Add to Cart with Options (Experimental)_ block. Select the _Stepper_ mode for the _Quantity Selector_ block.
8. Go to the frontend and paste this code in the _Console_ of your browser devtools (<kbd>F12</kbd>):
```JS
const inputEl = window.document.getElementsByClassName(
   'wc-block-components-quantity-selector__input'
);

inputEl[0].addEventListener('change', () => {
   alert("clicked")
});
```
9. Verify that clicking on the `-` and `+` buttons triggers the change event (the alert will appear).
