### PR TITLE
Allow resetting/resyncing email color palette in settings

### DIFF
--- a/plugins/woocommerce/changelog/52421-email-colors-reset-resync
+++ b/plugins/woocommerce/changelog/52421-email-colors-reset-resync
@@ -1,0 +1,3 @@
+Significance: patch
+Type: add
+Comment: This change adds controls to email color settings which allow to reset colors to defaults or resync them with theme.json. The color changes can be undone with the Undo button.

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
@@ -27,6 +27,7 @@ import {
 	possiblyRenderOrderAttributionSlot,
 	registerOrderAttributionSlotFill,
 } from '../order-attribution-install-banner/order-editor/slot';
+import { registerSettingsEmailColorPaletteFill } from '../settings-email/settings-email-color-palette-slotfill';
 import { registerSettingsEmailImageUrlFill } from '../settings-email/settings-email-image-url-slotfill';
 import { registerSettingsEmailPreviewFill } from '../settings-email/settings-email-preview-slotfill';
 
@@ -125,6 +126,7 @@ const registerSlotFills = () => {
 	registerOrderAttributionSlotFill();
 
 	if ( isFeatureEnabled( 'email_improvements' ) ) {
+		registerSettingsEmailColorPaletteFill();
 		registerSettingsEmailImageUrlFill();
 		registerSettingsEmailPreviewFill();
 	}

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
@@ -73,7 +73,7 @@ export const ResetStylesControl: React.FC< ResetStylesControlProps > = ( {
 				</Button>
 			) }
 			{ changed && (
-				<Button variant="secondary" onClick={ handleUndo }>
+				<Button variant="tertiary" onClick={ handleUndo }>
 					{ __( 'Undo changes', 'woocommerce' ) }
 				</Button>
 			) }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
@@ -34,13 +34,13 @@ export const ResetStylesControl: React.FC< ResetStylesControlProps > = ( {
 
 	const handleInputChange = () => {
 		setIsResetShown( areColorsChanged( defaultColors ) );
-		setChanged( true );
+		setChanged( areColorsChanged( initialValue ) );
 	};
 
 	const handleReset = () => {
 		setColors( defaultColors );
 		setIsResetShown( false );
-		setChanged( true );
+		setChanged( areColorsChanged( initialValue ) );
 	};
 
 	const handleUndo = () => {

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { DefaultColors } from './settings-email-color-palette-slotfill';
+import {
+	setColors,
+	getColors,
+	areColorsChanged,
+	addListeners,
+	removeListeners,
+} from './settings-email-color-palette-functions';
+
+type ResetStylesControlProps = {
+	defaultColors: DefaultColors;
+	hasThemeJson: boolean;
+};
+
+export const ResetStylesControl: React.FC< ResetStylesControlProps > = ( {
+	defaultColors,
+	hasThemeJson,
+} ) => {
+	const [ isResetShown, setIsResetShown ] = useState(
+		areColorsChanged( defaultColors )
+	);
+	const [ changed, setChanged ] = useState( false );
+	const [ initialValue ] = useState( getColors() );
+
+	const handleInputChange = () => {
+		setIsResetShown( areColorsChanged( defaultColors ) );
+		setChanged( true );
+	};
+
+	const handleReset = () => {
+		setColors( defaultColors );
+		setIsResetShown( false );
+		setChanged( true );
+	};
+
+	const handleUndo = () => {
+		setColors( initialValue );
+		setIsResetShown( areColorsChanged( defaultColors ) );
+		setChanged( false );
+	};
+
+	useEffect( () => {
+		addListeners( handleInputChange );
+		return () => {
+			removeListeners( handleInputChange );
+		};
+	} );
+
+	return (
+		<>
+			{ ! isResetShown && (
+				<span className="wc-settings-email-color-palette-message">
+					{ hasThemeJson
+						? __( 'Synced with theme.', 'woocommerce' )
+						: __( 'Using default values.', 'woocommerce' ) }
+				</span>
+			) }
+			{ isResetShown && (
+				<Button variant="secondary" onClick={ handleReset }>
+					{ hasThemeJson
+						? __( 'Sync with theme', 'woocommerce' )
+						: __( 'Reset', 'woocommerce' ) }
+				</Button>
+			) }
+			{ changed && (
+				<Button variant="secondary" onClick={ handleUndo }>
+					{ __( 'Undo changes', 'woocommerce' ) }
+				</Button>
+			) }
+		</>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-functions.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-functions.tsx
@@ -1,0 +1,81 @@
+/**
+ * Internal dependencies
+ */
+import { DefaultColors } from './settings-email-color-palette-slotfill';
+
+const colorFieldMap = {
+	woocommerce_email_base_color: 'baseColor',
+	woocommerce_email_background_color: 'bgColor',
+	woocommerce_email_body_background_color: 'bodyBgColor',
+	woocommerce_email_text_color: 'bodyTextColor',
+	woocommerce_email_footer_text_color: 'footerTextColor',
+};
+
+const setColor = ( inputId: string, color: string ) => {
+	const inputElement = document.getElementById( inputId ) as HTMLInputElement;
+	inputElement.value = color;
+	inputElement.dispatchEvent( new Event( 'change' ) );
+};
+
+const getColor = ( inputId: string ): string => {
+	const inputElement = document.getElementById( inputId ) as HTMLInputElement;
+	return inputElement.value;
+};
+
+export const setColors = ( colors: DefaultColors ) => {
+	for ( const [ inputId, colorName ] of Object.entries( colorFieldMap ) ) {
+		setColor( inputId, colors[ colorName as keyof DefaultColors ] );
+	}
+};
+
+export const getColors = (): DefaultColors => {
+	const colors = {} as DefaultColors;
+	for ( const [ inputId, colorName ] of Object.entries( colorFieldMap ) ) {
+		colors[ colorName as keyof DefaultColors ] = getColor( inputId );
+	}
+	return colors;
+};
+
+export const areColorsChanged = ( colors: DefaultColors ): boolean => {
+	for ( const [ inputId, colorName ] of Object.entries( colorFieldMap ) ) {
+		const inputElement = document.getElementById(
+			inputId
+		) as HTMLInputElement;
+		if (
+			inputElement.value !== colors[ colorName as keyof DefaultColors ]
+		) {
+			return true;
+		}
+	}
+	return false;
+};
+
+export const addListeners = ( listener: () => void ) => {
+	// Input listeners
+	for ( const inputId of Object.keys( colorFieldMap ) ) {
+		const inputElement = document.getElementById(
+			inputId
+		) as HTMLInputElement;
+		inputElement.addEventListener( 'change', listener );
+	}
+	// Color picker listeners
+	const $colorPickers = document.querySelectorAll( '.iris-picker' );
+	$colorPickers.forEach( ( item: Element ) =>
+		item.addEventListener( 'click', listener )
+	);
+};
+
+export const removeListeners = ( listener: () => void ) => {
+	// Input listeners
+	for ( const inputId of Object.keys( colorFieldMap ) ) {
+		const inputElement = document.getElementById(
+			inputId
+		) as HTMLInputElement;
+		inputElement.removeEventListener( 'change', listener );
+	}
+	// Color picker listeners
+	const $colorPickers = document.querySelectorAll( '.iris-picker' );
+	$colorPickers.forEach( ( item: Element ) =>
+		item.removeEventListener( 'click', listener )
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-slotfill.tsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { SETTINGS_SLOT_FILL_CONSTANT } from '~/settings/settings-slots';
+import { ResetStylesControl } from './settings-email-color-palette-control';
+
+const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
+
+export type DefaultColors = {
+	baseColor: string;
+	bgColor: string;
+	bodyBgColor: string;
+	bodyTextColor: string;
+	footerTextColor: string;
+};
+
+type EmailColorPaletteFillProps = {
+	defaultColors: DefaultColors;
+	hasThemeJson: boolean;
+};
+
+const EmailColorPaletteFill: React.FC< EmailColorPaletteFillProps > = ( {
+	defaultColors,
+	hasThemeJson,
+} ) => {
+	return (
+		<Fill>
+			<ResetStylesControl
+				defaultColors={ defaultColors }
+				hasThemeJson={ hasThemeJson }
+			/>
+		</Fill>
+	);
+};
+
+export const registerSettingsEmailColorPaletteFill = () => {
+	const slotElementId = 'wc_settings_email_color_palette_slotfill';
+	const slotElement = document.getElementById( slotElementId );
+
+	const defaultColorsData = slotElement?.getAttribute(
+		'data-default-colors'
+	);
+	let defaultColors = {} as DefaultColors;
+	try {
+		const {
+			base_color_default: baseColor,
+			bg_color_default: bgColor,
+			body_bg_color_default: bodyBgColor,
+			body_text_color_default: bodyTextColor,
+			footer_text_color_default: footerTextColor,
+		} = JSON.parse( defaultColorsData || '' );
+		defaultColors = {
+			baseColor,
+			bgColor,
+			bodyBgColor,
+			bodyTextColor,
+			footerTextColor,
+		};
+	} catch ( e ) {}
+
+	const hasThemeJson =
+		slotElement?.getAttribute( 'data-has-theme-json' ) !== null;
+
+	registerPlugin( 'woocommerce-admin-settings-email-color-palette', {
+		// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
+		scope: 'woocommerce-email-color-palette-settings',
+		render: () => (
+			<EmailColorPaletteFill
+				defaultColors={ defaultColors }
+				hasThemeJson={ hasThemeJson }
+			/>
+		),
+	} );
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -237,13 +237,7 @@ $wc-setting-email-preview-gap: 16px;
 }
 
 .wc-settings-email-color-palette-buttons {
+	align-items: center;
 	display: inline-flex;
-
-	button {
-		margin-right: 5px;
-	}
-}
-
-.wc-settings-email-color-palette-message {
-	margin: 8px 15px;
+	gap: 12px;
 }

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -230,3 +230,20 @@ $wc-setting-email-preview-gap: 16px;
 		}
 	}
 }
+
+.wc-settings-email-color-palette-title {
+	display: inline-block;
+	margin-right: 15px;
+}
+
+.wc-settings-email-color-palette-buttons {
+	display: inline-flex;
+
+	button {
+		margin-right: 5px;
+	}
+}
+
+.wc-settings-email-color-palette-message {
+	margin: 8px 15px;
+}

--- a/plugins/woocommerce/client/admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce/client/admin/client/settings/settings-slots.js
@@ -34,6 +34,10 @@ export const possiblyRenderSettingsSlots = () => {
 			id: 'wc_settings_email_image_url_slotfill',
 			scope: 'woocommerce-email-image-url-settings',
 		},
+		{
+			id: 'wc_settings_email_color_palette_slotfill',
+			scope: 'woocommerce-email-color-palette-settings',
+		},
 	];
 
 	slots.forEach( ( slot ) => {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -102,11 +102,14 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$footer_text_description = __( 'The text to appear in the footer of all WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url}' );
 		$footer_text_default     = '{site_title} &mdash; Built with {WooCommerce}';
 
-		$base_color_default        = BrandingController::get_default_email_base_color();
-		$bg_color_default          = '#f7f7f7';
-		$body_bg_color_default     = '#ffffff';
-		$body_text_color_default   = '#3c3c3c';
-		$footer_text_color_default = '#3c3c3c';
+		// These defaults should be chosen by the same logic as the other color option properties.
+		list(
+			'base_color_default' => $base_color_default,
+			'bg_color_default' => $bg_color_default,
+			'body_bg_color_default' => $body_bg_color_default,
+			'body_text_color_default' => $body_text_color_default,
+			'footer_text_color_default' => $footer_text_color_default,
+		) = $this->get_email_default_colors();
 
 		$base_color_title = __( 'Base color', 'woocommerce' );
 		/* translators: %s: default color */
@@ -169,21 +172,6 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			$footer_text_description = __( 'This text will appear in the footer of all of your WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url} {store_address} {store_email}' );
 			$footer_text_default     = '{site_title}<br />{store_address}';
 
-			$base_color_default        = '#8526ff';
-			$bg_color_default          = '#ffffff';
-			$body_bg_color_default     = '#ffffff';
-			$body_text_color_default   = '#1e1e1e';
-			$footer_text_color_default = '#787c82';
-
-			if ( wc_current_theme_is_fse_theme() && function_exists( 'wp_get_global_styles' ) ) {
-				$global_styles             = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
-				$base_color_default        = $global_styles['elements']['button']['color']['text'] ?? $base_color_default;
-				$bg_color_default          = $global_styles['color']['background'] ?? $bg_color_default;
-				$body_bg_color_default     = $global_styles['color']['background'] ?? $body_bg_color_default;
-				$body_text_color_default   = $global_styles['color']['text'] ?? $body_text_color_default;
-				$footer_text_color_default = $global_styles['elements']['caption']['color']['text'] ?? $footer_text_color_default;
-			}
-
 			$base_color_title = __( 'Accent', 'woocommerce' );
 			/* translators: %s: default color */
 			$base_color_desc = sprintf( __( 'Customize the color of your buttons and links. Default %s.', 'woocommerce' ), '<code>' . $base_color_default . '</code>' );
@@ -216,7 +204,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			);
 		}
 
-		// Reorder email color settings based on the email_improvements feature flag
+		// Reorder email color settings based on the email_improvements feature flag.
 
 		$base_color_setting = array(
 			'title'    => $base_color_title,
@@ -428,6 +416,42 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$settings = array_filter( $settings );
 
 		return apply_filters( 'woocommerce_email_settings', $settings );
+	}
+
+	/**
+	 * Get default colors for emails.
+	 */
+	private function get_email_default_colors() {
+		$base_color_default        = BrandingController::get_default_email_base_color();
+		$bg_color_default          = '#f7f7f7';
+		$body_bg_color_default     = '#ffffff';
+		$body_text_color_default   = '#3c3c3c';
+		$footer_text_color_default = '#3c3c3c';
+
+		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+			$base_color_default        = '#8526ff';
+			$bg_color_default          = '#ffffff';
+			$body_bg_color_default     = '#ffffff';
+			$body_text_color_default   = '#1e1e1e';
+			$footer_text_color_default = '#787c82';
+
+			if ( wc_current_theme_is_fse_theme() && function_exists( 'wp_get_global_styles' ) ) {
+				$global_styles             = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
+				$base_color_default        = $global_styles['elements']['button']['color']['text'] ?? $base_color_default;
+				$bg_color_default          = $global_styles['color']['background'] ?? $bg_color_default;
+				$body_bg_color_default     = $global_styles['color']['background'] ?? $body_bg_color_default;
+				$body_text_color_default   = $global_styles['color']['text'] ?? $body_text_color_default;
+				$footer_text_color_default = $global_styles['elements']['caption']['color']['text'] ?? $footer_text_color_default;
+			}
+		}
+
+		return compact(
+			'base_color_default',
+			'bg_color_default',
+			'body_bg_color_default',
+			'body_text_color_default',
+			'footer_text_color_default',
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -48,6 +48,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		add_action( 'woocommerce_admin_field_email_preview', array( $this, 'email_preview' ) );
 		add_action( 'woocommerce_admin_field_email_image_url', array( $this, 'email_image_url' ) );
 		add_action( 'woocommerce_admin_field_email_font_family', array( $this, 'email_font_family' ) );
+		add_action( 'woocommerce_admin_field_email_color_palette', array( $this, 'email_color_palette' ) );
 		parent::__construct();
 	}
 
@@ -194,7 +195,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 			$color_palette_section_header = array(
 				'title' => __( 'Color palette', 'woocommerce' ),
-				'type'  => 'title',
+				'type'  => 'email_color_palette',
 				'id'    => 'email_color_palette',
 			);
 
@@ -742,6 +743,26 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				</select>
 			</td>
 		</tr>
+		<?php
+	}
+
+	/**
+	 * Creates the React mount point for the email color palette title.
+	 *
+	 * @param array $value Field value array.
+	 */
+	public function email_color_palette( $value ) {
+		$default_colors = $this->get_email_default_colors();
+
+		?>
+		<h2 class="wc-settings-email-color-palette-title"><?php echo esc_html( $value['title'] ); ?></h2>
+		<div
+			class="wc-settings-email-color-palette-buttons"
+			id="wc_settings_email_color_palette_slotfill"
+			data-default-colors="<?php echo esc_attr( wp_json_encode( $default_colors ) ); ?>"
+			<?php echo wp_theme_has_theme_json() ? 'data-has-theme-json' : ''; ?>
+		></div>
+		<table class="form-table">
 		<?php
 	}
 }

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -391,7 +391,10 @@ test.describe( 'WooCommerce Email Settings', () => {
 		await page.fill( '#woocommerce_email_footer_text_color', dummyColor );
 
 		// Reset colors to defaults
-		await page.locator( resetButtonElement ).click();
+		await page
+			.locator( resetButtonElement )
+			.getByText( 'Sync with theme', { exact: true } )
+			.click();
 
 		// Verify colors are reset
 		await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -360,4 +360,77 @@ test.describe( 'WooCommerce Email Settings', () => {
 			expect.stringContaining( '{store_email}' )
 		);
 	} );
+
+	test( 'Reset color palette with a feature flag', async ( {
+		page,
+		baseURL,
+	} ) => {
+		const resetButtonElement = '.wc-settings-email-color-palette-buttons';
+
+		// Disable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'no' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		await expect( page.locator( resetButtonElement ) ).toHaveCount( 0 );
+
+		// Enable the email_improvements feature flag
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.reload();
+
+		await expect( page.locator( resetButtonElement ) ).toBeVisible();
+
+		// Change colors to make sure Reset button is active
+		const dummyColor = '#abcdef';
+		await page.fill( '#woocommerce_email_base_color', dummyColor );
+		await page.fill( '#woocommerce_email_background_color', dummyColor );
+		await page.fill(
+			'#woocommerce_email_body_background_color',
+			dummyColor
+		);
+		await page.fill( '#woocommerce_email_text_color', dummyColor );
+		await page.fill( '#woocommerce_email_footer_text_color', dummyColor );
+
+		// Reset colors to defaults
+		await page.locator( resetButtonElement ).click();
+
+		// Verify colors are reset
+		await expect(
+			page.locator( '#woocommerce_email_base_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_background_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_body_background_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_text_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_footer_text_color' )
+		).not.toHaveValue( dummyColor );
+
+		// Undo resetting
+		await page
+			.locator( resetButtonElement )
+			.getByText( 'Undo changes', { exact: true } )
+			.click();
+
+		// Verify colors are back to the state before resetting
+		await expect(
+			page.locator( '#woocommerce_email_base_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_background_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_body_background_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_text_color' )
+		).not.toHaveValue( dummyColor );
+		await expect(
+			page.locator( '#woocommerce_email_footer_text_color' )
+		).not.toHaveValue( dummyColor );
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the feature flag is enabled, a "Reset"/"Sync with theme" button is added to the "Color palette" section of the email settings, it allows to reset the colors to defaults or sync them to theme.json if a theme supports it. Also, an "Undo" button appears after any change is made, it allows to revert any unsaved changes.

Closes #52421.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Settings > Emails` and observe the absence of the "Reset"/"Sync with theme" button in color settings.
2. Enable the email_improvements feature flag. It's hidden in the UI, so this needs to be done in the database: set the `woocommerce_feature_email_improvements_enabled` option to `yes`.
3. Reload the email settings page.
4. You should now see the "Reset"/"Sync with theme" button next to the "Color palette" section. 
5. Modify any colors in the section by typing their hex values directly or choosing from the color picker. You'll see the "Undo" button appear. Click it to restore the colors to the ones saved in the DB.
5. Modify the colors again so they are different from defaults. Click the "Reset"/"Sync with theme" button and see that they are back to defaults. Try this with both block-based and non-block-based themes. Also see that the undo button works properly here as well.

<!-- End testing instructions -->