### PR TITLE
Update community PR team assignment automation for the currency package.

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -38,7 +38,7 @@
   - team: woo-fse
 
 "packages/js/currency/**/*":
-  - team: woo-fse
+  - team: fractal
 
 "packages/js/customer-effort-score/**/*":
   - team: woo-fse


### PR DESCRIPTION
As per some internal discussion, the Fractal team is assuming ownership of triaging/reviewing incoming PRs for the currency package.


