### PR TITLE
Add new required props to RouterProvider

### DIFF
--- a/plugins/woocommerce/changelog/fix-cys-router
+++ b/plugins/woocommerce/changelog/fix-cys-router
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add new required props to RouterProvider

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/index.tsx
@@ -183,7 +183,7 @@ export const AssemblerHub: CustomizeStoreComponent = ( props ) => {
 				<ShortcutProvider style={ { height: '100%' } }>
 					<OptInContextProvider>
 						<GlobalStylesProvider>
-							<RouterProvider>
+							<RouterProvider routes={ [] }>
 								<Layout />
 							</RouterProvider>
 							<OptInSubscribe />


### PR DESCRIPTION
### Changes proposed in this Pull Request:

_(Same PR as https://github.com/woocommerce/woocommerce/pull/53352 but now targetting WC 9.5, as the PRR wasn't approved.)_

This PR fixes an issue between Customize Your Store and the most recent nightly of Gutenberg. The changes in the API were introduced in https://github.com/WordPress/gutenberg/pull/67199 (thanks @gigitux for pointing it out!).

### How to test the changes in this Pull Request:

1. Install the latest [Gutenberg Nightly](https://github.com/Automattic/gutenberg-nightlies/releases).
2. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
3. Go to WooCommerce > Customize Your Store. Verify there are no errors displayed on the screen.
4. Smoke test the CYS functionality: change the logo, fonts, colors, some patterns, etc. and save it.
5. Verify at no moment you see an error and all redirects between screens work as expected.