### PR TITLE
Update arg on `set-active-payment-method` action

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -77,7 +77,7 @@ const PaymentMethodOptions = () => {
 			__internalSetActivePaymentMethod( value );
 			removeNotice( 'wc-payment-error', noticeContexts.PAYMENTS );
 			dispatchCheckoutEvent( 'set-active-payment-method', {
-				value,
+				paymentMethodSlug: value,
 			} );
 		},
 		[

--- a/plugins/woocommerce/changelog/fix-incorrect-payment-action-param
+++ b/plugins/woocommerce/changelog/fix-incorrect-payment-action-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the parameter passed in one of the set-active-payment-method events to use the paymentMethodSlug argument name, in line with the documentation


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In `saved-payment-method-options.tsx` we fire the `set-active-payment-method` action with a parameter of `paymentMethodSlug` however in `payment-method-options.js` the parameter is `value`. As the parameters are passed as an object, any consuming code destructuring the args will break.

This PR brings the `payment-method-options.js` in line with the documentation (which I updated in #53396) and the parameter used by the Google analytics integration. It's likely folks will have used that as an example, so I opted to stick with the param name used there.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you have a payment method that supports saved methods, for example Stripe.
2. Ensure you have some regular payment methods too like BACS or COD.
3. If you need saved payment methods, check out a few times using it and save the card.
4. Add an item to your cart and go to the Checkout block.
5. Open the dev console and add this code:
```js
wp.hooks.addAction(
	'experimental__woocommerce_blocks-checkout-set-active-payment-method',
	'plugin/namespace',
	( { paymentMethodSlug } ) => {
		console.log( `${ paymentMethodSlug } chosen.` );
	}
);
```

6. Switch between saved payment methods and regular payment methods ensuring you get a console log for each, and no console errors.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
