### PR TITLE
[e2e tests] Improve order-edit test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-improve-order-edit-test
+++ b/plugins/woocommerce/changelog/e2e-improve-order-edit-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: improve order-edit test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -35,12 +35,14 @@ test.describe( 'Edit order', { tag: [ '@services', '@hpos' ] }, () => {
 			.then( ( response ) => {
 				orderToCancel = response.data.id;
 			} );
+
+		const username = `big.archie.${ Date.now() }`;
 		await api
 			.post( 'customers', {
-				email: 'archie123@email.addr',
+				email: `${ username }@email.addr`,
 				first_name: 'Archie',
 				last_name: 'Greenback',
-				username: 'big.archie',
+				username,
 				billing: {
 					first_name: 'Archibald',
 					last_name: 'Greenback',
@@ -52,7 +54,7 @@ test.describe( 'Edit order', { tag: [ '@services', '@hpos' ] }, () => {
 					state: 'CA',
 					postcode: '94107',
 					phone: '123456789',
-					email: 'archie123@email.addr',
+					email: `${ username }@email.addr`,
 				},
 				shipping: {
 					first_name: 'Shipping First',
@@ -532,10 +534,10 @@ test.describe(
 				page.locator( 'button.revoke_access' )
 			).toBeVisible();
 			await expect(
-				page.locator( 'a:has-text("Copy link")' )
+				page.getByRole( 'link', { name: 'Copy link' } )
 			).toBeVisible();
 			await expect(
-				page.locator( 'a:has-text("View report")' )
+				page.getByRole( 'link', { name: 'View report' } )
 			).toBeVisible();
 		} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the `order-edit.spec.js` test to use a unique customer username.
Updated some locators to use getByRole, recommended by Playwright. My IDE was throwing an error on these 2, that why I only updated these and left others that could also use an update.

### How to test the changes in this Pull Request:

`order-edit.spec.js` passes on repeated runs

```
pnpm test:e2e order-edit.spec.js
```
