### PR TITLE
[dev] Override previous branches when changelog is compiled

### DIFF
--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -137,7 +137,11 @@ export const updateReleaseBranchChangelogs = async (
 		await git.commit(
 			`Update the readme files for the ${ version } release`
 		);
-		await git.push( 'origin', commitDirectToBase ? releaseBranch : branch );
+		await git.push(
+			'origin',
+			commitDirectToBase ? releaseBranch : branch,
+			commitDirectToBase ? [] : [ '--force' ]
+		);
 		await git.checkout( '.' );
 
 		if ( commitDirectToBase ) {
@@ -203,7 +207,7 @@ export const updateTrunkChangelog = async (
 			[ branch ]: null,
 		} );
 		await git.raw( [ 'cherry-pick', deletionCommitHash ] );
-		await git.push( 'origin', branch );
+		await git.push( 'origin', branch, [ '--force' ] );
 		Logger.notice( `Creating PR for ${ branch }` );
 		const pullRequest = await createPullRequest( {
 			owner,


### PR DESCRIPTION
The current build changelog step fails as the previous working branch exists, this change force pushes the new changes in the temporary branches created for changelogs.

Test run that overrides the previous temp branches: https://github.com/naman03malhotra/woocommerce/actions/runs/12178672360/job/33969173837