### PR TITLE
Product Gallery: add support for Compatibility Layer

### DIFF
--- a/plugins/woocommerce-blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blockified-templates/compatibility-layer.md
@@ -37,11 +37,6 @@ The following table shows where the hooks are injected into the page.
 | woocommerce_no_products_found           | No Results       | before   |
 | woocommerce_archive_description         | Term Description | before   |
 
-
-
-
-
-
 ## Single Product Templates - [SingleProductTemplateCompatibility](https://github.com/woocommerce/woocommerce-blocks/blob/c8d82b20f4e4b8a424f1f0ebff80aca6f62588e5/src/Templates/SingleProductTemplateCompatibility.php)
 
 The compatibility is built around the entire page. The classic Single Product Page has a main div with the class `product` that wraps all the elements, which has multiple classes: the style of the elements inside the wrapper is applied via CSS with the selector `.product`. For this reason, the Compatibility Layer wraps inside a div with the class `product` all the blocks related to the Single Product Template that aren’t interrupted by a template part.

--- a/plugins/woocommerce/changelog/add-52982
+++ b/plugins/woocommerce/changelog/add-52982
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Single Product Compatibility Layer: Treat Product Gallery as a Single Product block

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -388,7 +388,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * @return bool True if the template has a single product template block, false otherwise.
 	 */
 	private static function has_single_product_template_blocks( $parsed_blocks ) {
-		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
+		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
 
 		return BlockTemplateUtils::has_block_including_patterns( $single_product_template_blocks, $parsed_blocks );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Treat Product Gallery as Single Product block in Compatibility Layer.

Part of https://github.com/woocommerce/woocommerce/issues/52982

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.. Paste the following code into `functions.php`

<details> 
  <summary>Single Product hooks - PASTE IT IN functions.php</summary>

   ```
	add_action(
		'woocommerce_before_main_content',
		function () {
			echo '<p data-testid="woocommerce_before_main_content">
				Hook: woocommerce_before_main_content
			</p>';
		}
	);

	add_action(
		'woocommerce_sidebar',
		function () {
			echo '<p data-testid="woocommerce_sidebar">
				Hook: woocommerce_sidebar
			</p>';
		}
	);

	add_action(
		'woocommerce_before_single_product',
		function () {
			echo '<p data-testid="woocommerce_before_single_product">
				Hook: woocommerce_before_single_product
			</p>';
		}
	);

	add_action(
		'woocommerce_before_single_product_summary',
		function () {
			echo '<p data-testid="woocommerce_before_single_product_summary">
				Hook: woocommerce_before_single_product_summary
			</p>';
		}
	);

	add_action(
		'woocommerce_single_product_summary',
		function () {
			echo '<p data-testid="woocommerce_single_product_summary">
				Hook: woocommerce_single_product_summary
			</p>';
		}
	);

	add_action(
		'woocommerce_before_add_to_cart_button',
		function () {
			echo '<p data-testid="woocommerce_before_add_to_cart_button">
				Hook: woocommerce_before_add_to_cart_button
			</p>';
		}
	);


	add_action(
		'woocommerce_product_meta_start',
		function () {
			echo '<p data-testid="woocommerce_product_meta_start">
				Hook: woocommerce_product_meta_start
			</p>';
		}
	);

	add_action(
		'woocommerce_product_meta_end',
		function () {
			echo '<p data-testid="woocommerce_product_meta_end">
				Hook: woocommerce_product_meta_end
			</p>';
		}
	);

	add_action(
		'woocommerce_share',
		function () {
			echo '<p data-testid="woocommerce_share">
				Hook: woocommerce_share
			</p>';
		}
	);

	add_action(
		'woocommerce_after_single_product_summary',
		function () {
			echo '<p data-testid="woocommerce_after_single_product_summary">
				Hook: woocommerce_after_single_product_summary
			</p>';
		}
	);

	add_action(
		'woocommerce_after_single_product',
		function () {
			echo '<p data-testid="woocommerce_after_single_product">
				Hook: woocommerce_after_single_product
			</p>';
		}
	);

	add_action(
		'woocommerce_after_main_content',
		function () {
			echo '<p data-testid="woocommerce_after_main_content">
				Hook: woocommerce_after_main_content
			</p>';
		}
	);
   ```

</details>

2. Visit some product on the frontend and keep this tab open!
3. Go to Editor > Single Product Template.
3. Replace Product Image Gallery with Product Gallery (Beta) block
4. Visit the same product on the frontend
5. **Expected:** Compare two tabs and make sure hooks are displayed in the same places

#### Default view

Before (with Product Image Gallery) | After (with Product Gallery (Beta))
-- | --
<img width="767" alt="image" src="https://github.com/user-attachments/assets/9d4ea64a-559c-4e5e-88e9-95e7cd377c4a"> | <img width="725" alt="image" src="https://github.com/user-attachments/assets/72deb9d9-32bc-412c-9388-9883fd37d3a8">

#### Product Image Gallery or Product Gallery (Beta) as a first block

Before (with Product Image Gallery) | After (with Product Gallery (Beta))
-- | --
<img width="649" alt="image" src="https://github.com/user-attachments/assets/7e6f1c49-70a6-4ed2-809d-11fd8d5dca23"> | <img width="774" alt="image" src="https://github.com/user-attachments/assets/85f65450-d967-4c2f-903d-a4f2232e4734">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
