### PR TITLE
[Experimental] Add To Cart with Options: Select initially the Simple product type

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -3,6 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
+import { dispatch } from '@wordpress/data';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
@@ -13,7 +14,8 @@ import { isBoolean } from '@woocommerce/types';
 import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import './style.scss';
-import registerStore from './store';
+import registerStore, { store as woocommerceTemplateStateStore } from './store';
+import getProductTypeOptions from './utils/get-product-types';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -28,6 +30,11 @@ export const shouldRegisterBlock =
 if ( shouldRegisterBlock ) {
 	// Register the store
 	registerStore();
+
+	// loads the product types
+	dispatch( woocommerceTemplateStateStore ).setProductTypes(
+		getProductTypeOptions()
+	);
 
 	// Register the block
 	registerBlockType( metadata, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -36,6 +36,9 @@ if ( shouldRegisterBlock ) {
 		getProductTypeOptions()
 	);
 
+	// Select Simple product type
+	dispatch( woocommerceTemplateStateStore ).switchProductType( 'simple' );
+
 	// Register the block
 	registerBlockType( metadata, {
 		icon: <Icon icon={ button } />,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -11,10 +11,7 @@ import {
 	ACTION_SWITCH_PRODUCT_TYPE,
 	STORE_NAME,
 } from './constants';
-import getProductTypeOptions from '../utils/get-product-types';
 import type { ProductTypeProps } from '../types';
-
-const productTypesOptions = getProductTypeOptions();
 
 type StoreState = {
 	productTypes: {
@@ -31,7 +28,7 @@ type Actions = {
 
 const DEFAULT_STATE = {
 	productTypes: {
-		list: productTypesOptions,
+		list: [],
 		current: undefined,
 	},
 };

--- a/plugins/woocommerce/changelog/update-select-simple-product-initially
+++ b/plugins/woocommerce/changelog/update-select-simple-product-initially
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Comment: select initially the Simple product type


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR selects the `Simple product` type as default in the template state store.

Closes #53447

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Enable the `experimental-blocks` and `blockified-add-to-cart` features flags
  * Go to WooCommerce Admin Test Helper -> Features and enable `blockified-add-to-cart`

<img width="450" alt="Screenshot 2024-12-05 at 8 18 00 AM" src="https://github.com/user-attachments/assets/d61d0bb3-6ecf-41c6-a35e-7d388acd7cb5">

3. Edit the Simple Product template
4. Add a `Add to Cart with Options` block
5. Confirm the block shows the `Simple product` in types selector, in the block toolbar

<img width="652" alt="Screenshot 2024-12-05 at 11 49 30 AM" src="https://github.com/user-attachments/assets/09b4c947-2f8d-4c4e-af6a-bf7623b7f776">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
