### PR TITLE
Send test email from the email preview

### DIFF
--- a/plugins/woocommerce/changelog/52229-send-preview-email
+++ b/plugins/woocommerce/changelog/52229-send-preview-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Experimental: send a test email from email settings

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import { Button, Modal, TextControl } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
 import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { isValidEmail } from '@woocommerce/product-editor';
+import { WC_ADMIN_NAMESPACE } from '@woocommerce/data';
 
 type EmailPreviewSendProps = {
 	type: string;
@@ -19,9 +21,12 @@ export const EmailPreviewSend: React.FC< EmailPreviewSendProps > = ( {
 
 	const handleSendEmail = async () => {
 		setIsSending( true );
-		setTimeout( () => {
-			setIsSending( false );
-		}, 2000 );
+		await apiFetch( {
+			path: `${ WC_ADMIN_NAMESPACE }/settings/email/send-preview`,
+			method: 'POST',
+			data: { email, type },
+		} );
+		setIsSending( false );
 	};
 
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -6,7 +6,13 @@ import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { isValidEmail } from '@woocommerce/product-editor';
 
-export const EmailPreviewSend: React.FC = () => {
+type EmailPreviewSendProps = {
+	type: string;
+};
+
+export const EmailPreviewSend: React.FC< EmailPreviewSendProps > = ( {
+	type,
+} ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ email, setEmail ] = useState( '' );
 	const [ isSending, setIsSending ] = useState( false );

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -36,7 +36,10 @@ export const EmailPreviewSend: React.FC< EmailPreviewSendProps > = ( {
 			{ isModalOpen && (
 				<Modal
 					title={ __( 'Send a test email', 'woocommerce' ) }
-					onRequestClose={ () => setIsModalOpen( false ) }
+					onRequestClose={ () => {
+						setIsModalOpen( false );
+						setIsSending( false );
+					} }
 					className="wc-settings-email-preview-send-modal"
 				>
 					<p>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export const EmailPreviewSend: React.FC = () => {
+	return (
+		<div className="wc-settings-email-preview-send">
+			<Button variant="secondary">
+				{ __( 'Send a test email', 'woocommerce' ) }
+			</Button>
+		</div>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -1,15 +1,57 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 
 export const EmailPreviewSend: React.FC = () => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ email, setEmail ] = useState( '' );
+
 	return (
 		<div className="wc-settings-email-preview-send">
-			<Button variant="secondary">
+			<Button
+				variant="secondary"
+				onClick={ () => setIsModalOpen( true ) }
+			>
 				{ __( 'Send a test email', 'woocommerce' ) }
 			</Button>
+
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Send a test email', 'woocommerce' ) }
+					onRequestClose={ () => setIsModalOpen( false ) }
+					className="wc-settings-email-preview-send-modal"
+				>
+					<p>
+						{ __(
+							'Send yourself a test email to check how your email looks in different email apps.',
+							'woocommerce'
+						) }
+					</p>
+
+					<TextControl
+						label={ __( 'Send to', 'woocommerce' ) }
+						type="email"
+						value={ email }
+						placeholder={ __( 'Enter an email', 'woocommerce' ) }
+						onChange={ setEmail }
+					/>
+
+					<div className="wc-settings-email-preview-send-modal-buttons">
+						<Button
+							variant="tertiary"
+							onClick={ () => setIsModalOpen( false ) }
+						>
+							{ __( 'Cancel', 'woocommerce' ) }
+						</Button>
+						<Button variant="primary">
+							{ __( 'Send test email', 'woocommerce' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -4,6 +4,7 @@
 import { Button, Modal, TextControl } from '@wordpress/components';
 import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
+import { isValidEmail } from '@woocommerce/product-editor';
 
 export const EmailPreviewSend: React.FC = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -46,7 +47,10 @@ export const EmailPreviewSend: React.FC = () => {
 						>
 							{ __( 'Cancel', 'woocommerce' ) }
 						</Button>
-						<Button variant="primary">
+						<Button
+							variant="primary"
+							disabled={ ! isValidEmail( email ) }
+						>
 							{ __( 'Send test email', 'woocommerce' ) }
 						</Button>
 					</div>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -9,6 +9,14 @@ import { isValidEmail } from '@woocommerce/product-editor';
 export const EmailPreviewSend: React.FC = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ email, setEmail ] = useState( '' );
+	const [ isSending, setIsSending ] = useState( false );
+
+	const handleSendEmail = async () => {
+		setIsSending( true );
+		setTimeout( () => {
+			setIsSending( false );
+		}, 2000 );
+	};
 
 	return (
 		<div className="wc-settings-email-preview-send">
@@ -49,9 +57,13 @@ export const EmailPreviewSend: React.FC = () => {
 						</Button>
 						<Button
 							variant="primary"
-							disabled={ ! isValidEmail( email ) }
+							onClick={ handleSendEmail }
+							isBusy={ isSending }
+							disabled={ ! isValidEmail( email ) || isSending }
 						>
-							{ __( 'Send test email', 'woocommerce' ) }
+							{ isSending
+								? __( 'Sending…', 'woocommerce' )
+								: __( 'Send test email', 'woocommerce' ) }
 						</Button>
 					</div>
 				</Modal>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -62,7 +62,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 						deviceType={ deviceType }
 						setDeviceType={ setDeviceType }
 					/>
-					<EmailPreviewSend />
+					<EmailPreviewSend type={ emailType } />
 				</div>
 				<div
 					className={ `wc-settings-email-preview wc-settings-email-preview-${ deviceType }` }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -16,6 +16,7 @@ import {
 	DEVICE_TYPE_DESKTOP,
 } from './settings-email-preview-device-type';
 import { EmailPreviewHeader } from './settings-email-preview-header';
+import { EmailPreviewSend } from './settings-email-preview-send';
 import { EmailPreviewType } from './settings-email-preview-type';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
@@ -61,6 +62,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 						deviceType={ deviceType }
 						setDeviceType={ setDeviceType }
 					/>
+					<EmailPreviewSend />
 				</div>
 				<div
 					className={ `wc-settings-email-preview wc-settings-email-preview-${ deviceType }` }

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -100,6 +100,29 @@ $wc-setting-email-preview-gap: 16px;
 	width: 456px;
 }
 
+.wc-settings-email-preview-send-modal-notice {
+	align-items: center;
+	display: flex;
+
+	svg {
+		margin-right: 4px;
+	}
+}
+
+.wc-settings-email-preview-send-modal-notice-success {
+	svg {
+		fill: $alert-green;
+	}
+}
+
+.wc-settings-email-preview-send-modal-notice-error {
+	color: $alert-red;
+
+	svg {
+		fill: $alert-red;
+	}
+}
+
 .wc-settings-email-preview-send-modal-buttons {
 	display: flex;
 	justify-content: flex-end;

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -96,6 +96,20 @@ $wc-setting-email-preview-gap: 16px;
 	max-width: 360px;
 }
 
+.wc-settings-email-preview-send-modal {
+	width: 456px;
+}
+
+.wc-settings-email-preview-send-modal-buttons {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: $wc-setting-email-preview-gap * 2;
+
+	button {
+		margin-left: 12px;
+	}
+}
+
 .wc-settings-email-preview-header {
 	border-bottom: 1px solid $gray-200;
 	display: flex;

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -13,8 +13,13 @@ $wc-setting-email-preview-gap: 16px;
 }
 
 .wc-settings-email-preview-controls {
+	align-items: center;
 	display: flex;
 	justify-content: space-between;
+
+	div {
+		margin-bottom: 0;
+	}
 }
 
 .wc-settings-email-preview-type {
@@ -36,6 +41,7 @@ $wc-setting-email-preview-gap: 16px;
 	display: grid;
 	grid-gap: 8px;
 	grid-template-columns: 32px 32px;
+	padding-right: 8px;
 
 	button {
 		align-items: center;

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -200,10 +200,18 @@ class WC_Admin {
 
 			if ( isset( $_GET['type'] ) ) {
 				$type_param = sanitize_text_field( wp_unslash( $_GET['type'] ) );
-				$email_preview->set_email_type( $type_param );
+				try {
+					$email_preview->set_email_type( $type_param );
+				} catch ( InvalidArgumentException $e ) {
+					wp_die( esc_html__( 'Invalid email type.', 'woocommerce' ), 400 );
+				}
 			}
 
-			$message = $email_preview->render();
+			try {
+				$message = $email_preview->render();
+			} catch ( Throwable $e ) {
+				wp_die( esc_html__( 'There was an error rendering an email preview.', 'woocommerce' ), 404 );
+			}
 
 			// print the preview email.
 			// phpcs:ignore WordPress.Security.EscapeOutput

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -7,7 +7,7 @@
  * @version  2.6.0
  */
 
-use Automattic\WooCommerce\Internal\Admin\EmailPreview;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -197,7 +197,13 @@ class WC_Admin {
 			}
 
 			$email_preview = wc_get_container()->get( EmailPreview::class );
-			$message       = $email_preview->render();
+
+			if ( isset( $_GET['type'] ) ) {
+				$type_param = sanitize_text_field( wp_unslash( $_GET['type'] ) );
+				$email_preview->set_email_type( $type_param );
+			}
+
+			$message = $email_preview->render();
 
 			// print the preview email.
 			// phpcs:ignore WordPress.Security.EscapeOutput

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -344,6 +344,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\ReceiptRendering\ReceiptRenderingRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class )->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -22,6 +22,20 @@ class EmailPreview {
 	const DEFAULT_EMAIL_TYPE = 'WC_Email_Customer_Processing_Order';
 
 	/**
+	 * The email type to preview.
+	 *
+	 * @var string
+	 */
+	private string $email_type = self::DEFAULT_EMAIL_TYPE;
+
+	/**
+	 * List of available email types.
+	 *
+	 * @var array
+	 */
+	private array $email_types = array();
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var object
@@ -38,6 +52,20 @@ class EmailPreview {
 			static::$instance = new static();
 		}
 		return static::$instance;
+	}
+
+	/**
+	 * Set the email type to preview.
+	 *
+	 * @param string $email_type Email type.
+	 *
+	 * @throws \InvalidArgumentException When the email type is invalid.
+	 */
+	public function set_email_type( string $email_type ) {
+		if ( ! in_array( $email_type, $this->get_email_types(), true ) ) {
+			throw new \InvalidArgumentException( 'Invalid email type' );
+		}
+		$this->email_type = $email_type;
 	}
 
 	/**
@@ -63,6 +91,18 @@ class EmailPreview {
 			return $product;
 		}
 		return $this->get_dummy_product();
+	}
+
+	/**
+	 * Get the list of available email types.
+	 *
+	 * @return array
+	 */
+	private function get_email_types() {
+		if ( empty( $this->email_types ) ) {
+			$this->email_types = array_keys( WC()->mailer()->get_emails() );
+		}
+		return $this->email_types;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -145,12 +145,16 @@ class EmailPreview {
 		$email  = $emails[ $this->email_type ];
 
 		$order = $this->get_dummy_order();
+		$email->set_object( $order );
+
 		/**
-		 * An object used in email preview. Defaults to a dummy WC_Order.
+		 * Allow to modify the email object before rendering the preview to add additional data.
+		 *
+		 * @param WC_Email $email The email object.
 		 *
 		 * @since 9.6.0
 		 */
-		$email->set_object( apply_filters( 'woocommerce_email_preview_object', $order ) );
+		$email = apply_filters( 'woocommerce_prepare_email_for_preview', $email );
 
 		$content = $email->get_content_html();
 
@@ -182,9 +186,12 @@ class EmailPreview {
 		/**
 		 * A dummy WC_Order used in email preview.
 		 *
+		 * @param WC_Order $order The dummy order object.
+		 * @param string   $email_type The email type to preview.
+		 *
 		 * @since 9.6.0
 		 */
-		return apply_filters( 'woocommerce_email_preview_dummy_order', $order );
+		return apply_filters( 'woocommerce_email_preview_dummy_order', $order, $this->email_type );
 	}
 
 	/**
@@ -201,9 +208,12 @@ class EmailPreview {
 		/**
 		 * A dummy WC_Product used in email preview.
 		 *
+		 * @param WC_Product $product The dummy product object.
+		 * @param string     $email_type The email type to preview.
+		 *
 		 * @since 9.6.0
 		 */
-		return apply_filters( 'woocommerce_email_preview_dummy_product', $product );
+		return apply_filters( 'woocommerce_email_preview_dummy_product', $product, $this->email_type );
 	}
 
 	/**
@@ -228,9 +238,12 @@ class EmailPreview {
 		/**
 		 * A dummy address used in email preview as billing and shipping one.
 		 *
+		 * @param array  $address The dummy address.
+		 * @param string $email_type The email type to preview.
+		 *
 		 * @since 9.6.0
 		 */
-		return apply_filters( 'woocommerce_email_preview_dummy_address', $address );
+		return apply_filters( 'woocommerce_email_preview_dummy_address', $address, $this->email_type );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -141,7 +141,8 @@ class EmailPreview {
 	private function render_preview_email() {
 		$this->set_up_filters();
 
-		$email = $this->get_email();
+		$emails = WC()->mailer()->get_emails();
+		$email  = $emails[ $this->email_type ];
 
 		$order = $this->get_dummy_order();
 		$email->set_object( $order );
@@ -207,29 +208,6 @@ class EmailPreview {
 			'country'    => 'US',
 			'state'      => 'CA',
 		);
-	}
-
-	/**
-	 * Get the email class for email preview.
-	 *
-	 * @return WC_Email
-	 */
-	private function get_email() {
-		$emails     = WC()->mailer()->get_emails();
-		$email_type = self::DEFAULT_EMAIL_TYPE;
-
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		// Nonce verification is done in class-wc-admin.php in preview_emails() method.
-		if ( isset( $_GET['type'] ) ) {
-			$type_param = sanitize_text_field( wp_unslash( $_GET['type'] ) );
-			if ( array_key_exists( $type_param, $emails ) ) {
-				$email_type = $type_param;
-			}
-		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-		$email = $emails[ $email_type ];
-		return $email;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -5,7 +5,7 @@
 
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\Internal\Admin;
+namespace Automattic\WooCommerce\Internal\Admin\EmailPreview;
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Email;
@@ -110,7 +110,7 @@ class EmailPreview {
 
 		$this->clean_up_filters();
 
-		/** This filter is documented in src/Internal/Admin/EmailPreview.php */
+		/** This filter is documented in src/Internal/Admin/EmailPreview/EmailPreview.php */
 		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $content ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -145,7 +145,12 @@ class EmailPreview {
 		$email  = $emails[ $this->email_type ];
 
 		$order = $this->get_dummy_order();
-		$email->set_object( $order );
+		/**
+		 * An object used in email preview. Defaults to a dummy WC_Order.
+		 *
+		 * @since 9.6.0
+		 */
+		$email->set_object( apply_filters( 'woocommerce_email_preview_object', $order ) );
 
 		$content = $email->get_content_html();
 
@@ -174,7 +179,12 @@ class EmailPreview {
 		$order->set_billing_address( $address );
 		$order->set_shipping_address( $address );
 
-		return $order;
+		/**
+		 * A dummy WC_Order used in email preview.
+		 *
+		 * @since 9.6.0
+		 */
+		return apply_filters( 'woocommerce_email_preview_dummy_order', $order );
 	}
 
 	/**
@@ -187,7 +197,13 @@ class EmailPreview {
 		$product = new WC_Product();
 		$product->set_name( 'Dummy Product' );
 		$product->set_price( 25 );
-		return $product;
+
+		/**
+		 * A dummy WC_Product used in email preview.
+		 *
+		 * @since 9.6.0
+		 */
+		return apply_filters( 'woocommerce_email_preview_dummy_product', $product );
 	}
 
 	/**
@@ -196,7 +212,7 @@ class EmailPreview {
 	 * @return array
 	 */
 	private function get_dummy_address() {
-		return array(
+		$address = array(
 			'first_name' => 'John',
 			'last_name'  => 'Doe',
 			'company'    => 'Company',
@@ -208,6 +224,13 @@ class EmailPreview {
 			'country'    => 'US',
 			'state'      => 'CA',
 		);
+
+		/**
+		 * A dummy address used in email preview as billing and shipping one.
+		 *
+		 * @since 9.6.0
+		 */
+		return apply_filters( 'woocommerce_email_preview_dummy_address', $address );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -1,0 +1,90 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\EmailPreview;
+
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Controller for the REST endpoint to send an email preview.
+ */
+class EmailPreviewRestController extends RestApiControllerBase {
+
+	/**
+	 * The root namespace for the JSON REST API endpoints.
+	 *
+	 * @var string
+	 */
+	protected string $route_namespace = 'wc-admin';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected string $rest_base = 'settings/email';
+
+	/**
+	 * Get the WooCommerce REST API namespace for the class.
+	 *
+	 * @return string
+	 */
+	protected function get_rest_api_namespace(): string {
+		return 'wc-admin';
+	}
+
+	/**
+	 * Register the REST API endpoints handled by this controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/send-preview',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->send_email_preview( $request ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'type'  => array(
+							'description' => __( 'The email type to preview.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+						'email' => array(
+							'description'       => __( 'Email address to send the email preview to.', 'woocommerce' ),
+							'type'              => 'string',
+							'format'            => 'email',
+							'required'          => true,
+							'validate_callback' => 'rest_validate_request_arg',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission check for REST API endpoint.
+	 *
+	 * @param WP_REST_Request $request The request for which the permission is checked.
+	 * @return bool|WP_Error True if the current user has the capability, otherwise a WP_Error object.
+	 */
+	private function check_permissions( WP_REST_Request $request ) {
+		return $this->check_permission( $request, 'manage_woocommerce' );
+	}
+
+	/**
+	 * Handle the POST /settings/email/send-preview.
+	 *
+	 * @param WP_REST_Request $request The received request.
+	 * @return array|WP_Error Request response or an error.
+	 */
+	public function send_email_preview( WP_REST_Request $request ) {
+		return array(
+			'message' => __( 'Email preview was sent.', 'woocommerce' ),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -97,14 +97,15 @@ class EmailPreviewRestController extends RestApiControllerBase {
 
 		$email_address = $request->get_param( 'email' );
 		$email_content = $email_preview->render();
-		$email = new \WC_Emails();
-		$sent = $email->send( $email_address, 'test', $email_content );
+		$email         = new \WC_Emails();
+		$sent          = $email->send( $email_address, 'test', $email_content );
 
-		if ($sent) {
+		if ( $sent ) {
 			return array(
+				// translators: %s: Email address.
 				'message' => sprintf( __( 'Test email sent to %s.', 'woocommerce' ), $email_address ),
 			);
-		};
+		}
 		return new WP_Error(
 			'woocommerce_rest_email_preview_not_sent',
 			__( 'Error sending test email. Please try again.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController;
 
 /**
  * Service provider for the EmailPreview namespace.
@@ -18,6 +19,7 @@ class EmailPreviewServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = array(
 		EmailPreview::class,
+		EmailPreviewRestController::class,
 	);
 
 	/**
@@ -25,5 +27,6 @@ class EmailPreviewServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register() {
 		$this->share( EmailPreview::class );
+		$this->share( EmailPreviewRestController::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
-use Automattic\WooCommerce\Internal\Admin\EmailPreview;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 
 /**
  * Service provider for the EmailPreview namespace.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -118,6 +118,39 @@ test.describe( 'WooCommerce Email Settings', () => {
 		expect( sender ).toContain( newFromAddress );
 	} );
 
+	test( 'Send email preview', async ( { page, baseURL } ) => {
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		// Click the "Send a test email" button
+		await page.getByRole( 'button', { name: 'Send a test email' } ).click();
+
+		// Verify that the modal window is open
+		const modal = page.getByRole( 'dialog' );
+		await expect( modal ).toBeVisible();
+
+		// Verify that the "Send test email" button is disabled
+		const sendButton = modal.getByRole( 'button', {
+			name: 'Send test email',
+		} );
+		await expect( sendButton ).toBeDisabled();
+
+		// Fill in the email address field
+		const email = 'test@example.com';
+		const emailInput = modal.getByLabel( 'Send to' );
+		await emailInput.fill( email );
+
+		// Verify the "Send test email" button is now enabled
+		await expect( sendButton ).toBeEnabled();
+		await sendButton.click();
+
+		// Wait for the message, because sending will fail in test environment
+		const message = modal.locator(
+			'text=Error sending test email. Please try again.'
+		);
+		await expect( message ).toBeVisible();
+	} );
+
 	test( 'See email image url field with a feature flag', async ( {
 		page,
 		baseURL,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -100,7 +100,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test sending email preview by a user without the needed capabilities.
 	 */
 	public function test_send_preview_by_user_without_caps() {
-		$filter_callback = fn( $caps ) => array(
+		$filter_callback = fn() => array(
 			'manage_woocommerce' => false,
 		);
 		add_filter( 'user_has_cap', $filter_callback );
@@ -153,13 +153,13 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	/**
 	 * Helper method to construct a request to send an email preview.
 	 *
-	 * @param string|null $type
-	 * @param string|null $email
+	 * @param string|null $type Email type to preview.
+	 * @param string|null $email Email address to send the preview to.
 	 * @return WP_REST_Request
 	 */
 	private function get_email_preview_request( ?string $type = null, ?string $email = null ) {
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/send-preview' );
-		$params = array();
+		$params  = array();
 		if ( $type ) {
 			$params['type'] = $type;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -1,0 +1,136 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\EmailPreview;
+
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * EmailPreviewRestController API controller test.
+ *
+ * @class PaymentsRestController
+ */
+class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * Endpoint.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT = '/wc-admin/settings/email';
+
+	/**
+	 * Email address.
+	 *
+	 * @var string
+	 */
+	const EMAIL = 'example@wordpress.com';
+
+	/**
+	 * @var EmailPreviewRestController
+	 */
+	protected EmailPreviewRestController $controller;
+
+	/**
+	 * @var MockObject|EmailPreview
+	 */
+	protected $mock_service;
+
+	/**
+	 * The ID of the store admin user.
+	 *
+	 * @var int
+	 */
+	protected $store_admin_id;
+
+	/**
+	 * Set up test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->store_admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->store_admin_id );
+
+		$this->mock_service = $this->getMockBuilder( EmailPreview::class )->getMock();
+
+		$this->controller = new EmailPreviewRestController();
+		$this->controller->register_routes();
+	}
+
+	/**
+	 * Test sending email preview without required arguments
+	 */
+	public function test_send_preview_without_args() {
+		$request  = $this->get_email_preview_request();
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): type, email', $response->get_data()['message'] );
+
+		$request  = $this->get_email_preview_request( EmailPreview::DEFAULT_EMAIL_TYPE );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): email', $response->get_data()['message'] );
+
+		$request  = $this->get_email_preview_request( null, self::EMAIL );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): type', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test sending email preview with invalid arguments
+	 */
+	public function test_send_preview_with_invalid_args() {
+		$request  = $this->get_email_preview_request( 'non-existent-type', self::EMAIL );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Invalid email type.', $response->get_data()['message'] );
+
+		$request  = $this->get_email_preview_request( EmailPreview::DEFAULT_EMAIL_TYPE, 'invalid-email' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Invalid parameter(s): email', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test sending email preview by a user without the needed capabilities.
+	 */
+	public function test_send_preview_by_user_without_caps() {
+		$filter_callback = fn( $caps ) => array(
+			'manage_woocommerce' => false,
+		);
+		add_filter( 'user_has_cap', $filter_callback );
+
+		$request  = $this->get_email_preview_request( EmailPreview::DEFAULT_EMAIL_TYPE, self::EMAIL );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
+
+		remove_filter( 'user_has_cap', $filter_callback );
+	}
+
+
+	/**
+	 * Helper method to construct a request to send an email preview.
+	 *
+	 * @param string|null $type
+	 * @param string|null $email
+	 * @return WP_REST_Request
+	 */
+	private function get_email_preview_request( ?string $type = null, ?string $email = null ) {
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/send-preview' );
+		$params = array();
+		if ( $type ) {
+			$params['type'] = $type;
+		}
+		if ( $email ) {
+			$params['email'] = $email;
+		}
+		$request->set_body_params( $params );
+		return $request;
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -113,6 +113,42 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 		remove_filter( 'user_has_cap', $filter_callback );
 	}
 
+	/**
+	 * Test sending email preview with a successful sending.
+	 */
+	public function test_send_preview_success_response() {
+		$request  = $this->get_email_preview_request( EmailPreview::DEFAULT_EMAIL_TYPE, self::EMAIL );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Test email sent to ' . self::EMAIL . '.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test sending email preview with a failed sending.
+	 */
+	public function test_send_preview_error_response() {
+		add_filter( 'woocommerce_mail_callback', array( $this, 'simulate_failed_sending' ), 10, 0 );
+
+		$request  = $this->get_email_preview_request( EmailPreview::DEFAULT_EMAIL_TYPE, self::EMAIL );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 500, $response->get_status() );
+		$this->assertEquals( 'Error sending test email. Please try again.', $response->get_data()['message'] );
+
+		remove_filter( 'woocommerce_mail_callback', array( $this, 'simulate_failed_sending' ), 10 );
+	}
+
+	/**
+	 * Helper method to simulate a failed email sending.
+	 *
+	 * @return callable
+	 */
+	public function simulate_failed_sending() {
+		return function () {
+			return false;
+		};
+	}
 
 	/**
 	 * Helper method to construct a request to send an email preview.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -1,16 +1,16 @@
 <?php
 declare( strict_types = 1 );
 
-namespace Automattic\WooCommerce\Tests\Internal\Admin;
+namespace Automattic\WooCommerce\Tests\Internal\Admin\EmailPreview;
 
-use Automattic\WooCommerce\Internal\Admin\EmailPreview;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use WC_Emails;
 use WC_Unit_Test_Case;
 
 /**
  * EmailPreviewTest test.
  *
- * @covers \Automattic\WooCommerce\Internal\Admin\EmailPreview
+ * @covers \Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview
  */
 class EmailPreviewTest extends WC_Unit_Test_Case {
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<img width="660" alt="381147708-96430893-eeae-465f-9663-feaf811d97db" src="https://github.com/user-attachments/assets/45a344e7-c167-47d5-890a-29b3064fe342" />

Part of #52228. 

1. Adds an option to send an email preview to an email address.
2. Adds human-friendly error messages when email preview can't be rendered.
3. Adds new filters to allow extensions to provide required data for their emails:
    - `woocommerce_prepare_email_for_preview`
    - `woocommerce_email_preview_dummy_order`
    - `woocommerce_email_preview_dummy_product`
    - `woocommerce_email_preview_dummy_address`

Closes #52229.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Sending a test email

1. Enable `email_improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
5. Go to **WooCommerce > Settings > Emails**.
6. In the email preview, click `Send a test email`
7. Enter a valid email address.
8. Submit the form and check the response message. If your environment can send emails, you should also receive the email.

#### Human error messages in email preview

1. Enable `email_improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
2. Install WooCommerce Subscriptions plugin.
3. Go to **WooCommerce > Settings > Emails**.
4. Check that you see a list of all registered emails related to Subscriptions in the email preview. 
5. Choose any of the `Customer Notification:` emails - you should see `There was an error rendering an email preview.` message.

#### New filters 

1. Enable `email_improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
2. Try modifying email preview data using any of the `woocommerce_prepare_email_for_preview`, `woocommerce_email_preview_dummy_order`, `woocommerce_email_preview_dummy_product`, `woocommerce_email_preview_dummy_address` filters to see, that they work.

<!-- End testing instructions -->
