### PR TITLE
Render the product type toolbar button only when the product is not defined

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
@@ -24,9 +24,9 @@ export default function ToolbarProductTypeGroup() {
 	 * Get the product types and the current product type
 	 * from the store.
 	 */
-	const { productTypes, currentProduct } = useSelect< {
+	const { productTypes, currentProductType } = useSelect< {
 		productTypes: ProductTypeProps[];
-		currentProduct: ProductTypeProps;
+		currentProductType: ProductTypeProps;
 	} >( ( select ) => {
 		const { getProductTypes, getCurrentProductType } = select(
 			woocommerceTemplateStateStore
@@ -34,7 +34,7 @@ export default function ToolbarProductTypeGroup() {
 
 		return {
 			productTypes: getProductTypes(),
-			currentProduct: getCurrentProductType(),
+			currentProductType: getCurrentProductType(),
 		};
 	}, [] );
 
@@ -55,10 +55,10 @@ export default function ToolbarProductTypeGroup() {
 			<ToolbarDropdownMenu
 				icon={ <Icon icon={ eye } /> }
 				text={
-					currentProduct?.label ||
+					currentProductType?.label ||
 					__( 'Switch product type', 'woocommerce' )
 				}
-				value={ currentProduct?.slug }
+				value={ currentProductType?.slug }
 				controls={ productTypes.map( ( productType ) => ( {
 					title: productType.label,
 					onClick: () => switchProductType( productType.slug ),

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { eye } from '@woocommerce/icons';
+import { useProductDataContext } from '@woocommerce/shared-context';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import {
+	Icon,
+	ToolbarGroup,
+
+	// @ts-expect-error no exported member.
+	ToolbarDropdownMenu,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { store as woocommerceTemplateStateStore } from '../../store';
+import { ProductTypeProps } from '../../types';
+
+export default function ToolbarProductTypeGroup() {
+	/*
+	 * Get the product types and the current product type
+	 * from the store.
+	 */
+	const { productTypes, currentProduct } = useSelect< {
+		productTypes: ProductTypeProps[];
+		currentProduct: ProductTypeProps;
+	} >( ( select ) => {
+		const { getProductTypes, getCurrentProductType } = select(
+			woocommerceTemplateStateStore
+		);
+
+		return {
+			productTypes: getProductTypes(),
+			currentProduct: getCurrentProductType(),
+		};
+	}, [] );
+
+	const { switchProductType } = useDispatch( woocommerceTemplateStateStore );
+
+	const { product } = useProductDataContext();
+
+	/*
+	 * Do not render the component if the product is not set
+	 * or if there is only one product type.
+	 */
+	if ( product?.id || productTypes?.length < 2 ) {
+		return null;
+	}
+
+	return (
+		<ToolbarGroup>
+			<ToolbarDropdownMenu
+				icon={ <Icon icon={ eye } /> }
+				text={
+					currentProduct?.label ||
+					__( 'Switch product type', 'woocommerce' )
+				}
+				value={ currentProduct?.slug }
+				controls={ productTypes.map( ( productType ) => ( {
+					title: productType.label,
+					onClick: () => switchProductType( productType.slug ),
+				} ) ) }
+			/>
+		</ToolbarGroup>
+	);
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -9,25 +9,14 @@ import {
 } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { eye } from '@woocommerce/icons';
 import type { InnerBlockTemplate } from '@wordpress/blocks';
-import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	Icon,
-	ToolbarGroup,
-
-	// @ts-expect-error no exported member.
-	ToolbarDropdownMenu,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { useIsDescendentOfSingleProductBlock } from '../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { AddToCartOptionsSettings } from './settings';
-import { store as woocommerceTemplateStateStore } from './store';
-import { ProductTypeProps } from './types';
-import { useProductDataContext } from '@woocommerce/shared-context';
+import ToolbarProductTypeGroup from './components/toolbar-type-product-selector-group';
 export interface Attributes {
 	className?: string;
 	isDescendentOfSingleProductBlock: boolean;
@@ -61,22 +50,6 @@ const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
-	const { productTypes, currentProduct } = useSelect< {
-		productTypes: ProductTypeProps[];
-		currentProduct: ProductTypeProps;
-	} >( ( select ) => {
-		const { getProductTypes, getCurrentProductType } = select(
-			woocommerceTemplateStateStore
-		);
-
-		return {
-			productTypes: getProductTypes(),
-			currentProduct: getCurrentProductType(),
-		};
-	}, [] );
-
-	const { switchProductType } = useDispatch( woocommerceTemplateStateStore );
-
 	const blockProps = useBlockProps();
 	const { isDescendentOfSingleProductBlock } =
 		useIsDescendentOfSingleProductBlock( {
@@ -89,35 +62,18 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 		} );
 	}, [ setAttributes, isDescendentOfSingleProductBlock ] );
 
-	const { product } = useProductDataContext();
-
 	return (
 		<>
-			{ ! product?.id && (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarDropdownMenu
-							icon={ <Icon icon={ eye } /> }
-							text={
-								currentProduct?.label ||
-								__( 'Switch product type', 'woocommerce' )
-							}
-							value={ currentProduct?.slug }
-							controls={ productTypes.map( ( productType ) => ( {
-								title: productType.label,
-								onClick: () =>
-									switchProductType( productType.slug ),
-							} ) ) }
-						/>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
+			<BlockControls>
+				<ToolbarProductTypeGroup />
+			</BlockControls>
 
 			<AddToCartOptionsSettings
 				features={ {
 					isBlockifiedAddToCart: true,
 				} }
 			/>
+
 			<div { ...blockProps }>
 				<InnerBlocks template={ INNER_BLOCKS_TEMPLATE } />
 			</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -27,6 +27,7 @@ import { useIsDescendentOfSingleProductBlock } from '../../atomic/blocks/product
 import { AddToCartOptionsSettings } from './settings';
 import { store as woocommerceTemplateStateStore } from './store';
 import { ProductTypeProps } from './types';
+import { useProductDataContext } from '@woocommerce/shared-context';
 export interface Attributes {
 	className?: string;
 	isDescendentOfSingleProductBlock: boolean;
@@ -88,25 +89,29 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 		} );
 	}, [ setAttributes, isDescendentOfSingleProductBlock ] );
 
+	const { product } = useProductDataContext();
+
 	return (
 		<>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarDropdownMenu
-						icon={ <Icon icon={ eye } /> }
-						text={
-							currentProduct?.label ||
-							__( 'Switch product type', 'woocommerce' )
-						}
-						value={ currentProduct?.slug }
-						controls={ productTypes.map( ( productType ) => ( {
-							title: productType.label,
-							onClick: () =>
-								switchProductType( productType.slug ),
-						} ) ) }
-					/>
-				</ToolbarGroup>
-			</BlockControls>
+			{ ! product?.id && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarDropdownMenu
+							icon={ <Icon icon={ eye } /> }
+							text={
+								currentProduct?.label ||
+								__( 'Switch product type', 'woocommerce' )
+							}
+							value={ currentProduct?.slug }
+							controls={ productTypes.map( ( productType ) => ( {
+								title: productType.label,
+								onClick: () =>
+									switchProductType( productType.slug ),
+							} ) ) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
 
 			<AddToCartOptionsSettings
 				features={ {

--- a/plugins/woocommerce/changelog/update-dont-show-type-selector-when-product-defined
+++ b/plugins/woocommerce/changelog/update-dont-show-type-selector-when-product-defined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Comment: render the product type toolbar button only when the product is not defined


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Depends on #53398
Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Install and activate the WooCommerce Beta Tester plugin
2. Enable the `experimental-blocks` and `blockified-add-to-cart` features flags
  * Go to WooCommerce Admin Test Helper -> Features and enable `blockified-add-to-cart`

<img width="450" alt="Screenshot 2024-12-05 at 8 18 00 AM" src="https://github.com/user-attachments/assets/d61d0bb3-6ecf-41c6-a35e-7d388acd7cb5">

3. Create a new product.
4. Go to Pages > Add New Page.
5.  Create a new Single Product block instance
6.  Select the `Add To Cart with options (Experimental)` block
7.  Confirm it DOES NOT show the `Switch product type` toolbar button
8. Now, edit the `Single Product` template
9. insert a `Add to Cart with Options (Experimental)`
10. Confirm, the toolbar shows the button

<img width="886" alt="image" src="https://github.com/user-attachments/assets/bca18a2b-0797-4cc4-9553-7e54917fb867">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
