### PR TITLE
[WC Payments NOX] Handle testing plugin slugs when matching to suggestions

### DIFF
--- a/packages/js/data/changelog/update-53563-handle-beta-testing-plugin-installs
+++ b/packages/js/data/changelog/update-53563-handle-beta-testing-plugin-installs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the deactivatePlugin action to use a plugin file like the WP API expects.

--- a/packages/js/data/src/payment-settings/test-helpers/stub.ts
+++ b/packages/js/data/src/payment-settings/test-helpers/stub.ts
@@ -37,6 +37,7 @@ export const providersStub: PaymentProvider[] = [
 		plugin: {
 			_type: 'wporg',
 			slug: 'woocommerce-paypal-payments',
+			file: 'woocommerce-paypal-payments/woocommerce-paypal-payments',
 			status: 'installed',
 		},
 	},
@@ -90,6 +91,7 @@ export const providersStub: PaymentProvider[] = [
 		plugin: {
 			_type: 'wporg',
 			slug: 'woocommerce-payments',
+			file: 'woocommerce-payments/woocommerce-payments',
 			status: 'active',
 		},
 	},
@@ -101,6 +103,7 @@ export const providersStub: PaymentProvider[] = [
 		description: 'Allow shoppers to pay offline.',
 		plugin: {
 			slug: 'woocommerce',
+			file: 'woocommerce/woocommerce',
 			status: 'active',
 		},
 		icon: 'http://localhost:8082/wp-content/plugins/woocommerce/assets/images/payment_methods/cod.svg',
@@ -128,6 +131,7 @@ export const offlinePaymentGatewaysStub: OfflinePaymentGateway[] = [
 		icon: 'http://localhost:8082/wp-content/plugins/woocommerce/assets/images/payment_methods/bacs.svg',
 		plugin: {
 			slug: 'woocommerce',
+			file: 'woocommerce/woocommerce',
 			status: 'active',
 		},
 	},
@@ -151,6 +155,7 @@ export const offlinePaymentGatewaysStub: OfflinePaymentGateway[] = [
 		icon: 'http://localhost:8082/wp-content/plugins/woocommerce/assets/images/payment_methods/cheque.svg',
 		plugin: {
 			slug: 'woocommerce',
+			file: 'woocommerce/woocommerce',
 			status: 'active',
 		},
 	},
@@ -174,6 +179,7 @@ export const offlinePaymentGatewaysStub: OfflinePaymentGateway[] = [
 		icon: 'http://localhost:8082/wp-content/plugins/woocommerce/assets/images/payment_methods/cod.svg',
 		plugin: {
 			slug: 'woocommerce',
+			file: 'woocommerce/woocommerce',
 			status: 'active',
 		},
 	},
@@ -190,6 +196,7 @@ export const suggestionsStub: SuggestedPaymentExtension[] = [
 		plugin: {
 			_type: 'wporg',
 			slug: 'airwallex-online-payments-gateway',
+			file: 'airwallex-online-payments-gateway/airwallex-online-payments-gateway',
 			status: 'not_installed',
 		},
 		image: 'http://localhost:8082/wp-content/plugins/woocommerce/assets/images/onboarding/airwallex.png',
@@ -230,6 +237,7 @@ export const suggestionsStub: SuggestedPaymentExtension[] = [
 		plugin: {
 			_type: 'wporg',
 			slug: 'woocommerce-square',
+			file: 'woocommerce-square/woocommerce-square',
 			status: 'not_installed',
 		},
 		image: 'http://localhost:8082/wp-content/plugins/woocommerce/assets/images/onboarding/square-black.png',

--- a/packages/js/data/src/payment-settings/types.ts
+++ b/packages/js/data/src/payment-settings/types.ts
@@ -5,7 +5,8 @@ export interface PaymentGatewayLink {
 
 export interface PluginData {
 	_type?: string;
-	slug: string;
+	slug: string; // The plugin slug (e.g. 'woocommerce'). This is also the directory name of the plugin.
+	file: string; // Relative path to the main file of the plugin.
 	status: 'installed' | 'active' | 'not_installed';
 }
 
@@ -16,7 +17,7 @@ export interface StateData {
 }
 
 export interface ManagementData {
-	settings_url: string;
+	settings_url: string; // URL to the settings page for the payment gateway.
 }
 
 export type PaymentProvider = {

--- a/packages/js/data/src/plugins/actions.ts
+++ b/packages/js/data/src/plugins/actions.ts
@@ -412,10 +412,10 @@ export function* dismissRecommendedPlugins( type: RecommendedTypes ) {
 	return success;
 }
 
-export function* deactivatePlugin( pluginName: string ) {
+export function* deactivatePlugin( pluginFile: string ) {
 	try {
 		yield apiFetch( {
-			path: 'wp/v2/plugins/' + pluginName + '/' + pluginName, // WP API specifics
+			path: `/wp/v2/plugins/${ pluginFile }`,
 			method: 'POST',
 			data: { status: 'inactive' },
 		} );

--- a/plugins/woocommerce/changelog/update-53563-handle-beta-testing-plugin-installs
+++ b/plugins/woocommerce/changelog/update-53563-handle-beta-testing-plugin-installs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Take a best-effort approach when matching payment gateway installed or active plugins with payment extension suggestions and reduce false-negatives.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
@@ -20,7 +20,7 @@ import { getWooPaymentsResetAccountLink } from '~/settings-payments/utils';
 
 interface EllipsisMenuContentProps {
 	pluginId: string;
-	pluginName: string;
+	pluginFile: string;
 	isSuggestion: boolean;
 	onToggle: () => void;
 	links?: PaymentGatewayLink[];
@@ -32,7 +32,7 @@ interface EllipsisMenuContentProps {
 
 export const EllipsisMenuContent = ( {
 	pluginId,
-	pluginName,
+	pluginFile,
 	isSuggestion,
 	onToggle,
 	links = [],
@@ -65,7 +65,7 @@ export const EllipsisMenuContent = ( {
 
 	const deactivateGateway = () => {
 		setIsDeactivating( true );
-		deactivatePlugin( pluginName )
+		deactivatePlugin( pluginFile )
 			.then( () => {
 				createSuccessNotice(
 					__( 'Plugin was successfully deactivated.', 'woocommerce' )

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
@@ -73,7 +73,10 @@ export const PaymentExtensionSuggestionListItem = ( {
 					</Button>
 
 					<EllipsisMenu
-						label={ __( 'Task List Options', 'woocommerce' ) }
+						label={ __(
+							'Payment Provider Options',
+							'woocommerce'
+						) }
 						renderContent={ ( { onToggle } ) => (
 							<EllipsisMenuContent
 								pluginId={ extension.id }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
@@ -80,7 +80,7 @@ export const PaymentExtensionSuggestionListItem = ( {
 						renderContent={ ( { onToggle } ) => (
 							<EllipsisMenuContent
 								pluginId={ extension.id }
-								pluginName={ extension.plugin.slug }
+								pluginFile={ extension.plugin.file }
 								isSuggestion={ true }
 								links={ extension.links }
 								onToggle={ onToggle }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -95,7 +95,7 @@ export const PaymentGatewayListItem = ( {
 						renderContent={ ( { onToggle } ) => (
 							<EllipsisMenuContent
 								pluginId={ gateway.id }
-								pluginName={ gateway.plugin.slug }
+								pluginFile={ gateway.plugin.file }
 								isSuggestion={ false }
 								links={ gateway.links }
 								onToggle={ onToggle }

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	PLUGINS_STORE_NAME,
 	PAYMENT_SETTINGS_STORE_NAME,
@@ -47,9 +47,13 @@ export const SettingsPaymentsMain = () => {
 			urlParams.get( 'test_drive_error' ) === 'true';
 		if ( isAccountTestDriveError ) {
 			setErrorMessage(
-				__(
-					'An error occurred while setting up your sandbox account. Please try again.',
-					'woocommerce'
+				sprintf(
+					/* translators: %s: plugin name */
+					__(
+						'%s: An error occurred while setting up your sandbox account — please try again.',
+						'woocommerce'
+					),
+					'WooPayments'
 				)
 			);
 		}
@@ -59,9 +63,13 @@ export const SettingsPaymentsMain = () => {
 
 		if ( isJetpackConnectionError ) {
 			setErrorMessage(
-				__(
-					'There was a problem connecting your WordPress.com account - please try again.',
-					'woocommerce'
+				sprintf(
+					/* translators: %s: plugin name */
+					__(
+						'%s: There was a problem connecting your WordPress.com account — please try again.',
+						'woocommerce'
+					),
+					'WooPayments'
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -29,6 +29,8 @@ class Payments {
 	const EXTENSION_INSTALLED     = 'installed';
 	const EXTENSION_ACTIVE        = 'active';
 
+	const EXTENSION_TYPE_WPORG = 'wporg';
+
 	const USER_PAYMENTS_NOX_PROFILE_KEY = 'woocommerce_payments_nox_profile';
 
 	const PROVIDERS_ORDER_OPTION         = 'woocommerce_gateway_order';

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -615,7 +615,7 @@ class Payments {
 			'onboarding'  => array(
 				'recommended_payment_methods' => $this->get_payment_gateway_recommended_payment_methods( $payment_gateway, $country_code ),
 			),
-			'plugin' 	=> array(
+			'plugin'      => array(
 				'_type'  => 'wporg',
 				'slug'   => $plugin_slug,
 				'file'   => $plugin_file,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -714,10 +714,12 @@ class Payments {
 	 */
 	private function enhance_payment_gateway_details( array $gateway_details, WC_Payment_Gateway $payment_gateway, string $country_code ): array {
 		$plugin_slug = $this->get_payment_gateway_plugin_slug( $payment_gateway );
+		// The payment gateway plugin might use non-standard directory name.
+		// Try to normalize it to the common slug to avoid false negatives when matching.
+		$normalized_plugin_slug = Utils::normalize_plugin_slug( $plugin_slug );
 
 		// Handle core gateways.
-		// We check for multiple slugs to account for beta testing setups.
-		if ( in_array( $plugin_slug, array( 'woocommerce', 'woocommerce-dev' ), true ) ) {
+		if ( 'woocommerce' === $normalized_plugin_slug ) {
 			if ( $this->is_offline_payment_method( $gateway_details['id'] ) ) {
 				switch ( $gateway_details['id'] ) {
 					case 'bacs':
@@ -734,7 +736,7 @@ class Payments {
 		}
 
 		// If we have a matching suggestion, hoist details from there.
-		$suggestion = $this->get_extension_suggestion_by_plugin_slug( $plugin_slug, $country_code );
+		$suggestion = $this->get_extension_suggestion_by_plugin_slug( $normalized_plugin_slug, $country_code );
 		if ( ! is_null( $suggestion ) ) {
 			if ( empty( $gateway_details['image'] ) ) {
 				$gateway_details['image'] = $suggestion['image'];
@@ -772,11 +774,11 @@ class Payments {
 				} elseif ( ! empty( $gateway_details['plugin']['_type'] ) &&
 					ExtensionSuggestions::PLUGIN_TYPE_WPORG === $gateway_details['plugin']['_type'] ) {
 
-					// Fallback to constructing the WPORG plugin URI from the plugin slug.
+					// Fallback to constructing the WPORG plugin URI from the normalized plugin slug.
 					$gateway_details['links'] = array(
 						array(
 							'_type' => ExtensionSuggestions::LINK_TYPE_ABOUT,
-							'url'   => 'https://wordpress.org/plugins/' . $plugin_slug,
+							'url'   => 'https://wordpress.org/plugins/' . $normalized_plugin_slug,
 						),
 					);
 				}
@@ -1017,7 +1019,7 @@ class Payments {
 		$payment_gateways_order_map = array_flip( array_keys( $payment_gateways ) );
 		// Get the payment gateways to suggestions map.
 		$payment_gateways_to_suggestions_map = array_map(
-			fn( $gateway ) => $this->get_extension_suggestion_by_plugin_slug( $this->get_payment_gateway_plugin_slug( $gateway ) ),
+			fn( $gateway ) => $this->get_extension_suggestion_by_plugin_slug( Utils::normalize_plugin_slug( $this->get_payment_gateway_plugin_slug( $gateway ) ) ),
 			$payment_gateways
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -927,7 +927,7 @@ class Payments {
 		// Put in the default plugin file.
 		$extension['plugin']['file'] = '';
 		if ( ! empty( $extension['plugin']['slug'] ) ) {
-			// This is best-effort approach, as the plugin might be sitting under directory (slug) that we can't handle.
+			// This is a best-effort approach, as the plugin might be sitting under a directory (slug) that we can't handle.
 			// Always try the official plugin slug first, then the testing variations.
 			$plugin_slug_variations = Utils::generate_testing_plugin_slugs( $extension['plugin']['slug'], true );
 			foreach ( $plugin_slug_variations as $plugin_slug ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -736,6 +736,7 @@ class Payments {
 		}
 
 		// If we have a matching suggestion, hoist details from there.
+		// The suggestions only know about the normalized (aka official) plugin slug.
 		$suggestion = $this->get_extension_suggestion_by_plugin_slug( $normalized_plugin_slug, $country_code );
 		if ( ! is_null( $suggestion ) ) {
 			if ( empty( $gateway_details['image'] ) ) {
@@ -908,12 +909,19 @@ class Payments {
 				break;
 		}
 
-		// Determine the plugin status.
+		// Determine the PES's plugin status.
+		// Default to not installed.
 		$extension['plugin']['status'] = self::EXTENSION_NOT_INSTALLED;
-		if ( PluginsHelper::is_plugin_installed( $extension['plugin']['slug'] ) ) {
-			$extension['plugin']['status'] = self::EXTENSION_INSTALLED;
-			if ( PluginsHelper::is_plugin_active( $extension['plugin']['slug'] ) ) {
-				$extension['plugin']['status'] = self::EXTENSION_ACTIVE;
+		// This is best-effort approach, as the plugin might be sitting under directory (slug) that we can't handle.
+		// Always try the official plugin slug first, then the testing variations.
+		$plugin_slug_variations = Utils::generate_testing_plugin_slugs( $extension['plugin']['slug'], true );
+		foreach ( $plugin_slug_variations as $plugin_slug ) {
+			if ( PluginsHelper::is_plugin_installed( $plugin_slug ) ) {
+				$extension['plugin']['status'] = self::EXTENSION_INSTALLED;
+				if ( PluginsHelper::is_plugin_active( $plugin_slug ) ) {
+					$extension['plugin']['status'] = self::EXTENSION_ACTIVE;
+				}
+				break;
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -714,7 +714,7 @@ class Payments {
 	 */
 	private function enhance_payment_gateway_details( array $gateway_details, WC_Payment_Gateway $payment_gateway, string $country_code ): array {
 		$plugin_slug = $this->get_payment_gateway_plugin_slug( $payment_gateway );
-		// The payment gateway plugin might use non-standard directory name.
+		// The payment gateway plugin might use a non-standard directory name.
 		// Try to normalize it to the common slug to avoid false negatives when matching.
 		$normalized_plugin_slug = Utils::normalize_plugin_slug( $plugin_slug );
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -607,8 +607,15 @@ class PaymentsRestController extends RestApiControllerBase {
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
+						'file'   => array(
+							'type'        => 'string',
+							'description' => esc_html__( 'The plugin main file. This is a relative path to the plugins directory.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
 						'status' => array(
 							'type'        => 'string',
+							'enum'		  => array( Payments::EXTENSION_NOT_INSTALLED, Payments::EXTENSION_INSTALLED, Payments::EXTENSION_ACTIVE ),
 							'description' => esc_html__( 'The status of the plugin.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -928,6 +935,7 @@ class PaymentsRestController extends RestApiControllerBase {
 						),
 						'status' => array(
 							'type'        => 'string',
+							'enum'		  => array( Payments::EXTENSION_NOT_INSTALLED, Payments::EXTENSION_INSTALLED, Payments::EXTENSION_ACTIVE ),
 							'description' => esc_html__( 'The status of the plugin.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -615,7 +615,7 @@ class PaymentsRestController extends RestApiControllerBase {
 						),
 						'status' => array(
 							'type'        => 'string',
-							'enum'		  => array( Payments::EXTENSION_NOT_INSTALLED, Payments::EXTENSION_INSTALLED, Payments::EXTENSION_ACTIVE ),
+							'enum'        => array( Payments::EXTENSION_NOT_INSTALLED, Payments::EXTENSION_INSTALLED, Payments::EXTENSION_ACTIVE ),
 							'description' => esc_html__( 'The status of the plugin.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -935,7 +935,7 @@ class PaymentsRestController extends RestApiControllerBase {
 						),
 						'status' => array(
 							'type'        => 'string',
-							'enum'		  => array( Payments::EXTENSION_NOT_INSTALLED, Payments::EXTENSION_INSTALLED, Payments::EXTENSION_ACTIVE ),
+							'enum'        => array( Payments::EXTENSION_NOT_INSTALLED, Payments::EXTENSION_INSTALLED, Payments::EXTENSION_ACTIVE ),
 							'description' => esc_html__( 'The status of the plugin.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -597,6 +597,7 @@ class PaymentsRestController extends RestApiControllerBase {
 					'properties'  => array(
 						'_type'  => array(
 							'type'        => 'string',
+							'enum'        => array( Payments::EXTENSION_TYPE_WPORG ),
 							'description' => esc_html__( 'The type of the plugin.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -923,6 +924,7 @@ class PaymentsRestController extends RestApiControllerBase {
 					'properties' => array(
 						'_type'  => array(
 							'type'        => 'string',
+							'enum'        => array( Payments::EXTENSION_TYPE_WPORG ),
 							'description' => esc_html__( 'The type of the plugin.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -194,7 +194,7 @@ class Utils {
 	 * @return string[] The list of plugin slug suffixes used for handling non-standard testing slugs.
 	 */
 	public static function get_testing_plugin_slug_suffixes(): array {
-		return array( '-beta', '-rc', '-test', '-dev' );
+		return array( '-dev', '-rc', '-test', '-beta' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -187,4 +187,30 @@ class Utils {
 
 		return $updated_map;
 	}
+
+	/**
+	 * Normalize a plugin slug.
+	 *
+	 * It will remove beta testing suffixes and lowercase the slug.
+	 * It will NOT convert plugin titles to slugs or sanitize the slug like sanitize_title() does.
+	 *
+	 * @param string $slug The plugin slug.
+	 *
+	 * @return string The normalized plugin slug.
+	 */
+	public static function normalize_plugin_slug( string $slug ): string {
+		// If the slug is empty or contains anything other than alphanumeric and dash characters, it will be left as is.
+		if ( empty( $slug ) || ! preg_match( '/^[a-zA-Z0-9-]+$/', $slug, $matches ) ) {
+			return $slug;
+		}
+
+		// Lowercase the slug.
+		$slug = strtolower( $slug );
+		// Remove beta testing suffix.
+		$slug = str_ends_with( $slug, '-beta' ) ? substr( $slug, 0, -5 ) : $slug;
+		// Jetpack Beta Tester (used on Jurassic Ninja sites) uses the `-dev` suffix for live branches.
+		$slug = str_ends_with( $slug, '-dev' ) ? substr( $slug, 0, -4 ) : $slug;
+
+		return $slug;
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -194,7 +194,7 @@ class Utils {
 	 * @return string[] The list of plugin slug suffixes used for handling non-standard testing slugs.
 	 */
 	public static function get_testing_plugin_slug_suffixes(): array {
-		return array( '-dev', '-rc', '-test', '-beta' );
+		return array( '-dev', '-rc', '-test', '-beta', '-alpha' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -189,8 +189,40 @@ class Utils {
 	}
 
 	/**
-	 * Normalize a plugin slug.
+	 * Get the list of plugin slug suffixes used for handling non-standard testing slugs.
 	 *
+	 * @return string[] The list of plugin slug suffixes used for handling non-standard testing slugs.
+	 */
+	public static function get_testing_plugin_slug_suffixes(): array {
+		return array( '-beta', '-rc', '-test', '-dev' );
+	}
+
+	/**
+	 * Generate a list of testing plugin slugs from a standard/official plugin slug.
+	 *
+	 * @param string $slug             The standard/official plugin slug. Most likely the WPORG slug.
+	 * @param bool   $include_original Optional. Whether to include the original slug in the list.
+	 *                                 If true, the original slug will be the first item in the list.
+	 *
+	 * @return string[] The list of testing plugin slugs generated from the standard/official plugin slug.
+	 */
+	public static function generate_testing_plugin_slugs( string $slug, bool $include_original = false ): array {
+		$slugs = array();
+		if ( $include_original ) {
+			$slugs[] = $slug;
+		}
+
+		foreach ( self::get_testing_plugin_slug_suffixes() as $suffix ) {
+			$slugs[] = $slug . $suffix;
+		}
+
+		return $slugs;
+	}
+
+	/**
+	 * Normalize a plugin slug to a standard/official slug.
+	 *
+	 * This is a best-effort approach.
 	 * It will remove beta testing suffixes and lowercase the slug.
 	 * It will NOT convert plugin titles to slugs or sanitize the slug like sanitize_title() does.
 	 *
@@ -200,16 +232,16 @@ class Utils {
 	 */
 	public static function normalize_plugin_slug( string $slug ): string {
 		// If the slug is empty or contains anything other than alphanumeric and dash characters, it will be left as is.
-		if ( empty( $slug ) || ! preg_match( '/^[a-zA-Z0-9-]+$/', $slug, $matches ) ) {
+		if ( empty( $slug ) || ! preg_match( '/^[\w-]+$/', $slug, $matches ) ) {
 			return $slug;
 		}
 
 		// Lowercase the slug.
 		$slug = strtolower( $slug );
-		// Remove beta testing suffix.
-		$slug = str_ends_with( $slug, '-beta' ) ? substr( $slug, 0, -5 ) : $slug;
-		// Jetpack Beta Tester (used on Jurassic Ninja sites) uses the `-dev` suffix for live branches.
-		$slug = str_ends_with( $slug, '-dev' ) ? substr( $slug, 0, -4 ) : $slug;
+		// Remove testing suffixes.
+		foreach ( self::get_testing_plugin_slug_suffixes() as $suffix ) {
+			$slug = str_ends_with( $slug, $suffix ) ? substr( $slug, 0, -strlen( $suffix ) ) : $slug;
+		}
 
 		return $slug;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -1207,7 +1207,7 @@ class PaymentsTest extends WC_REST_Unit_Test_Case {
 			'description'       => 'Description 1',
 			'plugin'            => array(
 				'_type' => ExtensionSuggestions::PLUGIN_TYPE_WPORG,
-				'slug'  => 'slug1',
+				'slug'  => 'woocommerce', // Use WooCommerce because it is an installed plugin, obviously.
 			),
 			'image'             => 'http://example.com/image1.png',
 			'icon'              => 'http://example.com/icon1.png',
@@ -1235,11 +1235,12 @@ class PaymentsTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( $suggestion_details['_type'], $suggestion['_type'] );
 		$this->assertSame( $suggestion_details['title'], $suggestion['title'] );
 		$this->assertSame( $suggestion_details['description'], $suggestion['description'] );
-		$this->assertSame(
+		$this->assertEquals(
 			array(
 				'_type'  => ExtensionSuggestions::PLUGIN_TYPE_WPORG,
-				'slug'   => 'slug1',
-				'status' => Payments::EXTENSION_NOT_INSTALLED, // The plugin should be not installed.
+				'slug'   => 'woocommerce',
+				'file'   => 'woocommerce/woocommerce',
+				'status' => Payments::EXTENSION_INSTALLED, // WooCommerce is installed.
 			),
 			$suggestion['plugin']
 		);
@@ -1257,7 +1258,7 @@ class PaymentsTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_extension_suggestion_by_plugin_slug() {
 		// Arrange.
-		$slug               = 'slug1';
+		$slug               = 'woocommerce'; // Use WooCommerce because it is an active plugin.
 		$suggestion_details = array(
 			'id'                => 'suggestion1',
 			'_priority'         => 1,
@@ -1294,11 +1295,12 @@ class PaymentsTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( $suggestion_details['_type'], $suggestion['_type'] );
 		$this->assertSame( $suggestion_details['title'], $suggestion['title'] );
 		$this->assertSame( $suggestion_details['description'], $suggestion['description'] );
-		$this->assertSame(
+		$this->assertEquals(
 			array(
 				'_type'  => ExtensionSuggestions::PLUGIN_TYPE_WPORG,
-				'slug'   => 'slug1',
-				'status' => Payments::EXTENSION_NOT_INSTALLED, // The plugin should be not installed.
+				'slug'   => $slug,
+				'file'   => 'woocommerce/woocommerce',
+				'status' => Payments::EXTENSION_INSTALLED, // WooCommerce is installed.
 			),
 			$suggestion['plugin']
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
@@ -1475,10 +1475,11 @@ class UtilsTest extends WC_Unit_Test_Case {
 		$this->assertIsArray( $suffixes );
 		$this->assertNotEmpty( $suffixes );
 		$this->assertContainsOnly( 'string', $suffixes );
+		$this->assertContains( '-dev', $suffixes );
 		$this->assertContains( '-beta', $suffixes );
+		$this->assertContains( '-alpha', $suffixes );
 		$this->assertContains( '-rc', $suffixes );
 		$this->assertContains( '-test', $suffixes );
-		$this->assertContains( '-dev', $suffixes );
 	}
 
 	/**
@@ -1534,39 +1535,43 @@ class UtilsTest extends WC_Unit_Test_Case {
 	 */
 	public function data_provider_normalize_plugin_slug(): array {
 		return array(
-			'empty-slug'           => array(
+			'empty-slug'            => array(
 				'',
 				'',
 			),
-			'already-normalized'   => array(
+			'already-normalized'    => array(
 				'plugin-slug_01',
 				'plugin-slug_01',
 			),
-			'does-not-transform'   => array(
+			'does-not-transform'    => array(
 				'Plugin Title',
 				'Plugin Title',
 			),
-			'does-not-transform-2' => array(
+			'does-not-transform-2'  => array(
 				'Plugin*%$Title@#',
 				'Plugin*%$Title@#',
 			),
-			'lowercases'           => array(
+			'lowercases'            => array(
 				'PLugin-sLug_01',
 				'plugin-slug_01',
 			),
-			'beta-slug'            => array(
-				'plugin-slug-beta',
+			'suffix-not-at-the-end' => array(
+				'plugin-beta-slug',
+				'plugin-beta-slug',
+			),
+			'alpha-slug'            => array(
+				'plugin-slug-alpha',
 				'plugin-slug',
 			),
-			'rc-slug'              => array(
+			'rc-slug'               => array(
 				'plugin-slug-rc',
 				'plugin-slug',
 			),
-			'test-slug'            => array(
+			'test-slug'             => array(
 				'plugin-slug-test',
 				'plugin-slug',
 			),
-			'dev-slug'             => array(
+			'dev-slug'              => array(
 				'plugin-slug-dev',
 				'plugin-slug',
 			),

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
@@ -1463,4 +1463,55 @@ class UtilsTest extends WC_Unit_Test_Case {
 			),
 		);
 	}
+
+	/**
+	 * Test normalizing a plugin slug.
+	 *
+	 * @dataProvider data_provider_normalize_plugin_slug
+	 */
+	public function test_normalize_plugin_slug( $slug, $expected ) {
+		// Act.
+		$slug = Utils::normalize_plugin_slug( $slug );
+
+		// Assert.
+		$this->assertSame( $expected, $slug );
+	}
+
+	/**
+	 * Data provider for the test_normalize_plugin_slug test.
+	 *
+	 * @return array
+	 */
+	public function data_provider_normalize_plugin_slug(): array {
+		return array(
+			'empty-slug'           => array(
+				'',
+				'',
+			),
+			'already-normalized'   => array(
+				'plugin-slug',
+				'plugin-slug',
+			),
+			'does-not-transform'   => array(
+				'Plugin Title',
+				'Plugin Title',
+			),
+			'does-not-transform-2' => array(
+				'Plugin_Title',
+				'Plugin_Title',
+			),
+			'lowercases'           => array(
+				'PLugin-sLug',
+				'plugin-slug',
+			),
+			'beta-slug'            => array(
+				'plugin-slug-beta',
+				'plugin-slug',
+			),
+			'dev-slug'             => array(
+				'plugin-slug-dev',
+				'plugin-slug',
+			),
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/UtilsTest.php
@@ -1465,11 +1465,61 @@ class UtilsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting testing plugin slug suffixes list
+	 */
+	public function test_get_testing_plugin_slug_suffixes() {
+		// Act.
+		$suffixes = Utils::get_testing_plugin_slug_suffixes();
+
+		// Assert.
+		$this->assertIsArray( $suffixes );
+		$this->assertNotEmpty( $suffixes );
+		$this->assertContainsOnly( 'string', $suffixes );
+		$this->assertContains( '-beta', $suffixes );
+		$this->assertContains( '-rc', $suffixes );
+		$this->assertContains( '-test', $suffixes );
+		$this->assertContains( '-dev', $suffixes );
+	}
+
+	/**
+	 * Test generating testing plugin slugs.
+	 */
+	public function test_generate_testing_plugin_slugs() {
+		// Act.
+		$slugs = Utils::generate_testing_plugin_slugs( 'plugin-slug', false );
+
+		// Assert.
+		$this->assertIsArray( $slugs );
+		$this->assertNotEmpty( $slugs );
+		$this->assertContainsOnly( 'string', $slugs );
+		$this->assertNotContains( 'plugin-slug', $slugs );
+		$this->assertContains( 'plugin-slug-dev', $slugs );
+	}
+
+	/**
+	 * Test generating testing plugin slugs with the original slug included.
+	 */
+	public function test_generate_testing_plugin_slugs_with_original() {
+		// Act.
+		$slugs = Utils::generate_testing_plugin_slugs( 'plugin-slug', true );
+
+		// Assert.
+		$this->assertIsArray( $slugs );
+		$this->assertNotEmpty( $slugs );
+		$this->assertContainsOnly( 'string', $slugs );
+		$this->assertSame( 'plugin-slug', $slugs[0] );
+		$this->assertContains( 'plugin-slug-dev', $slugs );
+	}
+
+	/**
 	 * Test normalizing a plugin slug.
 	 *
 	 * @dataProvider data_provider_normalize_plugin_slug
+	 *
+	 * @param string $slug     The plugin slug to normalize.
+	 * @param string $expected The expected normalized plugin slug.
 	 */
-	public function test_normalize_plugin_slug( $slug, $expected ) {
+	public function test_normalize_plugin_slug( string $slug, string $expected ) {
 		// Act.
 		$slug = Utils::normalize_plugin_slug( $slug );
 
@@ -1489,23 +1539,31 @@ class UtilsTest extends WC_Unit_Test_Case {
 				'',
 			),
 			'already-normalized'   => array(
-				'plugin-slug',
-				'plugin-slug',
+				'plugin-slug_01',
+				'plugin-slug_01',
 			),
 			'does-not-transform'   => array(
 				'Plugin Title',
 				'Plugin Title',
 			),
 			'does-not-transform-2' => array(
-				'Plugin_Title',
-				'Plugin_Title',
+				'Plugin*%$Title@#',
+				'Plugin*%$Title@#',
 			),
 			'lowercases'           => array(
-				'PLugin-sLug',
-				'plugin-slug',
+				'PLugin-sLug_01',
+				'plugin-slug_01',
 			),
 			'beta-slug'            => array(
 				'plugin-slug-beta',
+				'plugin-slug',
+			),
+			'rc-slug'              => array(
+				'plugin-slug-rc',
+				'plugin-slug',
+			),
+			'test-slug'            => array(
+				'plugin-slug-test',
 				'plugin-slug',
 			),
 			'dev-slug'             => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We enhance the WC Payments NOX providers logic to be more greedy in matching installed or active payment extensions (PEs) to suggestions when constructing the providers list. This way, we account for testing scenarios like JurassicNinja sites with live branches.

Additionally, we fixed the provider extension deactivation via the WP API and made it work with the non-standard WP plugin slugs.

Before and after screenshots:

| Before | After |
|--------|--------|
| ![Screenshot 2024-12-10 at 12 37 54](https://github.com/user-attachments/assets/2895cbaa-0519-4ba8-b1f4-fd08dbf1b7ca) | ![Screenshot 2024-12-10 at 12 46 55](https://github.com/user-attachments/assets/3fbd3eb7-0441-4690-8f35-f47c2883f939) |
| ![Screenshot 2024-12-10 at 12 39 39](https://github.com/user-attachments/assets/e39e7f58-9759-473c-a8b5-58ebd4c9e5ed) | ![Screenshot 2024-12-10 at 12 47 11](https://github.com/user-attachments/assets/8fb16542-bec8-4b08-a3d7-1fbe9fd7ebc7) | 

Closes #53563 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja site with WooCommerce using this PR's live branch and the WooCommerce Beta Tester plugin (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=update/53563-handle-beta-testing-plugin-installs))
2. Access the WP admin of the newly created site, click on the WooCommerce menu item, and you should be taken to the WooCommerce profiler. Click "Skip guided setup" and choose `US` as the store's base location country.
3. Go to Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature.
4. Click on the Payments main menu item and you should see the Payments settings page with WooPayments and PayPal as payment extensions suggestions (PESs) in the main provider list and some others in the Others section:
![Screenshot 2024-12-09 at 19 32 23](https://github.com/user-attachments/assets/32927dc4-3ee8-4164-8e4e-fb9fb11dcc14)
5. Click on "Take offline payments" in the providers list and you should see a page with the offline payment methods options, with their icons properly showing:
![Screenshot 2024-12-09 at 19 34 21](https://github.com/user-attachments/assets/0336627b-d107-4e3a-b226-772d4e6f9590)
6. Go to Jetpack > Beta Tester and click on the Manage button for "WooCommerce Payments".
7. On the next page, "Activate" the most recent "Release Candidate" for WooPayments:
![Screenshot 2024-12-09 at 19 35 55](https://github.com/user-attachments/assets/23855f4d-8025-469e-a364-ee521f864c22)
8. Go to Plugins, and when you hover of the "Deactivate" link for WooPayments, you will see that the URL contains the `plugin` param with the value `woocommerce-payments-dev%2Fwoocommerce-payments.php` (notice the `woocommerce-payments-dev` that means the plugin is has that slug since it is installed in the `woocommerce-payments-dev` directory, not the regular `woocommerce-payments`):
![Screenshot 2024-12-09 at 19 38 15](https://github.com/user-attachments/assets/8f7c334b-68e8-44fa-852a-4e8c741cba7d)
9. Do the same for WooCommerce and notice the `woocommerce-dev` plugin slug.
10. Go to WooCommerce > Settings > Payments (the Payments main menu item no longer points there since it has been taken over by WooPayments) and notice that the WooPayments PES was replaced by the WooPayments payment gateway since the WooPayments PE was properly identified as active and matched with the PES (i.e., it has pricing, docs, and terms links in the ellipsis menu):
![Screenshot 2024-12-09 at 19 43 35](https://github.com/user-attachments/assets/cf3c897d-d17e-4d20-8d4c-64ea910f56f7)
![Screenshot 2024-12-09 at 19 46 37](https://github.com/user-attachments/assets/5d970f26-e988-4b85-b2cb-2e482d21beb0)
11. From WooPayments' ellipsis menu, click on "Deactivate" to deactivate the extension. The WooPayments provider should be replaced in-place with the WooPayments suggestion (titled "Accept payments with Woo").
12. For the "Accept payments with Woo" suggestion, click on "Enable" and you should be prompted to connect your store to WPCOM and then onboard with WooPayments. Don't accept the connection and you should be returned to the Payments settings page with a warning notice.
![Screenshot 2024-12-09 at 21 26 32](https://github.com/user-attachments/assets/eca96d7a-7880-44b2-8a50-10e346b2ed85)
![Screenshot 2024-12-09 at 21 27 11](https://github.com/user-attachments/assets/066278ed-8344-494e-9f0f-37005c1c3b06)
13. Expand the "Other payment options" section and install Stripe:
![Screenshot 2024-12-09 at 19 55 26](https://github.com/user-attachments/assets/f35c1af7-4c08-4b7f-9045-289dafd64111)
14. The Stripe provider should appear in the main list, at the bottom:
![Screenshot 2024-12-09 at 19 56 40](https://github.com/user-attachments/assets/9265e97e-eb6c-4831-9049-fcb637ac2e2c).
15. Deactivate Stripe from the context menu and Stripe should move back to the Other section.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
