### PR TITLE
[dev] Build tweaks for reducing size of wireit caches

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -12,15 +12,15 @@ if [ -n "$changedManifests" ]; then
 	pnpm install --frozen-lockfile
 fi
 
-# Cleanup .wireit cache that is older than 4 weeks (28 days); otherwise, the repository directory size keeps growing and growing.
+# Cleanup .wireit cache that is older than 2 weeks (14 days); otherwise, the repository directory size keeps growing and growing.
 staleWireitDirectories=$(( \
-	$( find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) + \
-	$( find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) + \
-	$( find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -print 2>/dev/null | wc -l ) \
+	$( find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +14 -print 2>/dev/null | wc -l ) + \
+	$( find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +14 -print 2>/dev/null | wc -l ) + \
+	$( find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +14 -print 2>/dev/null | wc -l ) \
 ))
 if [ $staleWireitDirectories -gt 0 ]; then
 	echo "Cleaning up stale wireit-cache ($staleWireitDirectories directories)"
-	find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
-	find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
-	find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +28 -exec rm -rf {} \; 2>/dev/null
+	find plugins/*/.wireit/* -maxdepth 0 -type d -ctime +14 -exec rm -rf {} \; 2>/dev/null
+	find packages/js/*/.wireit/* -maxdepth 0 -type d -ctime +14 -exec rm -rf {} \; 2>/dev/null
+	find plugins/woocommerce/client/*/.wireit/* -maxdepth 0 -type d -ctime +14 -exec rm -rf {} \; 2>/dev/null
 fi

--- a/plugins/woocommerce/changelog/dev-fix-wireit-cache-bloating
+++ b/plugins/woocommerce/changelog/dev-fix-wireit-cache-bloating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: build tweaks to reduce size of wireit-caches

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -16,9 +16,9 @@
 		"build:classic-assets": "pnpm --if-present --workspace-concurrency=Infinity --stream --filter=\"@woocommerce/classic-assets...\" --filter=\"$npm_package_name\" '/^build:project:.*$/'",
 		"build:zip": "./bin/build-zip.sh",
 		"build:project": "pnpm --if-present '/^build:project:.*$/'",
-		"build:project:copy-assets:legacy": "wireit",
-		"build:project:copy-assets:admin": "wireit",
-		"build:project:copy-assets:blocks": "wireit",
+		"build:project:copy-assets:legacy": "rsync -avhW --checksum --delete --quiet client/legacy/build/css/ assets/css && rsync -avhW --checksum --delete --quiet client/legacy/build/js/ assets/js",
+		"build:project:copy-assets:admin": "rsync -avhW --checksum --delete --quiet client/admin/build/ assets/client/admin",
+		"build:project:copy-assets:blocks": "rsync -avhW --checksum --delete --quiet ../woocommerce-blocks/build/ assets/client/blocks && rsync -avhW --checksum --quiet ../woocommerce-blocks/blocks.ini blocks.ini",
 		"build:project:actualize-translation-domains": "wireit",
 		"changelog": "XDEBUG_MODE=off composer install --quiet && composer exec -- changelogger",
 		"docker:down": "pnpm exec wc-e2e docker:down",
@@ -773,34 +773,6 @@
 		"ignoreRoot": []
 	},
 	"wireit": {
-		"build:project:copy-assets:legacy": {
-			"command": "rsync -avhW --checksum --delete --quiet client/legacy/build/css/ assets/css && rsync -avhW --checksum --delete --quiet client/legacy/build/js/ assets/js",
-			"files": [
-				"client/legacy/build/**/*.*"
-			],
-			"output": [
-				"assets/css",
-				"assets/js"
-			]
-		},
-		"build:project:copy-assets:admin": {
-			"command": "rsync -avhW --checksum --delete --quiet client/admin/build/ assets/client/admin",
-			"files": [
-				"client/admin/build/**/*.*"
-			],
-			"output": [
-				"assets/client/admin"
-			]
-		},
-		"build:project:copy-assets:blocks": {
-			"command": "rsync -avhW --checksum --delete --quiet ../woocommerce-blocks/build/ assets/client/blocks && rsync -avhW --checksum --quiet ../woocommerce-blocks/blocks.ini blocks.ini",
-			"files": [
-				"../woocommerce-blocks/build/**/*.*"
-			],
-			"output": [
-				"assets/client/blocks"
-			]
-		},
 		"build:project:actualize-translation-domains": {
 			"command": "node ./bin/package-update-textdomain.js",
 			"files": [


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1733332006879769-slack-C03CPM3UXDJ

In certain workflows `plugins/woocommerce/.wireit` directory size can grow to several GB.
In this PR we are:
- updating the build process to fix a flaw contributing to this 
- lowering wireit cache retention down to 14 days

### How to test the changes in this Pull Request:

- CI-checks shall pass