### PR TITLE
Fix flaky e2e test Core Profiler Can connect to WCCOM

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-e2e-test-can-connect-wccom
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-e2e-test-can-connect-wccom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: stabilized e2e test core profiler can connect to woo com to fix flakiness

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -540,8 +540,19 @@ test.describe(
 			} );
 
 			await test.step( 'Go to the extensions tab and connect store', async () => {
+				const connectButton = page.getByRole( 'link', {
+					name: 'Connect your store',
+				} );
 				await page.goto(
 					'wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions'
+				);
+				const waitForSubscriptionsResponse = page.waitForResponse(
+					( response ) =>
+						response
+							.url()
+							.includes(
+								'/wp-json/wc/v3/marketplace/subscriptions'
+							) && response.status() === 200
 				);
 				await expect(
 					page.getByText(
@@ -551,12 +562,13 @@ test.describe(
 				await expect(
 					page.getByRole( 'button', { name: 'My Subscriptions' } )
 				).toBeVisible();
-				await expect(
-					page.getByRole( 'link', { name: 'Connect your store' } )
-				).toBeVisible();
-				await page
-					.getByRole( 'link', { name: 'Connect your store' } )
-					.click();
+				await expect( connectButton ).toBeVisible();
+				await waitForSubscriptionsResponse;
+				await expect( connectButton ).toHaveAttribute(
+					'href',
+					/my-subscriptions/
+				);
+				await connectButton.click();
 			} );
 
 			await test.step( 'Check that we are sent to wp.com', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50380

This should stabilize the test to fix flakiness in clicking the button to connect to Woo com.

Not reproducible locally. No enough CI data to investigate and it happens very rarely and always successful in the retry. I will try to stabilize the test by waiting for a response and ensure the button contains the necessary attribute before attempting to click on it.

Investigating the trace file and the video from a flaky report, there were no any indications of a broken button's url or that something's missing. It seems to be some race condition effect and the changes proposed are there to help us better understand next time if it fails.

The button's link is pretty long and it takes time to generate so let's way for the response/attribute before clicking.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```
pnpm test:e2e tests/activate-and-setup/core-profiler.spec.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
