### PR TITLE
Make nullable parameters explicitly nullable in Remote Inbox Notification code

### DIFF
--- a/plugins/woocommerce/changelog/52081-nullable-rin
+++ b/plugins/woocommerce/changelog/52081-nullable-rin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make nullable params explicitly nullable in RIN code

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TransformerInterface.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TransformerInterface.php
@@ -28,7 +28,7 @@ interface TransformerInterface {
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = null );
+	public function transform( $value, ?stdClass $arguments = null, $default_value = null );
 
 	/**
 	 * Validate Transformer arguments.
@@ -37,5 +37,5 @@ interface TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null );
+	public function validate( ?stdClass $arguments = null );
 }

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluationLogger.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluationLogger.php
@@ -43,7 +43,7 @@ class EvaluationLogger {
 	 * @param string|null               $source Logger source.
 	 * @param \WC_Logger_Interface|null $logger Logger class to use. Default to using the WC logger.
 	 */
-	public function __construct( $slug, $source = null, \WC_Logger_Interface $logger = null ) {
+	public function __construct( $slug, $source = null, ?\WC_Logger_Interface $logger = null ) {
 		$this->slug = $slug;
 		if ( null === $logger ) {
 			$logger = wc_get_logger();

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayColumn.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayColumn.php
@@ -23,7 +23,7 @@ class ArrayColumn implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = array() ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = array() ) {
 		if ( ! is_array( $value ) ) {
 			return $default_value;
 		}
@@ -38,7 +38,7 @@ class ArrayColumn implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		if ( ! isset( $arguments->key ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayFlatten.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayFlatten.php
@@ -20,7 +20,7 @@ class ArrayFlatten implements TransformerInterface {
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = array() ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = array() ) {
 		if ( ! is_array( $value ) ) {
 			return $default_value;
 		}
@@ -43,7 +43,7 @@ class ArrayFlatten implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		return true;
 	}
 }

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayKeys.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayKeys.php
@@ -20,7 +20,7 @@ class ArrayKeys implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = array() ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = array() ) {
 		if ( ! is_array( $value ) ) {
 			return $default_value;
 		}
@@ -35,7 +35,7 @@ class ArrayKeys implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		return true;
 	}
 }

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArraySearch.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArraySearch.php
@@ -23,7 +23,7 @@ class ArraySearch implements TransformerInterface {
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = null ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = null ) {
 		if ( ! is_array( $value ) ) {
 			return $default_value;
 		}
@@ -43,7 +43,7 @@ class ArraySearch implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		if ( ! isset( $arguments->value ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayValues.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayValues.php
@@ -20,7 +20,7 @@ class ArrayValues implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = array() ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = array() ) {
 		if ( ! is_array( $value ) ) {
 			return $default_value;
 		}
@@ -35,7 +35,7 @@ class ArrayValues implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		return true;
 	}
 }

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/Count.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/Count.php
@@ -20,7 +20,7 @@ class Count implements TransformerInterface {
 	 *
 	 * @return number
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = null ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = null ) {
 		if ( ! is_array( $value ) && ! $value instanceof \Countable ) {
 			return $default_value;
 		}
@@ -35,7 +35,7 @@ class Count implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		return true;
 	}
 }

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/DotNotation.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/DotNotation.php
@@ -24,7 +24,7 @@ class DotNotation implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdclass $arguments = null, $default_value = null ) {
+	public function transform( $value, ?stdclass $arguments = null, $default_value = null ) {
 		if ( is_object( $value ) ) {
 			// if the value is an object, convert it to an array.
 			$value = json_decode( wp_json_encode( $value ), true );
@@ -69,7 +69,7 @@ class DotNotation implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		if ( ! isset( $arguments->path ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/PrepareUrl.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/PrepareUrl.php
@@ -20,7 +20,7 @@ class PrepareUrl implements TransformerInterface {
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = null ) {
+	public function transform( $value, ?stdClass $arguments = null, $default_value = null ) {
 		if ( ! is_string( $value ) ) {
 			return $default_value;
 		}
@@ -49,7 +49,7 @@ class PrepareUrl implements TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null ) {
+	public function validate( ?stdClass $arguments = null ) {
 		return true;
 	}
 }

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/TransformerInterface.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/TransformerInterface.php
@@ -21,7 +21,7 @@ interface TransformerInterface {
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null, $default_value = null );
+	public function transform( $value, ?stdClass $arguments = null, $default_value = null );
 
 	/**
 	 * Validate Transformer arguments.
@@ -30,5 +30,5 @@ interface TransformerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function validate( stdClass $arguments = null );
+	public function validate( ?stdClass $arguments = null );
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Beginning with PHP 8.4, implicitly nullable parameters in function signatures (such as `function f( int $x = null )`) [will trigger a deprecation notice](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). Those parameters now have to be explicitly made nullable (i.e. ` function f( ?int $x = null )`).

To reduce the amount of noise when running under this PHP version, this PR makes the relevant changes to code related to the Remote Inbox Notification functionality.

In particular, it fixes deprecation notices such as the following:

```
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\EvaluationLogger::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/EvaluationLogger.php on line 46
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\Transformers\DotNotation::transform(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/DotNotation.php on line 27
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\Transformers\DotNotation::validate(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/DotNotation.php on line 72
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\Transformers\TransformerInterface::transform(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/TransformerInterface.php on line 24
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\Transformers\TransformerInterface::validate(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/TransformerInterface.php on line 33
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\Transformers\ArrayColumn::transform(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayColumn.php on line 26
PHP Deprecated:  Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors\Transformers\ArrayColumn::validate(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in [...]woocommerce/src/Admin/RemoteSpecs/RuleProcessors/Transformers/ArrayColum
```

**Note:** The changes are mostly mechanical in nature, so for reviewing is probably enough to just make sure that things look ok and run some smoke tests comparing the output between trunk and this branch.

Related to #52081.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your test environment is running PHP 8.4+, has error logging enabled and that the error reporting level includes deprecation warnings. If opcache is in use, temporarily disable it. A PHP snippet such as the following could work:
   ```php
   <?php
   @error_reporting( -1 );
   @ini_set( 'opcache.enable', false );
   ```
2. Run some smoke tests and make sure that deprecation warnings (see description above for examples) related to `RemoteInboxNotifications/` and `RemoteSpecs/` do not appear in the log files.
   Optionally, compare the logged errors to those when running on the `trunk` branch, which doesn't have the fixes.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
