### PR TITLE
Add To Cart with Options: Add the product selector in the Template sidebar

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
@@ -3,7 +3,6 @@
  */
 import { eye } from '@woocommerce/icons';
 import { useProductDataContext } from '@woocommerce/shared-context';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	Icon,
@@ -16,29 +15,14 @@ import {
 /**
  * Internal dependencies
  */
-import { store as woocommerceTemplateStateStore } from '../../store';
-import { ProductTypeProps } from '../../types';
+import useProductTypeSelector from '../../hooks/use-product-type-selector';
 
 export default function ToolbarProductTypeGroup() {
-	/*
-	 * Get the product types and the current product type
-	 * from the store.
-	 */
-	const { productTypes, currentProductType } = useSelect< {
-		productTypes: ProductTypeProps[];
-		currentProductType: ProductTypeProps;
-	} >( ( select ) => {
-		const { getProductTypes, getCurrentProductType } = select(
-			woocommerceTemplateStateStore
-		);
-
-		return {
-			productTypes: getProductTypes(),
-			currentProductType: getCurrentProductType(),
-		};
-	}, [] );
-
-	const { switchProductType } = useDispatch( woocommerceTemplateStateStore );
+	const {
+		current: currentProductType,
+		productTypes,
+		set,
+	} = useProductTypeSelector();
 
 	const { product } = useProductDataContext();
 
@@ -61,7 +45,7 @@ export default function ToolbarProductTypeGroup() {
 				value={ currentProductType?.slug }
 				controls={ productTypes.map( ( productType ) => ( {
 					title: productType.label,
-					onClick: () => switchProductType( productType.slug ),
+					onClick: () => set( productType.slug ),
 				} ) ) }
 			/>
 		</ToolbarGroup>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -17,6 +17,8 @@ import type { InnerBlockTemplate } from '@wordpress/blocks';
 import { useIsDescendentOfSingleProductBlock } from '../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { AddToCartOptionsSettings } from './settings';
 import ToolbarProductTypeGroup from './components/toolbar-type-product-selector-group';
+import useProductTypeSelector from './hooks/use-product-type-selector';
+
 export interface Attributes {
 	className?: string;
 	isDescendentOfSingleProductBlock: boolean;
@@ -53,16 +55,29 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
 	const blockProps = useBlockProps();
+	const blockClientId = blockProps?.id;
 	const { isDescendentOfSingleProductBlock } =
 		useIsDescendentOfSingleProductBlock( {
-			blockClientId: blockProps?.id,
+			blockClientId,
 		} );
+
+	const { registerListener, unregisterListener } = useProductTypeSelector();
 
 	useEffect( () => {
 		setAttributes( {
 			isDescendentOfSingleProductBlock,
 		} );
-	}, [ setAttributes, isDescendentOfSingleProductBlock ] );
+		registerListener( blockClientId );
+		return () => {
+			unregisterListener( blockClientId );
+		};
+	}, [
+		setAttributes,
+		isDescendentOfSingleProductBlock,
+		blockClientId,
+		registerListener,
+		unregisterListener,
+	] );
 
 	return (
 		<>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { store as woocommerceTemplateStateStore } from '../../store';
+import type { ProductTypeProps } from '../../types';
+
+type ProductTypeSelector = {
+	productTypes: ProductTypeProps[];
+	current: ProductTypeProps;
+	set: ( productType: string ) => void;
+};
+
+/**
+ * Hook to get data from the store to manage the product type selector.
+ * Also, it provides a function to switch the current product type.
+ * It's a layer of abstraction to the store.
+ *
+ * @return {ProductTypeSelector} The product type selector data and functions.
+ */
+export default function useProductTypeSelector(): ProductTypeSelector {
+	/*
+	 * Get the product types and the current product type
+	 * from the store.
+	 */
+	const { productTypes, current } = useSelect< {
+		productTypes: ProductTypeProps[];
+		current: ProductTypeProps;
+	} >( ( select ) => {
+		const { getProductTypes, getCurrentProductType } = select(
+			woocommerceTemplateStateStore
+		);
+
+		return {
+			productTypes: getProductTypes(),
+			current: getCurrentProductType(),
+		};
+	}, [] );
+
+	const { switchProductType } = useDispatch( woocommerceTemplateStateStore );
+
+	return {
+		productTypes,
+		current,
+		set: switchProductType,
+	};
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
@@ -23,7 +23,7 @@ type ProductTypeSelector = {
  */
 export default function useProductTypeSelector(): ProductTypeSelector {
 	/*
-	 * Get the product types and the current product type
+	 * Get the available product types and the current product type
 	 * from the store.
 	 */
 	const { productTypes, current } = useSelect< {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
@@ -12,10 +12,13 @@ type ProductTypeSelector = {
 	productTypes: ProductTypeProps[];
 	current: ProductTypeProps;
 	set: ( productType: string ) => void;
+	registeredListeners: string[];
+	registerListener: ( listener: string ) => void;
+	unregisterListener: ( listener: string ) => void;
 };
 
 /**
- * Hook to get data from the store to manage the product type selector.
+ * Hook to get data from the store to manage the product type selector and listeners.
  * Also, it provides a function to switch the current product type.
  * It's a layer of abstraction to the store.
  *
@@ -23,22 +26,30 @@ type ProductTypeSelector = {
  */
 export default function useProductTypeSelector(): ProductTypeSelector {
 	/*
-	 * Get the available product types and the current product type
+	 * Get the registered listeners, available product types and the current product type
 	 * from the store.
 	 */
-	const { productTypes, current } = useSelect< {
+	const { productTypes, current, registeredListeners } = useSelect< {
 		productTypes: ProductTypeProps[];
 		current: ProductTypeProps;
+		registeredListeners: string[];
 	} >( ( select ) => {
-		const { getProductTypes, getCurrentProductType } = select(
-			woocommerceTemplateStateStore
-		);
+		const {
+			getProductTypes,
+			getCurrentProductType,
+			getRegisteredListeners,
+		} = select( woocommerceTemplateStateStore );
 
 		return {
 			productTypes: getProductTypes(),
 			current: getCurrentProductType(),
+			registeredListeners: getRegisteredListeners(),
 		};
 	}, [] );
+
+	const { registerListener, unregisterListener } = useDispatch(
+		woocommerceTemplateStateStore
+	);
 
 	const { switchProductType } = useDispatch( woocommerceTemplateStateStore );
 
@@ -46,5 +57,8 @@ export default function useProductTypeSelector(): ProductTypeSelector {
 		productTypes,
 		current,
 		set: switchProductType,
+		registeredListeners,
+		registerListener,
+		unregisterListener,
 	};
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -13,7 +13,7 @@ import { isBoolean } from '@woocommerce/types';
  * Internal dependencies
  */
 import registerStore, { store as woocommerceTemplateStateStore } from './store';
-import PluginDocumentSettingTemplateSelectorPanel from './plugins';
+import ProductTypeSelectorPlugin from './plugins';
 import getProductTypeOptions from './utils/get-product-types';
 import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
@@ -46,7 +46,7 @@ if ( shouldRegisterBlock ) {
 	const PLUGIN_NAME = 'document-settings-template-selector-pane';
 	if ( ! getPlugin( PLUGIN_NAME ) ) {
 		registerPlugin( PLUGIN_NAME, {
-			render: PluginDocumentSettingTemplateSelectorPanel,
+			render: ProductTypeSelectorPlugin,
 		} );
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -4,7 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
-import { registerPlugin } from '@wordpress/plugins';
+import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
@@ -43,9 +43,12 @@ if ( shouldRegisterBlock ) {
 	dispatch( woocommerceTemplateStateStore ).switchProductType( 'simple' );
 
 	// Extend editor, blocks, etc
-	registerPlugin( 'document-settings-template-selector-panel', {
-		render: PluginDocumentSettingTemplateSelectorPanel,
-	} );
+	const PLUGIN_NAME = 'document-settings-template-selector-pane';
+	if ( ! getPlugin( PLUGIN_NAME ) ) {
+		registerPlugin( PLUGIN_NAME, {
+			render: PluginDocumentSettingTemplateSelectorPanel,
+		} );
+	}
 
 	// Register the block
 	registerBlockType( metadata, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -4,6 +4,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
@@ -11,12 +12,13 @@ import { isBoolean } from '@woocommerce/types';
 /**
  * Internal dependencies
  */
+import registerStore, { store as woocommerceTemplateStateStore } from './store';
+import PluginDocumentSettingTemplateSelectorPanel from './plugins';
+import getProductTypeOptions from './utils/get-product-types';
 import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
-import './style.scss';
-import registerStore, { store as woocommerceTemplateStateStore } from './store';
-import getProductTypeOptions from './utils/get-product-types';
 import save from './save';
+import './style.scss';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -39,6 +41,11 @@ if ( shouldRegisterBlock ) {
 
 	// Select Simple product type
 	dispatch( woocommerceTemplateStateStore ).switchProductType( 'simple' );
+
+	// Extend editor, blocks, etc
+	registerPlugin( 'document-settings-template-selector-panel', {
+		render: PluginDocumentSettingTemplateSelectorPanel,
+	} );
 
 	// Register the block
 	registerBlockType( metadata, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -42,7 +42,7 @@ if ( shouldRegisterBlock ) {
 	// Select Simple product type
 	dispatch( woocommerceTemplateStateStore ).switchProductType( 'simple' );
 
-	// Extend editor, blocks, etc
+	// Register a plugin that adds a product type selector to the template sidebar.
 	const PLUGIN_NAME = 'document-settings-template-selector-pane';
 	if ( ! getPlugin( PLUGIN_NAME ) ) {
 		registerPlugin( PLUGIN_NAME, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { SelectControl } from '@wordpress/components';
+import {
+	// @ts-expect-error no exported member.
+	PluginDocumentSettingPanel,
+} from '@wordpress/editor';
+/**
+ * Internal dependencies
+ */
+import useProductTypeSelector from '../hooks/use-product-type-selector';
+
+export const productTypeSelectorTitle = __( 'Product Type', 'woocommerce' );
+
+function ProductTypeSwitcher() {
+	const { productTypes, current, set } = useProductTypeSelector();
+
+	return (
+		<SelectControl
+			label={ __( 'Type switcher', 'woocommerce' ) }
+			value={ current?.slug }
+			options={ productTypes.map( ( productType ) => ( {
+				label: productType.label,
+				value: productType.slug,
+			} ) ) }
+			onChange={ ( slug ) => set( slug ) }
+			help={ __(
+				'Switch product type to see how the template adapts to each one.',
+				'woocommerce'
+			) }
+		/>
+	);
+}
+
+export default function PluginDocumentSettingTemplateSelectorPanel() {
+	const { slug, type } = useSelect(
+		( select ) => select( 'core/editor' ).getCurrentPost(),
+		[]
+	);
+
+	// Only add the panel if the current post is a template.
+	if ( type !== 'wp_template' || slug !== 'single-product' ) {
+		return null;
+	}
+
+	return (
+		<PluginDocumentSettingPanel
+			name="woocommerce/product-type-selector"
+			title={ productTypeSelectorTitle }
+		>
+			<ProductTypeSwitcher />
+		</PluginDocumentSettingPanel>
+	);
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -13,8 +13,6 @@ import {
  */
 import useProductTypeSelector from '../hooks/use-product-type-selector';
 
-export const productTypeSelectorTitle = __( 'Product Type', 'woocommerce' );
-
 function ProductTypeSwitcher() {
 	const { productTypes, current, set } = useProductTypeSelector();
 
@@ -49,7 +47,7 @@ export default function PluginDocumentSettingTemplateSelectorPanel() {
 	return (
 		<PluginDocumentSettingPanel
 			name="woocommerce/product-type-selector"
-			title={ productTypeSelectorTitle }
+			title={ __( 'Product Type', 'woocommerce' ) }
 		>
 			<ProductTypeSwitcher />
 		</PluginDocumentSettingPanel>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -33,7 +33,7 @@ function ProductTypeSwitcher() {
 	);
 }
 
-export default function PluginDocumentSettingTemplateSelectorPanel() {
+export default function ProductTypeSelectorPlugin() {
 	const { slug, type } = useSelect(
 		( select ) => select( 'core/editor' ).getCurrentPost(),
 		[]

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -45,7 +45,7 @@ const includesAddToCartWithOptions = ( blocks: BlockInstance[] ) => {
 };
 
 export default function ProductTypeSelectorPlugin() {
-	const { slug, type, hasAddToCartWithOptions } = useSelect( ( select ) => {
+	const { slug, type, hasAddToCartBlock } = useSelect( ( select ) => {
 		const { slug: currentPostSlug, type: currentPostType } = select(
 			'core/editor'
 		).getCurrentPost< {
@@ -56,15 +56,15 @@ export default function ProductTypeSelectorPlugin() {
 		return {
 			slug: currentPostSlug,
 			type: currentPostType,
-			hasAddToCartWithOptions: includesAddToCartWithOptions( blocks ),
+			hasAddToCartBlock: includesAddToCartWithOptions( blocks ),
 		};
 	}, [] );
 
-	// Only add the panel if the current post is a template and the block is present.
+	// Only add the panel if the current post is a template and has the Add To Cart block.
 	const isPanelVisible =
 		type === 'wp_template' &&
 		slug === 'single-product' &&
-		hasAddToCartWithOptions;
+		hasAddToCartBlock;
 
 	if ( ! isPanelVisible ) {
 		return null;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -4,8 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { SelectControl } from '@wordpress/components';
-import { findBlock } from '@woocommerce/utils';
-import { BlockInstance } from '@wordpress/blocks';
 import {
 	// @ts-expect-error no exported member.
 	PluginDocumentSettingPanel,
@@ -36,35 +34,28 @@ function ProductTypeSwitcher() {
 	);
 }
 
-const includesAddToCartWithOptions = ( blocks: BlockInstance[] ) => {
-	return !! findBlock( {
-		blocks,
-		findCondition: ( block ) =>
-			block.name === 'woocommerce/add-to-cart-with-options',
-	} );
-};
-
 export default function ProductTypeSelectorPlugin() {
-	const { slug, type, hasAddToCartBlock } = useSelect( ( select ) => {
+	const { slug, type } = useSelect( ( select ) => {
 		const { slug: currentPostSlug, type: currentPostType } = select(
 			'core/editor'
 		).getCurrentPost< {
 			slug: string;
 			type: string;
 		} >();
-		const blocks = select( 'core/block-editor' ).getBlocks();
+
 		return {
 			slug: currentPostSlug,
 			type: currentPostType,
-			hasAddToCartBlock: includesAddToCartWithOptions( blocks ),
 		};
 	}, [] );
+
+	const { registeredListeners } = useProductTypeSelector();
 
 	// Only add the panel if the current post is a template and has the Add To Cart block.
 	const isPanelVisible =
 		type === 'wp_template' &&
 		slug === 'single-product' &&
-		hasAddToCartBlock;
+		registeredListeners.length > 0;
 
 	if ( ! isPanelVisible ) {
 		return null;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/constants.ts
@@ -5,3 +5,5 @@ export const STORE_NAME = 'woocommerce/template-state';
  */
 export const ACTION_SWITCH_PRODUCT_TYPE = 'SWITCH_PRODUCT_TYPE' as const;
 export const ACTION_SET_PRODUCT_TYPES = 'SET_PRODUCT_TYPES' as const;
+export const ACTION_REGISTER_LISTENER = 'REGISTER_LISTENER' as const;
+export const ACTION_UNREGISTER_LISTENER = 'UNREGISTER_LISTENER' as const;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -9,6 +9,8 @@ import { createReduxStore, register } from '@wordpress/data';
 import {
 	ACTION_SET_PRODUCT_TYPES,
 	ACTION_SWITCH_PRODUCT_TYPE,
+	ACTION_REGISTER_LISTENER,
+	ACTION_UNREGISTER_LISTENER,
 	STORE_NAME,
 } from './constants';
 import type { ProductTypeProps } from '../types';
@@ -18,12 +20,18 @@ type StoreState = {
 		list: ProductTypeProps[];
 		current: string | undefined;
 	};
+	listeners: string[];
 };
 
 type Actions = {
-	type: typeof ACTION_SET_PRODUCT_TYPES | typeof ACTION_SWITCH_PRODUCT_TYPE;
+	type:
+		| typeof ACTION_SET_PRODUCT_TYPES
+		| typeof ACTION_SWITCH_PRODUCT_TYPE
+		| typeof ACTION_REGISTER_LISTENER
+		| typeof ACTION_UNREGISTER_LISTENER;
 	productTypes?: ProductTypeProps[];
 	current?: string;
+	listener?: string;
 };
 
 const DEFAULT_STATE = {
@@ -31,6 +39,7 @@ const DEFAULT_STATE = {
 		list: [],
 		current: undefined,
 	},
+	listeners: [],
 };
 
 const actions = {
@@ -47,6 +56,20 @@ const actions = {
 			productTypes,
 		};
 	},
+
+	registerListener( listener: string ) {
+		return {
+			type: ACTION_REGISTER_LISTENER,
+			listener,
+		};
+	},
+
+	unregisterListener( listener: string ) {
+		return {
+			type: ACTION_UNREGISTER_LISTENER,
+			listener,
+		};
+	},
 };
 
 const selectors = {
@@ -57,6 +80,9 @@ const selectors = {
 		return state.productTypes.list.find(
 			( productType ) => productType.slug === state.productTypes.current
 		);
+	},
+	getRegisteredListeners( state: StoreState ) {
+		return state.listeners;
 	},
 };
 
@@ -78,6 +104,20 @@ const reducer = ( state: StoreState = DEFAULT_STATE, action: Actions ) => {
 					...state.productTypes,
 					current: action.current,
 				},
+			};
+
+		case ACTION_REGISTER_LISTENER:
+			return {
+				...state,
+				listeners: [ ...state.listeners, action.listener || '' ],
+			};
+
+		case ACTION_UNREGISTER_LISTENER:
+			return {
+				...state,
+				listeners: state.listeners.filter(
+					( listener ) => listener !== action.listener
+				),
 			};
 
 		default:

--- a/plugins/woocommerce/changelog/update-add-product-type-sidebar-panel
+++ b/plugins/woocommerce/changelog/update-add-product-type-sidebar-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: Add the product selector in the Template sidebar


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds a panel to the Single Product template document to switch the product type in a similar way to the Add To Cart with Options button does though its toolbar.

Closes #53479 #53207

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Enable the `experimental-blocks` and `blockified-add-to-cart` features flags
  * Go to WooCommerce Admin Test Helper -> Features and enable `blockified-add-to-cart`

<img width="450" alt="Screenshot 2024-12-05 at 8 18 00 AM" src="https://github.com/user-attachments/assets/d61d0bb3-6ecf-41c6-a35e-7d388acd7cb5">
3. Edit the `Single Product` template
4. Confirm the document sidebar shows the `Product Type` panel, closed as default

<img width="699" alt="Screenshot 2024-12-05 at 10 34 18 AM" src="https://github.com/user-attachments/assets/8eff608e-331b-4ac5-a77b-e1ee351c9075">

5. Confirm you can open select another type by picking an option from the select component

<img width="310" alt="image" src="https://github.com/user-attachments/assets/9073dee8-ba4f-41d4-a968-beaf9580eb0c">

6. You can add and focus the `Add To Cart with Options (Experimental)` block to show the toolbar
7. Confirm selected product type is consistent


https://github.com/user-attachments/assets/0c56abdb-fc03-416c-b893-b4cca89049ca


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
