### PR TITLE
[e2e tests] Update page loads spec to cover Coupons page with existing coupons

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-page-loads-test-coupons-main-element
+++ b/plugins/woocommerce/changelog/e2e-fix-page-loads-test-coupons-main-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: improve page-loads test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -93,8 +93,8 @@ const wcPages = [
 			{
 				name: 'Coupons',
 				heading: 'Coupons',
-				element: '.woocommerce-BlankState-cta.button-primary',
-				text: 'Create your first coupon',
+				element: '.page-title-action',
+				text: 'Add new coupon',
 			},
 		],
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The existing check of the Coupons page in page-loads spec only works when there are no coupons, not even in the Trash. This is prone to flakiness, because there are tests that create and use coupons.

Update the element to be checked to a more generic one, that will hopefully cover most if not all cases.

This should partially solve https://github.com/woocommerce/woocommerce/issues/53371

### How to test the changes in this Pull Request:

Run the page-loads.spec.js spec with and without existing coupons. It should pass.

```
pnpm tests:e2e page-loads.spec.js
```

