### PR TITLE
[e2e tests] Support dotenv files directly in env directories

### DIFF
--- a/plugins/woocommerce/changelog/e2e-improve-handling-of-dotenv-files
+++ b/plugins/woocommerce/changelog/e2e-improve-handling-of-dotenv-files
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+E2E tests: improve handling of dotenv files stored in env directories

--- a/plugins/woocommerce/tests/e2e-pw/run-tests-with-env.sh
+++ b/plugins/woocommerce/tests/e2e-pw/run-tests-with-env.sh
@@ -29,8 +29,11 @@ SCRIPT_PATH=$(
 echo "Setting up environment: $envName"
 
 if [ -f "$SCRIPT_PATH/envs/$envName/.env.enc" ]; then
-	echo "Found encrypted .env file for environment '$envName'"
+	echo "Found an encrypted .env file for environment '$envName'"
 	"$SCRIPT_PATH/bin/dotenv.sh" -d "$envName"
+elif [ -f "$SCRIPT_PATH/envs/$envName/.env" ]; then
+	echo "Found a non encrypted .env file for environment '$envName'. Will copy and overwrite the main .env (if it exists)"
+	cp "$SCRIPT_PATH/envs/$envName/.env" "$SCRIPT_PATH/.env"
 else
 	echo "No encrypted .env file found for environment '$envName'."
 	echo "Removing .env file if it exists."


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The current logic of environments management requires that any env that needs to override the default variables will store an encrypted .env file. This will be decrypted and used as the main .env, in the tests project root. This proves tedious if we only need to create a temporary environment to run some tests locally, because we don't really need to create the encrypted file in this case.
This PR addresses that, by also checking for a non-encrypted .env file in the environment directory and using it if found. If both encrypted and non-encrypted files are found the encrypted will take priority.


### How to test the changes in this Pull Request:

- Create a new environment directory or use an existing one. We'll call it `my-env`.
- Create a `.env` file `my-env` (make sure no `.env.enc` exists)
- Run `pnpm test:e2e:with-env my-env` and check the console output and the tests root folder for an `.env` file. `my-env/.env` was copied to `.env`
- Add a `.env.enc` (encrypt the .env file)
- Run the same command. The encrypted file is decrypted and used.
