### PR TITLE
Tag nullable typed params as explicitly nullable

### DIFF
--- a/plugins/woocommerce/changelog/52081-nullable
+++ b/plugins/woocommerce/changelog/52081-nullable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix implicit nullable deprecation warning when running on PHP 8.4.

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -17,10 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Output a text input box.
  *
- * @param array   $field Field data.
- * @param WC_Data $data WC_Data object, will be preferred over post object when passed.
+ * @param array        $field Field data.
+ * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
-function woocommerce_wp_text_input( $field, WC_Data $data = null ) {
+function woocommerce_wp_text_input( $field, ?WC_Data $data = null ) {
 	global $post;
 
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
@@ -84,10 +84,10 @@ function woocommerce_wp_text_input( $field, WC_Data $data = null ) {
 /**
  * Output a hidden input box.
  *
- * @param array   $field Field data.
- * @param WC_Data $data WC_Data object, will be preferred over post object when passed.
+ * @param array        $field Field data.
+ * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
-function woocommerce_wp_hidden_input( $field, WC_Data $data = null ) {
+function woocommerce_wp_hidden_input( $field, ?WC_Data $data = null ) {
 	global $post;
 
 	$field['value'] = isset( $field['value'] ) ? $field['value'] : OrderUtil::get_post_or_object_meta( $post, $data, $field['id'], true );
@@ -99,10 +99,10 @@ function woocommerce_wp_hidden_input( $field, WC_Data $data = null ) {
 /**
  * Output a textarea input box.
  *
- * @param array   $field Field data.
- * @param WC_Data $data WC_Data object, will be preferred over post object when passed.
+ * @param array        $field Field data.
+ * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
-function woocommerce_wp_textarea_input( $field, WC_Data $data = null ) {
+function woocommerce_wp_textarea_input( $field, ?WC_Data $data = null ) {
 	global $post;
 
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
@@ -144,10 +144,10 @@ function woocommerce_wp_textarea_input( $field, WC_Data $data = null ) {
 /**
  * Output a checkbox input box.
  *
- * @param array   $field Field data.
- * @param WC_Data $data WC_Data object, will be preferred over post object when passed.
+ * @param array        $field Field data.
+ * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
-function woocommerce_wp_checkbox( $field, WC_Data $data = null ) {
+function woocommerce_wp_checkbox( $field, ?WC_Data $data = null ) {
 	global $post;
 
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
@@ -214,10 +214,10 @@ function woocommerce_wp_checkbox( $field, WC_Data $data = null ) {
 /**
  * Output a select input box.
  *
- * @param array   $field Field data.
- * @param WC_Data $data WC_Data object, will be preferred over post object when passed.
+ * @param array        $field Field data.
+ * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
-function woocommerce_wp_select( $field, WC_Data $data = null ) {
+function woocommerce_wp_select( $field, ?WC_Data $data = null ) {
 	global $post;
 
 	$field = wp_parse_args(
@@ -272,10 +272,10 @@ function woocommerce_wp_select( $field, WC_Data $data = null ) {
 /**
  * Output a radio input box.
  *
- * @param array   $field Field data.
- * @param WC_Data $data WC_Data object, will be preferred over post object when passed.
+ * @param array        $field Field data.
+ * @param WC_Data|null $data  WC_Data object, will be preferred over post object when passed.
  */
-function woocommerce_wp_radio( $field, WC_Data $data = null ) {
+function woocommerce_wp_radio( $field, ?WC_Data $data = null ) {
 	global $post;
 
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';

--- a/plugins/woocommerce/lib/packages/League/Container/Container.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Container.php
@@ -47,9 +47,9 @@ class Container implements ContainerInterface
      * @param InflectorAggregateInterface|null       $inflectors
      */
     public function __construct(
-        DefinitionAggregateInterface      $definitions = null,
-        ServiceProviderAggregateInterface $providers = null,
-        InflectorAggregateInterface       $inflectors = null
+        ?DefinitionAggregateInterface      $definitions = null,
+        ?ServiceProviderAggregateInterface $providers = null,
+        ?InflectorAggregateInterface       $inflectors = null
     ) {
         $this->definitions = $definitions ?? new DefinitionAggregate;
         $this->providers   = $providers   ?? new ServiceProviderAggregate;
@@ -77,7 +77,7 @@ class Container implements ContainerInterface
      *
      * @return DefinitionInterface
      */
-    public function add(string $id, $concrete = null, bool $shared = null) : DefinitionInterface
+    public function add(string $id, $concrete = null, ?bool $shared = null) : DefinitionInterface
     {
         $concrete = $concrete ?? $id;
         $shared = $shared ?? $this->defaultToShared;
@@ -222,7 +222,7 @@ class Container implements ContainerInterface
      *
      * @return InflectorInterface
      */
-    public function inflector(string $type, callable $callback = null) : InflectorInterface
+    public function inflector(string $type, ?callable $callback = null) : InflectorInterface
     {
         return $this->inflectors->add($type, $callback);
     }

--- a/plugins/woocommerce/lib/packages/League/Container/Inflector/Inflector.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Inflector/Inflector.php
@@ -37,7 +37,7 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
      * @param string        $type
      * @param callable|null $callback
      */
-    public function __construct(string $type, callable $callback = null)
+    public function __construct(string $type, ?callable $callback = null)
     {
         $this->type     = $type;
         $this->callback = $callback;

--- a/plugins/woocommerce/lib/packages/League/Container/Inflector/InflectorAggregate.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Inflector/InflectorAggregate.php
@@ -17,7 +17,7 @@ class InflectorAggregate implements InflectorAggregateInterface
     /**
      * {@inheritdoc}
      */
-    public function add(string $type, callable $callback = null) : Inflector
+    public function add(string $type, ?callable $callback = null) : Inflector
     {
         $inflector          = new Inflector($type, $callback);
         $this->inflectors[] = $inflector;

--- a/plugins/woocommerce/lib/packages/League/Container/Inflector/InflectorAggregateInterface.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Inflector/InflectorAggregateInterface.php
@@ -15,7 +15,7 @@ interface InflectorAggregateInterface extends ContainerAwareInterface, IteratorA
      *
      * @return Inflector
      */
-    public function add(string $type, callable $callback = null) : Inflector;
+    public function add(string $type, ?callable $callback = null) : Inflector;
 
     /**
      * Applies all inflectors to an object.

--- a/plugins/woocommerce/src/Caching/CacheException.php
+++ b/plugins/woocommerce/src/Caching/CacheException.php
@@ -38,7 +38,7 @@ class CacheException extends \Exception {
 	 * @param mixed           $code An error code, if available.
 	 * @param \Throwable|null $previous The previous exception, if available.
 	 */
-	public function __construct( string $message, ObjectCache $thrower, $cached_id = null, ?array $errors = null, $code = 0, \Throwable $previous = null ) {
+	public function __construct( string $message, ObjectCache $thrower, $cached_id = null, ?array $errors = null, $code = 0, ?\Throwable $previous = null ) {
 		$this->errors    = $errors ?? array();
 		$this->thrower   = $thrower;
 		$this->cached_id = $cached_id;

--- a/plugins/woocommerce/src/Caching/ObjectCache.php
+++ b/plugins/woocommerce/src/Caching/ObjectCache.php
@@ -226,7 +226,7 @@ abstract class ObjectCache {
 	 * @return object|array|null Cached object, or null if it's not cached and can't be retrieved from datastore or via callback.
 	 * @throws CacheException Invalid id parameter.
 	 */
-	public function get( $id, int $expiration = self::DEFAULT_EXPIRATION, callable $get_from_datastore_callback = null ) {
+	public function get( $id, int $expiration = self::DEFAULT_EXPIRATION, ?callable $get_from_datastore_callback = null ) {
 		if ( ! is_string( $id ) && ! is_int( $id ) ) {
 			throw new CacheException( "Object id must be an int or a string for 'get'", $this );
 		}

--- a/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
@@ -80,7 +80,7 @@ abstract class TableMigrator {
 	 * @param string      $output Any of ARRAY_A | ARRAY_N | OBJECT | OBJECT_K constants.
 	 * @return mixed Whatever $wpdb->get_results returns.
 	 */
-	protected function db_get_results( string $query = null, string $output = OBJECT ) {
+	protected function db_get_results( ?string $query = null, string $output = OBJECT ) {
 		$wpdb = WC()->get_global( 'wpdb' );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -257,7 +257,7 @@ class BatchProcessingController {
 	 * @param float                   $time_taken Time take by the batch to complete processing.
 	 * @param \Exception|null         $last_error Exception object in processing the batch, if there was one.
 	 */
-	private function update_processor_state( BatchProcessorInterface $batch_processor, float $time_taken, \Exception $last_error = null ): void {
+	private function update_processor_state( BatchProcessorInterface $batch_processor, float $time_taken, ?\Exception $last_error = null ): void {
 		$current_status                      = $this->get_process_details( $batch_processor );
 		$current_status['total_time_spent'] += $time_taken;
 		$current_status['last_error']        = null !== $last_error ? $last_error->getMessage() : null;

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CogsAwareTrait.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CogsAwareTrait.php
@@ -17,7 +17,7 @@ trait CogsAwareTrait {
 	 *
 	 * @return bool True if the feature is enabled.
 	 */
-	protected function cogs_is_enabled( string $doing_it_wrong_function_name = null ): bool {
+	protected function cogs_is_enabled( ?string $doing_it_wrong_function_name = null ): bool {
 		if ( wc_get_container()->get( CostOfGoodsSoldController::class )->feature_is_enabled() ) {
 			return true;
 		}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -150,7 +150,7 @@ abstract class AbstractServiceProvider extends BaseServiceProvider {
 	 *
 	 * @return DefinitionInterface The generated container definition.
 	 */
-	protected function add( string $id, $concrete = null, bool $shared = null ) : DefinitionInterface {
+	protected function add( string $id, $concrete = null, ?bool $shared = null ) : DefinitionInterface {
 		return $this->getContainer()->add( $id, $concrete, $shared );
 	}
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ContainerException.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ContainerException.php
@@ -17,7 +17,7 @@ class ContainerException extends \Exception {
 	 * @param int             $code The error code.
 	 * @param \Exception|null $previous The previous throwable used for exception chaining.
 	 */
-	public function __construct( $message = null, $code = 0, \Exception $previous = null ) {
+	public function __construct( $message = null, $code = 0, ?\Exception $previous = null ) {
 		parent::__construct( $message, $code, $previous );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -67,7 +67,7 @@ class ExtendedContainer extends BaseContainer {
 	 * @return DefinitionInterface The generated definition for the container.
 	 * @throws ContainerException Invalid parameters.
 	 */
-	public function add( string $class_name, $concrete = null, bool $shared = null ): DefinitionInterface {
+	public function add( string $class_name, $concrete = null, ?bool $shared = null ): DefinitionInterface {
 		if ( ! $this->is_class_allowed( $class_name ) ) {
 			throw new ContainerException( "You cannot add '$class_name', only classes in the {$this->woocommerce_namespace} namespace are allowed." );
 		}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AbstractInterfaceServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AbstractInterfaceServiceProvider.php
@@ -56,7 +56,7 @@ abstract class AbstractInterfaceServiceProvider extends AbstractServiceProvider 
 	 *
 	 * @return DefinitionInterface
 	 */
-	protected function add_with_implements_tags( string $id, $concrete = null, bool $shared = null ): DefinitionInterface {
+	protected function add_with_implements_tags( string $id, $concrete = null, ?bool $shared = null ): DefinitionInterface {
 		$definition = $this->add( $id, $concrete, $shared );
 		foreach ( class_implements( $id ) as $interface ) {
 			$definition->addTag( $interface );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -554,7 +554,7 @@ class FeaturesController {
 	 *
 	 * @return bool True if 'woocommerce_init' has run or is running, false otherwise.
 	 */
-	private function verify_did_woocommerce_init( string $function_name = null ): bool {
+	private function verify_did_woocommerce_init( ?string $function_name = null ): bool {
 		if ( ! $this->proxy->call_function( 'did_action', 'woocommerce_init' ) &&
 			! $this->proxy->call_function( 'doing_action', 'woocommerce_init' ) ) {
 			if ( ! is_null( $function_name ) ) {

--- a/plugins/woocommerce/src/Internal/Utilities/Types.php
+++ b/plugins/woocommerce/src/Internal/Utilities/Types.php
@@ -30,7 +30,7 @@ class Types {
 	 *
 	 * @return mixed
 	 */
-	public static function ensure_instance_of( $thing, string $desired_type, callable $on_failure = null ) {
+	public static function ensure_instance_of( $thing, string $desired_type, ?callable $on_failure = null ) {
 		// If everything looks good, return early.
 		if ( $thing instanceof $desired_type ) {
 			return $thing;

--- a/plugins/woocommerce/src/Internal/Utilities/URL.php
+++ b/plugins/woocommerce/src/Internal/Utilities/URL.php
@@ -352,11 +352,11 @@ class URL {
 	/**
 	 * Outputs the path. Especially useful if it was a a regular filepath that was passed in originally.
 	 *
-	 * @param string $path_override If provided this will be used as the URL path. Does not impact drive letter.
+	 * @param string|null $path_override If provided this will be used as the URL path. Does not impact drive letter.
 	 *
 	 * @return string
 	 */
-	public function get_path( string $path_override = null ): string {
+	public function get_path( ?string $path_override = null ): string {
 		return ( $this->components['drive'] ? $this->components['drive'] . ':' : '' ) . ( $path_override ?? $this->components['path'] );
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -207,11 +207,11 @@ class CheckoutSchema extends AbstractSchema {
 	/**
 	 * Get the checkout response based on the current order and any payments.
 	 *
-	 * @param \WC_Order     $order Order object.
-	 * @param PaymentResult $payment_result Payment result object.
+	 * @param \WC_Order          $order          Order object.
+	 * @param PaymentResult|null $payment_result Payment result object.
 	 * @return array
 	 */
-	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null ) {
+	protected function get_checkout_response( \WC_Order $order, ?PaymentResult $payment_result = null ) {
 		return [
 			'order_id'          => $order->get_id(),
 			'status'            => $order->get_status(),

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/AbstractInterfaceServiceProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/AbstractInterfaceServiceProviderTest.php
@@ -59,7 +59,7 @@ class AbstractInterfaceServiceProviderTest extends \WC_Unit_Test_Case {
 			 *
 			 * @return DefinitionInterface
 			 */
-			public function add_with_implements_tags( string $id, $concrete = null, bool $shared = null ): DefinitionInterface {
+			public function add_with_implements_tags( string $id, $concrete = null, ?bool $shared = null ): DefinitionInterface {
 				return parent::add_with_implements_tags( $id, $concrete, $shared );
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Beginning with PHP 8.4, implicitly nullable parameters in function signatures (such as `function f( int $x = null )`) [will trigger a deprecation notice](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). Those parameters now have to be explicitly made nullable (i.e. ` function f( ?int $x = null )`).

To reduce the amount of noise when running under this PHP version, this PR makes some of the necessary adjustments in our codebase.

The following deprecation notices are among those resolved with this PR:

```
PHP Deprecated:  Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema::get_checkout_response(): Implicitly marking parameter $payment_result as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php on line 214
PHP Deprecated:  Automattic\WooCommerce\Internal\CostOfGoodsSold\CogsAwareTrait::cogs_is_enabled(): Implicitly marking parameter $doing_it_wrong_function_name as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/src/Internal/CostOfGoodsSold/CogsAwareTrait.php on line 20
PHP Deprecated:  Automattic\WooCommerce\Database\Migrations\TableMigrator::db_get_results(): Implicitly marking parameter $query as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/src/Database/Migrations/TableMigrator.php on line 83
PHP Deprecated:  Automattic\WooCommerce\Caching\ObjectCache::get(): Implicitly marking parameter $get_from_datastore_callback as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/src/Caching/ObjectCache.php on line 228
PHP Deprecated:  Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController::update_processor_state(): Implicitly marking parameter $last_error as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php on line 260
PHP Deprecated:  Automattic\WooCommerce\Internal\Features\FeaturesController::verify_did_woocommerce_init(): Implicitly marking parameter $function_name as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/src/Internal/Features/FeaturesController.php on line 591
PHP Deprecated:  woocommerce_wp_text_input(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/includes/admin/wc-meta-box-functions.php on line 23
PHP Deprecated:  woocommerce_wp_hidden_input(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/includes/admin/wc-meta-box-functions.php on line 90
PHP Deprecated:  woocommerce_wp_textarea_input(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/includes/admin/wc-meta-box-functions.php on line 105
PHP Deprecated:  woocommerce_wp_checkbox(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/includes/admin/wc-meta-box-functions.php on line 150
PHP Deprecated:  woocommerce_wp_select(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/includes/admin/wc-meta-box-functions.php on line 220
PHP Deprecated:  woocommerce_wp_radio(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in [...]/woocommerce/includes/admin/wc-meta-box-functions.php on line 278
```

Related to #52081.

**Note:** The changes are mostly mechanical in nature, so for reviewing is probably enough to just make sure that things look ok and run some smoke tests comparing the output between trunk and this branch. Patience, if you can spare some, would be very useful to have.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your test environment is running PHP 8.4+, has error logging enabled and that the error reporting level includes deprecation warnings. If opcache is in use, temporarily disable it. A PHP snippet such as the following could work:
   ```php
   <?php
   @error_reporting( -1 );
   @ini_set( 'opcache.enable', false );
   ```
2. Run some smoke tests and make sure that the deprecation notices mentioned above are not triggered. You might see other notices, which are covered in other PRs (#53526, #53525), so that's ok. Ensure no new exceptions or errors are generated.
   It's useful to compare the logged errors to those when running on the `trunk` branch, which doesn't have the fixes to see the reduction in noise.
   While navigating the frontend/admin should be enough to see some of these notices being triggered (or fixed), I'd suggest at least attempting to edit a product or an order, as well as toggling between HPOS/legacy and enabling/disabling compat mode.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
