### PR TITLE
[Checkout] Added selected rate name when showing multiple shipping packages in cart and checkout.

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { _n, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Label, Panel } from '@woocommerce/blocks-components';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { sanitizeHTML } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
@@ -36,12 +36,29 @@ export const ShippingRatesControlPackage = ( {
 			select( CART_STORE_KEY )?.getCartData()?.shippingRates?.length
 	);
 
+	const packageClass = 'wc-block-components-shipping-rates-control__package';
+	const [ instanceCount, setInstanceCount ] = useState( 0 );
+
 	// We have no built-in way of checking if other extensions have added packages e.g. if subscriptions has added them.
-	const multiplePackages =
-		internalPackageCount > 1 ||
-		document.querySelectorAll(
-			'.wc-block-components-shipping-rates-control__package'
-		).length > 1;
+	const multiplePackages = internalPackageCount > 1 || instanceCount > 1;
+
+	useEffect( () => {
+		const updateCount = () => {
+			setInstanceCount(
+				document.querySelectorAll( `.${ packageClass }` ).length
+			);
+		};
+
+		updateCount();
+
+		const observer = new MutationObserver( updateCount );
+		observer.observe( document.body, { childList: true, subtree: true } );
+
+		return () => {
+			updateCount();
+			observer.disconnect();
+		};
+	}, [] );
 
 	// If showItems is not set, we check if we have multiple packages.
 	// We sometimes don't want to show items even if we have multiple packages.

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -55,7 +55,6 @@ export const ShippingRatesControlPackage = ( {
 		observer.observe( document.body, { childList: true, subtree: true } );
 
 		return () => {
-			updateCount();
 			observer.disconnect();
 		};
 	}, [] );

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-items.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-items.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { Label } from '@woocommerce/blocks-components';
+
+/**
+ * Internal dependencies
+ */
+import type { PackageData, PackageItem } from './types';
+
+export const PackageItems = ( {
+	packageData,
+}: {
+	packageData: PackageData;
+} ): JSX.Element => {
+	return (
+		<ul className="wc-block-components-shipping-rates-control__package-items">
+			{ Object.values( packageData.items ).map( ( v: PackageItem ) => {
+				const name = decodeEntities( v.name );
+				const quantity = v.quantity;
+				return (
+					<li
+						key={ v.key }
+						className="wc-block-components-shipping-rates-control__package-item"
+					>
+						<Label
+							label={
+								quantity > 1
+									? `${ name } × ${ quantity }`
+									: `${ name }`
+							}
+							screenReaderLabel={ sprintf(
+								/* translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package */
+								_n(
+									'%1$s (%2$d unit)',
+									'%1$s (%2$d units)',
+									quantity,
+									'woocommerce'
+								),
+								name,
+								quantity
+							) }
+						/>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+};
+
+export default PackageItems;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -16,12 +16,6 @@
 		padding-top: em($gap-small);
 	}
 
-	&:last-child {
-		.wc-block-components-panel__button {
-			padding-bottom: 0;
-		}
-	}
-
 	.wc-block-components-panel__content {
 		padding-bottom: em($gap-small);
 	}
@@ -45,11 +39,19 @@
 	}
 }
 
+.wc-block-components-shipping-rates-control__package-header {
+	margin: 0 0 $gap-small 0;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
 .wc-block-components-shipping-rates-control__package-items {
 	@include font-size(small);
-	display: block;
+	display: inline-block;
 	list-style: none;
-	margin: 0 0 $gap-small 0;
+	margin: 0;
 	padding: 0;
 }
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -40,7 +40,7 @@
 }
 
 .wc-block-components-shipping-rates-control__package-header {
-	margin: 0 0 $gap-small 0;
+	margin: 0 0 $gap-small;
 
 	&:last-child {
 		margin-bottom: 0;

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -17,7 +17,11 @@
 		display: block;
 	}
 
-	.wc-block-components-totals-shipping__options,
+	.wc-block-components-totals-shipping__options {
+		display: block;
+		margin: 0;
+	}
+
 	.wc-block-components-totals-shipping-address-summary {
 		display: inline-block;
 		margin: 0;

--- a/plugins/woocommerce-blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/form-step/style.scss
@@ -100,6 +100,7 @@
 	}
 }
 
+.wc-block-checkout__shipping-option .wc-block-components-checkout-step__content,
 .wc-block-checkout__payment-method .wc-block-components-checkout-step__content {
 	padding-top: $gap-smaller;
 }

--- a/plugins/woocommerce-blocks/packages/components/panel/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/panel/style.scss
@@ -16,7 +16,6 @@
 .wc-block-components-panel__button {
 	box-sizing: border-box;
 	height: auto;
-	margin-top: em(6px);
 	padding-right: #{24px + $gap-smaller};
 	padding-top: em($gap-small - 6px);
 	padding-left: 0 !important;

--- a/plugins/woocommerce/changelog/fix-51041
+++ b/plugins/woocommerce/changelog/fix-51041
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added selected rate name when showing multiple shipping packages in cart and checkout.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the display of multiple shipping packages in conjunction with subscriptions which utilises them. Selected rates are shown in the panel header so you can see selections, and the initial render is fixed.

Cart view:

![Screenshot 2024-12-09 at 16 01 15](https://github.com/user-attachments/assets/48e6b594-90bb-41a0-909f-49308e256800)

Checkout view:

![Screenshot 2024-12-09 at 16 01 23](https://github.com/user-attachments/assets/532bea2f-0570-4821-9a86-c89117976a09)

Notice the rate name is shown below the package name.

Closes #51041

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce subscriptions. Create some subscriptions with different billing intervals e.g. weekly and monthly.
2. Add a regular product, and your new subscription products to the cart.
3. Ensure some shipping methods are setup.
4. View the cart and checkout and see how packages are displayed. Toggle open the panels and ensure its rendered correcrly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
