### PR TITLE
[Delayed Account Creation] Update account password text to include customer email address

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
@@ -162,27 +162,29 @@ const Form = ( {
 			<input type="hidden" name="create-account" value="1" />
 			<input type="hidden" name="_wpnonce" value={ nonceToken } />
 			<div className="wc-block-order-confirmation-create-account-description">
-				{ registrationGeneratePassword && (
-					<p>
-						{ createInterpolateElement(
-							__(
-								"We'll email <email/> a link to set up your account password.",
-								'woocommerce'
-							),
-							{
-								email: <strong>{ customerEmail }</strong>,
-							}
-						) }
-					</p>
-				) }
 				<p>
+					{ registrationGeneratePassword && (
+						<>
+							{ createInterpolateElement(
+								__(
+									'Check your email at <email/> for the link to set up an account password.',
+									'woocommerce'
+								),
+								{
+									email: <>{ customerEmail }</>,
+								}
+							) }{ ' ' }
+						</>
+					) }
 					{ createInterpolateElement(
-						/* translators: %1$s terms page link, %2$s privacy page link. */
 						__(
 							'By creating an account you agree to our <terms/> and <privacy/>.',
 							'woocommerce'
 						),
-						{ terms: termsPageLink, privacy: privacyPageLink }
+						{
+							terms: termsPageLink,
+							privacy: privacyPageLink,
+						}
 					) }
 				</p>
 			</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
@@ -164,9 +164,14 @@ const Form = ( {
 			<div className="wc-block-order-confirmation-create-account-description">
 				{ registrationGeneratePassword && (
 					<p>
-						{ __(
-							"We'll email you a link to set up an account password.",
-							'woocommerce'
+						{ createInterpolateElement(
+							__(
+								"We'll email <email/> a link to set up your account password.",
+								'woocommerce'
+							),
+							{
+								email: <strong>{ customerEmail }</strong>,
+							}
 						) }
 					</p>
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
@@ -66,7 +66,7 @@
 
 		.wc-block-order-confirmation-create-account-description {
 			p {
-				@include font-size(small);
+				@include font-size(smaller);
 				text-align: center;
 
 				a,

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
@@ -74,10 +74,6 @@
 					white-space: nowrap;
 				}
 			}
-
-			p + p {
-				margin-top: $gap-small;
-			}
 		}
 
 		.wc-block-components-password-strength.hidden {

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/style.scss
@@ -74,6 +74,10 @@
 					white-space: nowrap;
 				}
 			}
+
+			p + p {
+				margin-top: $gap-small;
+			}
 		}
 
 		.wc-block-components-password-strength.hidden {

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
@@ -149,7 +149,7 @@ describe( 'CreateAccountFrontendBlock - Automatic password generation on', () =>
 			expect(
 				await queryByText(
 					textContentMatcher(
-						"We'll email test@test.com a link to set up your account password."
+						'Check your email at test@test.com for the link to set up an account password.'
 					)
 				)
 			).toBeInTheDocument();

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
@@ -150,8 +150,7 @@ describe( 'CreateAccountFrontendBlock - Automatic password generation on', () =>
 				await queryByText(
 					textContentMatcher(
 						'Check your email at test@test.com for the link to set up an account password.'
-					),
-					{ exact: false }
+					)
 				)
 			).toBeInTheDocument();
 		} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
@@ -149,7 +149,7 @@ describe( 'CreateAccountFrontendBlock - Automatic password generation on', () =>
 			expect(
 				await queryByText(
 					textContentMatcher(
-						"We'll email you a link to set up an account password."
+						"We'll email test@test.com a link to set up your account password."
 					)
 				)
 			).toBeInTheDocument();

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/test/frontend-block.test.tsx
@@ -150,7 +150,8 @@ describe( 'CreateAccountFrontendBlock - Automatic password generation on', () =>
 				await queryByText(
 					textContentMatcher(
 						'Check your email at test@test.com for the link to set up an account password.'
-					)
+					),
+					{ exact: false }
 				)
 			).toBeInTheDocument();
 		} );

--- a/plugins/woocommerce-blocks/tests/utils/find-by-text.ts
+++ b/plugins/woocommerce-blocks/tests/utils/find-by-text.ts
@@ -9,7 +9,7 @@ import type { MatcherFunction } from '@testing-library/react';
  */
 export const textContentMatcher = ( text: string ): MatcherFunction => {
 	return ( _content, node ) => {
-		const hasText = ( _node ) => _node.textContent === text;
+		const hasText = ( _node ) => _node.textContent?.includes( text );
 		const nodeHasText = hasText( node );
 		const childrenDontHaveText = Array.from( node?.children || [] ).every(
 			( child ) => ! hasText( child )

--- a/plugins/woocommerce/changelog/update-delayed-account-email-text-52986
+++ b/plugins/woocommerce/changelog/update-delayed-account-email-text-52986
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updated delayed account creation wording when emailing password set up links.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the wording in delayed account creation to include the email address where the password setup link will be sent.

![Screenshot 2024-12-09 at 12 20 06](https://github.com/user-attachments/assets/fd05af53-f127-4207-9ba3-d4ba9197cb18)

Closes #52986

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Ensure you're using block checkout and have enabled account creation "after" checkout under Settings > Accounts and Privacy. Also enable the option to send the account password to the user.
2. Log out and place an order as a guest. Ensure you've never used the email address before to checkout.
3. On the confirmation page, the email should be shown below the create account button.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
