### PR TITLE
Remove shipping if there is no address, always allow hide shipping costs option

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	formatShippingAddress,
 	hasShippingRate,
+	isAddressComplete,
 } from '@woocommerce/base-utils';
 import { useStoreCart } from '@woocommerce/base-context';
 import {
@@ -14,6 +15,7 @@ import {
 import { useSelect } from '@wordpress/data';
 import { checkoutStore } from '@woocommerce/block-data';
 import { createInterpolateElement, useContext } from '@wordpress/element';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -40,6 +42,21 @@ export const ShippingAddress = (): JSX.Element => {
 		: // Translators: <address/> is the formatted shipping address.
 		  __( 'No delivery options available for <address/>', 'woocommerce' );
 
+	const addressComplete = isAddressComplete( shippingAddress, [
+		'state',
+		'city',
+		'country',
+		'postcode',
+	] );
+
+	const shippingCostRequiresAddress = getSetting< boolean >(
+		'shippingCostRequiresAddress',
+		false
+	);
+
+	const showEnterAddressMessage =
+		shippingCostRequiresAddress && ! addressComplete;
+
 	const addressLabel = prefersCollection
 		? // Translators: <address/> is the pickup location.
 		  __( 'Collection from <address/>', 'woocommerce' )
@@ -47,7 +64,7 @@ export const ShippingAddress = (): JSX.Element => {
 
 	const title = (
 		<p className="wc-block-components-totals-shipping-address-summary">
-			{ !! formattedAddress ? (
+			{ !! formattedAddress && ! showEnterAddressMessage ? (
 				createInterpolateElement( addressLabel, {
 					address: <strong>{ formattedAddress }</strong>,
 				} )

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
@@ -277,4 +277,35 @@ describe( 'TotalsShipping', () => {
 			screen.queryByText( 'Enter address to check delivery options' )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'should not show a calculator button label if no shipping methods exist', () => {
+		baseContextHooks.useStoreCart.mockReturnValue( {
+			...baseContextHooks.useStoreCart(),
+			shippingAddress: {
+				...shippingAddress,
+				city: '',
+				country: '',
+				postcode: '',
+			},
+		} );
+
+		render(
+			<SlotFillProvider>
+				<ShippingCalculatorContext.Provider
+					value={ {
+						showCalculator: false,
+						isShippingCalculatorOpen: false,
+						setIsShippingCalculatorOpen: jest.fn(),
+						shippingCalculatorID:
+							'shipping-calculator-form-wrapper',
+					} }
+				>
+					<TotalsShipping />
+				</ShippingCalculatorContext.Provider>
+			</SlotFillProvider>
+		);
+		expect(
+			screen.queryByText( 'Enter address to check delivery options' )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx
@@ -13,6 +13,7 @@ import {
 	allRatesAreCollectable,
 } from '@woocommerce/base-utils';
 import { getSetting } from '@woocommerce/settings';
+import { SHIPPING_METHODS_EXIST } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -33,10 +34,9 @@ const Block = ( { className }: { className: string } ): JSX.Element | null => {
 		return null;
 	}
 
-	const showCalculator = getSetting< boolean >(
-		'isShippingCalculatorEnabled',
-		true
-	);
+	const showCalculator =
+		getSetting< boolean >( 'isShippingCalculatorEnabled', true ) &&
+		SHIPPING_METHODS_EXIST;
 
 	const hasSelectedCollectionOnly =
 		selectedRatesAreCollectable( shippingRates );

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/edit.tsx
@@ -4,8 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ExternalLink } from '@wordpress/components';
-import { ADMIN_URL, getSetting } from '@woocommerce/settings';
+import { ADMIN_URL } from '@woocommerce/settings';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
+import { SHIPPING_ENABLED } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -24,13 +25,12 @@ export const Edit = ( {
 	};
 } ): JSX.Element => {
 	const { className } = attributes;
-	const shippingEnabled = getSetting( 'shippingEnabled', true );
 	const blockProps = useBlockProps();
 
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>
-				{ !! shippingEnabled && (
+				{ !! SHIPPING_ENABLED && (
 					<PanelBody
 						title={ __( 'Shipping Calculations', 'woocommerce' ) }
 					>

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -62,16 +62,21 @@ const FrontendBlock = ( {
 		isCollectable,
 	} = useShippingData();
 
+	const shouldForceShow =
+		LOCAL_PICKUP_ENABLED &&
+		SHIPPING_METHODS_EXIST &&
+		shippingCostRequiresAddress;
+
 	// Note that display logic is also found in plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
 	// where the block is not registered if the conditions are not met.
 	if (
+		! shouldForceShow &&
 		( ! needsShipping ||
 			! hasCalculatedShipping ||
 			! isCollectable ||
 			! LOCAL_PICKUP_ENABLED ||
-			! SHIPPING_METHODS_EXIST ) &&
-		! shippingRates &&
-		! shippingCostRequiresAddress
+			! SHIPPING_METHODS_EXIST ||
+			! shippingRates )
 	) {
 		return null;
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -10,6 +10,7 @@ import { useShippingData } from '@woocommerce/base-context/hooks';
 import {
 	LOCAL_PICKUP_ENABLED,
 	SHIPPING_METHODS_EXIST,
+	SHIPPING_ENABLED,
 } from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 import { getSetting } from '@woocommerce/settings';
@@ -63,6 +64,7 @@ const FrontendBlock = ( {
 	} = useShippingData();
 
 	const shouldForceShow =
+		SHIPPING_ENABLED &&
 		LOCAL_PICKUP_ENABLED &&
 		SHIPPING_METHODS_EXIST &&
 		shippingCostRequiresAddress;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -13,7 +13,6 @@ import {
 	SHIPPING_ENABLED,
 } from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
-import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -12,6 +12,7 @@ import {
 	SHIPPING_METHODS_EXIST,
 } from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -48,6 +49,11 @@ const FrontendBlock = ( {
 			};
 		}
 	);
+
+	const shippingCostRequiresAddress = getSetting< boolean >(
+		'shippingCostRequiresAddress',
+		false
+	);
 	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
 	const {
 		shippingRates,
@@ -59,12 +65,13 @@ const FrontendBlock = ( {
 	// Note that display logic is also found in plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
 	// where the block is not registered if the conditions are not met.
 	if (
-		! needsShipping ||
-		! hasCalculatedShipping ||
-		! shippingRates ||
-		! isCollectable ||
-		! LOCAL_PICKUP_ENABLED ||
-		! SHIPPING_METHODS_EXIST
+		( ! needsShipping ||
+			! hasCalculatedShipping ||
+			! isCollectable ||
+			! LOCAL_PICKUP_ENABLED ||
+			! SHIPPING_METHODS_EXIST ) &&
+		! shippingRates &&
+		! shippingCostRequiresAddress
 	) {
 		return null;
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -51,10 +51,6 @@ const FrontendBlock = ( {
 		}
 	);
 
-	const shippingCostRequiresAddress = getSetting< boolean >(
-		'shippingCostRequiresAddress',
-		false
-	);
 	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
 	const { needsShipping, isCollectable } = useShippingData();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -56,29 +56,16 @@ const FrontendBlock = ( {
 		false
 	);
 	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
-	const {
-		shippingRates,
-		needsShipping,
-		hasCalculatedShipping,
-		isCollectable,
-	} = useShippingData();
-
-	const shouldForceShow =
-		SHIPPING_ENABLED &&
-		LOCAL_PICKUP_ENABLED &&
-		SHIPPING_METHODS_EXIST &&
-		shippingCostRequiresAddress;
+	const { needsShipping, isCollectable } = useShippingData();
 
 	// Note that display logic is also found in plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
 	// where the block is not registered if the conditions are not met.
 	if (
-		! shouldForceShow &&
-		( ! needsShipping ||
-			! hasCalculatedShipping ||
-			! isCollectable ||
-			! LOCAL_PICKUP_ENABLED ||
-			! SHIPPING_METHODS_EXIST ||
-			! shippingRates )
+		! SHIPPING_ENABLED ||
+		! needsShipping ||
+		! isCollectable ||
+		! LOCAL_PICKUP_ENABLED ||
+		! SHIPPING_METHODS_EXIST
 	) {
 		return null;
 	}

--- a/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/settings-context.tsx
+++ b/plugins/woocommerce-blocks/assets/js/extensions/shipping-methods/pickup-location/settings-context.tsx
@@ -13,6 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import fastDeepEqual from 'fast-deep-equal/es6';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -162,7 +163,7 @@ export const SettingsProvider = ( {
 					data.pickup_locations
 				)
 			) {
-				dispatch( 'core/notices' ).createSuccessNotice(
+				dispatch( noticesStore ).createSuccessNotice(
 					__(
 						'Local Pickup settings have been saved.',
 						'woocommerce'

--- a/plugins/woocommerce-blocks/assets/js/previews/cart.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/cart.ts
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
+import {
+	SHIPPING_ENABLED,
+	WC_BLOCKS_IMAGE_URL,
+} from '@woocommerce/block-settings';
 import { CartResponse } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
 
@@ -542,7 +545,7 @@ export const previewCart: CartResponse = {
 	items_count: 3,
 	items_weight: 0,
 	needs_payment: true,
-	needs_shipping: getSetting( 'shippingEnabled', true ),
+	needs_shipping: SHIPPING_ENABLED,
 	has_calculated_shipping: true,
 	shipping_address: {
 		first_name: '',

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -56,6 +56,10 @@ export const SHIPPING_METHODS_EXIST = getSetting< boolean >(
 	'shippingMethodsExist',
 	false
 );
+export const SHIPPING_ENABLED = getSetting< boolean >(
+	'shippingEnabled',
+	true
+);
 
 type FieldsLocations = {
 	address: ( keyof AddressForm )[];

--- a/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -62,9 +62,7 @@ test.describe( 'Shopper → Shipping', () => {
 		// Note that the default customer location is set to the shop country/region, which
 		// is why this label is pre-populated with the shop country/region.
 		await expect(
-			userPage.getByText(
-				'No delivery options available for CALIFORNIA, UNITED STATES (US)'
-			)
+			userPage.getByText( 'Enter address to check delivery options' )
 		).toBeVisible();
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -755,13 +755,20 @@ test.describe( 'Shopper → Place Virtual Order', () => {
 		await frontendUtils.goToCart();
 
 		await expect(
-			page.getByText( 'Shipping', { exact: true } )
+			page.getByText( 'Delivery', { exact: true } )
 		).toBeHidden();
 
 		await frontendUtils.goToCheckout();
 
+		// Delivery total in the sidebar.
 		await expect(
-			page.getByText( 'Shipping', { exact: true } )
+			page.getByText( 'Delivery', { exact: true } )
+		).toBeHidden();
+
+		// Ship/Pickup method selector.
+		await expect( page.getByText( 'Ship', { exact: true } ) ).toBeHidden();
+		await expect(
+			page.getByText( 'Pickup', { exact: true } )
 		).toBeHidden();
 
 		await checkoutPageObject.fillInCheckoutWithTestData();
@@ -783,17 +790,24 @@ test.describe( 'Shopper → Place Virtual Order', () => {
 		await localPickupUtils.enableLocalPickup();
 
 		await frontendUtils.goToShop();
-		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+		await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await frontendUtils.goToCart();
 
 		await expect(
-			page.getByText( 'Shipping', { exact: true } )
+			page.getByText( 'Delivery', { exact: true } )
 		).toBeHidden();
 
 		await frontendUtils.goToCheckout();
 
+		// Delivery total in the sidebar.
 		await expect(
-			page.getByText( 'Shipping', { exact: true } )
+			page.getByText( 'Delivery', { exact: true } )
+		).toBeHidden();
+
+		// Ship/Pickup method selector.
+		await expect( page.getByText( 'Ship', { exact: true } ) ).toBeHidden();
+		await expect(
+			page.getByText( 'Pickup', { exact: true } )
 		).toBeHidden();
 
 		await checkoutPageObject.fillInCheckoutWithTestData();

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -245,7 +245,7 @@ test.describe( 'Shopper → Local pickup', () => {
 		await frontendUtils.goToCheckout();
 
 		await expect(
-			page.getByRole( 'radio', { name: 'Local Pickup', exact: true } )
+			page.getByRole( 'radio', { name: 'Pickup', exact: true } )
 		).toBeHidden();
 
 		await expect(
@@ -310,7 +310,7 @@ test.describe( 'Shopper → Local pickup', () => {
 		await frontendUtils.goToCheckout();
 
 		await expect(
-			page.getByRole( 'radio', { name: 'Local Pickup', exact: true } )
+			page.getByRole( 'radio', { name: 'Pickup', exact: true } )
 		).toBeHidden();
 
 		await expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -199,12 +199,30 @@ test.describe( 'Shopper → Local pickup', () => {
 		);
 	} );
 
-	test( 'Delivery/pickup toggle is not shown when other shipping methods are disabled', async ( {
+	test( 'Delivery/pickup toggle is not shown when other shipping methods are disabled and hide rates until address is entered is off', async ( {
 		admin,
 		page,
 		frontendUtils,
 		checkoutPageObject,
 	} ) => {
+		// Disable hide rates until address is entered.
+		await admin.visitAdminPage(
+			'admin.php',
+			'page=wc-settings&tab=shipping&section=options'
+		);
+
+		await admin.page
+			.getByLabel( 'Hide shipping costs until an address is entered' )
+			.uncheck();
+
+		let saveButton = admin.page.getByRole( 'button', {
+			name: 'Save changes',
+		} );
+
+		if ( await saveButton.isEnabled() ) {
+			await saveButton.click();
+		}
+
 		// Disable all other shipping methods.
 		await admin.visitAdminPage(
 			'admin.php',
@@ -214,9 +232,11 @@ test.describe( 'Shopper → Local pickup', () => {
 		// There are 2 shipping methods and 2 toggles with our test data. Disable both.
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).last().click();
-		const saveButton = admin.page.getByRole( 'button', {
+
+		saveButton = admin.page.getByRole( 'button', {
 			name: 'Save changes',
 		} );
+
 		await saveButton.click();
 
 		// Go to checkout.
@@ -227,6 +247,7 @@ test.describe( 'Shopper → Local pickup', () => {
 		await expect(
 			page.getByRole( 'radio', { name: 'Local Pickup', exact: true } )
 		).toBeHidden();
+
 		await expect(
 			page.getByRole( 'radio', { name: 'Ship', exact: true } )
 		).toBeHidden();

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -32,7 +32,6 @@ export class LocalPickupUtils {
 
 	async saveLocalPickupSettings() {
 		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();
-
 		await this.page.waitForFunction( () => {
 			return window.wp.data
 				.select( window.wp.notices.store )

--- a/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/local-pickup/local-pickup-utils.page.ts
@@ -32,9 +32,10 @@ export class LocalPickupUtils {
 
 	async saveLocalPickupSettings() {
 		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();
+
 		await this.page.waitForFunction( () => {
 			return window.wp.data
-				.select( 'core/notices' )
+				.select( window.wp.notices.store )
 				.getNotices()
 				.some(
 					( notice: Notice ) =>

--- a/plugins/woocommerce/changelog/53466-dev-52335
+++ b/plugins/woocommerce/changelog/53466-dev-52335
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Improve how we show/hide shipping address at cart and checkout based on options.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -121,6 +121,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 				array(
 					'desc'          => __( 'Hide shipping costs until an address is entered', 'woocommerce' ),
+					'desc_tip'      => __( 'Local pickup rates will display in the Checkout, even without an address.', 'woocommerce' ),
 					'id'            => 'woocommerce_shipping_cost_requires_address',
 					'default'       => 'no',
 					'type'          => 'checkbox',

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -121,7 +121,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 				array(
 					'desc'          => __( 'Hide shipping costs until an address is entered', 'woocommerce' ),
-					'desc_tip'      => __( 'Local pickup rates will display in the Checkout, even without an address.', 'woocommerce' ),
 					'id'            => 'woocommerce_shipping_cost_requires_address',
 					'default'       => 'no',
 					'type'          => 'checkbox',

--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -367,6 +367,12 @@ class WC_Shipping {
 			 */
 			$package['rates'] = apply_filters( 'woocommerce_package_rates', $package['rates'], $package );
 
+			// Package rates should be an array, if it was filtered into a non-array, reset it. Don't reset to the
+			// unfiltered value, as e.g. a 3pd could have set it to "false" to remove rates.
+			if ( ! is_array( $package['rates'] ) ) {
+				$package['rates'] = array();
+			}
+
 			// Store in session to avoid recalculation.
 			WC()->session->set(
 				$wc_session_key,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -251,6 +251,7 @@ class Cart extends AbstractBlock {
 
 		$this->asset_data_registry->add( 'localPickupEnabled', $pickup_location_settings['enabled'] );
 		$this->asset_data_registry->add( 'collectableMethodIds', $local_pickup_method_ids );
+		$this->asset_data_registry->add( 'shippingMethodsExist', CartCheckoutUtils::shipping_methods_exist() > 0 );
 
 		$is_block_editor = $this->is_block_editor();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -451,19 +451,7 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'localPickupText', $pickup_location_settings['title'] );
 		$this->asset_data_registry->add( 'localPickupCost', $pickup_location_settings['cost'] );
 		$this->asset_data_registry->add( 'collectableMethodIds', $local_pickup_method_ids );
-
-		// Local pickup is included with legacy shipping methods since they do not support shipping zones.
-		$local_pickup_count = count(
-			array_filter(
-				WC()->shipping()->get_shipping_methods(),
-				function ( $method ) {
-					return isset( $method->enabled ) && 'yes' === $method->enabled && ! $method->supports( 'shipping-zones' ) && $method->supports( 'local-pickup' );
-				}
-			)
-		);
-
-		$shipping_methods_count = wc_get_shipping_method_count( true, true ) - $local_pickup_count;
-		$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 0 );
+		$this->asset_data_registry->add( 'shippingMethodsExist', CartCheckoutUtils::shipping_methods_exist() > 0 );
 
 		$is_block_editor = $this->is_block_editor();
 

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -76,26 +76,7 @@ class ShippingController {
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'remove_shipping_if_no_address' ), 11 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
 
-		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
-		// returns based on the option's value in the DB and we can't override it any other way.
-		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
-
 		add_action( 'rest_pre_serve_request', array( $this, 'track_local_pickup' ), 10, 4 );
-	}
-
-	/**
-	 * Overrides the option to force shipping calculations NOT to wait until an address is entered, but only if the
-	 * Checkout page contains the Checkout Block.
-	 *
-	 * @param boolean $value Whether shipping cost calculation requires address to be entered.
-	 * @return boolean Whether shipping cost calculation should require an address to be entered before calculating.
-	 */
-	public function override_cost_requires_address_option( $value ) {
-		if ( is_checkout() && CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
-			return 'no';
-		}
-
-		return $value;
 	}
 
 	/**
@@ -462,11 +443,7 @@ class ShippingController {
 	 * @return array
 	 */
 	public function remove_shipping_if_no_address( $packages ) {
-		// We have to remove and re-add the filter here because we override to short circuit `show_shipping` from class-wc-cart.php.
-		// We want the true value of the option in this function.
-		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 		$shipping_cost_requires_address = wc_string_to_bool( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ) );
-		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 
 		// Return early here for a small performance gain if we don't need to hide shipping costs until an address is entered.
 		if ( ! $shipping_cost_requires_address ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -443,7 +443,6 @@ class ShippingController {
 
 		// These are the important fields required to get the shipping rates.
 		$shipping_address = array(
-			'shipping_address_1'  => $customer->get_shipping_address_1(),
 			'shipping_city'       => $customer->get_shipping_city(),
 			'shipping_state'      => $customer->get_shipping_state(),
 			'shipping_postcode'   => $customer->get_shipping_postcode(),

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -91,7 +91,7 @@ class ShippingController {
 	 * @return boolean Whether shipping cost calculation should require an address to be entered before calculating.
 	 */
 	public function override_cost_requires_address_option( $value ) {
-		if ( is_checkout() && ! is_admin() && CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
+		if ( is_checkout() && CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			return 'no';
 		}
 
@@ -446,7 +446,7 @@ class ShippingController {
 		$has_address = $customer->has_shipping_address();
 
 		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
-		$option_checked = filter_var( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ), FILTER_VALIDATE_BOOLEAN );
+		$option_checked = wc_string_to_bool( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ) );
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 
 		if ( ! $has_address && $option_checked ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -145,8 +145,10 @@ class ShippingController {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc'] =
-						__( 'Hide shipping costs until an address is entered (Local pickup rates will display in the Checkout block, even without an address)', 'woocommerce' );
+					$settings[ $index ]['desc']     =
+						__( 'Hide shipping costs until an address is entered', 'woocommerce' );
+					$settings[ $index ]['desc_tip'] =
+						__( 'Local pickup rates will display in the Checkout block, even without an address', 'woocommerce' );
 					break;
 				}
 			}
@@ -450,7 +452,7 @@ class ShippingController {
 		if ( ! $has_address && $option_checked ) {
 			$packages = array_map(
 				function ( $package ) {
-					if ( ! is_array( $package['rates'] ) ) {
+					if ( isset( $package['rates'] ) && ! is_array( $package['rates'] ) ) {
 						$package['rates'] = array();
 						return $package;
 					}

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -450,8 +450,7 @@ class ShippingController {
 			'shipping_postcode' => $customer->get_shipping_postcode(),
 			'shipping_country'  => $customer->get_shipping_country(),
 		);
-
-		$address_fields = WC()->countries->get_address_fields( $shipping_address['country'] ?? '', 'shipping_' );
+		$address_fields   = WC()->countries->get_country_locale();
 
 		// For all fields in $shipping_address, check if they are required in $address_fields and if so, check if they are not empty.
 		foreach ( $shipping_address as $key => $value ) {
@@ -471,13 +470,19 @@ class ShippingController {
 	 * @return array
 	 */
 	public function remove_shipping_if_no_address( $packages ) {
-		$has_full_address = $this->has_full_shipping_address();
-
 		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
-		$option_checked = wc_string_to_bool( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ) );
+		$shipping_cost_requires_address = wc_string_to_bool( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ) );
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 
-		if ( ! $has_full_address && $option_checked ) {
+		// Return early here if we don't need to hide shipping costs until an address is entered. Saves us busting the
+		// locale cache in `has_full_shipping_address`.
+		if ( ! $shipping_cost_requires_address ) {
+			return $packages;
+		}
+
+		$has_full_address = $this->has_full_shipping_address();
+
+		if ( ! $has_full_address ) {
 			$packages = array_map(
 				function ( $package ) {
 					if ( isset( $package['rates'] ) && ! is_array( $package['rates'] ) ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -432,16 +432,18 @@ class ShippingController {
 	}
 
 	/**
-	 * Remove shipping if no address is entered.
+	 * Remove shipping (i.e. delivery, not local pickup) if
+	 * "Hide shipping costs until an address is entered" is enabled,
+	 * and no address has been entered yet.
 	 *
 	 * @param array $packages Array of shipping packages.
 	 * @return array
 	 */
 	public function remove_shipping_if_no_address( $packages ) {
-		$customer = wc()->customer;
+		$customer    = wc()->customer;
 		$has_address = $customer->has_shipping_address();
 
-		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );		
+		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 		$option_checked = filter_var( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ), FILTER_VALIDATE_BOOLEAN );
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -69,10 +69,11 @@ class ShippingController {
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
 		add_filter( 'woocommerce_order_hide_shipping_address', array( $this, 'hide_shipping_address_for_local_pickup' ), 10 );
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
+		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
 		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
 		add_filter( 'pre_update_option_pickup_location_pickup_locations', array( $this, 'flush_cache' ) );
-		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
+		add_filter( 'woocommerce_shipping_packages', array( $this, 'remove_shipping_if_no_address' ), 11 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
 
 		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
@@ -90,9 +91,10 @@ class ShippingController {
 	 * @return boolean Whether shipping cost calculation should require an address to be entered before calculating.
 	 */
 	public function override_cost_requires_address_option( $value ) {
-		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
+		if ( is_checkout() && ! is_admin() && CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			return 'no';
 		}
+
 		return $value;
 	}
 
@@ -143,13 +145,8 @@ class ShippingController {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc'] = sprintf(
-						/* translators: %s: URL to the documentation. */
-						__( 'Hide shipping costs until an address is entered (Not available when using the <a href="%s">Local pickup options powered by the Checkout block</a>)', 'woocommerce' ),
-						'https://woocommerce.com/document/woocommerce-blocks-local-pickup/'
-					);
-					$settings[ $index ]['disabled'] = true;
-					$settings[ $index ]['value']    = 'no';
+					$settings[ $index ]['desc'] =
+						__( 'Hide shipping costs until an address is entered (Local pickup rates will display in the Checkout block, even without an address)', 'woocommerce' );
 					break;
 				}
 			}
@@ -411,7 +408,7 @@ class ShippingController {
 			}
 		);
 
-		// Remove pickup location from rates arrays.
+		// Remove pickup location from rates arrays if not all packages can be picked up or support local pickup.
 		if ( count( $valid_packages ) !== count( $packages ) ) {
 			$packages = array_map(
 				function ( $package ) {
@@ -434,6 +431,42 @@ class ShippingController {
 		return $packages;
 	}
 
+	/**
+	 * Remove shipping if no address is entered.
+	 *
+	 * @param array $packages Array of shipping packages.
+	 * @return array
+	 */
+	public function remove_shipping_if_no_address( $packages ) {
+		$customer = wc()->customer;
+		$has_address = $customer->has_shipping_address();
+
+		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );		
+		$option_checked = filter_var( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ), FILTER_VALIDATE_BOOLEAN );
+		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
+
+		if ( ! $has_address && $option_checked ) {
+			$packages = array_map(
+				function ( $package ) {
+					if ( ! is_array( $package['rates'] ) ) {
+						$package['rates'] = array();
+						return $package;
+					}
+					$package['rates'] = array_filter(
+						$package['rates'],
+						function ( $rate ) {
+							return in_array( $rate->get_method_id(), LocalPickupUtils::get_local_pickup_method_ids(), true );
+						}
+					);
+					return $package;
+				},
+				$packages
+			);
+
+		}
+
+		return $packages;
+	}
 	/**
 	 * Track local pickup settings changes via Store API
 	 *

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -70,7 +70,6 @@ class ShippingController {
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
 		add_filter( 'woocommerce_order_hide_shipping_address', array( $this, 'hide_shipping_address_for_local_pickup' ), 10 );
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
-		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
 		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
 		add_filter( 'pre_update_option_pickup_location_pickup_locations', array( $this, 'flush_cache' ) );
@@ -134,28 +133,6 @@ class ShippingController {
 			__( 'Collection from <strong>%s</strong>:', 'woocommerce' ),
 			$location
 		) . '<br/><address>' . str_replace( ',', ',<br/>', $address ) . '</address><br/>' . $details;
-	}
-
-	/**
-	 * When using the cart and checkout blocks this method is used to adjust core shipping settings via a filter hook.
-	 *
-	 * @param array $settings The default WC shipping settings.
-	 * @return array|mixed The filtered settings.
-	 */
-	public function remove_shipping_settings( $settings ) {
-		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
-			foreach ( $settings as $index => $setting ) {
-				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc']     =
-						__( 'Hide shipping costs until an address is entered', 'woocommerce' );
-					$settings[ $index ]['desc_tip'] =
-						__( 'Local pickup rates will display in the Checkout block, even without an address', 'woocommerce' );
-					break;
-				}
-			}
-		}
-
-		return $settings;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -470,12 +470,13 @@ class ShippingController {
 	 * @return array
 	 */
 	public function remove_shipping_if_no_address( $packages ) {
+		// We have to remove and re-add the filter here because we override to short circuit `show_shipping` from class-wc-cart.php.
+		// We want the true value of the option in this function.
 		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 		$shipping_cost_requires_address = wc_string_to_bool( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ) );
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 
-		// Return early here if we don't need to hide shipping costs until an address is entered. Saves us busting the
-		// locale cache in `has_full_shipping_address`.
+		// Return early here for a small performance gain if we don't need to hide shipping costs until an address is entered.
 		if ( ! $shipping_cost_requires_address ) {
 			return $packages;
 		}

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -127,10 +127,8 @@ class ShippingController {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['desc']     =
-						__( 'Hide shipping costs until an address is entered', 'woocommerce' );
 					$settings[ $index ]['desc_tip'] =
-						__( 'Local pickup rates will display in the Checkout block, even without an address', 'woocommerce' );
+						__( 'Local pickup rates will display in the Cart and Checkout blocks, even without an address.', 'woocommerce' );
 					break;
 				}
 			}

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -470,24 +470,23 @@ class ShippingController {
 
 		$has_full_address = $this->has_full_shipping_address();
 
-		if ( ! $has_full_address ) {
-			$packages = array_map(
-				function ( $package ) {
-					// Package rates is always an array due to a check in core.
-					$package['rates'] = array_filter(
-						$package['rates'],
-						function ( $rate ) {
-							return $rate instanceof WC_Shipping_Rate && in_array( $rate->get_method_id(), LocalPickupUtils::get_local_pickup_method_ids(), true );
-						}
-					);
-					return $package;
-				},
-				$packages
-			);
-
+		if ( $has_full_address ) {
+			return $packages;
 		}
 
-		return $packages;
+		return array_map(
+			function ( $package ) {
+				// Package rates is always an array due to a check in core.
+				$package['rates'] = array_filter(
+					$package['rates'],
+					function ( $rate ) {
+						return $rate instanceof WC_Shipping_Rate && in_array( $rate->get_method_id(), LocalPickupUtils::get_local_pickup_method_ids(), true );
+					}
+				);
+				return $package;
+			},
+			$packages
+		);
 	}
 	/**
 	 * Track local pickup settings changes via Store API

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -445,16 +445,31 @@ class ShippingController {
 
 		// These are the important fields required to get the shipping rates.
 		$shipping_address = array(
-			'shipping_city'     => $customer->get_shipping_city(),
-			'shipping_state'    => $customer->get_shipping_state(),
-			'shipping_postcode' => $customer->get_shipping_postcode(),
-			'shipping_country'  => $customer->get_shipping_country(),
+			'city'     => $customer->get_shipping_city(),
+			'state'    => $customer->get_shipping_state(),
+			'postcode' => $customer->get_shipping_postcode(),
+			'country'  => $customer->get_shipping_country(),
 		);
 		$address_fields   = WC()->countries->get_country_locale();
+		$locale_key       = ! empty( $shipping_address['country'] ) && array_key_exists( $shipping_address['country'], $address_fields ) ? $shipping_address['country'] : 'default';
+		$default_locale   = $address_fields['default'];
+		$country_locale   = $address_fields[ $locale_key ] ?? array();
 
-		// For all fields in $shipping_address, check if they are required in $address_fields and if so, check if they are not empty.
+		// For all fields in $shipping_address, check if they are required in the country-specific locale first, if
+		// not set, orn$address_fields and if so, check if they are not empty.
 		foreach ( $shipping_address as $key => $value ) {
-			if ( isset( $address_fields[ $key ] ) && $address_fields[ $key ]['required'] && empty( $value ) ) {
+			// Skip further checks if the field has a value. From this point on $value is empty.
+			if ( ! empty( $value ) ) {
+				continue;
+			}
+
+			// If the country-specific locale does not require the field, continue.
+			if ( isset( $country_locale[ $key ]['required'] ) && false === filter_var( $country_locale[ $key ]['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
+				continue;
+			}
+
+			// If the default locale requires the field return false.
+			if ( isset( $default_locale[ $key ]['required'] ) && true === filter_var( $default_locale[ $key ]['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -434,8 +434,13 @@ class ShippingController {
 		$default_locale   = $address_fields['default'];
 		$country_locale   = $address_fields[ $locale_key ] ?? array();
 
-		// For all fields in $shipping_address, check if they are required in the country-specific locale first, if
-		// not set, orn$address_fields and if so, check if they are not empty.
+		/**
+		 * Checks all shipping address fields against the country's locale settings.
+		 *
+		 * If there's a `required` setting for the field in the country-specific locale, that setting is used, otherwise
+		 * the default locale's setting is used. If the default locale doesn't have a setting either, the field is
+		 * considered optional and therefore valid, even if empty.
+		 */
 		foreach ( $shipping_address as $key => $value ) {
 			// Skip further checks if the field has a value. From this point on $value is empty.
 			if ( ! empty( $value ) ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -70,6 +70,7 @@ class ShippingController {
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
 		add_filter( 'woocommerce_order_hide_shipping_address', array( $this, 'hide_shipping_address_for_local_pickup' ), 10 );
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
+		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
 		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
 		add_filter( 'pre_update_option_pickup_location_pickup_locations', array( $this, 'flush_cache' ) );
@@ -114,6 +115,28 @@ class ShippingController {
 			__( 'Collection from <strong>%s</strong>:', 'woocommerce' ),
 			$location
 		) . '<br/><address>' . str_replace( ',', ',<br/>', $address ) . '</address><br/>' . $details;
+	}
+
+	/**
+	 * When using the cart and checkout blocks this method is used to adjust core shipping settings via a filter hook.
+	 *
+	 * @param array $settings The default WC shipping settings.
+	 * @return array|mixed The filtered settings.
+	 */
+	public function remove_shipping_settings( $settings ) {
+		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
+			foreach ( $settings as $index => $setting ) {
+				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
+					$settings[ $index ]['desc']     =
+						__( 'Hide shipping costs until an address is entered', 'woocommerce' );
+					$settings[ $index ]['desc_tip'] =
+						__( 'Local pickup rates will display in the Checkout block, even without an address', 'woocommerce' );
+					break;
+				}
+			}
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -442,13 +442,10 @@ class ShippingController {
 				continue;
 			}
 
-			// If the country-specific locale does not require the field, continue.
-			if ( isset( $country_locale[ $key ]['required'] ) && false === filter_var( $country_locale[ $key ]['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
-				continue;
-			}
+			$locale_to_check = isset( $country_locale[ $key ]['required'] ) ? $country_locale : $default_locale;
 
-			// If the default locale requires the field return false.
-			if ( isset( $default_locale[ $key ]['required'] ) && true === filter_var( $default_locale[ $key ]['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
+			// If the locale requires the field return false.
+			if ( isset( $locale_to_check[ $key ]['required'] ) && true === wc_string_to_bool( $locale_to_check[ $key ]['required'] ) ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -435,6 +435,32 @@ class ShippingController {
 	}
 
 	/**
+	 * @return bool Whether the customer has a full shipping address (address_1, city, state, postcode, country).
+	 * Only required fields are checked.
+	 */
+	public function has_full_shipping_address() {
+		$customer = WC()->customer;
+
+		// These are the important fields required to get the shipping rates.
+		$shipping_address = array(
+			'shipping_address_1'  => $customer->get_shipping_address_1(),
+			'shipping_city'       => $customer->get_shipping_city(),
+			'shipping_state'      => $customer->get_shipping_state(),
+			'shipping_postcode'   => $customer->get_shipping_postcode(),
+			'shipping_country'    => $customer->get_shipping_country()
+		);
+		$address_fields = WC()->countries->get_address_fields( $shipping_address['country'] ?? '', 'shipping_' );
+
+		// For all fields in $shipping_address, check if they are required in $address_fields and if so, check if they are not empty.
+		foreach ( $shipping_address as $key => $value ) {
+			if ( isset( $address_fields[ $key ] ) && $address_fields[ $key ]['required'] && empty( $value ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Remove shipping (i.e. delivery, not local pickup) if
 	 * "Hide shipping costs until an address is entered" is enabled,
 	 * and no address has been entered yet.

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
+use WC_Customer;
 use WC_Shipping_Rate;
 use WC_Tracks;
 
@@ -421,6 +422,10 @@ class ShippingController {
 	 */
 	public function has_full_shipping_address() {
 		$customer = WC()->customer;
+
+		if ( ! $customer instanceof WC_Customer ) {
+			return false;
+		}
 
 		// These are the important fields required to get the shipping rates.
 		$shipping_address = array(

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -443,11 +443,12 @@ class ShippingController {
 
 		// These are the important fields required to get the shipping rates.
 		$shipping_address = array(
-			'shipping_city'       => $customer->get_shipping_city(),
-			'shipping_state'      => $customer->get_shipping_state(),
-			'shipping_postcode'   => $customer->get_shipping_postcode(),
-			'shipping_country'    => $customer->get_shipping_country()
+			'shipping_city'     => $customer->get_shipping_city(),
+			'shipping_state'    => $customer->get_shipping_state(),
+			'shipping_postcode' => $customer->get_shipping_postcode(),
+			'shipping_country'  => $customer->get_shipping_country(),
 		);
+
 		$address_fields = WC()->countries->get_address_fields( $shipping_address['country'] ?? '', 'shipping_' );
 
 		// For all fields in $shipping_address, check if they are required in $address_fields and if so, check if they are not empty.

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -469,14 +469,13 @@ class ShippingController {
 	 * @return array
 	 */
 	public function remove_shipping_if_no_address( $packages ) {
-		$customer    = wc()->customer;
-		$has_address = $customer->has_shipping_address();
+		$has_full_address = $this->has_full_shipping_address();
 
 		remove_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 		$option_checked = wc_string_to_bool( get_option( 'woocommerce_shipping_cost_requires_address', 'no' ) );
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
 
-		if ( ! $has_address && $option_checked ) {
+		if ( ! $has_full_address && $option_checked ) {
 			$packages = array_map(
 				function ( $package ) {
 					if ( isset( $package['rates'] ) && ! is_array( $package['rates'] ) ) {

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -435,6 +435,8 @@ class ShippingController {
 	}
 
 	/**
+	 * Checks whether the address is "full" in the sense that it contains all required fields to calculate shipping rates.
+	 *
 	 * @return bool Whether the customer has a full shipping address (address_1, city, state, postcode, country).
 	 * Only required fields are checked.
 	 */

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
+use WC_Shipping_Rate;
 use WC_Tracks;
 
 /**
@@ -459,7 +460,7 @@ class ShippingController {
 					$package['rates'] = array_filter(
 						$package['rates'],
 						function ( $rate ) {
-							return in_array( $rate->get_method_id(), LocalPickupUtils::get_local_pickup_method_ids(), true );
+							return $rate instanceof WC_Shipping_Rate && in_array( $rate->get_method_id(), LocalPickupUtils::get_local_pickup_method_ids(), true );
 						}
 					);
 					return $package;

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -476,10 +476,7 @@ class ShippingController {
 		if ( ! $has_full_address ) {
 			$packages = array_map(
 				function ( $package ) {
-					if ( isset( $package['rates'] ) && ! is_array( $package['rates'] ) ) {
-						$package['rates'] = array();
-						return $package;
-					}
+					// Package rates is always an array due to a check in core.
 					$package['rates'] = array_filter(
 						$package['rates'],
 						function ( $rate ) {

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -27,6 +27,26 @@ class CartCheckoutUtils {
 	}
 
 	/**
+	 * Returns true if shipping methods exist in the store. Excludes local pickup and only counts enabled shipping methods.
+	 *
+	 * @return bool true if shipping methods exist.
+	 */
+	public static function shipping_methods_exist() {
+		// Local pickup is included with legacy shipping methods since they do not support shipping zones.
+		$local_pickup_count = count(
+			array_filter(
+				WC()->shipping()->get_shipping_methods(),
+				function ( $method ) {
+					return isset( $method->enabled ) && 'yes' === $method->enabled && ! $method->supports( 'shipping-zones' ) && $method->supports( 'local-pickup' );
+				}
+			)
+		);
+
+		$shipping_methods_count = wc_get_shipping_method_count( true, true ) - $local_pickup_count;
+		return $shipping_methods_count > 0;
+	}
+
+	/**
 	 * Returns true if:
 	 * - The checkout page is being viewed.
 	 * - The page contains a checkout block, checkout shortcode or classic shortcode block with the checkout attribute.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use WC_Tax;
 
 /**
@@ -342,8 +343,12 @@ class CartSchema extends AbstractSchema {
 		// calculated so we can avoid returning costs and rates prematurely.
 		$has_calculated_shipping = $cart->show_shipping();
 
-		// Get shipping packages to return in the response from the cart.
-		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages() : [];
+		$has_local_pickup_methods = LocalPickupUtils::is_local_pickup_enabled() && count( LocalPickupUtils::get_local_pickup_method_ids() ) > 0;
+
+		// Get shipping packages to return in the response from the cart. Always get the shipping packages if local
+		// pickup is enabled and has methods. If the address is required then regular shipping rates will be filtered
+		// out later.
+		$shipping_packages = $has_calculated_shipping || $has_local_pickup_methods ? $controller->get_shipping_packages() : [];
 
 		// Get visible cross sells products.
 		$cross_sells = array_filter( array_map( 'wc_get_product', $cart->get_cross_sells() ), 'wc_products_array_filter_visible' );

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Blocks\Shipping;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
+
+/**
+ * Unit tests for the PatternRegistry class.
+ */
+class ShippingControllerTest extends \WP_UnitTestCase {
+	/**
+	 * The registry instance.
+	 *
+	 * @var ShippingController $controller
+	 */
+	private ShippingController $shipping_controller;
+
+	/**
+	 * Initialize the registry instance.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->shipping_controller = new ShippingController(
+			Package::container()->get( Api::class ),
+			Package::container()->get( AssetDataRegistry::class )
+		);
+		WC()->customer->set_shipping_postcode( '' );
+		WC()->customer->set_shipping_city( '' );
+		WC()->customer->set_shipping_state( '' );
+		WC()->customer->set_shipping_country( '' );
+	}
+
+	/**
+	 * Test that a pattern should not be registered without a slug.
+	 */
+	public function test_has_full_shipping_address_returns_correctly() {
+		// With GB, state is not required. Test it returns false with only a country, nothing else.
+		WC()->customer->set_shipping_country( 'GB' );
+		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+
+		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
+		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+
+		WC()->customer->set_shipping_city( 'Preston' );
+		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+
+		// Now switch to US, ensure that it returns false because state is not input.
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_postcode( '90210' );
+		WC()->customer->set_shipping_city( 'Beverly Hills' );
+		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+
+		// Now add state, ensure that it returns true.
+		WC()->customer->set_shipping_state( 'CA' );
+		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+
+		// Now add a filter to set US state to optional, and UK state to required.
+		add_filter(
+			'woocommerce_get_country_locale',
+			function ( $locale ) {
+				$locale['US']['state']['required'] = false;
+				$locale['GB']['state']['required'] = true;
+				return $locale;
+			}
+		);
+		// Unset the cached locale because this filter runs later. Typically that sort of filter would be applied before
+		// the locale is cached, but in unit tests the site is already set up before the test runs.
+		unset( WC()->countries->locale );
+
+		// Test that US state is now optional.
+		WC()->customer->set_shipping_state( '' );
+		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+
+		// Test that UK state is now required.
+		WC()->customer->set_shipping_country( 'GB' );
+		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
+		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+
+
+		// Finally test that it passes when an ordinarily optional prop filtered to be required is provided.
+		WC()->customer->set_shipping_state( 'Lancashire' );
+		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -63,13 +63,14 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 		add_filter(
 			'woocommerce_get_country_locale',
 			function ( $locale ) {
-				$locale['US']['state']['required'] = false;
-				$locale['GB']['state']['required'] = true;
+				$locale['US']['state']['required']      = false;
+				$locale['GB']['state']['required']      = true;
+				$locale['default']['state']['required'] = false;
 				return $locale;
 			}
 		);
 
-		// Unset the cached locale because this filter runs later. Typically that sort of filter would be applied before
+		// Unset the cached locale because this filter runs later. Typically, that sort of filter would be applied before
 		// the locale is cached, but in unit tests the site is already set up before the test runs.
 		unset( WC()->countries->locale );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -36,7 +36,7 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a pattern should not be registered without a slug.
+	 * Test that the has_full_shipping_address method returns correctly.
 	 */
 	public function test_has_full_shipping_address_returns_correctly() {
 		// With GB, state is not required. Test it returns false with only a country, nothing else.

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -1,5 +1,5 @@
 <?php
-
+declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\Shipping;
 
 use Automattic\WooCommerce\Blocks\Assets\Api;
@@ -68,6 +68,7 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 				return $locale;
 			}
 		);
+
 		// Unset the cached locale because this filter runs later. Typically that sort of filter would be applied before
 		// the locale is cached, but in unit tests the site is already set up before the test runs.
 		unset( WC()->countries->locale );
@@ -80,7 +81,6 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 		WC()->customer->set_shipping_country( 'GB' );
 		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
 		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
-
 
 		// Finally test that it passes when an ordinarily optional prop filtered to be required is provided.
 		WC()->customer->set_shipping_state( 'Lancashire' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -603,6 +603,7 @@ class Checkout extends MockeryTestCase {
 			}
 		);
 
+		unset( WC()->countries->locale );
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 


### PR DESCRIPTION
Closes #52335 

With some adjustments:

1. We used to disable "hide shipping costs until an address is entered" when local pickup was enabled. We now allow it to be enabled but we explain the behaviour (`Local pickup rates will display in the Checkout block, even without an address`). @opr and I agreed this experience felt clearer and covered all cases well, but it would be good to get some feedback about this cc @pmcpinto 

2. If an address has not been entered and the user has hide shipping costs enabled we do not display the *Shipping* options

Added by @opr 

- Changes the shipping calculator logic to display "Enter an address to check delivery options" if only a partial address has been entered (e.g. when the shopper has a default location)
- We previously hid the "Ship" selector when:
  - Shipping is not required
  - Shipping calculations have not been completed
  - No shipping rates are available
  - The item is not collectible
  - Local pickup is not enabled
  - No shipping methods are currently available
- however this would hide it even if rates _might_ become available later, after a full address had been entered. Instead I changed the logic to force the control to show if the following is true:
  - Shipping is enabled, and
  - The cart needs shipping, and
  - All packages in the cart support collectible, and
  - Local pickup is enabled, and
  - Shipping methods exist on the site
- Updated shipping calculator so it doesn't show a "No delivery options available for XXX, XX" message unless there's a full address. I figured the shopper could be negatively affected by such a message if they haven't even filled their address in and they're already seeing a message saying there are no shipping methods. Because of this, I updated the tests in `plugins/woocommerce-blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts`.
- Added a `has_full_shipping_address` method to `ShippingController` - this uses `WC()->countries->get_country_locale` to determine whether the state, city, country, postcode (based on locale requirement) is filled before stripping out "shipping" methods (and leaving pickup methods intact).
  - Needed because we have to determine whether to remove rates from the response if shipping requires a full address.
  

### How to test the changes in this Pull Request:

Smoke test a few scenarios to ensure no regressions. For the shopper part it is best to open an incognito window to clear the address state that would be remembered between scenarios.

#### Scenario 1
1. Have local pickup disabled
2. Have hide shipping costs until address entered **enabled**
3. As shopper go through cart and checkout and ensure that shipping costs are not shown on cart page / checkout page until address entered

#### Scenario 2

1.  Have local pickup disabled
2. Have hide shipping costs until address entered **disabled**
3. As a shopper go through cart and checkout and ensure that shipping and pick up options are visible before address is entered

#### Scenario 3

1. Have local pickup enabled
2. Have hide shipping costs until address entered **enabled**
3.  As a shopper go through cart and checkout and ensure that shipping options are not shown but pickup options are still shown.

#### Scenario 4

1. Go to WC -> Settings -> General. Set Shipping location(s) to `Disable shipping & shipping calculations`
2. Try to check out with a physical product. You should not be able to enter a shipping address or select local pickup. Checkout should succeed.
3. Try to check out with a virtual product. You should not be able to enter a shipping address or select local pickup. Checkout should succeed.

#### General testing

Test with various setups of:
- Local pickup enabled/disabled
- Hide shipping costs until an address is entered enabled/disabled
- Shipping calculator enabled/disabled
- No shipping zones enabled on the whole site
- Only fallback shipping zones enabled
- No fallback zones enabled, but methods exist for specific countries. Test with addresses in and out of these countries.
- Mixtures of virtual, downloadable, and physical products in the cart. Try with each type individually too.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Improve how we show/hide shipping address at cart and checkout based on options.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
