### PR TITLE
[e2e-utils-playwright] Fix insertBlock function with latest Gutenberg

### DIFF
--- a/packages/js/e2e-utils-playwright/changelog/e2e-utils-playwright-port-53294-fix-for-editor-with-gb
+++ b/packages/js/e2e-utils-playwright/changelog/e2e-utils-playwright-port-53294-fix-for-editor-with-gb
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Port a fix for editor util with Gutenberg installed (original fix in PR 53294)

--- a/packages/js/e2e-utils-playwright/src/editor.js
+++ b/packages/js/e2e-utils-playwright/src/editor.js
@@ -55,12 +55,21 @@ export const goToPostEditor = async ( { page } ) => {
 };
 
 export const insertBlock = async ( page, blockName ) => {
+	// Focus on "Empty block" element before inserting a new block.
+	// Otherwise, Gutenberg nightly (v19.9-nightly) would display "{Block name} can't be inserted."
+	const emptyBlock = ( await getCanvas( page ) ).getByLabel( 'Empty block' );
+	if ( await emptyBlock.isVisible() ) {
+		await emptyBlock.click();
+	}
+
+	// With Gutenberg active we have Block Inserter name
 	await page
 		.getByRole( 'button', {
-			name: 'Toggle block inserter',
+			name: /Toggle block inserter|Block Inserter/,
 			expanded: false,
 		} )
 		.click();
+
 	await page.getByPlaceholder( 'Search', { exact: true } ).fill( blockName );
 	await page.getByRole( 'option', { name: blockName, exact: true } ).click();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes an issue with the e2e tests when having latest Gutenberg installed and active.
The issue was initially fixed in the "local" utils and this ports it into the package.

Issue: https://github.com/woocommerce/woocommerce/issues/53064
Initial fix to trunk: https://github.com/woocommerce/woocommerce/pull/53294

### How to test the changes in this Pull Request:

All e2e tests pass.
CI validates the flows without Gutenberg.
Run with Gutenberg:

```
pnpm test:e2e:with-env gutenberg-stable merchant/create-cart-block.spec.js
```
```
pnpm test:e2e:with-env gutenberg-nightly merchant/create-cart-block.spec.js
```
