### PR TITLE
Make nullable parameters explicitly nullable in various admin packages

### DIFF
--- a/packages/php/blueprint/src/ImportSchema.php
+++ b/packages/php/blueprint/src/ImportSchema.php
@@ -44,7 +44,7 @@ class ImportSchema {
 	 * @param JsonSchema     $schema The schema instance.
 	 * @param Validator|null $validator The validator instance, optional.
 	 */
-	public function __construct( JsonSchema $schema, Validator $validator = null ) {
+	public function __construct( JsonSchema $schema, ?Validator $validator = null ) {
 		$this->schema = $schema;
 		if ( null === $validator ) {
 			$validator = new Validator();

--- a/plugins/woocommerce/changelog/52081-nullable-admin
+++ b/plugins/woocommerce/changelog/52081-nullable-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make nullable parameters explicitly nullable in various admin packages

--- a/plugins/woocommerce/lib/packages/Detection/MobileDetect.php
+++ b/plugins/woocommerce/lib/packages/Detection/MobileDetect.php
@@ -829,7 +829,7 @@ class MobileDetect
      * @param string|null $userAgent Inject the User-Agent header. If null, will use HTTP_USER_AGENT
      *                               from the $headers array instead.
      */
-    public function __construct(array $headers = null, string $userAgent = null)
+    public function __construct(?array $headers = null, ?string $userAgent = null)
     {
         $this->setHttpHeaders($headers);
         $this->setUserAgent($userAgent);
@@ -854,7 +854,7 @@ class MobileDetect
      * @param array|null $httpHeaders The headers to set. If null, then using PHP's _SERVER to extract
      *                           the headers. The default null is left for backwards compatibility.
      */
-    public function setHttpHeaders(array $httpHeaders = null)
+    public function setHttpHeaders(?array $httpHeaders = null)
     {
         // use global _SERVER if $httpHeaders aren't defined
         if (!is_array($httpHeaders) || !count($httpHeaders)) {
@@ -942,7 +942,7 @@ class MobileDetect
      *
      * @return bool If there were CloudFront headers to be set
      */
-    public function setCfHeaders(array $cfHeaders = null): bool
+    public function setCfHeaders(?array $cfHeaders = null): bool
     {
         // use global _SERVER if $cfHeaders aren't defined
         if (!is_array($cfHeaders) || !count($cfHeaders)) {
@@ -992,7 +992,7 @@ class MobileDetect
      *
      * @return string|null
      */
-    public function setUserAgent(string $userAgent = null): ?string
+    public function setUserAgent(?string $userAgent = null): ?string
     {
         // Invalidate cache due to #375
         $this->cache = array();
@@ -1167,7 +1167,7 @@ class MobileDetect
      * @param string|null $userAgent deprecated
      * @return bool
      */
-    protected function matchDetectionRulesAgainstUA(string $userAgent = null): bool
+    protected function matchDetectionRulesAgainstUA(?string $userAgent = null): bool
     {
         // Begin general search.
         foreach ($this->getRules() as $_regex) {
@@ -1219,7 +1219,7 @@ class MobileDetect
      * @param array|null $httpHeaders deprecated
      * @return bool
      */
-    public function isMobile(string $userAgent = null, array $httpHeaders = null): bool
+    public function isMobile(?string $userAgent = null, ?array $httpHeaders = null): bool
     {
 
         if ($httpHeaders) {
@@ -1255,7 +1255,7 @@ class MobileDetect
      * @param array|null $httpHeaders deprecated
      * @return bool
      */
-    public function isTablet(string $userAgent = null, array $httpHeaders = null): bool
+    public function isTablet(?string $userAgent = null, ?array $httpHeaders = null): bool
     {
         // Check specifically for cloudfront headers if the useragent === 'Amazon CloudFront'
         if ($this->getUserAgent() === 'Amazon CloudFront') {
@@ -1286,7 +1286,7 @@ class MobileDetect
      *
      * @todo: The httpHeaders part is not yet used.
      */
-    public function is(string $key, string $userAgent = null, array $httpHeaders = null): bool
+    public function is(string $key, ?string $userAgent = null, ?array $httpHeaders = null): bool
     {
         // Set the UA and HTTP headers only if needed (eg. batch mode).
         if ($httpHeaders) {
@@ -1315,7 +1315,7 @@ class MobileDetect
      *
      * @todo: search in the HTTP headers too.
      */
-    public function match(string $regex, string $userAgent = null): bool
+    public function match(string $regex, ?string $userAgent = null): bool
     {
         if (!\is_string($userAgent) && !\is_string($this->userAgent)) {
             return false;

--- a/plugins/woocommerce/src/Admin/Features/MarketingRecommendations/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/MarketingRecommendations/Init.php
@@ -82,7 +82,7 @@ class Init extends RemoteSpecsEngine {
 	 * @param array|null $specs Marketing recommendations spec array.
 	 * @return array
 	 */
-	protected static function evaluate_specs( array $specs = null ) {
+	protected static function evaluate_specs( ?array $specs = null ) {
 		$suggestions = array();
 		$errors      = array();
 

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -33,7 +33,7 @@ class Init extends RemoteSpecsEngine {
 	 * @param array|null $specs payment suggestion spec array.
 	 * @return array
 	 */
-	public static function get_suggestions( array $specs = null ) {
+	public static function get_suggestions( ?array $specs = null ) {
 		$locale = get_user_locale();
 
 		$specs           = is_array( $specs ) ? $specs : self::get_specs();

--- a/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/ShippingPartnerSuggestions.php
+++ b/plugins/woocommerce/src/Admin/Features/ShippingPartnerSuggestions/ShippingPartnerSuggestions.php
@@ -16,7 +16,7 @@ class ShippingPartnerSuggestions extends RemoteSpecsEngine {
 	 * @param array|null $specs shipping partner suggestion spec array.
 	 * @return array
 	 */
-	public static function get_suggestions( array $specs = null ) {
+	public static function get_suggestions( ?array $specs = null ) {
 		$locale = get_user_locale();
 
 		$specs           = is_array( $specs ) ? $specs : self::get_specs();

--- a/plugins/woocommerce/src/Admin/Marketing/MarketingCampaign.php
+++ b/plugins/woocommerce/src/Admin/Marketing/MarketingCampaign.php
@@ -65,7 +65,7 @@ class MarketingCampaign {
 	 * @param Price|null            $cost       The cost of the marketing campaign with the currency.
 	 * @param Price|null            $sales      The sales of the marketing campaign with the currency.
 	 */
-	public function __construct( string $id, MarketingCampaignType $type, string $title, string $manage_url, Price $cost = null, Price $sales = null ) {
+	public function __construct( string $id, MarketingCampaignType $type, string $title, string $manage_url, ?Price $cost = null, ?Price $sales = null ) {
 		$this->id         = $id;
 		$this->type       = $type;
 		$this->title      = $title;

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -217,7 +217,7 @@ class PluginsHelper {
 	 *
 	 * @return array
 	 */
-	public static function install_plugins( $plugins, PluginsInstallLogger $logger = null ) {
+	public static function install_plugins( $plugins, ?PluginsInstallLogger $logger = null ) {
 		/**
 		 * Filter the list of plugins to install.
 		 *
@@ -420,7 +420,7 @@ class PluginsHelper {
 	 *
 	 * @return WP_Error|array Plugin Status
 	 */
-	public static function activate_plugins( $plugins, PluginsInstallLogger $logger = null ) {
+	public static function activate_plugins( $plugins, ?PluginsInstallLogger $logger = null ) {
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
 			return new WP_Error(
 				'woocommerce_plugins_invalid_plugins',

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsyncPluginsInstallLogger.php
@@ -122,7 +122,7 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 	 *
 	 * @return void
 	 */
-	public function add_error( string $plugin_name, string $error_message = null ) {
+	public function add_error( string $plugin_name, ?string $error_message = null ) {
 		$option = $this->get();
 
 		$option['plugins'][ $plugin_name ]['errors'][] = $error_message;

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/PluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/PluginsInstallLogger.php
@@ -39,7 +39,7 @@ interface PluginsInstallLogger {
 	 * @param string|null $error_message error message.
 	 * @return mixed
 	 */
-	public function add_error( string $plugin_name, string $error_message = null);
+	public function add_error( string $plugin_name, ?string $error_message = null);
 
 	/**
 	 * Called when all plugins are processed.

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/MailchimpScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/MailchimpScheduler.php
@@ -31,7 +31,7 @@ class MailchimpScheduler {
 	 * @internal
 	 * @param \WC_Logger_Interface|null $logger Logger instance.
 	 */
-	public function __construct( \WC_Logger_Interface $logger = null ) {
+	public function __construct( ?\WC_Logger_Interface $logger = null ) {
 		if ( null === $logger ) {
 			$logger = wc_get_logger();
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Beginning with PHP 8.4, implicitly nullable parameters in function signatures (such as `function f( int $x = null )`) [will trigger a deprecation notice](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). Those parameters now have to be explicitly made nullable (i.e. ` function f( ?int $x = null )`).

To reduce the amount of noise when running under this PHP version, this PR makes the relevant changes to code related to various admin functionality (particularly, marketing related stuff).

In particular, it fixes deprecation notices such as the following:

```
PHP Deprecated:  Automattic\WooCommerce\Admin\PluginsHelper::install_plugins(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in [...]/src/Admin/PluginsHelper.php on line 220
PHP Deprecated:  Automattic\WooCommerce\Admin\PluginsHelper::activate_plugins(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in [...]/src/Admin/PluginsHelper.php on line 42
PHP Deprecated:  Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init::get_suggestions(): Implicitly marking parameter $specs as nullable is deprecated, the explicit nullable type must be used instead in [...]/src/Admin/Features/PaymentGatewaySuggestions/Init.php on line 36
PHP Deprecated:  Automattic\WooCommerce\Admin\Features\MarketingRecommendations\Init::evaluate_specs(): Implicitly marking parameter $specs as nullable is deprecated, the explicit nullable type must be used instead in [...]/src/Admin/Features/MarketingRecommendations/Init.php on line 85
```

**Note:** The changes are mostly mechanical in nature, so for reviewing is probably enough to just make sure that things look ok and run some smoke tests comparing the output between trunk and this branch.

Related to #52081.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your test environment is running PHP 8.4+, has error logging enabled and that the error reporting level includes deprecation warnings. If opcache is in use, temporarily disable it. A PHP snippet such as the following could work:
   ```php
   <?php
   @error_reporting( -1 );
   @ini_set( 'opcache.enable', false );
   ```
2. Run some smoke tests and make sure that deprecation warnings (see description above for examples) related to the following list of namespaces do not appear in the log files:
   * `Automattic\WooCommerce\Blueprint`
   * `Automattic\WooCommerce\Vendor\Detection`
   * `Automattic\WooCommerce\Admin\Features\MarketingRecommendations`
   * `Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions`
   * `Automattic\WooCommerce\Admin\Features\ShippingPartnerSuggestions`
   * `Automattic\WooCommerce\Admin\Marketing`
   * `Automattic\WooCommerce\Admin\PluginsInstallLoggers`
   * `Automattic\WooCommerce\Internal\Admin\Schedulers`
   It's useful to compare the logged errors to those when running on the `trunk` branch, which doesn't have the fixes.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
