### PR TITLE
Fix namespace conflict between Payments and EmailPreview REST API routes

### DIFF
--- a/plugins/woocommerce/changelog/email-preview-rest-not-found
+++ b/plugins/woocommerce/changelog/email-preview-rest-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix conflicting namespace between EmailPreviewRestController and PaymentRestController causing Payments settings to fail to load

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -7,7 +7,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { isValidEmail } from '@woocommerce/product-editor';
-import { WC_ADMIN_NAMESPACE } from '@woocommerce/data';
 
 type EmailPreviewSendProps = {
 	type: string;
@@ -39,7 +38,7 @@ export const EmailPreviewSend: React.FC< EmailPreviewSendProps > = ( {
 		setNotice( '' );
 		try {
 			const response: EmailPreviewSendResponse = await apiFetch( {
-				path: `${ WC_ADMIN_NAMESPACE }/settings/email/send-preview`,
+				path: 'wc-admin-email/settings/email/send-preview',
 				method: 'POST',
 				data: { email, type },
 			} );

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -17,7 +17,7 @@ class EmailPreviewRestController extends RestApiControllerBase {
 	 *
 	 * @var string
 	 */
-	protected string $route_namespace = 'wc-admin';
+	protected string $route_namespace = 'wc-admin-email';
 
 	/**
 	 * Route base.
@@ -32,7 +32,7 @@ class EmailPreviewRestController extends RestApiControllerBase {
 	 * @return string
 	 */
 	protected function get_rest_api_namespace(): string {
-		return 'wc-admin';
+		return 'wc-admin-email';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailPreviewServiceProvider.php
@@ -3,14 +3,13 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
-use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController;
 
 /**
  * Service provider for the EmailPreview namespace.
  */
-class EmailPreviewServiceProvider extends AbstractServiceProvider {
+class EmailPreviewServiceProvider extends AbstractInterfaceServiceProvider {
 
 	/**
 	 * The classes/interfaces that are serviced by this service provider.
@@ -27,6 +26,6 @@ class EmailPreviewServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register() {
 		$this->share( EmailPreview::class );
-		$this->share( EmailPreviewRestController::class );
+		$this->share_with_implements_tags( EmailPreviewRestController::class );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -20,7 +20,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	const ENDPOINT = '/wc-admin/settings/email';
+	const ENDPOINT = '/wc-admin-email/settings/email';
 
 	/**
 	 * Email address.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes conflict in REST API routes between Payments and EmailPreview. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooCommerce Beta Tester.
2. Go to **Tools > WCA Test Helper > Features** and enable `reactify-classic-payments-settings`. 
3. Check out the ebdf122925 commit (which caused the issue). 
4. Go to **WooCommerce > Settings > Payments** (`wp-admin/admin.php?page=wc-settings&tab=checkout`) and observe that the page is blank and in DevTools, there is a 404 response on `/wc-admin/settings/payments/providers`  response
    ![image (1)](https://github.com/user-attachments/assets/83db8cd7-486c-4a80-a82c-1158c5816a1d)
5. Check out this branch.
6. Reload the page.
7. Observe that the Payments settings page loads properly.

<!-- End testing instructions -->
