### PR TITLE
Add To Cart with Options: Introduce Add To Cart with Options button creating a core/button variation

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -39,22 +39,29 @@ const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		},
 	],
 	[
-		'core/button',
-		{
-			className: 'wc-block-product-add-to-cart-with-options-button',
-			text: __( 'Add to Cart', 'woocommerce' ),
-			withRole: 'add-to-cart-with-options-button',
-			metadata: {
-				bindings: {
-					url: {
-						source: 'core/post-meta',
-						args: {
-							key: 'add_to_cart_url',
+		'core/buttons',
+		{},
+		[
+			[
+				'core/button',
+				{
+					className:
+						'wc-block-product-add-to-cart-with-options-button',
+					text: __( 'Add to Cart', 'woocommerce' ),
+					withRole: 'add-to-cart-with-options-button',
+					metadata: {
+						bindings: {
+							url: {
+								source: 'core/post-meta',
+								args: {
+									key: 'add_to_cart_url',
+								},
+							},
 						},
 					},
 				},
-			},
-		},
+			],
+		],
 	],
 ];
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -39,10 +39,21 @@ const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		},
 	],
 	[
-		'woocommerce/product-button',
+		'core/button',
 		{
-			textAlign: 'center',
-			fontSize: 'small',
+			className: 'wc-block-product-add-to-cart-with-options-button',
+			text: __( 'Add to Cart', 'woocommerce' ),
+			withRole: 'add-to-cart-with-options-button',
+			metadata: {
+				bindings: {
+					url: {
+						source: 'core/post-meta',
+						args: {
+							key: 'add_to_cart_url',
+						},
+					},
+				},
+			},
 		},
 	],
 ];

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/extend/core-button/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/extend/core-button/frontend.ts
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { store } from '@woocommerce/interactivity';
+
+store( 'woocommerce/add-to-cart-with-options', {
+	actions: {
+		addToCart: () => {
+			console.log( 'Add to cart' ); // eslint-disable-line no-console
+		},
+	},
+} );

--- a/plugins/woocommerce-blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce-blocks/bin/webpack-entries.js
@@ -26,6 +26,10 @@ const blocks = {
 		customDir: 'add-to-cart-with-options/quantity-selector',
 		isExperimental: true,
 	},
+	'add-to-cart-with-options-button': {
+		customDir: 'add-to-cart-with-options/extend/core-button',
+		isExperimental: true,
+	},
 	'all-products': {
 		customDir: 'products/all-products',
 	},

--- a/plugins/woocommerce/changelog/update-introduce-add-to-cart-with-options-button
+++ b/plugins/woocommerce/changelog/update-introduce-add-to-cart-with-options-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: introduce Add To Cart with Options button creating a core/button variation

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -30,6 +30,10 @@ class AddToCartWithOptions extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
+
+		// Register a core/button variation for the Add To Cart Button block.
+		add_filter( 'register_block_type_args', array( $this, 'add_core_button_variation_for_add_to_cart_button' ), 10, 2 );
+
 		add_filter( 'wc_add_to_cart_message_html', array( $this, 'add_to_cart_message_html_filter' ), 10, 2 );
 		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
 	}
@@ -207,5 +211,50 @@ class AddToCartWithOptions extends AbstractBlock {
 		}
 
 		return $url;
+	}
+	
+	/**
+	 * Add a core/button variation for the Add To Cart Button block.
+	 * It registers a new block `withRole` attribute
+	 * to identify when it's active.
+	 *
+	 * @param array  $args Block type args.
+	 * @param string $block_name Block name.
+	 * @return array
+	 */
+	public function add_core_button_variation_for_add_to_cart_button( $args, $block_name ) {
+		if ( 'core/button' !== $block_name ) {
+			return $args;
+		}
+
+		/*
+		 * Add withRole attribute to the block.
+		 * This attribute is used to identify when the block is active.
+		 */
+		$args['attributes']['withRole'] = array(
+			'type' => 'string',
+		);
+
+		if ( ! isset( $args['variations'] ) ) {
+			$args['variations'] = array();
+		}
+
+		$args['variations'][] = array(
+			'name'        => 'woocommerce/product-add-to-cart-with-options-button',
+			'title'       => __( 'Add To Cart Button (Experimental)', 'woocommerce' ),
+			'description' => __( 'Add a Button block to add product quantity to cart.', 'woocommerce' ),
+			'attributes'  => array(
+				'className' => 'wc-block-product-add-to-cart-with-options-button',
+				'withRole'  => 'add-to-cart-with-options-button',
+				'text'      => __( 'Add to Cart', 'woocommerce' ),
+			),
+			'scope'       => array(
+				'block',
+			),
+			'isActive'    => [ 'withRole' ],
+			'isDefault'   => false,
+		);
+
+		return $args;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -251,9 +251,6 @@ class AddToCartWithOptions extends AbstractBlock {
 				'withRole'  => 'add-to-cart-with-options-button',
 				'text'      => __( 'Add to Cart', 'woocommerce' ),
 			),
-			'scope'       => array(
-				'block',
-			),
 			'isActive'    => [ 'withRole' ],
 			'isDefault'   => false,
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -215,7 +215,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		return $url;
 	}
-	
+
 	/**
 	 * Add a core/button variation for the Add To Cart Button block.
 	 * It registers a new block `withRole` attribute
@@ -267,7 +267,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 */
 	public function render_product_add_to_cart_with_options_button( $block_content, $block ) {
 		// Only extend the core/button block.
-		if ( $block['blockName'] !== 'core/button' ) {
+		if ( 'core/button' !== $block['blockName'] ) {
 			return $block_content;
 		}
 
@@ -281,7 +281,6 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		/*
 		 * Register the frontend script for the block.
-		 * ToDo: Check if this is the correct way to register the script.
 		 */
 		$block_name = $this->block_name . '-button';
 		$path       = $this->asset_api->get_block_asset_build_path( $block_name . '-frontend' );
@@ -303,10 +302,12 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$processor = new \WP_HTML_Tag_Processor( $block_content );
 
-		if ( $processor->next_tag( array(
-			'tag_name'   => 'div',
-			'class_name' => 'wc-block-product-add-to-cart-with-options-button',
-		) ) ) {
+		if ( $processor->next_tag(
+			array(
+				'tag_name'   => 'div',
+				'class_name' => 'wc-block-product-add-to-cart-with-options-button',
+			)
+		) ) {
 			$processor->set_attribute( 'data-wc-interactive', $data_wc_interactive );
 
 			if ( $processor->next_tag( array( 'tag_name' => 'a', 'class_name' => 'wp-element-button' ) ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -34,6 +34,9 @@ class AddToCartWithOptions extends AbstractBlock {
 		// Register a core/button variation for the Add To Cart Button block.
 		add_filter( 'register_block_type_args', array( $this, 'add_core_button_variation_for_add_to_cart_button' ), 10, 2 );
 
+		// Extend core/block rendering.
+		add_filter( 'render_block', array( $this, 'render_product_add_to_cart_with_options_button' ), 10, 3 );
+
 		add_filter( 'wc_add_to_cart_message_html', array( $this, 'add_to_cart_message_html_filter' ), 10, 2 );
 		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
 	}
@@ -256,5 +259,49 @@ class AddToCartWithOptions extends AbstractBlock {
 		);
 
 		return $args;
+	}
+
+	/**
+	 * Render the Add To Cart Button block.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block The block.
+	 * @return string
+	 */
+	public function render_product_add_to_cart_with_options_button( $block_content, $block ) {
+		// Only extend the core/button block.
+		if ( $block['blockName'] !== 'core/button' ) {
+			return $block_content;
+		}
+
+		/*
+		 * Only extend the Add To Cart Button variation,
+		 * identified by the `withRole` attribute.
+		 */
+		if ( ! isset( $block['attrs']['withRole'] ) || 'add-to-cart-with-options-button' !== $block['attrs']['withRole'] ) {
+			return $block_content;
+		}
+
+		// Interactivity API - Namespace and Context.
+		$i_api_namespace     = $this->get_full_block_name();
+		$data_wc_interactive = wp_json_encode( array( 'namespace' => $i_api_namespace ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
+
+		// Interactivity API - Add to Cart Button / Actions.
+		$data_wc_add_to_cart_action = $i_api_namespace . '::actions.addToCart';
+
+		$processor = new \WP_HTML_Tag_Processor( $block_content );
+
+		if ( $processor->next_tag( array(
+			'tag_name'   => 'div',
+			'class_name' => 'wc-block-product-add-to-cart-with-options-button',
+		) ) ) {
+			$processor->set_attribute( 'data-wc-interactive', $data_wc_interactive );
+
+			if ( $processor->next_tag( array( 'tag_name' => 'a', 'class_name' => 'wp-element-button' ) ) ) {
+				$processor->set_attribute( 'data-wc-on--click', $data_wc_add_to_cart_action );
+			}
+		}
+
+		return $processor->get_updated_html();
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -282,6 +282,21 @@ class AddToCartWithOptions extends AbstractBlock {
 			return $block_content;
 		}
 
+		/*
+		 * Register the frontend script for the block.
+		 * ToDo: Check if this is the correct way to register the script.
+		 */
+		$block_name = $this->block_name . '-button';
+		$path       = $this->asset_api->get_block_asset_build_path( $block_name . '-frontend' );
+
+		$this->asset_api->register_script(
+			$block_name,
+			$path,
+			$this->integration_registry->get_all_registered_script_handles()
+		);
+
+		wp_enqueue_script( $block_name );
+
 		// Interactivity API - Namespace and Context.
 		$i_api_namespace     = $this->get_full_block_name();
 		$data_wc_interactive = wp_json_encode( array( 'namespace' => $i_api_namespace ), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -243,7 +243,7 @@ class AddToCartWithOptions extends AbstractBlock {
 		}
 
 		$args['variations'][] = array(
-			'name'        => 'woocommerce/product-add-to-cart-with-options-button',
+			'name'        => 'woocommerce/add-to-cart-with-options-button',
 			'title'       => __( 'Add To Cart Button (Experimental)', 'woocommerce' ),
 			'description' => __( 'Add a Button block to add product quantity to cart.', 'woocommerce' ),
 			'attributes'  => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a block variation of `core/button` block to implement the `Add To Cart with Options` button.
It's based on research we did recently [here](https://github.com/woocommerce/woocommerce/pull/53249).

## Approach

### Extend `core/block` block

The PR extends the `core/button` block, adding a new `withRole` attribute.
This attribute will be used to identify the variation when rendering the block instancess

### Create `woocommerce/product-add-to-cart-with-options-button` block variation

With this variation, we can identify the Add to Cart block button. It defines a few attributes, such as CSS class and the `withRole`, to identify it.
The variation defined its `scope` to hide in the block selector.
However, [the scope was removed](https://github.com/woocommerce/woocommerce/pull/53454/commits/dc3c34fefa71184b6810b334dbfdeb75d3143e1a), at least for now.
We can roll this change back if we consider it appropriate.

### Interactivity

A new frontend file is registered and enqueued when the block variation instance is added to the editor canvas.
It shows a simple console log when the user clicks on it.

Closes #53010

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Enable the `experimental-blocks` and `blockified-add-to-cart` features flags
  * Go to WooCommerce Admin Test Helper -> Features and enable `blockified-add-to-cart`

<img width="450" alt="Screenshot 2024-12-05 at 8 18 00 AM" src="https://github.com/user-attachments/assets/d61d0bb3-6ecf-41c6-a35e-7d388acd7cb5">

3. Create/edit a new post/page.
4. Create a regular `core/buttons` block instance

<img width="961" alt="image" src="https://github.com/user-attachments/assets/e4f6b091-fc82-4839-b830-919c95d1ba5d">
6. Confirm you can add a new Add To Cart button from the Buttons (parent) block instance

<img width="960" alt="image" src="https://github.com/user-attachments/assets/690aa577-dddb-40bd-8adf-9ee12c62aee4">

7. Create an instance. Apply a few styles (color, dimms, etc)
<img width="959" alt="image" src="https://github.com/user-attachments/assets/a28ba8c9-436c-4ff9-9f0c-f473264ef9bc">

9. Save the post/page
10. Confirm the pos/page shows the button
11. Open the dev console
12. Confirm you see the log when clicking on the button

<img width="815" alt="Screenshot 2024-12-05 at 9 07 56 AM" src="https://github.com/user-attachments/assets/0aaf8607-b796-4453-a565-8a47c57f2f69">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
