### PR TITLE
[e2e tests] Fix create order test for multiple environments

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-notice-check-when-creating-order
+++ b/plugins/woocommerce/changelog/e2e-fix-notice-check-when-creating-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix create order test for multiple environments

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
@@ -370,9 +370,7 @@ test.describe(
 
 			// Create the order
 			await page.getByRole( 'button', { name: 'Create' } ).click();
-			await expect( page.locator( 'div.notice-success' ) ).toContainText(
-				'Order updated.'
-			);
+			await expect( page.getByText( 'Order updated' ) ).toBeVisible();
 
 			// Confirm the details
 			await expect(
@@ -415,9 +413,7 @@ test.describe(
 
 			// Create the order
 			await page.getByRole( 'button', { name: 'Create' } ).click();
-			await expect( page.locator( 'div.notice-success' ) ).toContainText(
-				'Order updated.'
-			);
+			await expect( page.getByText( 'Order updated' ) ).toBeVisible();
 
 			// Confirm the details
 			await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the locator for the `Order updated` notice to a more robust version. In some environments (e.g. JN) there are other notices displayed causing a strict mode violation.

### How to test the changes in this Pull Request:

`create-order.spec.js` passes on repeated runs

```
pnpm test:e2e create-order.spec.js
```
