### PR TITLE
Update documentation for the `experimental_` prefixed actions

### DIFF
--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -341,5 +341,24 @@ wp.hooks.addAction(
 );
 ```
 
--   `experimental__woocommerce_blocks-checkout-set-shipping-address` - Fired when a shipping address is added during checkout.
--   `experimental__woocommerce_blocks-checkout-set-billing-address` - Fired when a billing address is added during checkout.
+#### `experimental__woocommerce_blocks-checkout-set-shipping-address`
+
+Fired when a shipping address is added during checkout.
+
+##### Args
+
+This action has no arguments.
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-cart-set-shipping-address',
+	'plugin/namespace',
+	( { product, quantity } ) => {
+		console.log( 'The shipping address was changed.' );
+	}
+);
+```
+
+- `experimental__woocommerce_blocks-checkout-set-billing-address` - Fired when a billing address is added during checkout.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -119,7 +119,7 @@ These are [`@wordpress/hooks`](https://developer.wordpress.org/block-editor/refe
 -   `experimental__woocommerce_blocks-` is used for store events.
 -   `experimental__woocommerce_blocks-checkout-` is used for checkout events.
 
-### Current list of events:
+### Current list of events
 
 #### `experimental__woocommerce_blocks-cart-add-item`
 
@@ -318,6 +318,7 @@ wp.hooks.addAction(
 	}
 );
 ```
+
 #### `experimental__woocommerce_blocks-checkout-set-email-address`
 
 Fired when an email address is added during checkout.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -280,7 +280,27 @@ wp.hooks.addAction(
 );
 ```
 
--   `experimental__woocommerce_blocks-checkout-set-active-payment-method` - Fired when a payment method is chosen on checkout.
+#### `experimental__woocommerce_blocks-checkout-set-active-payment-method`
+
+Fired when a payment method is chosen on checkout.
+
+##### Args
+
+| Argument   | Type     | Description                      |
+|------------|----------|----------------------------------|
+| `paymentMethodSlug`  | `string` | The payment method slug.         |
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-checkout-set-active-payment-method',
+	'plugin/namespace',
+	( { paymentMethodSlug } ) => {
+		console.log( `The selected payment method was changed to ${ paymentMethodSlug }` );
+	}
+);
+```
 -   `experimental__woocommerce_blocks-checkout-render-checkout-form` - Fired when the checkout form is rendered.
 -   `experimental__woocommerce_blocks-checkout-set-email-address` - Fired when an email address is added during checkout.
 -   `experimental__woocommerce_blocks-checkout-set-shipping-address` - Fired when a shipping address is added during checkout.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -225,10 +225,39 @@ Fired when a search is submitted.
 
 This documentation will be amended following a review of this action.
 
--
--   `experimental__woocommerce_blocks-store-notice-create` - Fired when a store notice is created.
--   `experimental__woocommerce_blocks-product-render` - Fired when a single product block is rendered.
--   `experimental__woocommerce_blocks-checkout-submit` - Fired when the checkout form is submitted.
+#### `experimental__woocommerce_blocks-store-notice-create`
+
+Fired when a store notice is created.
+
+This documentation will be amended following a review of this action.
+
+#### `experimental__woocommerce_blocks-product-render`
+
+Fired when a single product block is rendered.
+
+This documentation will be amended following a review of this action.
+
+
+#### `experimental__woocommerce_blocks-checkout-submit`
+
+Fired when the checkout form is submitted.
+
+##### Args
+
+This action has no arguments.
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-checkout-submit',
+	'plugin/namespace',
+	() => {
+		console.log( 'The checkout form was submitted.' );
+	}
+);
+```
+
 -   `experimental__woocommerce_blocks-checkout-set-selected-shipping-rate` - Fired when a shipping rate is chosen on checkout.
 -   `experimental__woocommerce_blocks-checkout-set-active-payment-method` - Fired when a payment method is chosen on checkout.
 -   `experimental__woocommerce_blocks-checkout-render-checkout-form` - Fired when the checkout form is rendered.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -301,7 +301,26 @@ wp.hooks.addAction(
 	}
 );
 ```
--   `experimental__woocommerce_blocks-checkout-render-checkout-form` - Fired when the checkout form is rendered.
+
+#### `experimental__woocommerce_blocks-checkout-render-checkout-form`
+
+Fired when the checkout form is rendered.
+
+##### Args
+
+This action has no arguments.
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-checkout-render-checkout-form',
+	'plugin/namespace',
+	() => {
+		console.log( 'The checkout form was rendered.' );
+	}
+);
+```
 -   `experimental__woocommerce_blocks-checkout-set-email-address` - Fired when an email address is added during checkout.
 -   `experimental__woocommerce_blocks-checkout-set-shipping-address` - Fired when a shipping address is added during checkout.
 -   `experimental__woocommerce_blocks-checkout-set-billing-address` - Fired when a billing address is added during checkout.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -361,4 +361,22 @@ wp.hooks.addAction(
 );
 ```
 
-- `experimental__woocommerce_blocks-checkout-set-billing-address` - Fired when a billing address is added during checkout.
+#### `experimental__woocommerce_blocks-checkout-set-billing-address`
+
+Fired when a billing address is added during checkout.
+
+##### Args
+
+This action has no arguments.
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-cart-set-billing-address',
+	'plugin/namespace',
+	( { product, quantity } ) => {
+		console.log( 'The billing address was changed.' );
+	}
+);
+```

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -193,8 +193,6 @@ wp.hooks.addAction(
 
 Fired when a product link is clicked.
 
-
-
 ##### Args
 
 | Argument   | Type     | Description                             |
@@ -236,7 +234,6 @@ This documentation will be amended following a review of this action.
 Fired when a single product block is rendered.
 
 This documentation will be amended following a review of this action.
-
 
 #### `experimental__woocommerce_blocks-checkout-submit`
 

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -258,7 +258,28 @@ wp.hooks.addAction(
 );
 ```
 
--   `experimental__woocommerce_blocks-checkout-set-selected-shipping-rate` - Fired when a shipping rate is chosen on checkout.
+#### `experimental__woocommerce_blocks-checkout-set-selected-shipping-rate
+
+Fired when a shipping rate is chosen on checkout.
+
+##### Args
+
+| Argument   | Type     | Description                    |
+|------------|----------|--------------------------------|
+| `shippingRateId`  | `string` | The selected shipping rate ID. |
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-checkout-set-selected-shipping-rate',
+	'plugin/namespace',
+	( { shippingRateId } ) => {
+		console.log( `Selected shipping rate was changed to ${ shippingRateId }` );
+	}
+);
+```
+
 -   `experimental__woocommerce_blocks-checkout-set-active-payment-method` - Fired when a payment method is chosen on checkout.
 -   `experimental__woocommerce_blocks-checkout-render-checkout-form` - Fired when the checkout form is rendered.
 -   `experimental__woocommerce_blocks-checkout-set-email-address` - Fired when an email address is added during checkout.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -166,7 +166,29 @@ wp.hooks.addAction(
 );
 ```
 
--   `experimental__woocommerce_blocks-cart-remove-item` - Fired when a cart item is removed from the cart.
+#### `experimental__woocommerce_blocks-cart-remove-item`
+
+Fired when a cart item is removed from the cart. Fires on the Mini-cart block and the Cart block.
+
+##### Args
+
+| Argument   | Type     | Description                                      |
+|------------|----------|--------------------------------------------------|
+| `product`  | `object` | The product that was added to the cart.          |
+| `quantity` | `number` | The quantity of the product when it was removed. |
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-cart-remove-item',
+	'plugin/namespace',
+	( { product, quantity } ) => {
+		console.log( `${ product.name } was removed from the cart. There were ${ quantity } in the cart.` );
+	}
+);
+```
+
 -   `experimental__woocommerce_blocks-product-view-link` - Fired when a product link is clicked.
 -   `experimental__woocommerce_blocks-product-list-render` - Fired when a product list is rendered.
 -   `experimental__woocommerce_blocks-product-search` - Fired when a search is submitted.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -321,7 +321,7 @@ wp.hooks.addAction(
 
 #### `experimental__woocommerce_blocks-checkout-set-email-address`
 
-Fired when an email address is added during checkout.
+Fired when the email address is added or changed on the Checkout block.
 
 ##### Args
 
@@ -333,7 +333,7 @@ This action has no arguments.
 wp.hooks.addAction(
 	'experimental__woocommerce_blocks-checkout-set-email-address',
 	'plugin/namespace',
-	( { product, quantity } ) => {
+	() => {
 		console.log( 'The email address was changed.' );
 	}
 );
@@ -341,7 +341,7 @@ wp.hooks.addAction(
 
 #### `experimental__woocommerce_blocks-checkout-set-shipping-address`
 
-Fired when a shipping address is added during checkout.
+Fired when the shipping address is added or changed on the Checkout block.
 
 ##### Args
 
@@ -353,7 +353,7 @@ This action has no arguments.
 wp.hooks.addAction(
 	'experimental__woocommerce_blocks-cart-set-shipping-address',
 	'plugin/namespace',
-	( { product, quantity } ) => {
+	() => {
 		console.log( 'The shipping address was changed.' );
 	}
 );
@@ -361,7 +361,7 @@ wp.hooks.addAction(
 
 #### `experimental__woocommerce_blocks-checkout-set-billing-address`
 
-Fired when a billing address is added during checkout.
+Fired when the billing address is added or changed on the Checkout block.
 
 ##### Args
 
@@ -373,7 +373,7 @@ This action has no arguments.
 wp.hooks.addAction(
 	'experimental__woocommerce_blocks-cart-set-billing-address',
 	'plugin/namespace',
-	( { product, quantity } ) => {
+	() => {
 		console.log( 'The billing address was changed.' );
 	}
 );

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -15,7 +15,7 @@
     -   [Misc](#misc)
 -   [Usages of `experimental` prefix](#usages-of-experimental-prefix)
 
-We also use an `__experimental` prefix for any experimental interfaces. This is a signal to those reading our code that it should not be implemented in for production use. Currently this prefix is used in the following ways:
+We also use an `__experimental` prefix for any experimental interfaces. This is a signal to those reading our code that it should not be implemented in for production use. Currently, this prefix is used in the following ways:
 
 -   Prefixing references that are experimental. An example would be PHP action or filter slugs.
 -   Prefixing functions or methods that are experimental.
@@ -108,7 +108,7 @@ We also have individual features or code blocks behind a feature flag, this is a
 
 ### Misc
 
--   `__experimental_woocommerce_blocks_hidden` property allows overwriting the `hidden` property for cart item data. This is useful to make some cart item data visible/hidden depending if it needs to be displayed in the Cart Block or the Cart Shortcode ([experimental property](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/9c4288b0ee46960bdc2bf8ef351d05ac23073b0c/src/StoreApi/Schemas/CartItemSchema.php#L439-L441)). This was added in [this PR](https://github.com/woocommerce/woocommerce-blocks/pull/3732) to resolve [this issue with Subscriptions](https://github.com/woocommerce/woocommerce-blocks/issues/3731). This property will not be needed if the blocks replace the shortcode experience, since in that scenario, the `hidden` property would be sufficient.
+-   `__experimental_woocommerce_blocks_hidden` property allows overwriting the `hidden` property for cart item data. This is useful to make some cart item data visible/hidden depending on whether it needs to be displayed in the Cart Block or the Cart Shortcode ([experimental property](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/9c4288b0ee46960bdc2bf8ef351d05ac23073b0c/src/StoreApi/Schemas/CartItemSchema.php#L439-L441)). This was added in [this PR](https://github.com/woocommerce/woocommerce-blocks/pull/3732) to resolve [this issue with Subscriptions](https://github.com/woocommerce/woocommerce-blocks/issues/3731). This property will not be needed if the blocks replace the shortcode experience, since in that scenario, the `hidden` property would be sufficient.
 
 ## Usages of `experimental` prefix
 

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -114,6 +114,8 @@ We also have individual features or code blocks behind a feature flag, this is a
 
 `useStoreEvents` makes use of an `experimental__` prefix for wp-hook actions (since `__experimental` is not a valid prefix in that context).
 
+These are [`@wordpress/hooks`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-hooks/) actions that are fired at certain times while using WooCommerce Blocks. We separate them into "store" events (events that happen in the store, i.e. while browsing the store or cart) and "checkout events" (events that happen on the checkout page)
+
 -   `experimental__woocommerce_blocks-` is used for store events.
 -   `experimental__woocommerce_blocks-checkout-` is used for checkout events.
 

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -143,7 +143,29 @@ wp.hooks.addAction(
 );
 ```
 
--   `experimental__woocommerce_blocks-cart-set-item-quantity` - Fired when cart item quantity is changed by the customer.
+#### `experimental__woocommerce_blocks-cart-set-item-quantity`
+
+Fired when cart item quantity is changed by the customer. Fires on the Mini-cart block and the Cart block.
+
+##### Args
+
+| Argument   | Type     | Description                             |
+|------------|----------|-----------------------------------------|
+| `product`  | `object` | The product that was added to the cart. |
+| `quantity` | `number` | The new quantity of the product.        |
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-cart-set-item-quantity',
+	'plugin/namespace',
+	( { product, quantity } ) => {
+		console.log( `${ product.name }'s quantity was changed to ${ quantity }` );
+	}
+);
+```
+
 -   `experimental__woocommerce_blocks-cart-remove-item` - Fired when a cart item is removed from the cart.
 -   `experimental__woocommerce_blocks-product-view-link` - Fired when a product link is clicked.
 -   `experimental__woocommerce_blocks-product-list-render` - Fired when a product list is rendered.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -119,9 +119,30 @@ These are [`@wordpress/hooks`](https://developer.wordpress.org/block-editor/refe
 -   `experimental__woocommerce_blocks-` is used for store events.
 -   `experimental__woocommerce_blocks-checkout-` is used for checkout events.
 
-Current list of events:
+### Current list of events:
 
--   `experimental__woocommerce_blocks-cart-add-item` - Fired when an item is added to the cart.
+#### `experimental__woocommerce_blocks-cart-add-item`
+
+Fired when an item is added to the cart.
+
+##### Args
+
+| Argument | Type   | Description |
+|----------|--------|--------|
+| `product` | `object` | The product that was added to the cart. |
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-cart-add-item',
+	'plugin/namespace',
+	( { product } ) => {
+		console.log( `${ product.name } was added to the cart` );
+	}
+);
+```
+
 -   `experimental__woocommerce_blocks-cart-set-item-quantity` - Fired when cart item quantity is changed by the customer.
 -   `experimental__woocommerce_blocks-cart-remove-item` - Fired when a cart item is removed from the cart.
 -   `experimental__woocommerce_blocks-product-view-link` - Fired when a product link is clicked.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -189,9 +189,43 @@ wp.hooks.addAction(
 );
 ```
 
--   `experimental__woocommerce_blocks-product-view-link` - Fired when a product link is clicked.
--   `experimental__woocommerce_blocks-product-list-render` - Fired when a product list is rendered.
--   `experimental__woocommerce_blocks-product-search` - Fired when a search is submitted.
+#### `experimental__woocommerce_blocks-product-view-link`
+
+Fired when a product link is clicked.
+
+
+
+##### Args
+
+| Argument   | Type     | Description                             |
+|------------|----------|-----------------------------------------|
+| `product`  | `object` | The product that was added to the cart. |
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-product-view-link',
+	'plugin/namespace',
+	( { product } ) => {
+		console.log( `${ product.name } view link clicked.` );
+	}
+);
+```
+
+#### `experimental__woocommerce_blocks-product-list-render`
+
+Fired when a product list is rendered.
+
+This documentation will be amended following a review of this action.
+
+#### `experimental__woocommerce_blocks-product-search`
+
+Fired when a search is submitted.
+
+This documentation will be amended following a review of this action.
+
+-
 -   `experimental__woocommerce_blocks-store-notice-create` - Fired when a store notice is created.
 -   `experimental__woocommerce_blocks-product-render` - Fired when a single product block is rendered.
 -   `experimental__woocommerce_blocks-checkout-submit` - Fired when the checkout form is submitted.

--- a/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -321,6 +321,25 @@ wp.hooks.addAction(
 	}
 );
 ```
--   `experimental__woocommerce_blocks-checkout-set-email-address` - Fired when an email address is added during checkout.
+#### `experimental__woocommerce_blocks-checkout-set-email-address`
+
+Fired when an email address is added during checkout.
+
+##### Args
+
+This action has no arguments.
+
+##### Example
+
+```js
+wp.hooks.addAction(
+	'experimental__woocommerce_blocks-checkout-set-email-address',
+	'plugin/namespace',
+	( { product, quantity } ) => {
+		console.log( 'The email address was changed.' );
+	}
+);
+```
+
 -   `experimental__woocommerce_blocks-checkout-set-shipping-address` - Fired when a shipping address is added during checkout.
 -   `experimental__woocommerce_blocks-checkout-set-billing-address` - Fired when a billing address is added during checkout.

--- a/plugins/woocommerce/changelog/add-experimental-prefix-docs
+++ b/plugins/woocommerce/changelog/add-experimental-prefix-docs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This is a documentation update only.
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update documentation for the `experimental_` prefixed actions - some of them are currently left undocumented because they are not called anywhere in the codebase right now. [There is an open issue about them](https://github.com/woocommerce/woocommerce/issues/53390).

I did add documentation for two of the actions (`experimental__woocommerce_blocks-cart-add-item` and `experimental__woocommerce_blocks-product-view-link`) that aren't called, but do exist in the codebase. This is because the context and args are still available, whereas with the others, I don't know how they were used, or if they'll continue to be used this way if/when reimplemented.

Closes #45191 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. View the documentation, ensure it's formatted well and reads OK grammatically.
2. Try the examples out. (Note, the examples for the actions listed in #53390 won't work until they're reimplemented)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
