### PR TITLE
[e2e tests] Update Playwright tags and configs

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-external-envs-pw-configs
+++ b/plugins/woocommerce/changelog/e2e-update-external-envs-pw-configs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: update Playwright tags and configs for environments

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-hpos-disabled/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-hpos-disabled/playwright.config.js
@@ -1,4 +1,5 @@
 let config = require( '../../playwright.config.js' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 process.env.USE_WP_ENV = 'true';
 process.env.DISABLE_HPOS = '1';
@@ -8,7 +9,7 @@ config = {
 	projects: [
 		{
 			name: 'ui',
-			grep: /@hpos/,
+			grep: new RegExp( tags.HPOS ),
 		},
 		{
 			name: 'api',

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
@@ -1,24 +1,25 @@
 let config = require( '../../playwright.config.js' );
 const { devices } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
+
+const grepInvert = new RegExp(
+	`${ tags.SKIP_ON_PRESSABLE }|${ tags.SKIP_ON_EXTERNAL_ENV }|${ tags.COULD_BE_LOWER_LEVEL_TEST }|${ tags.NON_CRITICAL }|${ tags.TO_BE_REMOVED }`
+);
 
 config = {
 	...config,
 	projects: [
 		{
-			name: 'default pressable',
+			name: 'ui',
 			use: { ...devices[ 'Desktop Chrome' ] },
-			testMatch: [
-				'**/basic.spec.js',
-				'**/activate-and-setup/**/*.spec.js',
-				'**/admin-analytics/**/*.spec.js',
-				'**/admin-marketing/**/*.spec.js',
-				'**/admin-tasks/**/*.spec.js',
-				'**/customize-store/**/*.spec.js',
-				'**/merchant/**/*.spec.js',
-				'**/shopper/**/*.spec.js',
-				'**/api-tests/**/*.test.js',
-			],
-			grepInvert: /@skip-on-default-pressable/,
+			testIgnore: [ '**/api-tests/**' ],
+			grepInvert,
+		},
+		{
+			name: 'api',
+			use: { ...devices[ 'Desktop Chrome' ] },
+			testMatch: [ '**/api-tests/**' ],
+			grepInvert,
 		},
 	],
 };

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
@@ -12,7 +12,11 @@ config = {
 		{
 			name: 'ui',
 			use: { ...devices[ 'Desktop Chrome' ] },
-			testIgnore: [ '**/api-tests/**' ],
+			testIgnore: [
+				'**/api-tests/**',
+				'**/customize-store/**',
+				'**/js-file-monitor/**',
+			],
 			grepInvert,
 		},
 		{

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
@@ -1,23 +1,25 @@
 let config = require( '../../playwright.config.js' );
 const { devices } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
+
+const grepInvert = new RegExp(
+	`${ tags.SKIP_ON_WPCOM }|${ tags.SKIP_ON_EXTERNAL_ENV }|${ tags.COULD_BE_LOWER_LEVEL_TEST }|${ tags.NON_CRITICAL }|${ tags.TO_BE_REMOVED }`
+);
 
 config = {
 	...config,
 	projects: [
 		{
-			name: 'default wpcom',
+			name: 'ui',
 			use: { ...devices[ 'Desktop Chrome' ] },
-			testMatch: [
-				'**/basic.spec.js',
-				'**/activate-and-setup/**/*.spec.js',
-				'**/admin-analytics/**/*.spec.js',
-				'**/admin-marketing/**/*.spec.js',
-				'**/admin-tasks/**/*.spec.js',
-				'**/merchant/**/*.spec.js',
-				'**/shopper/**/*.spec.js',
-				'**/api-tests/**/*.test.js',
-			],
-			grepInvert: /@skip-on-default-wpcom/,
+			testIgnore: [ '**/api-tests/**' ],
+			grepInvert,
+		},
+		{
+			name: 'api',
+			use: { ...devices[ 'Desktop Chrome' ] },
+			testMatch: [ '**/api-tests/**' ],
+			grepInvert,
 		},
 	],
 };

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
@@ -12,7 +12,11 @@ config = {
 		{
 			name: 'ui',
 			use: { ...devices[ 'Desktop Chrome' ] },
-			testIgnore: [ '**/api-tests/**' ],
+			testIgnore: [
+				'**/api-tests/**',
+				'**/customize-store/**',
+				'**/js-file-monitor/**',
+			],
 			grepInvert,
 		},
 		{

--- a/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-stable/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/gutenberg-stable/playwright.config.js
@@ -1,4 +1,5 @@
 let config = require( '../../playwright.config.js' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 process.env.USE_WP_ENV = 'true';
 
@@ -7,7 +8,7 @@ config = {
 	projects: [
 		{
 			name: 'Gutenberg',
-			grep: /@gutenberg/,
+			grep: new RegExp( tags.GUTENBERG ),
 		},
 	],
 };

--- a/plugins/woocommerce/tests/e2e-pw/envs/woocommerce-payments/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/woocommerce-payments/playwright.config.js
@@ -1,4 +1,5 @@
 let config = require( '../../playwright.config.js' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 process.env.USE_WP_ENV = 'true';
 
@@ -7,7 +8,7 @@ config = {
 	projects: [
 		{
 			name: 'WooPayments',
-			grep: /@payments/,
+			grep: new RegExp( tags.PAYMENTS ),
 		},
 	],
 };

--- a/plugins/woocommerce/tests/e2e-pw/envs/woocommerce-paypal-payments/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/woocommerce-paypal-payments/playwright.config.js
@@ -1,4 +1,5 @@
 let config = require( '../../playwright.config.js' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 process.env.USE_WP_ENV = 'true';
 
@@ -7,7 +8,7 @@ config = {
 	projects: [
 		{
 			name: 'WooCommerce PayPal Payments',
-			grep: /@payments/,
+			grep: new RegExp( tags.PAYMENTS ),
 		},
 	],
 };

--- a/plugins/woocommerce/tests/e2e-pw/envs/woocommerce-services/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/woocommerce-services/playwright.config.js
@@ -1,4 +1,5 @@
 let config = require( '../../playwright.config.js' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 process.env.USE_WP_ENV = 'true';
 
@@ -7,7 +8,7 @@ config = {
 	projects: [
 		{
 			name: 'WooCommerce Shipping & Tax',
-			grep: /@services/,
+			grep: new RegExp( tags.SERVICES ),
 		},
 	],
 };

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/api-tests-fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/api-tests-fixtures.js
@@ -1,5 +1,6 @@
 const base = require( '@playwright/test' );
 const { admin } = require( '../test-data/data' );
+const { tags } = require( './fixtures' );
 
 exports.test = base.test.extend( {
 	extraHTTPHeaders: {
@@ -11,3 +12,4 @@ exports.test = base.test.extend( {
 } );
 
 exports.expect = base.expect;
+exports.tags = tags;

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
@@ -107,6 +107,10 @@ exports.test = base.test.extend( {
 exports.expect = base.expect;
 exports.request = base.request;
 exports.tags = {
+	GUTENBERG: '@gutenberg',
+	SERVICES: '@services',
+	PAYMENTS: '@payments',
+	HPOS: '@hpos',
 	SKIP_ON_EXTERNAL_ENV: '@skip-on-external-env',
 	SKIP_ON_WPCOM: '@skip-on-wpcom',
 	SKIP_ON_PRESSABLE: '@skip-on-pressable',

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
@@ -105,3 +105,13 @@ exports.test = base.test.extend( {
 } );
 
 exports.expect = base.expect;
+exports.request = base.request;
+exports.tags = {
+	SKIP_ON_EXTERNAL_ENV: '@skip-on-external-env',
+	SKIP_ON_WPCOM: '@skip-on-wpcom',
+	SKIP_ON_PRESSABLE: '@skip-on-pressable',
+	COULD_BE_LOWER_LEVEL_TEST: '@could-be-lower-level-test',
+	NON_CRITICAL: '@non-critical',
+	TO_BE_REMOVED: '@to-be-removed',
+	NOT_E2E: '@not-e2e',
+};

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/core-profiler.spec.js
@@ -1,4 +1,5 @@
 const { test, expect, request } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const { setOption } = require( '../../utils/options' );
 
 const getPluginLocator = ( page, slug ) => {
@@ -9,7 +10,7 @@ const getPluginLocator = ( page, slug ) => {
 
 test.describe(
 	'Store owner can complete the core profiler',
-	{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+	{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 
@@ -470,7 +471,7 @@ test.describe(
 
 test.describe(
 	'Store owner can skip the core profiler',
-	{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+	{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const { exec } = require( 'child_process' );
 
 test.describe( 'WC Home Task List >', () => {
@@ -45,8 +46,8 @@ test.describe( 'WC Home Task List >', () => {
 	} );
 
 	test(
-		' Can hide the task list',
-		{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+		'Can hide the task list',
+		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 		async ( { page } ) => {
 			await test.step( 'Load the WC Admin page', async () => {
 				await page.goto( 'wp-admin/admin.php?page=wc-admin' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -26,7 +26,7 @@ const test = baseTest.extend( {
 test.describe(
 	'Analytics-related tests',
 	{
-		tag: [ '@payments', tags.SERVICES ],
+		tag: [ tags.PAYMENTS, tags.SERVICES ],
 	},
 	() => {
 		let categoryIds, productIds, orderIds, setupPage;

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -26,7 +26,7 @@ const test = baseTest.extend( {
 test.describe(
 	'Analytics-related tests',
 	{
-		tag: [ '@payments', '@services' ],
+		tag: [ '@payments', tags.SERVICES ],
 	},
 	() => {
 		let categoryIds, productIds, orderIds, setupPage;

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
@@ -195,7 +195,7 @@ test.describe(
 
 		test.describe(
 			'moving sections',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			() => {
 				test( 'should not display move up for the top, or move down for the bottom section', async () => {
 					await test.step( `Check the top section`, async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
@@ -114,7 +114,7 @@ const resetSections = async () => {
 
 test.describe(
 	'Analytics pages',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
@@ -1,5 +1,6 @@
 const { test, expect, Page, Locator } = require( '@playwright/test' );
 const { admin } = require( '../../test-data/data' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 const EXPECTED_SECTION_HEADERS = [ 'Performance', 'Charts', 'Leaderboards' ];
 
@@ -111,181 +112,190 @@ const resetSections = async () => {
 	} );
 };
 
-test.describe( 'Analytics pages', { tag: [ '@payments', '@services' ] }, () => {
-	test.use( { storageState: process.env.ADMINSTATE } );
+test.describe(
+	'Analytics pages',
+	{ tag: [ '@payments', tags.SERVICES ] },
+	() => {
+		test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeAll( async ( { browser } ) => {
-		page = await browser.newPage();
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
 
-		await test.step( `Send GET request to get the current user id`, async () => {
-			const request = page.request;
-			const data = {
-				_fields: 'id',
-			};
-			const response = await request.get( './wp-json/wp/v2/users/me', {
-				data,
-				headers,
-			} );
-			const { id } = await response.json();
+			await test.step( `Send GET request to get the current user id`, async () => {
+				const request = page.request;
+				const data = {
+					_fields: 'id',
+				};
+				const response = await request.get(
+					'./wp-json/wp/v2/users/me',
+					{
+						data,
+						headers,
+					}
+				);
+				const { id } = await response.json();
 
-			userId = id;
-		} );
-
-		await resetSections();
-
-		await test.step( `Initialize locators`, async () => {
-			const pattern = new RegExp( EXPECTED_SECTION_HEADERS.join( '|' ) );
-
-			headings_sections = page.getByRole( 'heading', {
-				name: pattern,
+				userId = id;
 			} );
 
-			heading_performance = page.getByRole( 'heading', {
-				name: 'Performance',
-			} );
+			await resetSections();
 
-			buttons_ellipsis = page.getByRole( 'button', {
-				name: 'Choose which',
-			} );
+			await test.step( `Initialize locators`, async () => {
+				const pattern = new RegExp(
+					EXPECTED_SECTION_HEADERS.join( '|' )
+				);
 
-			menuitem_moveUp = page.getByRole( 'menuitem', {
-				name: 'Move up',
-			} );
-
-			menuitem_moveDown = page.getByRole( 'menuitem', {
-				name: 'Move down',
-			} );
-		} );
-	} );
-
-	test.beforeEach( async () => {
-		await test.step( `Go to Analytics > Overview`, async () => {
-			await page.goto(
-				'wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview'
-			);
-		} );
-	} );
-
-	test.afterEach( async () => {
-		await resetSections();
-	} );
-
-	test.afterAll( async () => {
-		await page.close();
-	} );
-
-	test( 'a user should see 3 sections by default - Performance, Charts, and Leaderboards', async () => {
-		for ( const expectedSection of EXPECTED_SECTION_HEADERS ) {
-			await test.step( `Assert that the "${ expectedSection }" section is visible`, async () => {
-				await expect(
-					headings_sections.filter( { hasText: expectedSection } )
-				).toBeVisible();
-			} );
-		}
-	} );
-
-	test.describe(
-		'moving sections',
-		{ tag: [ '@could-be-lower-level-test' ] },
-		() => {
-			test( 'should not display move up for the top, or move down for the bottom section', async () => {
-				await test.step( `Check the top section`, async () => {
-					await buttons_ellipsis.first().click();
-					await expect( menuitem_moveUp ).toBeHidden();
-					await expect( menuitem_moveDown ).toBeVisible();
-					await page.keyboard.press( 'Escape' );
+				headings_sections = page.getByRole( 'heading', {
+					name: pattern,
 				} );
 
-				await test.step( `Check the bottom section`, async () => {
-					await buttons_ellipsis.last().click();
-					await expect( menuitem_moveDown ).toBeHidden();
-					await expect( menuitem_moveUp ).toBeVisible();
-					await page.keyboard.press( 'Escape' );
+				heading_performance = page.getByRole( 'heading', {
+					name: 'Performance',
+				} );
+
+				buttons_ellipsis = page.getByRole( 'button', {
+					name: 'Choose which',
+				} );
+
+				menuitem_moveUp = page.getByRole( 'menuitem', {
+					name: 'Move up',
+				} );
+
+				menuitem_moveDown = page.getByRole( 'menuitem', {
+					name: 'Move down',
 				} );
 			} );
+		} );
 
-			test( 'should allow a user to move a section down', async () => {
-				const firstSection = await headings_sections
-					.first()
-					.innerText();
-				const secondSection = await headings_sections
-					.nth( 1 )
-					.innerText();
+		test.beforeEach( async () => {
+			await test.step( `Go to Analytics > Overview`, async () => {
+				await page.goto(
+					'wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview'
+				);
+			} );
+		} );
 
-				await test.step( `Move first section down`, async () => {
-					await buttons_ellipsis.first().click();
-					await menuitem_moveDown.click();
+		test.afterEach( async () => {
+			await resetSections();
+		} );
+
+		test.afterAll( async () => {
+			await page.close();
+		} );
+
+		test( 'a user should see 3 sections by default - Performance, Charts, and Leaderboards', async () => {
+			for ( const expectedSection of EXPECTED_SECTION_HEADERS ) {
+				await test.step( `Assert that the "${ expectedSection }" section is visible`, async () => {
+					await expect(
+						headings_sections.filter( { hasText: expectedSection } )
+					).toBeVisible();
+				} );
+			}
+		} );
+
+		test.describe(
+			'moving sections',
+			{ tag: [ '@could-be-lower-level-test' ] },
+			() => {
+				test( 'should not display move up for the top, or move down for the bottom section', async () => {
+					await test.step( `Check the top section`, async () => {
+						await buttons_ellipsis.first().click();
+						await expect( menuitem_moveUp ).toBeHidden();
+						await expect( menuitem_moveDown ).toBeVisible();
+						await page.keyboard.press( 'Escape' );
+					} );
+
+					await test.step( `Check the bottom section`, async () => {
+						await buttons_ellipsis.last().click();
+						await expect( menuitem_moveDown ).toBeHidden();
+						await expect( menuitem_moveUp ).toBeVisible();
+						await page.keyboard.press( 'Escape' );
+					} );
 				} );
 
-				await test.step( `Expect the second section to become first, and first becomes second.`, async () => {
-					await expect( headings_sections.first() ).toHaveText(
-						secondSection
-					);
+				test( 'should allow a user to move a section down', async () => {
+					const firstSection = await headings_sections
+						.first()
+						.innerText();
+					const secondSection = await headings_sections
+						.nth( 1 )
+						.innerText();
 
-					await expect( headings_sections.nth( 1 ) ).toHaveText(
-						firstSection
-					);
+					await test.step( `Move first section down`, async () => {
+						await buttons_ellipsis.first().click();
+						await menuitem_moveDown.click();
+					} );
+
+					await test.step( `Expect the second section to become first, and first becomes second.`, async () => {
+						await expect( headings_sections.first() ).toHaveText(
+							secondSection
+						);
+
+						await expect( headings_sections.nth( 1 ) ).toHaveText(
+							firstSection
+						);
+					} );
 				} );
+
+				test( 'should allow a user to move a section up', async () => {
+					const firstSection = await headings_sections
+						.first()
+						.innerText();
+					const secondSection = await headings_sections
+						.nth( 1 )
+						.innerText();
+
+					await test.step( `Move second section up`, async () => {
+						await buttons_ellipsis.nth( 1 ).click();
+						await menuitem_moveUp.click();
+					} );
+
+					await test.step( `Expect second section becomes first section, first becomes second`, async () => {
+						await expect( headings_sections.first() ).toHaveText(
+							secondSection
+						);
+						await expect( headings_sections.nth( 1 ) ).toHaveText(
+							firstSection
+						);
+					} );
+				} );
+			}
+		);
+
+		test( 'should allow a user to remove a section', async () => {
+			await test.step( `Remove the Performance section`, async () => {
+				await page
+					.getByRole( 'button', {
+						name: 'Choose which analytics to display and the section name',
+					} )
+					.click();
+				await page
+					.getByRole( 'menuitem', { name: 'Remove section' } )
+					.click();
+				await page.waitForResponse(
+					( response ) =>
+						response.url().includes( '/users' ) && response.ok()
+				);
 			} );
 
-			test( 'should allow a user to move a section up', async () => {
-				const firstSection = await headings_sections
-					.first()
-					.innerText();
-				const secondSection = await headings_sections
-					.nth( 1 )
-					.innerText();
-
-				await test.step( `Move second section up`, async () => {
-					await buttons_ellipsis.nth( 1 ).click();
-					await menuitem_moveUp.click();
-				} );
-
-				await test.step( `Expect second section becomes first section, first becomes second`, async () => {
-					await expect( headings_sections.first() ).toHaveText(
-						secondSection
-					);
-					await expect( headings_sections.nth( 1 ) ).toHaveText(
-						firstSection
-					);
-				} );
+			await test.step( `Expect the Performance section to be hidden`, async () => {
+				await expect( headings_sections ).toHaveCount( 2 );
+				await expect( heading_performance ).toBeHidden();
 			} );
-		}
-	);
-
-	test( 'should allow a user to remove a section', async () => {
-		await test.step( `Remove the Performance section`, async () => {
-			await page
-				.getByRole( 'button', {
-					name: 'Choose which analytics to display and the section name',
-				} )
-				.click();
-			await page
-				.getByRole( 'menuitem', { name: 'Remove section' } )
-				.click();
-			await page.waitForResponse(
-				( response ) =>
-					response.url().includes( '/users' ) && response.ok()
-			);
 		} );
 
-		await test.step( `Expect the Performance section to be hidden`, async () => {
-			await expect( headings_sections ).toHaveCount( 2 );
-			await expect( heading_performance ).toBeHidden();
-		} );
-	} );
+		test( 'should allow a user to add a section back in', async () => {
+			await hidePerformanceSection( page );
+			await page.reload();
 
-	test( 'should allow a user to add a section back in', async () => {
-		await hidePerformanceSection( page );
-		await page.reload();
+			await test.step( `Add the Performance section back in.`, async () => {
+				await page.getByTitle( 'Add more sections' ).click();
+				await page.getByTitle( 'Add Performance section' ).click();
+			} );
 
-		await test.step( `Add the Performance section back in.`, async () => {
-			await page.getByTitle( 'Add more sections' ).click();
-			await page.getByTitle( 'Add Performance section' ).click();
+			await test.step( `Expect the Performance section to be added back.`, async () => {
+				await expect( heading_performance ).toBeVisible();
+			} );
 		} );
-
-		await test.step( `Expect the Performance section to be added back.`, async () => {
-			await expect( heading_performance ).toBeVisible();
-		} );
-	} );
-} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics.spec.js
@@ -1,35 +1,40 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 
-test.describe( 'Analytics pages', { tag: [ '@payments', '@services' ] }, () => {
-	test.use( { storageState: process.env.ADMINSTATE } );
+test.describe(
+	'Analytics pages',
+	{ tag: [ '@payments', tags.SERVICES ] },
+	() => {
+		test.use( { storageState: process.env.ADMINSTATE } );
 
-	for ( const aPages of [
-		'Overview',
-		'Products',
-		'Revenue',
-		'Orders',
-		'Variations',
-		'Categories',
-		'Coupons',
-		'Taxes',
-		'Downloads',
-		'Stock',
-		'Settings',
-	] ) {
-		test( `A user can view the ${ aPages } page without it crashing`, async ( {
-			page,
-		} ) => {
-			const urlTitle = aPages.toLowerCase();
-			await page.goto(
-				`wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2F${ urlTitle }`
-			);
-			const pageTitle = page.locator(
-				'.woocommerce-layout__header-wrapper > h1'
-			);
-			await expect( pageTitle ).toContainText( aPages );
-			await expect(
-				page.locator( '#woocommerce-layout__primary' )
-			).toBeVisible();
-		} );
+		for ( const aPages of [
+			'Overview',
+			'Products',
+			'Revenue',
+			'Orders',
+			'Variations',
+			'Categories',
+			'Coupons',
+			'Taxes',
+			'Downloads',
+			'Stock',
+			'Settings',
+		] ) {
+			test( `A user can view the ${ aPages } page without it crashing`, async ( {
+				page,
+			} ) => {
+				const urlTitle = aPages.toLowerCase();
+				await page.goto(
+					`wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2F${ urlTitle }`
+				);
+				const pageTitle = page.locator(
+					'.woocommerce-layout__header-wrapper > h1'
+				);
+				await expect( pageTitle ).toContainText( aPages );
+				await expect(
+					page.locator( '#woocommerce-layout__primary' )
+				).toBeVisible();
+			} );
+		}
 	}
-} );
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics.spec.js
@@ -3,7 +3,7 @@ const { tags } = require( '../../fixtures/fixtures' );
 
 test.describe(
 	'Analytics pages',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 test.describe( 'Marketing page', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
@@ -17,7 +18,7 @@ test.describe( 'Marketing page', () => {
 
 	test(
 		'Marketing Overview page have relevant content',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		async ( { page } ) => {
 			// Go to the Marketing page.
 			await page.goto(
@@ -56,7 +57,7 @@ test.describe( 'Marketing page', () => {
 
 	test(
 		'Introduction can be dismissed',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { page } ) => {
 			// Go to the Marketing page.
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/coupons/coupons.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/coupons/coupons.test.js
@@ -1,4 +1,8 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
 const { coupon, order } = require( '../../../data' );
 
 test.describe( 'Coupons API tests', () => {
@@ -71,7 +75,7 @@ test.describe( 'Coupons API tests', () => {
 
 	test(
 		'can permanently delete a coupon',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		async ( { request } ) => {
 			//call API to delete previously created coupon
 			const response = await request.delete(
@@ -186,7 +190,7 @@ test.describe( 'Batch update coupons', () => {
 
 	test(
 		'can batch delete coupons',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		async ( { request } ) => {
 			// Batch delete the 2 coupons.
 			const couponIdsToDelete = expectedCoupons.map( ( { id } ) => id );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -1,9 +1,13 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
 const { admin } = require( '../../../test-data/data' );
 
 test.describe(
 	'Customers API tests: CRUD',
-	{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+	{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 	() => {
 		let customerId;
 		let subscriberUserId;

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
@@ -1,5 +1,8 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
-
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
 const {
 	getOrderExample,
 	getTaxRateExamples,
@@ -210,7 +213,7 @@ test.describe( 'Orders API test', () => {
 
 	test(
 		'can add complex order',
-		{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 		async ( { request } ) => {
 			//ensure tax calculations are enabled
 			await request.put(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -1,4 +1,8 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
 const { order } = require( '../../../data' );
 
 /**
@@ -36,7 +40,7 @@ const updatedCustomerShipping = {
 
 test.describe.serial(
 	'Orders API tests',
-	{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+	{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 	() => {
 		let orderId, sampleData;
 
@@ -239,7 +243,7 @@ test.describe.serial(
 			const createSampleSimpleProducts = async (
 				categories,
 				attributes,
-				tags
+				productTags
 			) => {
 				const description =
 					'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
@@ -813,7 +817,7 @@ test.describe.serial(
 									],
 									tags: [
 										{
-											id: tags.coolJSON.id,
+											id: productTags.coolJSON.id,
 										},
 									],
 									attributes: [
@@ -890,7 +894,7 @@ test.describe.serial(
 									],
 									tags: [
 										{
-											id: tags.coolJSON.id,
+											id: productTags.coolJSON.id,
 										},
 									],
 									attributes: [],
@@ -1097,7 +1101,7 @@ test.describe.serial(
 									],
 									tags: [
 										{
-											id: tags.coolJSON.id,
+											id: productTags.coolJSON.id,
 										},
 									],
 									attributes: [
@@ -2120,7 +2124,7 @@ test.describe.serial(
 
 				const attributes = await createSampleAttributes();
 
-				const tags = await createSampleTags();
+				const productTags = await createSampleTags();
 
 				const shippingClasses = await createSampleShippingClasses();
 
@@ -2129,7 +2133,7 @@ test.describe.serial(
 				const simpleProducts = await createSampleSimpleProducts(
 					categories,
 					attributes,
-					tags
+					productTags
 				);
 
 				const externalProducts = await createSampleExternalProducts(
@@ -2159,7 +2163,7 @@ test.describe.serial(
 				return {
 					categories,
 					attributes,
-					tags,
+					productTags,
 					shippingClasses,
 					taxClasses,
 					simpleProducts,
@@ -2503,7 +2507,7 @@ test.describe.serial(
 				const {
 					categories,
 					attributes,
-					tags,
+					productTags,
 					shippingClasses,
 					taxClasses,
 					simpleProducts,
@@ -2578,7 +2582,7 @@ test.describe.serial(
 					);
 				}
 
-				for ( const tag of Object.values( tags ) ) {
+				for ( const tag of Object.values( productTags ) ) {
 					await request.delete(
 						`./wp-json/wc/v3/products/tags/${ tag.id }`,
 						{

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
@@ -1,9 +1,13 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
 
 test.describe( 'Payment Gateways API tests', () => {
 	test(
 		'can view all payment gateways',
-		{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 		async ( { request } ) => {
 			// call API to retrieve the payment gateways
 			const response = await request.get(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -1,7 +1,7 @@
 const {
 	test,
 	expect,
-	tags,
+	tags: pwTags,
 } = require( '../../../fixtures/api-tests-fixtures' );
 
 test.describe( 'Products API tests: List All Products', () => {
@@ -202,7 +202,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		const createSampleSimpleProducts = async (
 			categories,
 			attributes,
-			productTags
+			tags
 		) => {
 			const description =
 				'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
@@ -777,7 +777,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								],
 								tags: [
 									{
-										id: productTags.coolJSON.id,
+										id: tags.coolJSON.id,
 									},
 								],
 								attributes: [
@@ -854,7 +854,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								],
 								tags: [
 									{
-										id: productTags.coolJSON.id,
+										id: tags.coolJSON.id,
 									},
 								],
 								attributes: [],
@@ -1061,7 +1061,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								],
 								tags: [
 									{
-										id: productTags.coolJSON.id,
+										id: tags.coolJSON.id,
 									},
 								],
 								attributes: [
@@ -2074,7 +2074,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			const attributes = await createSampleAttributes();
 
-			const productTags = await createSampleTags();
+			const tags = await createSampleTags();
 
 			const shippingClasses = await createSampleShippingClasses();
 
@@ -2083,7 +2083,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const simpleProducts = await createSampleSimpleProducts(
 				categories,
 				attributes,
-				productTags
+				tags
 			);
 			const externalProducts = await createSampleExternalProducts(
 				categories
@@ -2127,7 +2127,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const {
 				categories,
 				attributes,
-				productTags,
+				tags,
 				shippingClasses,
 				taxClasses,
 				simpleProducts,
@@ -2200,7 +2200,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				);
 			}
 
-			for ( const tag of Object.values( productTags ) ) {
+			for ( const tag of Object.values( tags ) ) {
 				await request.delete(
 					`./wp-json/wc/v3/products/tags/${ tag.id }`,
 					{
@@ -2239,7 +2239,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 	test.describe(
 		'List all products',
-		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
+		{ tag: [ pwTags.SKIP_ON_PRESSABLE, pwTags.SKIP_ON_WPCOM ] },
 		() => {
 			test( 'defaults', async ( { request } ) => {
 				const result = await request.get( 'wp-json/wc/v3/products', {
@@ -2579,7 +2579,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			test(
 				'categories',
-				{ tag: tags.SKIP_ON_WPCOM },
+				{ tag: pwTags.SKIP_ON_WPCOM },
 				async ( { request } ) => {
 					const accessory = [
 						expect.objectContaining( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -1,4 +1,8 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
 
 test.describe( 'Products API tests: List All Products', () => {
 	const PRODUCTS_COUNT = 20;
@@ -198,7 +202,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		const createSampleSimpleProducts = async (
 			categories,
 			attributes,
-			tags
+			productTags
 		) => {
 			const description =
 				'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
@@ -773,7 +777,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								],
 								tags: [
 									{
-										id: tags.coolJSON.id,
+										id: productTags.coolJSON.id,
 									},
 								],
 								attributes: [
@@ -850,7 +854,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								],
 								tags: [
 									{
-										id: tags.coolJSON.id,
+										id: productTags.coolJSON.id,
 									},
 								],
 								attributes: [],
@@ -1057,7 +1061,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								],
 								tags: [
 									{
-										id: tags.coolJSON.id,
+										id: productTags.coolJSON.id,
 									},
 								],
 								attributes: [
@@ -2070,7 +2074,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			const attributes = await createSampleAttributes();
 
-			const tags = await createSampleTags();
+			const productTags = await createSampleTags();
 
 			const shippingClasses = await createSampleShippingClasses();
 
@@ -2079,7 +2083,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const simpleProducts = await createSampleSimpleProducts(
 				categories,
 				attributes,
-				tags
+				productTags
 			);
 			const externalProducts = await createSampleExternalProducts(
 				categories
@@ -2123,7 +2127,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const {
 				categories,
 				attributes,
-				tags,
+				productTags,
 				shippingClasses,
 				taxClasses,
 				simpleProducts,
@@ -2196,7 +2200,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				);
 			}
 
-			for ( const tag of Object.values( tags ) ) {
+			for ( const tag of Object.values( productTags ) ) {
 				await request.delete(
 					`./wp-json/wc/v3/products/tags/${ tag.id }`,
 					{
@@ -2235,7 +2239,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 	test.describe(
 		'List all products',
-		{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 		() => {
 			test( 'defaults', async ( { request } ) => {
 				const result = await request.get( 'wp-json/wc/v3/products', {
@@ -2575,7 +2579,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			test(
 				'categories',
-				{ tag: '@skip-on-default-wpcom' },
+				{ tag: tags.SKIP_ON_WPCOM },
 				async ( { request } ) => {
 					const accessory = [
 						expect.objectContaining( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -1,6 +1,7 @@
 const {
 	test: baseTest,
 	expect,
+	tags,
 } = require( '../../../fixtures/api-tests-fixtures' );
 const { BASE_URL } = process.env;
 const { admin } = require( '../../../test-data/data' );
@@ -591,7 +592,7 @@ test.describe( 'Products API tests: CRUD', () => {
 
 	test.describe(
 		'Product review tests: CRUD',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		() => {
 			let productReviewId;
 			let reviewsTestProduct;
@@ -983,7 +984,7 @@ test.describe( 'Products API tests: CRUD', () => {
 
 		test(
 			'can batch update product shipping classes',
-			{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+			{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 			async ( { request } ) => {
 				// Batch create product shipping classes.
 				const response = await request.post(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1,4 +1,9 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
+
 const { BASE_URL } = process.env;
 const shouldSkip = ! BASE_URL.includes( 'localhost' );
 
@@ -1021,7 +1026,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 	test.describe( 'List all Tax settings options', () => {
 		test(
 			'can retrieve all tax settings',
-			{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+			{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 			async ( { request } ) => {
 				// call API to retrieve all settings options
 				const response = await request.get(
@@ -1620,7 +1625,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 
 	test.describe(
 		'List all Advanced settings options',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		() => {
 			test( 'can retrieve all advanced settings', async ( {
 				request,
@@ -2013,7 +2018,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 	test.describe( 'List all Email Failed Order settings', () => {
 		test(
 			'can retrieve all email failed order settings',
-			{ tag: '@skip-on-default-pressable' },
+			{ tag: tags.SKIP_ON_PRESSABLE },
 			async ( { request } ) => {
 				// call API to retrieve all settings options
 				const response = await request.get(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
@@ -1,11 +1,16 @@
-const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const {
+	test,
+	expect,
+	tags,
+} = require( '../../../fixtures/api-tests-fixtures' );
+
 const { BASE_URL } = process.env;
 const shouldSkip = BASE_URL !== undefined && ! BASE_URL.includes( 'localhost' );
 
 test.describe( 'System Status API tests', () => {
 	test(
 		'can view all system status items',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		async ( { request } ) => {
 			// call API to view all system status items
 			const response = await request.get(

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
@@ -2,6 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( './assembler/assembler.page' );
 const { activateTheme } = require( '../../utils/themes' );
 const { setOption } = require( '../../utils/options' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 const ASSEMBLER_HUB_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub';
@@ -17,7 +18,7 @@ const test = base.extend( {
 
 test.describe(
 	'Store owner can view Assembler Hub for store customization',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
@@ -7,6 +7,7 @@ const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 const { setOption } = require( '../../../utils/options' );
 const { admin } = require( '../../../test-data/data' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const test = base.extend( {
 	assemblerPageObject: async ( { page }, use ) => {
@@ -217,7 +218,7 @@ test.describe( 'Assembler -> Color Pickers', { tag: '@gutenberg' }, () => {
 
 	test(
 		'Selected color palette should be applied on the frontend',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { assemblerPageObject, page, baseURL } ) => {
 			const assembler = await assemblerPageObject.getAssembler();
 			const colorPicker = assembler
@@ -317,7 +318,7 @@ test.describe( 'Assembler -> Color Pickers', { tag: '@gutenberg' }, () => {
 
 	test(
 		'Create "your own" pickers should be visible',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { assemblerPageObject, baseURL }, testInfo ) => {
 			testInfo.snapshotSuffix = '';
 			const wordPressVersion = await getInstalledWordPressVersion();

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/color-picker.spec.js
@@ -34,7 +34,7 @@ const colorPalette = {
 	},
 };
 
-test.describe( 'Assembler -> Color Pickers', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler -> Color Pickers', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -51,7 +51,7 @@ const slugFontMap = {
 	'Raleway, sans-serif': 'Raleway',
 };
 
-test.describe( 'Assembler -> Font Picker', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler -> Font Picker', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -2,6 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { setOption } = require( '../../../utils/options' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
@@ -2,6 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { setOption } = require( '../../../utils/options' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const extractFooterClass = ( footerPickerClass ) => {
 	const regex = /\bwc-blocks-pattern-footer\S*/;
@@ -18,7 +19,7 @@ const test = base.extend( {
 	},
 } );
 
-test.describe( 'Assembler -> Footers', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler -> Footers', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -3,6 +3,7 @@ const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { setOption } = require( '../../../utils/options' );
 const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {
@@ -98,7 +99,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 
 	test(
 		'The list of categories should be displayed',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { pageObject, baseURL } ) => {
 			await prepareAssembler( pageObject, baseURL );
 			const assembler = await pageObject.getAssembler();
@@ -346,7 +347,7 @@ test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
 
 	test(
 		'Clicking opt-in new patterns should be available',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { pageObject, baseURL } ) => {
 			await prepareAssembler( pageObject, baseURL );
 			const assembler = await pageObject.getAssembler();

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/full-composability.spec.js
@@ -36,344 +36,352 @@ async function deleteAllPatterns( editor, assembler ) {
 	}
 }
 
-test.describe( 'Assembler -> Full composability', { tag: '@gutenberg' }, () => {
-	test.use( { storageState: process.env.ADMINSTATE } );
+test.describe(
+	'Assembler -> Full composability',
+	{ tag: tags.GUTENBERG },
+	() => {
+		test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeAll( async ( { baseURL } ) => {
-		try {
-			// In some environments the tour blocks clicking other elements.
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_customize_store_onboarding_tour_hidden',
-				'yes'
-			);
+		test.beforeAll( async ( { baseURL } ) => {
+			try {
+				// In some environments the tour blocks clicking other elements.
+				await setOption(
+					request,
+					baseURL,
+					'woocommerce_customize_store_onboarding_tour_hidden',
+					'yes'
+				);
 
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_allow_tracking',
-				'no'
-			);
-		} catch ( error ) {
-			console.log( 'Store completed option not updated' );
-		}
+				await setOption(
+					request,
+					baseURL,
+					'woocommerce_allow_tracking',
+					'no'
+				);
+			} catch ( error ) {
+				console.log( 'Store completed option not updated' );
+			}
 
-		const wordPressVersion = await getInstalledWordPressVersion();
+			const wordPressVersion = await getInstalledWordPressVersion();
 
-		if ( wordPressVersion <= 6.5 ) {
-			test.skip(
-				'Skipping Full Composability tests: WordPress version is below 6.5, which does not support this feature.'
-			);
-		}
-	} );
+			if ( wordPressVersion <= 6.5 ) {
+				test.skip(
+					'Skipping Full Composability tests: WordPress version is below 6.5, which does not support this feature.'
+				);
+			}
+		} );
 
-	test.afterAll( async ( { baseURL } ) => {
-		try {
-			// In some environments the tour blocks clicking other elements.
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_customize_store_onboarding_tour_hidden',
-				'no'
-			);
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_admin_customize_store_completed',
-				'no'
-			);
+		test.afterAll( async ( { baseURL } ) => {
+			try {
+				// In some environments the tour blocks clicking other elements.
+				await setOption(
+					request,
+					baseURL,
+					'woocommerce_customize_store_onboarding_tour_hidden',
+					'no'
+				);
+				await setOption(
+					request,
+					baseURL,
+					'woocommerce_admin_customize_store_completed',
+					'no'
+				);
 
-			await setOption(
-				request,
-				baseURL,
-				'woocommerce_allow_tracking',
-				'no'
-			);
+				await setOption(
+					request,
+					baseURL,
+					'woocommerce_allow_tracking',
+					'no'
+				);
 
-			await activateTheme( baseURL, DEFAULT_THEME );
-		} catch ( error ) {
-			console.log( 'Store completed option not updated' );
-		}
-	} );
+				await activateTheme( baseURL, DEFAULT_THEME );
+			} catch ( error ) {
+				console.log( 'Store completed option not updated' );
+			}
+		} );
 
-	test(
-		'The list of categories should be displayed',
-		{ tag: tags.SKIP_ON_PRESSABLE },
-		async ( { pageObject, baseURL } ) => {
+		test(
+			'The list of categories should be displayed',
+			{ tag: tags.SKIP_ON_PRESSABLE },
+			async ( { pageObject, baseURL } ) => {
+				await prepareAssembler( pageObject, baseURL );
+				const assembler = await pageObject.getAssembler();
+
+				const categories = assembler.locator(
+					'.woocommerce-customize-store__sidebar-homepage-content .components-item-group'
+				);
+
+				await expect( categories ).toHaveCount( 6 );
+			}
+		);
+
+		test( 'Clicking on "Design your homepage" should open the Intro sidebar by default', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
 			await prepareAssembler( pageObject, baseURL );
 			const assembler = await pageObject.getAssembler();
 
-			const categories = assembler.locator(
-				'.woocommerce-customize-store__sidebar-homepage-content .components-item-group'
-			);
+			await expect(
+				await assembler
+					.locator(
+						'.woocommerce-customize-store-edit-site-layout__sidebar-extra__pattern__header'
+					)
+					.textContent()
+			).toContain( 'Intro' );
+		} );
 
-			await expect( categories ).toHaveCount( 6 );
-		}
-	);
+		test( 'Clicking on a category should open the sidebar for it', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
+			await prepareAssembler( pageObject, baseURL );
+			const assembler = await pageObject.getAssembler();
 
-	test( 'Clicking on "Design your homepage" should open the Intro sidebar by default', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-
-		await expect(
-			await assembler
+			const categories = await assembler
 				.locator(
-					'.woocommerce-customize-store-edit-site-layout__sidebar-extra__pattern__header'
+					'.woocommerce-edit-site-sidebar-navigation-screen-patterns__group-homepage-label-container > span:first-child'
 				)
-				.textContent()
-		).toContain( 'Intro' );
-	} );
+				.all();
 
-	test( 'Clicking on a category should open the sidebar for it', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
+			for ( const category of categories ) {
+				const name = await category.textContent();
+				await category.click();
 
-		const categories = await assembler
-			.locator(
-				'.woocommerce-edit-site-sidebar-navigation-screen-patterns__group-homepage-label-container > span:first-child'
-			)
-			.all();
+				const sidebar = assembler.locator(
+					'.woocommerce-customize-store-edit-site-layout__sidebar-extra'
+				);
+				await expect( sidebar ).toBeVisible();
 
-		for ( const category of categories ) {
-			const name = await category.textContent();
-			await category.click();
+				const sidebarTitle = await sidebar
+					.locator(
+						'.woocommerce-customize-store-edit-site-layout__sidebar-extra__pattern__header'
+					)
+					.textContent();
 
-			const sidebar = assembler.locator(
-				'.woocommerce-customize-store-edit-site-layout__sidebar-extra'
-			);
-			await expect( sidebar ).toBeVisible();
+				await expect( sidebarTitle ).toBe( name );
+				await expect( async () => {
+					const count = await sidebar
+						.locator(
+							'.block-editor-block-patterns-list__list-item'
+						)
+						.count();
+					expect( count ).toBeGreaterThan( 0 );
+				} ).toPass();
+			}
+		} );
 
-			const sidebarTitle = await sidebar
-				.locator(
-					'.woocommerce-customize-store-edit-site-layout__sidebar-extra__pattern__header'
-				)
+		test( 'Clicking on a pattern should insert it in the preview', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
+			await prepareAssembler( pageObject, baseURL );
+			const assembler = await pageObject.getAssembler();
+			const editor = await pageObject.getEditor();
+
+			await deleteAllPatterns( editor, assembler );
+
+			const sidebarPattern = assembler
+				.locator( '.block-editor-block-patterns-list__list-item' )
+				.first();
+
+			const sidebarPatternContent = await sidebarPattern
+				.frameLocator( 'iframe' )
+				.locator( '.is-root-container' )
 				.textContent();
 
-			await expect( sidebarTitle ).toBe( name );
-			await expect( async () => {
-				const count = await sidebar
-					.locator( '.block-editor-block-patterns-list__list-item' )
-					.count();
-				expect( count ).toBeGreaterThan( 0 );
-			} ).toPass();
-		}
-	} );
+			await sidebarPattern.click();
 
-	test( 'Clicking on a pattern should insert it in the preview', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-		const editor = await pageObject.getEditor();
+			const insertedPatternContent = await editor
+				.locator(
+					'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+				)
+				.first()
+				.textContent();
 
-		await deleteAllPatterns( editor, assembler );
+			await expect( insertedPatternContent ).toContain(
+				sidebarPatternContent
+			);
+		} );
 
-		const sidebarPattern = assembler
-			.locator( '.block-editor-block-patterns-list__list-item' )
-			.first();
-
-		const sidebarPatternContent = await sidebarPattern
-			.frameLocator( 'iframe' )
-			.locator( '.is-root-container' )
-			.textContent();
-
-		await sidebarPattern.click();
-
-		const insertedPatternContent = await editor
-			.locator(
-				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-			)
-			.first()
-			.textContent();
-
-		await expect( insertedPatternContent ).toContain(
-			sidebarPatternContent
-		);
-	} );
-
-	test( 'Clicking on a pattern should always scroll the page to the inserted pattern', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-		const editor = await pageObject.getEditor();
-
-		await deleteAllPatterns( editor, assembler );
-
-		const sidebarPattern = assembler.locator(
-			'.block-editor-block-patterns-list__list-item'
-		);
-
-		// add first 3 patterns
-		for ( let i = 0; i < 4; i++ ) {
-			await sidebarPattern.nth( i ).click();
-		}
-
-		const insertedPattern = editor
-			.locator(
-				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-			)
-			.nth( 3 );
-
-		await expect( insertedPattern ).toBeInViewport();
-	} );
-
-	test( 'Clicking the "Move up/down" buttons should change the pattern order in the preview', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-		const editor = await pageObject.getEditor();
-
-		const sidebarPattern = assembler
-			.locator( '.block-editor-block-patterns-list__list-item' )
-			.nth( 2 );
-
-		const sidebarPatternContent = await sidebarPattern
-			.frameLocator( 'iframe' )
-			.locator( '.is-root-container' )
-			.textContent();
-
-		await sidebarPattern.click();
-
-		const insertedPattern = editor
-			.locator(
-				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-			)
-			.nth( 1 );
-		await insertedPattern.click();
-
-		const moveUpButton = assembler.locator(
-			'button[aria-label="Move up"]'
-		);
-		await moveUpButton.click();
-
-		const firstPattern = editor
-			.locator(
-				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-			)
-			.first();
-		const firstPatternContent = await firstPattern.textContent();
-
-		expect( firstPatternContent ).toContain( sidebarPatternContent );
-	} );
-
-	test( 'Clicking the "Shuffle" button on a patterns should replace it for another one', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-		const editor = await pageObject.getEditor();
-
-		await deleteAllPatterns( editor, assembler );
-
-		const sidebarPattern = assembler
-			.locator( '.block-editor-block-patterns-list__list-item' )
-			.first();
-		await sidebarPattern.click();
-
-		const insertedPattern = editor
-			.locator(
-				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-			)
-			.first();
-
-		const insertedPatternContent = await insertedPattern.textContent();
-
-		await insertedPattern.click();
-		const shuffleButton = assembler.locator(
-			'button[aria-label="Shuffle"]'
-		);
-		await shuffleButton.click();
-
-		const shuffledPattern = editor.locator(
-			'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-		);
-
-		await expect( await shuffledPattern ).not.toHaveText(
-			insertedPatternContent
-		);
-	} );
-
-	test( 'Clicking the "Delete" button on a pattern should remove it from the preview', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-		const editor = await pageObject.getEditor();
-
-		await deleteAllPatterns( editor, assembler );
-
-		const emptyPatternsBlock = editor.getByText(
-			'Add one or more of our homepage patterns to create a page that welcomes shoppers.'
-		);
-		await expect( emptyPatternsBlock ).toBeVisible();
-	} );
-
-	test( 'Clicking the "Add patterns" button on the No Blocks view should add a default pattern', async ( {
-		pageObject,
-		baseURL,
-	} ) => {
-		await prepareAssembler( pageObject, baseURL );
-		const assembler = await pageObject.getAssembler();
-		const editor = await pageObject.getEditor();
-
-		await deleteAllPatterns( editor, assembler );
-		const addPatternsButton = editor.locator(
-			'.no-blocks-insert-pattern-button'
-		);
-		await addPatternsButton.click();
-		const emptyPatternsBlock = editor.getByText(
-			'Add one or more of our homepage patterns to create a page that welcomes shoppers.'
-		);
-		const defaultPattern = editor.locator(
-			'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
-		);
-		await expect( emptyPatternsBlock ).toBeHidden();
-		await expect( defaultPattern ).toBeVisible();
-	} );
-
-	test(
-		'Clicking opt-in new patterns should be available',
-		{ tag: tags.SKIP_ON_PRESSABLE },
-		async ( { pageObject, baseURL } ) => {
+		test( 'Clicking on a pattern should always scroll the page to the inserted pattern', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
 			await prepareAssembler( pageObject, baseURL );
 			const assembler = await pageObject.getAssembler();
+			const editor = await pageObject.getEditor();
 
-			await assembler.getByText( 'Usage tracking' ).click();
-			await expect(
-				assembler.getByText( 'Access more patterns' )
-			).toBeVisible();
-
-			await assembler.getByRole( 'button', { name: 'Opt in' } ).click();
-
-			await assembler
-				.getByText( 'Access more patterns' )
-				.waitFor( { state: 'hidden' } );
+			await deleteAllPatterns( editor, assembler );
 
 			const sidebarPattern = assembler.locator(
-				'.block-editor-block-patterns-list'
+				'.block-editor-block-patterns-list__list-item'
 			);
 
-			await sidebarPattern.waitFor( { state: 'visible' } );
+			// add first 3 patterns
+			for ( let i = 0; i < 4; i++ ) {
+				await sidebarPattern.nth( i ).click();
+			}
 
-			await expect(
-				assembler.locator(
-					'.block-editor-block-patterns-list__list-item'
+			const insertedPattern = editor
+				.locator(
+					'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
 				)
-			).toHaveCount( 10 );
-		}
-	);
-} );
+				.nth( 3 );
+
+			await expect( insertedPattern ).toBeInViewport();
+		} );
+
+		test( 'Clicking the "Move up/down" buttons should change the pattern order in the preview', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
+			await prepareAssembler( pageObject, baseURL );
+			const assembler = await pageObject.getAssembler();
+			const editor = await pageObject.getEditor();
+
+			const sidebarPattern = assembler
+				.locator( '.block-editor-block-patterns-list__list-item' )
+				.nth( 2 );
+
+			const sidebarPatternContent = await sidebarPattern
+				.frameLocator( 'iframe' )
+				.locator( '.is-root-container' )
+				.textContent();
+
+			await sidebarPattern.click();
+
+			const insertedPattern = editor
+				.locator(
+					'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+				)
+				.nth( 1 );
+			await insertedPattern.click();
+
+			const moveUpButton = assembler.locator(
+				'button[aria-label="Move up"]'
+			);
+			await moveUpButton.click();
+
+			const firstPattern = editor
+				.locator(
+					'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+				)
+				.first();
+			const firstPatternContent = await firstPattern.textContent();
+
+			expect( firstPatternContent ).toContain( sidebarPatternContent );
+		} );
+
+		test( 'Clicking the "Shuffle" button on a patterns should replace it for another one', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
+			await prepareAssembler( pageObject, baseURL );
+			const assembler = await pageObject.getAssembler();
+			const editor = await pageObject.getEditor();
+
+			await deleteAllPatterns( editor, assembler );
+
+			const sidebarPattern = assembler
+				.locator( '.block-editor-block-patterns-list__list-item' )
+				.first();
+			await sidebarPattern.click();
+
+			const insertedPattern = editor
+				.locator(
+					'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+				)
+				.first();
+
+			const insertedPatternContent = await insertedPattern.textContent();
+
+			await insertedPattern.click();
+			const shuffleButton = assembler.locator(
+				'button[aria-label="Shuffle"]'
+			);
+			await shuffleButton.click();
+
+			const shuffledPattern = editor.locator(
+				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+			);
+
+			await expect( await shuffledPattern ).not.toHaveText(
+				insertedPatternContent
+			);
+		} );
+
+		test( 'Clicking the "Delete" button on a pattern should remove it from the preview', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
+			await prepareAssembler( pageObject, baseURL );
+			const assembler = await pageObject.getAssembler();
+			const editor = await pageObject.getEditor();
+
+			await deleteAllPatterns( editor, assembler );
+
+			const emptyPatternsBlock = editor.getByText(
+				'Add one or more of our homepage patterns to create a page that welcomes shoppers.'
+			);
+			await expect( emptyPatternsBlock ).toBeVisible();
+		} );
+
+		test( 'Clicking the "Add patterns" button on the No Blocks view should add a default pattern', async ( {
+			pageObject,
+			baseURL,
+		} ) => {
+			await prepareAssembler( pageObject, baseURL );
+			const assembler = await pageObject.getAssembler();
+			const editor = await pageObject.getEditor();
+
+			await deleteAllPatterns( editor, assembler );
+			const addPatternsButton = editor.locator(
+				'.no-blocks-insert-pattern-button'
+			);
+			await addPatternsButton.click();
+			const emptyPatternsBlock = editor.getByText(
+				'Add one or more of our homepage patterns to create a page that welcomes shoppers.'
+			);
+			const defaultPattern = editor.locator(
+				'[data-is-parent-block="true"]:not([data-type="core/template-part"])'
+			);
+			await expect( emptyPatternsBlock ).toBeHidden();
+			await expect( defaultPattern ).toBeVisible();
+		} );
+
+		test(
+			'Clicking opt-in new patterns should be available',
+			{ tag: tags.SKIP_ON_PRESSABLE },
+			async ( { pageObject, baseURL } ) => {
+				await prepareAssembler( pageObject, baseURL );
+				const assembler = await pageObject.getAssembler();
+
+				await assembler.getByText( 'Usage tracking' ).click();
+				await expect(
+					assembler.getByText( 'Access more patterns' )
+				).toBeVisible();
+
+				await assembler
+					.getByRole( 'button', { name: 'Opt in' } )
+					.click();
+
+				await assembler
+					.getByText( 'Access more patterns' )
+					.waitFor( { state: 'hidden' } );
+
+				const sidebarPattern = assembler.locator(
+					'.block-editor-block-patterns-list'
+				);
+
+				await sidebarPattern.waitFor( { state: 'visible' } );
+
+				await expect(
+					assembler.locator(
+						'.block-editor-block-patterns-list__list-item'
+					)
+				).toHaveCount( 10 );
+			}
+		);
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
@@ -2,6 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { AssemblerPage } = require( './assembler.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../utils/themes' );
 const { setOption } = require( '../../../utils/options' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const extractHeaderClass = ( headerPickerClass ) => {
 	const regex = /\bwc-blocks-pattern-header\S*/;
@@ -18,7 +19,7 @@ const test = base.extend( {
 	},
 } );
 
-test.describe( 'Assembler -> headers', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler -> headers', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -24,7 +24,7 @@ async function prepareAssembler( pageObject, baseURL ) {
 		.waitFor( { state: 'hidden' } );
 }
 
-test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler -> Homepage', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -5,6 +5,7 @@ const { getInstalledWordPressVersion } = require( '../../../utils/wordpress' );
 const { setOption } = require( '../../../utils/options' );
 const { encodeCredentials } = require( '../../../utils/plugin-utils' );
 const { admin } = require( '../../../test-data/data' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {
@@ -72,7 +73,7 @@ test.describe( 'Assembler -> Homepage', { tag: '@gutenberg' }, () => {
 
 	test(
 		'Available homepage should be displayed',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { pageObject, baseURL } ) => {
 			await prepareAssembler( pageObject, baseURL );
 
@@ -250,7 +251,7 @@ test.describe( 'Homepage tracking banner', () => {
 
 	test(
 		'Should show the "Want more patterns?" banner with the PTK API unavailable message',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { baseURL, pageObject, page } ) => {
 			await setOption(
 				request,
@@ -322,7 +323,7 @@ test.describe( 'Homepage tracking banner', () => {
 
 	test(
 		'Should not show the "Want more patterns?" banner when tracking is allowed',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { baseURL, pageObject } ) => {
 			await setOption(
 				request,

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -4,6 +4,7 @@ const { LogoPickerPage } = require( './logo-picker.page' );
 const { activateTheme, DEFAULT_THEME } = require( '../../../../utils/themes' );
 const { CustomizeStorePage } = require( '../../customize-store.page' );
 const { setOption } = require( '../../../../utils/options' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const test = base.extend( {
 	assemblerPageObject: async ( { page }, use ) => {
@@ -221,7 +222,7 @@ test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
 
 	test(
 		'Enabling the "use as site icon" option should set the image as the site icon',
-		{ tag: '@skip-on-default-pressable' },
+		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { page, assemblerPageObject, logoPickerPageObject } ) => {
 			const assembler = await assemblerPageObject.getAssembler();
 			const emptyLogoPicker =

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -24,7 +24,7 @@ const test = base.extend( {
 	},
 } );
 
-test.describe( 'Assembler -> Logo Picker', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler -> Logo Picker', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -2,6 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { activateTheme, DEFAULT_THEME } = require( '../../utils/themes' );
 const { setOption } = require( '../../utils/options' );
 const { AssemblerPage } = require( './assembler/assembler.page' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 const CUSTOMIZE_STORE_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store';
@@ -15,7 +16,7 @@ const test = base.extend( {
 
 test.describe(
 	'Store owner can view the Intro page',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -7,6 +7,7 @@ const {
 	createRequestsToSetupStoreDictionary,
 	setupRequestInterceptor,
 } = require( './loading-screen.utils' );
+const { tags } = require( '../../../fixtures/fixtures' );
 
 const test = base.extend( {
 	pageObject: async ( { page }, use ) => {
@@ -21,7 +22,7 @@ const steps = [
 	'Opening the doors',
 ];
 
-test.describe( 'Assembler - Loading Page', { tag: '@gutenberg' }, () => {
+test.describe( 'Assembler - Loading Page', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/transitional.spec.js
@@ -2,6 +2,7 @@ const { test: base, expect, request } = require( '@playwright/test' );
 const { setOption } = require( '../../utils/options' );
 const { activateTheme, DEFAULT_THEME } = require( '../../utils/themes' );
 const { AssemblerPage } = require( './assembler/assembler.page' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 const CUSTOMIZE_STORE_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store';
@@ -17,7 +18,7 @@ const test = base.extend( {
 
 test.describe(
 	'Store owner can view the Transitional page',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 /**
  * External dependencies
@@ -56,7 +56,7 @@ const test = baseTest.extend( {
 
 test(
 	'can use the "Add new product" command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page } ) => {
 		await clickOnCommandPaletteOption( {
 			page,
@@ -72,7 +72,7 @@ test(
 
 test(
 	'can use the "Add new order" command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page } ) => {
 		await clickOnCommandPaletteOption( {
 			page,
@@ -88,7 +88,7 @@ test(
 
 test(
 	'can use the "Products" command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page } ) => {
 		await clickOnCommandPaletteOption( {
 			page,
@@ -104,7 +104,7 @@ test(
 
 test(
 	'can use the "Orders" command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page } ) => {
 		await clickOnCommandPaletteOption( {
 			page,
@@ -120,7 +120,7 @@ test(
 
 test(
 	'can use the product search command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page, product } ) => {
 		await clickOnCommandPaletteOption( {
 			page,
@@ -136,7 +136,7 @@ test(
 
 test(
 	'can use a settings command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page } ) => {
 		await clickOnCommandPaletteOption( {
 			page,
@@ -150,7 +150,7 @@ test(
 
 test(
 	'can use an analytics command',
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page } ) => {
 		await clickOnCommandPaletteOption( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
@@ -22,7 +22,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Transform Classic Cart To Cart Block',
-	{ tag: [ '@gutenberg', tags.SERVICES, tags.SKIP_ON_PRESSABLE ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES, tags.SKIP_ON_PRESSABLE ] },
 	() => {
 		test( 'can transform classic cart to cart block', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const {
 	fillPageTitle,
 	transformIntoBlocks,
@@ -22,7 +22,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Transform Classic Cart To Cart Block',
-	{ tag: [ '@gutenberg', '@services', '@skip-on-default-pressable' ] },
+	{ tag: [ '@gutenberg', '@services', tags.SKIP_ON_PRESSABLE ] },
 	() => {
 		test( 'can transform classic cart to cart block', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-cart-block.spec.js
@@ -22,7 +22,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Transform Classic Cart To Cart Block',
-	{ tag: [ '@gutenberg', '@services', tags.SKIP_ON_PRESSABLE ] },
+	{ tag: [ '@gutenberg', tags.SERVICES, tags.SKIP_ON_PRESSABLE ] },
 	() => {
 		test( 'can transform classic cart to cart block', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const {
 	fillPageTitle,
 	transformIntoBlocks,
@@ -76,7 +76,7 @@ test.describe(
 
 		test(
 			'can transform classic checkout to checkout block',
-			{ tag: '@skip-on-default-pressable' },
+			{ tag: tags.SKIP_ON_PRESSABLE },
 			async ( { page, api, testPage } ) => {
 				await goToPageEditor( { page } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
@@ -29,7 +29,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Transform Classic Checkout To Checkout Block',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { api } ) => {
 			// enable COD

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-checkout-block.spec.js
@@ -29,7 +29,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Transform Classic Checkout To Checkout Block',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { api } ) => {
 			// enable COD

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const couponData = {
 	fixedCart: {
@@ -41,7 +41,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Coupon management',
-	{ tag: [ '@services', '@skip-on-default-wpcom' ] },
+	{ tag: [ '@services', tags.SKIP_ON_WPCOM ] },
 	() => {
 		for ( const couponType of Object.keys( couponData ) ) {
 			test( `can create new ${ couponType } coupon`, async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
@@ -41,7 +41,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Coupon management',
-	{ tag: [ '@services', tags.SKIP_ON_WPCOM ] },
+	{ tag: [ tags.SERVICES, tags.SKIP_ON_WPCOM ] },
 	() => {
 		for ( const couponType of Object.keys( couponData ) ) {
 			test( `can create new ${ couponType } coupon`, async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { random } = require( '../../utils/helpers' );
 
 const taxClasses = [
@@ -254,7 +254,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'WooCommerce Orders > Add new order',
-	{ tag: [ '@services', '@hpos' ] },
+	{ tag: [ tags.SERVICES, '@hpos' ] },
 	() => {
 		test.beforeAll( async ( { api } ) => {
 			// enable taxes on the account

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-order.spec.js
@@ -254,7 +254,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'WooCommerce Orders > Add new order',
-	{ tag: [ tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.beforeAll( async ( { api } ) => {
 			// enable taxes on the account

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest } = require( '../../fixtures/fixtures' );
+const { test: baseTest, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle, publishPage } = require( '../../utils/editor' );
 
 /**
@@ -16,7 +16,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Can create a new page',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		// eslint-disable-next-line playwright/expect-expect
 		test( 'can create new page', async ( { page, testPage } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-page.spec.js
@@ -16,7 +16,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Can create a new page',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		// eslint-disable-next-line playwright/expect-expect
 		test( 'can create new page', async ( { page, testPage } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest } = require( '../../fixtures/fixtures' );
+const { test: baseTest, tags } = require( '../../fixtures/fixtures' );
 const {
 	goToPostEditor,
 	fillPageTitle,
@@ -16,7 +16,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Can create a new post',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test( 'can create new post', async ( { page, testPost } ) => {
 			await goToPostEditor( { page } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -16,7 +16,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Can create a new post',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test( 'can create new post', async ( { page, testPost } ) => {
 			await goToPostEditor( { page } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
@@ -105,7 +105,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Restricted coupon management',
-	{ tag: [ '@services', tags.SKIP_ON_WPCOM ] },
+	{ tag: [ tags.SERVICES, tags.SKIP_ON_WPCOM ] },
 	() => {
 		for ( const couponType of Object.keys( couponData ) ) {
 			test( `can create new ${ couponType } coupon`, async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-restricted-coupons.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const couponData = {
 	minimumSpend: {
@@ -105,7 +105,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Restricted coupon management',
-	{ tag: [ '@services', '@skip-on-default-wpcom' ] },
+	{ tag: [ '@services', tags.SKIP_ON_WPCOM ] },
 	() => {
 		for ( const couponType of Object.keys( couponData ) ) {
 			test( `can create new ${ couponType } coupon`, async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle, publishPage } = require( '../../utils/editor' );
 const { getInstalledWordPressVersion } = require( '../../utils/wordpress' );
 
@@ -58,8 +58,8 @@ test.describe(
 		tag: [
 			'@gutenberg',
 			'@services',
-			'@skip-on-default-pressable',
-			'@skip-on-default-wpcom',
+			tags.SKIP_ON_PRESSABLE,
+			tags.SKIP_ON_WPCOM,
 		],
 	},
 	() => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -57,7 +57,7 @@ test.describe(
 	{
 		tag: [
 			'@gutenberg',
-			'@services',
+			tags.SERVICES,
 			tags.SKIP_ON_PRESSABLE,
 			tags.SKIP_ON_WPCOM,
 		],

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-blocks.spec.js
@@ -56,7 +56,7 @@ test.describe(
 	'Add WooCommerce Blocks Into Page',
 	{
 		tag: [
-			'@gutenberg',
+			tags.GUTENBERG,
 			tags.SERVICES,
 			tags.SKIP_ON_PRESSABLE,
 			tags.SKIP_ON_WPCOM,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-patterns.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-patterns.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle, publishPage } = require( '../../utils/editor' );
 const { getInstalledWordPressVersion } = require( '../../utils/wordpress' );
 
@@ -35,8 +35,8 @@ test.describe(
 		tag: [
 			'@gutenberg',
 			'@services',
-			'@skip-on-default-pressable',
-			'@skip-on-default-wpcom',
+			tags.SKIP_ON_PRESSABLE,
+			tags.SKIP_ON_WPCOM,
 		],
 	},
 	() => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-patterns.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-patterns.spec.js
@@ -33,7 +33,7 @@ test.describe(
 	'Add WooCommerce Patterns Into Page',
 	{
 		tag: [
-			'@gutenberg',
+			tags.GUTENBERG,
 			tags.SERVICES,
 			tags.SKIP_ON_PRESSABLE,
 			tags.SKIP_ON_WPCOM,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-patterns.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-woocommerce-patterns.spec.js
@@ -34,7 +34,7 @@ test.describe(
 	{
 		tag: [
 			'@gutenberg',
-			'@services',
+			tags.SERVICES,
 			tags.SKIP_ON_PRESSABLE,
 			tags.SKIP_ON_WPCOM,
 		],

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-list.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -86,7 +86,7 @@ test.describe( 'Merchant > Customer List', { tag: '@services' }, () => {
 
 	test(
 		'Merchant can view a list of all customers, filter and download',
-		{ tag: [ '@skip-on-default-pressable', '@skip-on-default-wpcom' ] },
+		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 		async ( { page, customers } ) => {
 			await test.step( 'Go to the customers reports page', async () => {
 				const responsePromise = page.waitForResponse(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-list.spec.js
@@ -78,7 +78,7 @@ const test = baseTest.extend( {
 	},
 } );
 
-test.describe( 'Merchant > Customer List', { tag: '@services' }, () => {
+test.describe( 'Merchant > Customer List', { tag: tags.SERVICES }, () => {
 	test.beforeEach( async ( { context } ) => {
 		// prevents the column picker from saving state between tests
 		await context.route( '**/users/**', ( route ) => route.abort() );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 let productId, orderId;
@@ -7,7 +8,7 @@ const productPrice = '15.99';
 
 test.describe(
 	'WooCommerce Merchant Flow: Orders > Customer Payment Page',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/customer-payment-page.spec.js
@@ -8,7 +8,7 @@ const productPrice = '15.99';
 
 test.describe(
 	'WooCommerce Merchant Flow: Orders > Customer Payment Page',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
@@ -5,7 +5,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Launch Your Store - logged in',
-	{ tag: [ '@gutenberg', '@services', tags.SKIP_ON_WPCOM ] },
+	{ tag: [ '@gutenberg', tags.SERVICES, tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
@@ -1,10 +1,11 @@
-const { test, expect, request } = require( '@playwright/test' );
+const { request } = require( '@playwright/test' );
+const { test, expect, tags } = require( '../../fixtures/fixtures' );
 const { setOption } = require( '../../utils/options' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Launch Your Store - logged in',
-	{ tag: [ '@gutenberg', '@services', '@skip-on-default-wpcom' ] },
+	{ tag: [ '@gutenberg', '@services', tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/launch-your-store.spec.js
@@ -5,7 +5,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Launch Your Store - logged in',
-	{ tag: [ '@gutenberg', tags.SERVICES, tags.SKIP_ON_WPCOM ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES, tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
@@ -1,7 +1,8 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
-test.describe( 'Bulk edit orders', { tag: [ '@services', '@hpos' ] }, () => {
+test.describe( 'Bulk edit orders', { tag: [ tags.SERVICES, '@hpos' ] }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	let orderId1, orderId2, orderId3, orderId4, orderId5;

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
@@ -2,7 +2,7 @@ const { test, expect } = require( '@playwright/test' );
 const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
-test.describe( 'Bulk edit orders', { tag: [ tags.SERVICES, '@hpos' ] }, () => {
+test.describe( 'Bulk edit orders', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	let orderId1, orderId2, orderId3, orderId4, orderId5;

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
@@ -2,140 +2,144 @@ const { test, expect } = require( '@playwright/test' );
 const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
-test.describe( 'Bulk edit orders', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
-	test.use( { storageState: process.env.ADMINSTATE } );
+test.describe(
+	'Bulk edit orders',
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
+	() => {
+		test.use( { storageState: process.env.ADMINSTATE } );
 
-	let orderId1, orderId2, orderId3, orderId4, orderId5;
+		let orderId1, orderId2, orderId3, orderId4, orderId5;
 
-	test.beforeAll( async ( { baseURL } ) => {
-		const api = new wcApi( {
-			url: baseURL,
-			consumerKey: process.env.CONSUMER_KEY,
-			consumerSecret: process.env.CONSUMER_SECRET,
-			version: 'wc/v3',
+		test.beforeAll( async ( { baseURL } ) => {
+			const api = new wcApi( {
+				url: baseURL,
+				consumerKey: process.env.CONSUMER_KEY,
+				consumerSecret: process.env.CONSUMER_SECRET,
+				version: 'wc/v3',
+			} );
+			await api
+				.post( 'orders', {
+					status: 'processing',
+				} )
+				.then( ( response ) => {
+					orderId1 = response.data.id;
+				} );
+			await api
+				.post( 'orders', {
+					status: 'processing',
+				} )
+				.then( ( response ) => {
+					orderId2 = response.data.id;
+				} );
+			await api
+				.post( 'orders', {
+					status: 'processing',
+				} )
+				.then( ( response ) => {
+					orderId3 = response.data.id;
+				} );
+			await api
+				.post( 'orders', {
+					status: 'processing',
+				} )
+				.then( ( response ) => {
+					orderId4 = response.data.id;
+				} );
+			await api
+				.post( 'orders', {
+					status: 'processing',
+				} )
+				.then( ( response ) => {
+					orderId5 = response.data.id;
+				} );
 		} );
-		await api
-			.post( 'orders', {
-				status: 'processing',
-			} )
-			.then( ( response ) => {
-				orderId1 = response.data.id;
-			} );
-		await api
-			.post( 'orders', {
-				status: 'processing',
-			} )
-			.then( ( response ) => {
-				orderId2 = response.data.id;
-			} );
-		await api
-			.post( 'orders', {
-				status: 'processing',
-			} )
-			.then( ( response ) => {
-				orderId3 = response.data.id;
-			} );
-		await api
-			.post( 'orders', {
-				status: 'processing',
-			} )
-			.then( ( response ) => {
-				orderId4 = response.data.id;
-			} );
-		await api
-			.post( 'orders', {
-				status: 'processing',
-			} )
-			.then( ( response ) => {
-				orderId5 = response.data.id;
-			} );
-	} );
 
-	test.afterAll( async ( { baseURL } ) => {
-		const api = new wcApi( {
-			url: baseURL,
-			consumerKey: process.env.CONSUMER_KEY,
-			consumerSecret: process.env.CONSUMER_SECRET,
-			version: 'wc/v3',
+		test.afterAll( async ( { baseURL } ) => {
+			const api = new wcApi( {
+				url: baseURL,
+				consumerKey: process.env.CONSUMER_KEY,
+				consumerSecret: process.env.CONSUMER_SECRET,
+				version: 'wc/v3',
+			} );
+			await api.delete( `orders/${ orderId1 }`, { force: true } );
+			await api.delete( `orders/${ orderId2 }`, { force: true } );
+			await api.delete( `orders/${ orderId3 }`, { force: true } );
+			await api.delete( `orders/${ orderId4 }`, { force: true } );
+			await api.delete( `orders/${ orderId5 }`, { force: true } );
 		} );
-		await api.delete( `orders/${ orderId1 }`, { force: true } );
-		await api.delete( `orders/${ orderId2 }`, { force: true } );
-		await api.delete( `orders/${ orderId3 }`, { force: true } );
-		await api.delete( `orders/${ orderId4 }`, { force: true } );
-		await api.delete( `orders/${ orderId5 }`, { force: true } );
-	} );
 
-	test( 'can bulk update order status', async ( { page } ) => {
-		await page.goto( 'wp-admin/admin.php?page=wc-orders' );
+		test( 'can bulk update order status', async ( { page } ) => {
+			await page.goto( 'wp-admin/admin.php?page=wc-orders' );
 
-		// expect order status 'processing' to show
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId1 }, #post-${ orderId1 })` )
-				.getByText( 'Processing' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId2 }, #post-${ orderId2 })` )
-				.getByText( 'Processing' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId3 }, #post-${ orderId3 })` )
-				.getByText( 'Processing' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId4 }, #post-${ orderId4 })` )
-				.getByText( 'Processing' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId5 }, #post-${ orderId5 })` )
-				.getByText( 'Processing' )
-				.nth( 1 )
-		).toBeVisible();
+			// expect order status 'processing' to show
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId1 }, #post-${ orderId1 })` )
+					.getByText( 'Processing' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId2 }, #post-${ orderId2 })` )
+					.getByText( 'Processing' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId3 }, #post-${ orderId3 })` )
+					.getByText( 'Processing' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId4 }, #post-${ orderId4 })` )
+					.getByText( 'Processing' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId5 }, #post-${ orderId5 })` )
+					.getByText( 'Processing' )
+					.nth( 1 )
+			).toBeVisible();
 
-		await page.locator( '#cb-select-all-1' ).click();
-		await page
-			.locator( '#bulk-action-selector-top' )
-			.selectOption( 'Change status to completed' );
-		await page.locator( '#doaction' ).click();
+			await page.locator( '#cb-select-all-1' ).click();
+			await page
+				.locator( '#bulk-action-selector-top' )
+				.selectOption( 'Change status to completed' );
+			await page.locator( '#doaction' ).click();
 
-		// expect order status 'completed' to show
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId1 }, #post-${ orderId1 })` )
-				.getByText( 'Completed' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId2 }, #post-${ orderId2 })` )
-				.getByText( 'Completed' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId3 }, #post-${ orderId3 })` )
-				.getByText( 'Completed' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId4 }, #post-${ orderId4 })` )
-				.getByText( 'Completed' )
-				.nth( 1 )
-		).toBeVisible();
-		await expect(
-			page
-				.locator( `:is(#order-${ orderId5 }, #post-${ orderId5 })` )
-				.getByText( 'Completed' )
-				.nth( 1 )
-		).toBeVisible();
-	} );
-} );
+			// expect order status 'completed' to show
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId1 }, #post-${ orderId1 })` )
+					.getByText( 'Completed' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId2 }, #post-${ orderId2 })` )
+					.getByText( 'Completed' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId3 }, #post-${ orderId3 })` )
+					.getByText( 'Completed' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId4 }, #post-${ orderId4 })` )
+					.getByText( 'Completed' )
+					.nth( 1 )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( `:is(#order-${ orderId5 }, #post-${ orderId5 })` )
+					.getByText( 'Completed' )
+					.nth( 1 )
+			).toBeVisible();
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
@@ -11,7 +11,7 @@ const discountedPrice = ( productPrice - couponAmount ).toString();
 
 test.describe(
 	'WooCommerce Orders > Apply Coupon',
-	{ tag: [ tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
@@ -11,7 +11,7 @@ const discountedPrice = ( productPrice - couponAmount ).toString();
 
 test.describe(
 	'WooCommerce Orders > Apply Coupon',
-	{ tag: [ '@services', '@hpos' ] },
+	{ tag: [ tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require( '@playwright/test' );
+const { test, expect, tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 let productId, couponId, orderId;
@@ -121,7 +121,7 @@ test.describe(
 
 		test(
 			'can remove a coupon',
-			{ tag: [ '@skip-on-default-wpcom' ] },
+			{ tag: [ tags.SKIP_ON_WPCOM ] },
 			async ( { page } ) => {
 				await page.goto(
 					`wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -3,7 +3,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const uuid = require( 'uuid' );
 const { tags } = require( '../../fixtures/fixtures' );
 
-test.describe( 'Edit order', { tag: [ tags.SERVICES, '@hpos' ] }, () => {
+test.describe( 'Edit order', { tag: [ tags.SERVICES, tags.HPOS ] }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	let orderId, secondOrderId, orderToCancel, customerId;
@@ -370,7 +370,7 @@ test.describe( 'Edit order', { tag: [ tags.SERVICES, '@hpos' ] }, () => {
 
 test.describe(
 	'Edit order > Downloadable product permissions',
-	{ tag: [ tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -1,8 +1,9 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const uuid = require( 'uuid' );
+const { tags } = require( '../../fixtures/fixtures' );
 
-test.describe( 'Edit order', { tag: [ '@services', '@hpos' ] }, () => {
+test.describe( 'Edit order', { tag: [ tags.SERVICES, '@hpos' ] }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	let orderId, secondOrderId, orderToCancel, customerId;
@@ -369,7 +370,7 @@ test.describe( 'Edit order', { tag: [ '@services', '@hpos' ] }, () => {
 
 test.describe(
 	'Edit order > Downloadable product permissions',
-	{ tag: [ '@services', '@hpos' ] },
+	{ tag: [ tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -6,7 +6,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Merchant > Order Action emails received',
-	{ tag: [ tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -6,7 +6,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Merchant > Order Action emails received',
-	{ tag: [ '@services', '@hpos' ] },
+	{ tag: [ tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const { admin } = require( '../../test-data/data' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -121,7 +122,7 @@ test.describe(
 
 		test(
 			'can receive completed email',
-			{ tag: '@skip-on-default-wpcom' },
+			{ tag: tags.SKIP_ON_WPCOM },
 			async ( { page, baseURL } ) => {
 				// Completed order emails are sent automatically when an order's payment is completed.
 				// Verify that the email is sent, and that the content is the expected one

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-refund.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-refund.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe.serial(
@@ -143,7 +144,7 @@ test.describe.serial(
 
 test.describe(
 	'WooCommerce Orders > Refund and restock an order item',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		let productWithStockId, productWithNoStockId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-refund.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-refund.spec.js
@@ -144,7 +144,7 @@ test.describe.serial(
 
 test.describe(
 	'WooCommerce Orders > Refund and restock an order item',
-	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		let productWithStockId, productWithNoStockId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-refund.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-refund.spec.js
@@ -4,7 +4,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe.serial(
 	'WooCommerce Orders > Refund an order',
-	{ tag: [ '@payments', '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.HPOS ] },
 	() => {
 		let productId, orderId, currencySymbol;
 
@@ -144,7 +144,7 @@ test.describe.serial(
 
 test.describe(
 	'WooCommerce Orders > Refund and restock an order item',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@hpos' ] },
 	() => {
 		let productWithStockId, productWithNoStockId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-search.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-search.spec.js
@@ -72,7 +72,7 @@ const deleteCustomer = async ( api ) => {
 
 test.describe(
 	'WooCommerce Orders > Search orders',
-	{ tag: [ tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-search.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-search.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 const searchString = 'James Doe';
@@ -71,7 +72,7 @@ const deleteCustomer = async ( api ) => {
 
 test.describe(
 	'WooCommerce Orders > Search orders',
-	{ tag: [ '@services', '@hpos' ] },
+	{ tag: [ tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-status-filter.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-status-filter.spec.js
@@ -19,7 +19,7 @@ const orderStatus = [
 
 test.describe(
 	'WooCommerce Orders > Filter Order by Status',
-	{ tag: [ tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-status-filter.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-status-filter.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 const orderBatchId = [];
@@ -18,7 +19,7 @@ const orderStatus = [
 
 test.describe(
 	'WooCommerce Orders > Filter Order by Status',
-	{ tag: [ '@services', '@hpos' ] },
+	{ tag: [ tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -114,7 +114,7 @@ for ( const currentPage of wcPages ) {
 	};
 	test.describe(
 		`WooCommerce Page Load > Load ${ currentPage.name } sub pages`,
-		{ tag: [ '@gutenberg', '@services' ] },
+		{ tag: [ '@gutenberg', tags.SERVICES ] },
 		() => {
 			test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -114,7 +114,7 @@ for ( const currentPage of wcPages ) {
 	};
 	test.describe(
 		`WooCommerce Page Load > Load ${ currentPage.name } sub pages`,
-		{ tag: [ '@gutenberg', tags.SERVICES ] },
+		{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 		() => {
 			test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 // a representation of the menu structure for WC
@@ -203,7 +204,7 @@ for ( const currentPage of wcPages ) {
 			for ( let i = 0; i < currentPage.subpages.length; i++ ) {
 				test(
 					`Can load ${ currentPage.subpages[ i ].name }`,
-					{ tag: '@skip-on-default-wpcom' },
+					{ tag: tags.SKIP_ON_WPCOM },
 					async ( { page } ) => {
 						await page
 							.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const productData = {
 	virtual: {
@@ -66,7 +66,7 @@ const test = baseTest.extend( {
 for ( const productType of Object.keys( productData ) ) {
 	test(
 		`can create a simple ${ productType } product`,
-		{ tag: [ '@gutenberg', '@services' ] },
+		{ tag: [ '@gutenberg', tags.SERVICES ] },
 		async ( { page, category, product } ) => {
 			await test.step( 'add new product', async () => {
 				await page.goto( 'wp-admin/post-new.php?post_type=product' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -66,7 +66,7 @@ const test = baseTest.extend( {
 for ( const productType of Object.keys( productData ) ) {
 	test(
 		`can create a simple ${ productType } product`,
-		{ tag: [ '@gutenberg', tags.SERVICES ] },
+		{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 		async ( { page, category, product } ) => {
 			await test.step( 'add new product', async () => {
 				await page.goto( 'wp-admin/post-new.php?post_type=product' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-delete.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-delete.spec.js
@@ -36,7 +36,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Products > Delete Product',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test( 'can delete a product from edit view', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-delete.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-delete.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -36,7 +36,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Products > Delete Product',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test( 'can delete a product from edit view', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-edit.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -32,7 +32,7 @@ const test = baseTest.extend( {
 
 test(
 	'can edit a product and save the changes',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto(
 			`wp-admin/post.php?post=${ products[ 0 ].id }&action=edit`
@@ -92,7 +92,7 @@ test(
 
 test(
 	'can bulk edit products',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto( `wp-admin/edit.php?post_type=product` );
 
@@ -191,7 +191,7 @@ test(
 
 test(
 	'can restore regular price when bulk editing products',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto( `wp-admin/edit.php?post_type=product` );
 
@@ -288,7 +288,7 @@ test(
 
 test(
 	'can decrease the sale price if the product was not previously in sale when bulk editing products',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto( `wp-admin/edit.php?post_type=product` );
 
@@ -342,7 +342,7 @@ test(
 
 test(
 	'increasing the sale price from 0 does not change the sale price when bulk editing products',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	async ( { page, api, products } ) => {
 		let product;
 		await api

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-edit.spec.js
@@ -32,7 +32,7 @@ const test = baseTest.extend( {
 
 test(
 	'can edit a product and save the changes',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto(
 			`wp-admin/post.php?post=${ products[ 0 ].id }&action=edit`
@@ -92,7 +92,7 @@ test(
 
 test(
 	'can bulk edit products',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto( `wp-admin/edit.php?post_type=product` );
 
@@ -191,7 +191,7 @@ test(
 
 test(
 	'can restore regular price when bulk editing products',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto( `wp-admin/edit.php?post_type=product` );
 
@@ -288,7 +288,7 @@ test(
 
 test(
 	'can decrease the sale price if the product was not previously in sale when bulk editing products',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	async ( { page, products } ) => {
 		await page.goto( `wp-admin/edit.php?post_type=product` );
 
@@ -342,7 +342,7 @@ test(
 
 test(
 	'increasing the sale price from 0 does not change the sale price when bulk editing products',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	async ( { page, api, products } ) => {
 		let product;
 		await api

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
@@ -73,7 +73,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Products > Product Images',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test( 'can set product image', async ( { page, product } ) => {
 			await test.step( 'Navigate to product edit page', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-images.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 async function addImageFromLibrary( page, imageName, actionButtonName ) {
 	await page.getByRole( 'tab', { name: 'Media Library' } ).click();
@@ -73,7 +73,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Products > Product Images',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test( 'can set product image', async ( { page, product } ) => {
 			await test.step( 'Navigate to product edit page', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const path = require( 'path' );
+const { tags } = require( '../../fixtures/fixtures' );
 const filePath = path.resolve( 'tests/e2e-pw/test-data/sample_products.csv' );
 const filePathOverride = path.resolve(
 	'tests/e2e-pw/test-data/sample_products_override.csv'
@@ -93,7 +94,7 @@ const errorMessage = 'File is empty. Please upload something more substantial.';
 
 test.describe.serial(
 	'Import Products from a CSV file',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
@@ -94,7 +94,7 @@ const errorMessage = 'File is empty. Please upload something more substantial.';
 
 test.describe.serial(
 	'Import Products from a CSV file',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-linked-products.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-linked-products.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -29,7 +29,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Products > Related products',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		async function navigate( page, productId ) {
 			await test.step( 'Navigate to product edit page', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-linked-products.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-linked-products.spec.js
@@ -29,7 +29,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Products > Related products',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		async function navigate( page, productId ) {
 			await test.step( 'Navigate to product edit page', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-reviews.spec.js
@@ -49,7 +49,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Product Reviews',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test( 'can view products reviews list', async ( { page, reviews } ) => {
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-reviews.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -49,7 +49,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Product Reviews',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test( 'can view products reviews list', async ( { page, reviews } ) => {
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-search.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-search.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 let productId;
@@ -9,7 +10,7 @@ const productPrice = '9.99';
 
 test.describe(
 	'Products > Search and View a product',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-search.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-search.spec.js
@@ -10,7 +10,7 @@ const productPrice = '9.99';
 
 test.describe(
 	'Products > Search and View a product',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-settings.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-settings.spec.js
@@ -1,8 +1,9 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 test.describe(
 	'WooCommerce Products > Downloadable Product Settings',
-	{ tag: [ '@gutenberg', '@services' ] },
+	{ tag: [ '@gutenberg', tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-settings.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-settings.spec.js
@@ -3,7 +3,7 @@ const { tags } = require( '../../fixtures/fixtures' );
 
 test.describe(
 	'WooCommerce Products > Downloadable Product Settings',
-	{ tag: [ '@gutenberg', tags.SERVICES ] },
+	{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-product-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-product-attributes.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const { variableProducts: utils } = require( '../../../../utils' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 const {
 	createVariableProduct,
 	showVariableProductTour,
@@ -25,7 +26,7 @@ const step_goToAttributesTab = async ( page ) => {
 
 test.describe.configure( { mode: 'serial' } );
 
-test.describe( 'Add product attributes', { tag: '@gutenberg' }, () => {
+test.describe( 'Add product attributes', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { browser } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variable-product.spec.js
@@ -1,12 +1,13 @@
 const { test, expect } = require( '@playwright/test' );
 const { variableProducts: utils, api } = require( '../../../../utils' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 const { showVariableProductTour } = utils;
 const productPageURL = 'wp-admin/post-new.php?post_type=product';
 const variableProductName = 'Variable Product with Three Variations';
 
 let productId;
 
-test.describe( 'Add variable product', { tag: '@gutenberg' }, () => {
+test.describe( 'Add variable product', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { browser } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variations.spec.js
@@ -14,7 +14,7 @@ let expectedGeneratedVariations,
 	productId_generateVariations,
 	variationsToManuallyCreate;
 
-test.describe( 'Add variations', { tag: '@gutenberg' }, () => {
+test.describe( 'Add variations', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { browser } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variations.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 const { variableProducts: utils } = require( '../../../../utils' );
 const {
 	createVariableProduct,
@@ -86,7 +87,7 @@ test.describe( 'Add variations', { tag: '@gutenberg' }, () => {
 
 	test(
 		'can manually add a variation',
-		{ tag: '@skip-on-default-wpcom' },
+		{ tag: tags.SKIP_ON_WPCOM },
 		async ( { page } ) => {
 			await test.step( `Open "Edit product" page of product id ${ productId_addManually }`, async () => {
 				await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/update-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/update-variations.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const { variableProducts: utils } = require( '../../../../utils' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 const {
 	createVariableProduct,
 	showVariableProductTour,
@@ -27,7 +28,7 @@ let productId_indivEdit,
 	defaultVariation,
 	variationIds_indivEdit;
 
-test.describe( 'Update variations', { tag: '@gutenberg' }, () => {
+test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { browser } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-grouped-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-grouped-product-block-editor.spec.js
@@ -3,6 +3,7 @@ const { expect } = require( '@playwright/test' );
 
 const { clickOnTab } = require( '../../../../utils/simple-products' );
 const { api } = require( '../../../../utils' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
@@ -29,7 +30,7 @@ const groupedProductsData = [
 
 const productIds = [];
 
-test.describe( 'General tab', { tag: '@gutenberg' }, () => {
+test.describe( 'General tab', { tag: tags.GUTENBERG }, () => {
 	test.describe( 'Grouped product', () => {
 		test.beforeAll( async () => {
 			for ( const product of groupedProductsData ) {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -6,6 +6,7 @@ const {
 	getInstalledWordPressVersion,
 } = require( '../../../../utils/wordpress' );
 const { insertBlock } = require( '../../../../utils/editor' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
@@ -61,7 +62,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 		test(
 			'can create a simple product',
-			{ tag: '@skip-on-default-pressable' },
+			{ tag: tags.SKIP_ON_PRESSABLE },
 			async ( { page } ) => {
 				await test.step( 'add new product', async () => {
 					await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -37,7 +37,7 @@ const productData = {
 
 test.describe.configure( { mode: 'serial' } );
 
-test.describe( 'General tab', { tag: '@gutenberg' }, () => {
+test.describe( 'General tab', { tag: tags.GUTENBERG }, () => {
 	test.describe( 'Simple product form', () => {
 		test( 'renders each block without error', async ( { page } ) => {
 			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -41,7 +41,7 @@ let productId_editVariations,
 	productId_deleteVariations,
 	productId_singleVariation;
 
-test.describe( 'Variations tab', { tag: '@gutenberg' }, () => {
+test.describe( 'Variations tab', { tag: tags.GUTENBERG }, () => {
 	test.describe( 'Create variable products', () => {
 		test.beforeAll( async ( { browser } ) => {
 			productId_editVariations = await createVariableProduct(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-variable-product-block-editor.spec.js
@@ -13,6 +13,7 @@ const tabs = require( './data/tabs' );
 const {
 	waitForGlobalAttributesLoaded,
 } = require( './helpers/wait-for-global-attributes-loaded' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const {
 	createVariableProduct,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
@@ -7,6 +7,7 @@ const {
 	toggleBlockProductEditor,
 } = require( '../../../../utils/simple-products' );
 const { toggleBlockProductTour } = require( '../../../../utils/tours' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 let isNewProductEditorEnabled = false;
 
@@ -22,7 +23,7 @@ async function dismissFeedbackModalIfShown( page ) {
 
 test.describe.serial(
 	'Disable block product editor',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/enable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/enable-block-product-editor.spec.js
@@ -6,6 +6,7 @@ const {
 	isBlockProductEditorEnabled,
 	toggleBlockProductEditor,
 } = require( '../../../../utils/simple-products' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const ALL_PRODUCTS_URL = 'wp-admin/edit.php?post_type=product';
 const NEW_EDITOR_ADD_PRODUCT_URL =
@@ -26,7 +27,7 @@ async function disableNewEditorIfEnabled( browser ) {
 
 test.describe.configure( { mode: 'serial' } );
 
-test.describe( 'Enable block product editor', { tag: '@gutenberg' }, () => {
+test.describe( 'Enable block product editor', { tag: tags.GUTENBERG }, () => {
 	test.describe( 'Enabled', () => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -3,6 +3,7 @@ const { expect } = require( '@playwright/test' );
 
 const { clickOnTab } = require( '../../../../utils/simple-products' );
 const { helpers } = require( '../../../../utils' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
@@ -70,7 +71,7 @@ test.describe( 'General tab', { tag: '@gutenberg' }, () => {
 
 		test(
 			'can create a product with linked products',
-			{ tag: '@skip-on-default-pressable' },
+			{ tag: tags.SKIP_ON_PRESSABLE },
 			async ( { page } ) => {
 				await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
 				await clickOnTab( 'General', page );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/linked-product-tab-product-block-editor.spec.js
@@ -23,7 +23,7 @@ const linkedProductsData = [],
 	productIds = [];
 let productId = 0;
 
-test.describe( 'General tab', { tag: '@gutenberg' }, () => {
+test.describe( 'General tab', { tag: tags.GUTENBERG }, () => {
 	test.describe( 'Linked product', () => {
 		test.beforeAll( async ( { api } ) => {
 			await api

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/organization-tab-product-block-editor.spec.js
@@ -2,6 +2,7 @@ const { test } = require( '../../../../fixtures/block-editor-fixtures' );
 const { expect } = require( '@playwright/test' );
 
 const { clickOnTab } = require( '../../../../utils/simple-products' );
+const { tags } = require( '../../../../fixtures/fixtures' );
 
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
@@ -21,7 +22,7 @@ const tagName = `my-tag-${ new Date().getTime().toString() }`;
 
 test.describe.configure( { mode: 'serial' } );
 
-test.describe( 'General tab', { tag: '@gutenberg' }, () => {
+test.describe( 'General tab', { tag: tags.GUTENBERG }, () => {
 	test.describe( 'Create product - Organization tab', () => {
 		let productId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-attributes-block-editor.spec.js
@@ -1,7 +1,7 @@
 const {
 	test: baseTest,
 } = require( '../../../../fixtures/block-editor-fixtures' );
-const { expect } = require( '../../../../fixtures/fixtures' );
+const { expect, tags } = require( '../../../../fixtures/fixtures' );
 const { updateProduct } = require( '../../../../utils/product-block-editor' );
 const { clickOnTab } = require( '../../../../utils/simple-products' );
 const attributesData = require( './fixtures/attributes' );
@@ -101,7 +101,7 @@ const test = baseTest.extend( {
 
 test(
 	'add local attribute (with terms) to the Product',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, product } ) => {
 		await test.step( 'go to product editor -> Organization tab -> Click on `Add new`', async () => {
 			await page.goto(
@@ -272,7 +272,7 @@ test(
 
 test(
 	'can add existing attributes',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, product, attributes } ) => {
 		await test.step( 'go to product editor, Organization tab', async () => {
 			await page.goto(
@@ -358,7 +358,7 @@ test(
 
 test(
 	'can update product attributes',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, productWithAttributes } ) => {
 		const attribute = productWithAttributes.attributes[ 0 ];
 
@@ -462,7 +462,7 @@ test(
 
 test(
 	'can remove product attributes',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, productWithAttributes, attributes } ) => {
 		await test.step( 'go to product editor, Organization tab', async () => {
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-edit-block-editor.spec.js
@@ -1,7 +1,7 @@
 const {
 	test: baseTest,
 } = require( '../../../../fixtures/block-editor-fixtures' );
-const { expect } = require( '../../../../fixtures/fixtures' );
+const { expect, tags } = require( '../../../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	product: async ( { api }, use ) => {
@@ -29,7 +29,7 @@ const test = baseTest.extend( {
 
 test(
 	'can update the general information of a product',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, product } ) => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
 
@@ -82,7 +82,7 @@ test(
 	}
 );
 
-test.describe( 'Publish dropdown options', { tag: '@gutenberg' }, () => {
+test.describe( 'Publish dropdown options', { tag: tags.GUTENBERG }, () => {
 	test( 'can schedule a product publication', async ( { page, product } ) => {
 		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-images-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-images-block-editor.spec.js
@@ -1,7 +1,7 @@
 const {
 	test: baseTest,
 } = require( '../../../../fixtures/block-editor-fixtures' );
-const { expect } = require( '../../../../fixtures/fixtures' );
+const { expect, tags } = require( '../../../../fixtures/fixtures' );
 
 async function selectImagesInLibrary( page, imagesNames ) {
 	const dataIds = [];
@@ -70,55 +70,61 @@ const test = baseTest.extend( {
 	},
 } );
 
-test( 'can add images', { tag: '@gutenberg' }, async ( { page, product } ) => {
-	const images = [ 'image-01', 'image-02' ];
+test(
+	'can add images',
+	{ tag: tags.GUTENBERG },
+	async ( { page, product } ) => {
+		const images = [ 'image-01', 'image-02' ];
 
-	await test.step( 'navigate to product edit page', async () => {
-		await page.goto( `wp-admin/post.php?post=${ product.id }&action=edit` );
-	} );
+		await test.step( 'navigate to product edit page', async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ product.id }&action=edit`
+			);
+		} );
 
-	await test.step( 'add images', async () => {
-		await page.getByText( 'Choose an image' ).click();
-		const dataIds = await selectImagesInLibrary( page, images );
+		await test.step( 'add images', async () => {
+			await page.getByText( 'Choose an image' ).click();
+			const dataIds = await selectImagesInLibrary( page, images );
 
-		await expect(
-			page.getByLabel( 'Block: Product images' ).locator( 'img' )
-		).toHaveCount( images.length );
-
-		for ( const dataId of dataIds ) {
 			await expect(
-				page
-					.getByLabel( 'Block: Product images' )
-					.locator( `img[id="${ dataId }"]` )
-			).toBeVisible();
-		}
-	} );
+				page.getByLabel( 'Block: Product images' ).locator( 'img' )
+			).toHaveCount( images.length );
 
-	await test.step( 'update the product', async () => {
-		await page.getByRole( 'button', { name: 'Update' } ).click();
-		// Verify product was updated
-		await expect( page.getByLabel( 'Dismiss this notice' ) ).toContainText(
-			'Product updated'
-		);
-	} );
+			for ( const dataId of dataIds ) {
+				await expect(
+					page
+						.getByLabel( 'Block: Product images' )
+						.locator( `img[id="${ dataId }"]` )
+				).toBeVisible();
+			}
+		} );
 
-	await test.step( 'verify product image was set', async () => {
-		// Verify image in store frontend
-		await page.goto( product.permalink );
-
-		for ( const image of images ) {
+		await test.step( 'update the product', async () => {
+			await page.getByRole( 'button', { name: 'Update' } ).click();
+			// Verify product was updated
 			await expect(
-				// By scopping the locator to the link, we exclude the zoom image and
-				// ensure the correct image is displayed.
-				page.locator( `a > img[src*="${ image }"]` )
-			).toBeVisible();
-		}
-	} );
-} );
+				page.getByLabel( 'Dismiss this notice' )
+			).toContainText( 'Product updated' );
+		} );
+
+		await test.step( 'verify product image was set', async () => {
+			// Verify image in store frontend
+			await page.goto( product.permalink );
+
+			for ( const image of images ) {
+				await expect(
+					// By scopping the locator to the link, we exclude the zoom image and
+					// ensure the correct image is displayed.
+					page.locator( `a > img[src*="${ image }"]` )
+				).toBeVisible();
+			}
+		} );
+	}
+);
 
 test(
 	'can replace an image',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, productWithGallery } ) => {
 		const initialImagesCount = productWithGallery.images.length;
 		const newImageName = 'image-01';
@@ -175,7 +181,7 @@ test(
 
 test(
 	'can remove an image',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, productWithGallery } ) => {
 		const initialImagesCount = productWithGallery.images.length;
 		const removedImgLocator = page
@@ -226,7 +232,7 @@ test(
 
 test(
 	'can set an image as cover',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, productWithGallery } ) => {
 		const newCoverImgLocator = page
 			.getByLabel( 'Block: Product images' )

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-inventory-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/product-inventory-block-editor.spec.js
@@ -1,7 +1,7 @@
 const {
 	test: baseTest,
 } = require( '../../../../fixtures/block-editor-fixtures' );
-const { expect } = require( '../../../../fixtures/fixtures' );
+const { expect, tags } = require( '../../../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	product: async ( { api }, use ) => {
@@ -45,39 +45,45 @@ const test = baseTest.extend( {
 	},
 } );
 
-test( 'can update sku', { tag: '@gutenberg' }, async ( { page, product } ) => {
-	const sku = `SKU_${ Date.now() }`;
+test(
+	'can update sku',
+	{ tag: tags.GUTENBERG },
+	async ( { page, product } ) => {
+		const sku = `SKU_${ Date.now() }`;
 
-	await test.step( 'update the sku value', async () => {
-		await page.locator( '[name="woocommerce-product-sku"]' ).click();
-		await page.locator( '[name="woocommerce-product-sku"]' ).fill( sku );
-	} );
+		await test.step( 'update the sku value', async () => {
+			await page.locator( '[name="woocommerce-product-sku"]' ).click();
+			await page
+				.locator( '[name="woocommerce-product-sku"]' )
+				.fill( sku );
+		} );
 
-	await test.step( 'update the product', async () => {
-		await page.getByRole( 'button', { name: 'Update' } ).click();
-		// Verify product was updated
-		await expect( page.getByLabel( 'Dismiss this notice' ) ).toContainText(
-			'Product updated'
-		);
-	} );
+		await test.step( 'update the product', async () => {
+			await page.getByRole( 'button', { name: 'Update' } ).click();
+			// Verify product was updated
+			await expect(
+				page.getByLabel( 'Dismiss this notice' )
+			).toContainText( 'Product updated' );
+		} );
 
-	await test.step( 'verify the change in product editor', async () => {
-		await expect(
-			page.locator( '[name="woocommerce-product-sku"]' )
-		).toHaveValue( sku );
-	} );
+		await test.step( 'verify the change in product editor', async () => {
+			await expect(
+				page.locator( '[name="woocommerce-product-sku"]' )
+			).toHaveValue( sku );
+		} );
 
-	await test.step( 'verify the changes in the store frontend', async () => {
-		// Verify image in store frontend
-		await page.goto( product.permalink );
+		await test.step( 'verify the changes in the store frontend', async () => {
+			// Verify image in store frontend
+			await page.goto( product.permalink );
 
-		await expect( page.getByText( `SKU: ${ sku }` ) ).toBeVisible();
-	} );
-} );
+			await expect( page.getByText( `SKU: ${ sku }` ) ).toBeVisible();
+		} );
+	}
+);
 
 test(
 	'can update stock status',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, product } ) => {
 		await test.step( 'update the sku value', async () => {
 			await page.getByLabel( 'Out of stock' ).check();
@@ -106,7 +112,7 @@ test(
 
 test(
 	'can track stock quantity',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, product } ) => {
 		await test.step( 'enable track stock quantity', async () => {
 			await page.getByLabel( 'Track inventory' ).check();
@@ -184,7 +190,7 @@ test(
 
 test(
 	'can limit purchases',
-	{ tag: '@gutenberg' },
+	{ tag: tags.GUTENBERG },
 	async ( { page, product } ) => {
 		await test.step( 'ensure limit purchases is disabled', async () => {
 			// await closeTourModal( { page, timeout: 2000 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-general.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-general.spec.js
@@ -1,7 +1,8 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
-test.describe( 'WooCommerce General Settings', { tag: '@services' }, () => {
+test.describe( 'WooCommerce General Settings', { tag: tags.SERVICES }, () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.afterAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
@@ -5,7 +5,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 test.describe(
 	'WooCommerce woo.com Settings',
 	{
-		tag: [ '@services', tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ],
+		tag: [ tags.SERVICES, tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ],
 	},
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
@@ -1,14 +1,11 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'WooCommerce woo.com Settings',
 	{
-		tag: [
-			'@services',
-			'@skip-on-default-pressable',
-			'@skip-on-default-wpcom',
-		],
+		tag: [ '@services', tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ],
 	},
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-create.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-create.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { logIn } = require( '../../utils/login' );
 
 const now = Date.now();
@@ -32,7 +32,7 @@ const test = baseTest.extend( {
 for ( const userData of users ) {
 	test(
 		`can create a new ${ userData.role }`,
-		{ tag: '@services' },
+		{ tag: tags.SERVICES },
 		async ( { page, user } ) => {
 			await page.goto( `wp-admin/user-new.php` );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/users-manage.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -85,7 +85,7 @@ async function userDeletionTest( page, username ) {
 
 test(
 	`can update customer data`,
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page, customer } ) => {
 		await page.goto( `wp-admin/user-edit.php?user_id=${ customer.id }` );
 		await expect( page ).toHaveTitle( /Edit User/ );
@@ -300,7 +300,7 @@ test(
 
 test(
 	`can update shop manager data`,
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page, manager } ) => {
 		await page.goto( `wp-admin/user-edit.php?user_id=${ manager.id }` );
 		await expect( page ).toHaveTitle( /Edit User/ );
@@ -333,7 +333,7 @@ test(
 
 test(
 	`can delete a customer`,
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page, customer } ) => {
 		expect(
 			await userDeletionTest( page, customer.username )
@@ -343,7 +343,7 @@ test(
 
 test(
 	`can delete a shop manager`,
-	{ tag: '@services' },
+	{ tag: tags.SERVICES },
 	async ( { page, manager } ) => {
 		expect( await userDeletionTest( page, manager.username ) ).toBeTruthy();
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { admin, customer } = require( '../../test-data/data' );
 
 const emailContent = '#wp-mail-logging-modal-content-body-content';
@@ -23,7 +23,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Shopper Account Email Receiving',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.beforeEach( async ( { page, user } ) => {
 			await page.goto(
@@ -197,7 +197,7 @@ test.describe(
 
 test.describe(
 	'Shopper Password Reset Email Receiving',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.beforeEach( async ( { page } ) => {
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
@@ -23,7 +23,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Shopper Account Email Receiving',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeEach( async ( { page, user } ) => {
 			await page.goto(
@@ -197,7 +197,7 @@ test.describe(
 
 test.describe(
 	'Shopper Password Reset Email Receiving',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeEach( async ( { page } ) => {
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
@@ -12,7 +12,7 @@ const productPrice = '13.99';
 
 test.describe(
 	'Add to Cart behavior',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		let productId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { tags } = require( '../../fixtures/fixtures' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 /**
@@ -11,7 +12,7 @@ const productPrice = '13.99';
 
 test.describe(
 	'Add to Cart behavior',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		let productId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -41,7 +41,7 @@ const DEFAULT_BILLING_LABEL = 'CALIFORNIA, UNITED STATES (US)';
 
 test.describe(
 	'Cart Block Calculate Shipping',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		let product1Id, product2Id, shippingZoneNLId, shippingZonePTId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -140,7 +140,7 @@ test.describe(
 
 		test(
 			'allows customer to calculate Free Shipping in cart block if in Netherlands',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, context, cartBlockPage } ) => {
 				await context.clearCookies();
 
@@ -189,7 +189,7 @@ test.describe(
 
 		test(
 			'allows customer to calculate Flat rate and Local pickup in cart block if in Portugal',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, context, cartBlockPage } ) => {
 				await context.clearCookies();
 
@@ -244,7 +244,7 @@ test.describe(
 
 		test(
 			'should show correct total cart block price after updating quantity',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, context, cartBlockPage } ) => {
 				await context.clearCookies();
 
@@ -286,7 +286,7 @@ test.describe(
 
 		test(
 			'should show correct total cart block price with 2 different products and flat rate/local pickup',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, context, cartBlockPage } ) => {
 				await context.clearCookies();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
 
 /**
@@ -41,7 +41,7 @@ const DEFAULT_BILLING_LABEL = 'CALIFORNIA, UNITED STATES (US)';
 
 test.describe(
 	'Cart Block Calculate Shipping',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		let product1Id, product2Id, shippingZoneNLId, shippingZonePTId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
@@ -133,7 +133,7 @@ test.describe(
 
 		test(
 			'allows cart block to apply coupon of any type',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				const totals = [ '$50.00', '$27.50', '$45.00' ];
 
@@ -178,7 +178,7 @@ test.describe(
 
 		test(
 			'allows cart block to apply multiple coupons',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				const totals = [ '$50.00', '$22.50', '$12.50' ];
 				const totalsReverse = [ '$17.50', '$45.00', '$55.00' ];
@@ -229,7 +229,7 @@ test.describe(
 
 		test(
 			'prevents cart block applying same coupon twice',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				// try to add two same coupons and verify the error message
 				await page
@@ -263,7 +263,7 @@ test.describe(
 
 		test(
 			'prevents cart block applying coupon with usage limit',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				// add coupon with usage limit
 				await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
 
 /**
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Cart Block Applying Coupons',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		const couponBatchId = [];
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Cart Block Applying Coupons',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		const couponBatchId = [];
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
@@ -82,7 +82,7 @@ test.describe(
 
 		test(
 			'can see empty cart, add and remove simple & cross sell product, increase to max quantity',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, testPage } ) => {
 				await goToPageEditor( { page } );
 				await fillPageTitle( page, testPage.title );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
 
 /**
@@ -30,179 +30,195 @@ const test = baseTest.extend( {
 	testPageTitlePrefix: 'Cart Block',
 } );
 
-test.describe( 'Cart Block page', { tag: [ '@payments', '@services' ] }, () => {
-	test.beforeAll( async ( { api } ) => {
-		// make sure the currency is USD
-		await api.put( 'settings/general/woocommerce_currency', {
-			value: 'USD',
-		} );
-		// add 3 products
-		await api
-			.post( 'products', {
-				name: `${ simpleProductName } Cross-Sell 1`,
-				type: 'simple',
-				regular_price: firstCrossSellProductPrice,
-			} )
-			.then( ( response ) => {
-				product2Id = response.data.id;
+test.describe(
+	'Cart Block page',
+	{ tag: [ '@payments', tags.SERVICES ] },
+	() => {
+		test.beforeAll( async ( { api } ) => {
+			// make sure the currency is USD
+			await api.put( 'settings/general/woocommerce_currency', {
+				value: 'USD',
 			} );
-		await api
-			.post( 'products', {
-				name: `${ simpleProductName } Cross-Sell 2`,
-				type: 'simple',
-				regular_price: secondCrossSellProductPrice,
-			} )
-			.then( ( response ) => {
-				product3Id = response.data.id;
-			} );
-		await api
-			.post( 'products', {
-				name: simpleProductName,
-				description: simpleProductDesc,
-				type: 'simple',
-				regular_price: singleProductFullPrice,
-				sale_price: singleProductSalePrice,
-				cross_sell_ids: [ product2Id, product3Id ],
-				manage_stock: true,
-				stock_quantity: 2,
-			} )
-			.then( ( response ) => {
-				product1Id = response.data.id;
-			} );
-	} );
-
-	test.afterAll( async ( { api } ) => {
-		await api.post( 'products/batch', {
-			delete: [ product1Id, product2Id, product3Id ],
-		} );
-	} );
-
-	test(
-		'can see empty cart, add and remove simple & cross sell product, increase to max quantity',
-		{ tag: [ '@could-be-lower-level-test' ] },
-		async ( { page, testPage } ) => {
-			await goToPageEditor( { page } );
-			await fillPageTitle( page, testPage.title );
-			await insertBlockByShortcut( page, 'Cart' );
-			await publishPage( page, testPage.title );
-
-			// go to the page to test empty cart block
-			await page.goto( testPage.slug );
-			await expect(
-				page.getByRole( 'heading', { name: testPage.title } )
-			).toBeVisible();
-			await expect(
-				await page.getByText( 'Your cart is currently empty!' ).count()
-			).toBeGreaterThan( 0 );
-			await expect(
-				page.getByRole( 'link', { name: 'Browse store' } )
-			).toBeVisible();
-			await page.getByRole( 'link', { name: 'Browse store' } ).click();
-			await expect(
-				page.getByRole( 'heading', { name: 'Shop' } )
-			).toBeVisible();
-
-			await addAProductToCart( page, product1Id );
-			await page.goto( testPage.slug );
-			await expect(
-				page.getByRole( 'heading', { name: testPage.title } )
-			).toBeVisible();
-			await expect(
-				page.getByRole( 'link', {
-					name: simpleProductName,
-					exact: true,
+			// add 3 products
+			await api
+				.post( 'products', {
+					name: `${ simpleProductName } Cross-Sell 1`,
+					type: 'simple',
+					regular_price: firstCrossSellProductPrice,
 				} )
-			).toBeVisible();
-			await expect( page.getByText( simpleProductDesc ) ).toBeVisible();
-			await expect(
-				page.getByText( `Save $${ singleProductSalePrice }` )
-			).toBeVisible();
+				.then( ( response ) => {
+					product2Id = response.data.id;
+				} );
+			await api
+				.post( 'products', {
+					name: `${ simpleProductName } Cross-Sell 2`,
+					type: 'simple',
+					regular_price: secondCrossSellProductPrice,
+				} )
+				.then( ( response ) => {
+					product3Id = response.data.id;
+				} );
+			await api
+				.post( 'products', {
+					name: simpleProductName,
+					description: simpleProductDesc,
+					type: 'simple',
+					regular_price: singleProductFullPrice,
+					sale_price: singleProductSalePrice,
+					cross_sell_ids: [ product2Id, product3Id ],
+					manage_stock: true,
+					stock_quantity: 2,
+				} )
+				.then( ( response ) => {
+					product1Id = response.data.id;
+				} );
+		} );
 
-			// increase product quantity to its maximum
-			await expect( page.getByText( '2 left in stock' ) ).toBeVisible();
-			await page
-				.getByRole( 'button' )
-				.filter( { hasText: '＋', exact: true } )
-				.click();
-			await expect(
-				page.locator(
-					'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-				)
-			).toContainText( `$${ doubleProductsPrice.toString() }` );
-			await expect(
-				page
+		test.afterAll( async ( { api } ) => {
+			await api.post( 'products/batch', {
+				delete: [ product1Id, product2Id, product3Id ],
+			} );
+		} );
+
+		test(
+			'can see empty cart, add and remove simple & cross sell product, increase to max quantity',
+			{ tag: [ '@could-be-lower-level-test' ] },
+			async ( { page, testPage } ) => {
+				await goToPageEditor( { page } );
+				await fillPageTitle( page, testPage.title );
+				await insertBlockByShortcut( page, 'Cart' );
+				await publishPage( page, testPage.title );
+
+				// go to the page to test empty cart block
+				await page.goto( testPage.slug );
+				await expect(
+					page.getByRole( 'heading', { name: testPage.title } )
+				).toBeVisible();
+				await expect(
+					await page
+						.getByText( 'Your cart is currently empty!' )
+						.count()
+				).toBeGreaterThan( 0 );
+				await expect(
+					page.getByRole( 'link', { name: 'Browse store' } )
+				).toBeVisible();
+				await page
+					.getByRole( 'link', { name: 'Browse store' } )
+					.click();
+				await expect(
+					page.getByRole( 'heading', { name: 'Shop' } )
+				).toBeVisible();
+
+				await addAProductToCart( page, product1Id );
+				await page.goto( testPage.slug );
+				await expect(
+					page.getByRole( 'heading', { name: testPage.title } )
+				).toBeVisible();
+				await expect(
+					page.getByRole( 'link', {
+						name: simpleProductName,
+						exact: true,
+					} )
+				).toBeVisible();
+				await expect(
+					page.getByText( simpleProductDesc )
+				).toBeVisible();
+				await expect(
+					page.getByText( `Save $${ singleProductSalePrice }` )
+				).toBeVisible();
+
+				// increase product quantity to its maximum
+				await expect(
+					page.getByText( '2 left in stock' )
+				).toBeVisible();
+				await page
 					.getByRole( 'button' )
 					.filter( { hasText: '＋', exact: true } )
-			).toBeDisabled();
+					.click();
+				await expect(
+					page.locator(
+						'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+					)
+				).toContainText( `$${ doubleProductsPrice.toString() }` );
+				await expect(
+					page
+						.getByRole( 'button' )
+						.filter( { hasText: '＋', exact: true } )
+				).toBeDisabled();
 
-			// add cross-sell products to cart
-			await expect(
-				page.getByRole( 'heading', {
-					name: 'You may be interested in…',
-				} )
-			).toBeVisible();
-			await page
-				.getByLabel(
-					`Add to cart: “${ simpleProductName } Cross-Sell 1”`
-				)
-				.click();
-			await expect(
-				page
-					.locator( '.wc-block-cart-items' )
-					.getByText( `${ simpleProductName } Cross-Sell 1` )
-			).toBeVisible();
-			await page
-				.getByLabel(
-					`Add to cart: “${ simpleProductName } Cross-Sell 2”`
-				)
-				.click();
-			await expect(
-				page
-					.locator( '.wc-block-cart-items' )
-					.getByText( `${ simpleProductName } Cross-Sell 2` )
-			).toBeVisible();
+				// add cross-sell products to cart
+				await expect(
+					page.getByRole( 'heading', {
+						name: 'You may be interested in…',
+					} )
+				).toBeVisible();
+				await page
+					.getByLabel(
+						`Add to cart: “${ simpleProductName } Cross-Sell 1”`
+					)
+					.click();
+				await expect(
+					page
+						.locator( '.wc-block-cart-items' )
+						.getByText( `${ simpleProductName } Cross-Sell 1` )
+				).toBeVisible();
+				await page
+					.getByLabel(
+						`Add to cart: “${ simpleProductName } Cross-Sell 2”`
+					)
+					.click();
+				await expect(
+					page
+						.locator( '.wc-block-cart-items' )
+						.getByText( `${ simpleProductName } Cross-Sell 2` )
+				).toBeVisible();
 
-			await page.goto( testPage.slug );
-			await expect(
-				page.getByRole( 'heading', { name: testPage.title } )
-			).toBeVisible();
-			await expect(
-				page.getByRole( 'heading', {
-					name: 'You may be interested in…',
-				} )
-			).toBeHidden();
-			await expect(
-				page.locator(
-					'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
-				)
-			).toContainText(
-				`$${ singleProductWithCrossSellProducts.toString() }`
-			);
+				await page.goto( testPage.slug );
+				await expect(
+					page.getByRole( 'heading', { name: testPage.title } )
+				).toBeVisible();
+				await expect(
+					page.getByRole( 'heading', {
+						name: 'You may be interested in…',
+					} )
+				).toBeHidden();
+				await expect(
+					page.locator(
+						'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
+					)
+				).toContainText(
+					`$${ singleProductWithCrossSellProducts.toString() }`
+				);
 
-			// remove cross-sell products from cart
-			await page.locator( ':nth-match(:text("Remove item"), 3)' ).click();
-			await page.locator( ':nth-match(:text("Remove item"), 2)' ).click();
-			await expect(
-				page.getByRole( 'heading', {
-					name: 'You may be interested in…',
-				} )
-			).toBeVisible();
+				// remove cross-sell products from cart
+				await page
+					.locator( ':nth-match(:text("Remove item"), 3)' )
+					.click();
+				await page
+					.locator( ':nth-match(:text("Remove item"), 2)' )
+					.click();
+				await expect(
+					page.getByRole( 'heading', {
+						name: 'You may be interested in…',
+					} )
+				).toBeVisible();
 
-			// check if the link to proceed to the checkout exists
-			await expect(
-				page.getByRole( 'link', {
-					name: 'Proceed to Checkout',
-				} )
-			).toBeVisible();
+				// check if the link to proceed to the checkout exists
+				await expect(
+					page.getByRole( 'link', {
+						name: 'Proceed to Checkout',
+					} )
+				).toBeVisible();
 
-			// remove product from cart
-			await page.locator( ':text("Remove item")' ).click();
-			await expect(
-				page.getByText( 'Your cart is currently empty!' )
-			).toBeVisible();
-			await expect(
-				page.getByRole( 'link', { name: 'Browse store' } )
-			).toBeVisible();
-		}
-	);
-} );
+				// remove product from cart
+				await page.locator( ':text("Remove item")' ).click();
+				await expect(
+					page.getByText( 'Your cart is currently empty!' )
+				).toBeVisible();
+				await expect(
+					page.getByRole( 'link', { name: 'Browse store' } )
+				).toBeVisible();
+			}
+		);
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
@@ -32,7 +32,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Cart Block page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { api } ) => {
 			// make sure the currency is USD

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
@@ -136,7 +136,7 @@ test.describe(
 
 		test(
 			'allows customer to calculate Free Shipping if in Germany',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				await page.goto( 'cart/' );
 				// Set shipping country to Germany
@@ -158,7 +158,7 @@ test.describe(
 
 		test(
 			'allows customer to calculate Flat rate and Local pickup if in France',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				await page.goto( 'cart/' );
 				// Set shipping country to France
@@ -188,7 +188,7 @@ test.describe(
 
 		test(
 			'should show correct total cart price after updating quantity',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				await page.goto( 'cart/' );
 				await page.locator( 'input.qty' ).fill( '4' );
@@ -209,7 +209,7 @@ test.describe(
 
 		test(
 			'should show correct total cart price with 2 products and flat rate',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				await addAProductToCart( page, secondProductId );
 
@@ -231,7 +231,7 @@ test.describe(
 
 		test(
 			'should show correct total cart price with 2 products without flat rate',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page } ) => {
 				await addAProductToCart( page, secondProductId );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
@@ -28,7 +28,7 @@ const shippingCountryFR = 'FR';
 
 test.describe(
 	'Cart Calculate Shipping',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		let firstProductId, secondProductId, shippingZoneDEId, shippingZoneFRId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -22,7 +28,7 @@ const shippingCountryFR = 'FR';
 
 test.describe(
 	'Cart Calculate Shipping',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		let firstProductId, secondProductId, shippingZoneDEId, shippingZoneFRId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
@@ -256,7 +256,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Rounding',
-	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.COULD_BE_LOWER_LEVEL_TEST ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -500,7 +500,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Levels',
-	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.COULD_BE_LOWER_LEVEL_TEST ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -825,7 +825,7 @@ test.describe(
 
 test.describe(
 	'Shipping Cart & Checkout Block Tax',
-	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.COULD_BE_LOWER_LEVEL_TEST ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
@@ -49,10 +49,10 @@ test.describe(
 	'Shopper Cart & Checkout Block Tax Display',
 	{
 		tag: [
-			'@payments',
+			tags.PAYMENTS,
 			tags.SERVICES,
-			'@hpos',
-			'@could-be-lower-level-test',
+			tags.HPOS,
+			tags.COULD_BE_LOWER_LEVEL_TEST,
 		],
 	},
 	() => {
@@ -256,7 +256,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Rounding',
-	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@could-be-lower-level-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -500,7 +500,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Levels',
-	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@could-be-lower-level-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -825,7 +825,7 @@ test.describe(
 
 test.describe(
 	'Shipping Cart & Checkout Block Tax',
-	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@could-be-lower-level-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
@@ -1,8 +1,3 @@
-const { test, expect } = require( '@playwright/test' );
-const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-const { fillPageTitle } = require( '../../utils/editor' );
-const { random } = require( '../../utils/helpers' );
-
 /**
  * External dependencies
  */
@@ -12,6 +7,16 @@ import {
 	goToPageEditor,
 	publishPage,
 } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { fillPageTitle } = require( '../../utils/editor' );
+const { random } = require( '../../utils/helpers' );
 
 const productName = 'First Product Cart Block Taxing';
 const productPrice = '100.00';
@@ -45,7 +50,7 @@ test.describe(
 	{
 		tag: [
 			'@payments',
-			'@services',
+			tags.SERVICES,
 			'@hpos',
 			'@could-be-lower-level-test',
 		],
@@ -251,7 +256,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Rounding',
-	{ tag: [ '@payments', '@services', '@could-be-lower-level-test' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -495,7 +500,7 @@ test.describe(
 
 test.describe(
 	'Shopper Cart & Checkout Block Tax Levels',
-	{ tag: [ '@payments', '@services', '@could-be-lower-level-test' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {
@@ -820,7 +825,7 @@ test.describe(
 
 test.describe(
 	'Shipping Cart & Checkout Block Tax',
-	{ tag: [ '@payments', '@services', '@could-be-lower-level-test' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -1,13 +1,17 @@
+/**
+ * External dependencies
+ */
+import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+
 const { test, expect, request } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { customer } = require( '../../test-data/data' );
 const { random } = require( '../../utils/helpers' );
 const { setOption } = require( '../../utils/options' );
-
-/**
- * External dependencies
- */
-import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 const productName = `Taxed products are awesome ${ random() }`;
 const productPrice = '200.00';
@@ -32,7 +36,7 @@ test.describe.serial(
 	{
 		tag: [
 			'@payments',
-			'@services',
+			tags.SERVICES,
 			'@hpos',
 			'@could-be-lower-level-test',
 		],

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -35,10 +35,10 @@ test.describe.serial(
 	'Tax rates in the cart and checkout',
 	{
 		tag: [
-			'@payments',
+			tags.PAYMENTS,
 			tags.SERVICES,
-			'@hpos',
-			'@could-be-lower-level-test',
+			tags.HPOS,
+			tags.COULD_BE_LOWER_LEVEL_TEST,
 		],
 	},
 	() => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
@@ -35,7 +35,7 @@ const totals = [ '$15.00', '$10.00', '$13.00' ];
 
 test.describe(
 	'Cart & Checkout applying coupons',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		let firstProductId;
 		const couponBatchId = [];

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
@@ -317,7 +317,7 @@ test.describe(
 
 		test(
 			'restores total when coupons are removed',
-			{ tag: [ '@could-be-lower-level-test' ] },
+			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, context } ) => {
 				await test.step( 'Load cart page and try restoring total when removed coupons', async () => {
 					await addAProductToCart( page, firstProductId );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -29,7 +35,7 @@ const totals = [ '$15.00', '$10.00', '$13.00' ];
 
 test.describe(
 	'Cart & Checkout applying coupons',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		let firstProductId;
 		const couponBatchId = [];

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
@@ -45,10 +45,10 @@ test.describe(
 	'Cart & Checkout Restricted Coupons',
 	{
 		tag: [
-			'@payments',
+			tags.PAYMENTS,
 			tags.SERVICES,
-			'@hpos',
-			'@could-be-lower-level-test',
+			tags.HPOS,
+			tags.COULD_BE_LOWER_LEVEL_TEST,
 		],
 	},
 	() => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
@@ -5,6 +5,10 @@ import {
 	addAProductToCart,
 	getOrderIdFromUrl,
 } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -42,7 +46,7 @@ test.describe(
 	{
 		tag: [
 			'@payments',
-			'@services',
+			tags.SERVICES,
 			'@hpos',
 			'@could-be-lower-level-test',
 		],

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
@@ -8,7 +8,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Cart > Redirect to cart from shop',
-	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@not-e2e' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.NOT_E2E ] },
 	() => {
 		let productId;
 		const productName = 'A redirect product test';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
@@ -1,9 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Cart > Redirect to cart from shop',
-	{ tag: [ '@payments', '@services', '@not-e2e' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@not-e2e' ] },
 	() => {
 		let productId;
 		const productName = 'A redirect product test';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
@@ -8,7 +8,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe(
 	'Cart > Redirect to cart from shop',
-	{ tag: [ '@payments', tags.SERVICES, '@not-e2e' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, '@not-e2e' ] },
 	() => {
 		let productId;
 		const productName = 'A redirect product test';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -10,7 +10,7 @@ const productPrice = '13.99';
 const twoProductPrice = +productPrice * 2;
 const fourProductPrice = +productPrice * 4;
 
-test.describe( 'Cart page', { tag: [ '@payments', tags.SERVICES ] }, () => {
+test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 	let productId, product2Id, product3Id;
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -87,7 +87,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should display no item in the cart',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			await page.goto( 'cart/' );
 			await expect(
@@ -98,7 +98,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should add the product to the cart from the shop page',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			await goToShopPageAndAddProductToCart( page, productName );
 
@@ -111,7 +111,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should increase item quantity when "Add to cart" of the same product is clicked',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			let qty = 2;
 			while ( qty-- ) {
@@ -125,7 +125,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should update quantity when updated via quantity input',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			await goToShopPageAndAddProductToCart( page, productName );
 
@@ -141,7 +141,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should remove the item from the cart when remove is clicked',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			await goToShopPageAndAddProductToCart( page, productName );
 			await page.goto( 'cart/' );
@@ -164,7 +164,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should update subtotal in cart totals when adding product to the cart',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			await goToShopPageAndAddProductToCart( page, productName );
 
@@ -184,7 +184,7 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 
 	test(
 		'should go to the checkout page when "Proceed to Checkout" is clicked',
-		{ tag: [ '@could-be-lower-level-test' ] },
+		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page } ) => {
 			await goToShopPageAndAddProductToCart( page, productName );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -6,7 +10,7 @@ const productPrice = '13.99';
 const twoProductPrice = +productPrice * 2;
 const fourProductPrice = +productPrice * 4;
 
-test.describe( 'Cart page', { tag: [ '@payments', '@services' ] }, () => {
+test.describe( 'Cart page', { tag: [ '@payments', tags.SERVICES ] }, () => {
 	let productId, product2Id, product3Id;
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block-coupons.spec.js
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Checkout Block Applying Coupons',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		const couponBatchId = [];
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block-coupons.spec.js
@@ -8,7 +8,7 @@ import {
 	goToPageEditor,
 } from '@woocommerce/e2e-utils-playwright';
 const { fillPageTitle } = require( '../../utils/editor' );
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { random } = require( '../../utils/helpers' );
 
 const simpleProductName = `Checkout Coupons Product ${ random() }`;
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Checkout Block Applying Coupons',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		const couponBatchId = [];
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Checkout Block page',
-	{ tag: [ '@payments', '@services', '@hpos', tags.SKIP_ON_WPCOM ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos', tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Checkout Block page',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos', tags.SKIP_ON_WPCOM ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS, tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -1,6 +1,6 @@
 const { fillPageTitle } = require( '../../utils/editor' );
 const { request } = require( '@playwright/test' );
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin, customer } = require( '../../test-data/data' );
@@ -61,7 +61,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Checkout Block page',
-	{ tag: [ '@payments', '@services', '@hpos', '@skip-on-default-wpcom' ] },
+	{ tag: [ '@payments', '@services', '@hpos', tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
@@ -1,7 +1,3 @@
-const { test, expect } = require( '@playwright/test' );
-const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-const { admin } = require( '../../test-data/data' );
-
 /**
  * External dependencies
  */
@@ -9,12 +5,19 @@ import {
 	addAProductToCart,
 	getOrderIdFromUrl,
 } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { admin } = require( '../../test-data/data' );
 
 const billingEmail = 'marge-test-account@example.com';
 
 test.describe(
 	'Shopper Checkout Create Account',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		let productId, orderId, shippingZoneId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
@@ -17,7 +17,7 @@ const billingEmail = 'marge-test-account@example.com';
 
 test.describe(
 	'Shopper Checkout Create Account',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		let productId, orderId, shippingZoneId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
@@ -109,7 +109,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Shopper Checkout Login Account',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		test( 'can login to an existing account during checkout', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
@@ -5,7 +5,7 @@ import {
 	addAProductToCart,
 	getOrderIdFromUrl,
 } from '@woocommerce/e2e-utils-playwright';
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { getFakeCustomer, getFakeProduct } = require( '../../utils/data' );
 
 const test = baseTest.extend( {
@@ -109,7 +109,7 @@ const test = baseTest.extend( {
 
 test.describe(
 	'Shopper Checkout Login Account',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		test( 'can login to an existing account during checkout', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -21,7 +21,7 @@ const guestEmail = 'checkout-guest@example.com';
 
 test.describe(
 	'Checkout page',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		const singleProductPrice = '9.99';
 		const simpleProductName = 'Checkout Page Product';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -12,12 +12,16 @@ import {
 	addOneOrMoreProductToCart,
 	getOrderIdFromUrl,
 } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 
 const guestEmail = 'checkout-guest@example.com';
 
 test.describe(
 	'Checkout page',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		const singleProductPrice = '9.99';
 		const simpleProductName = 'Checkout Page Product';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/dashboard-access.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/dashboard-access.spec.js
@@ -6,7 +6,7 @@ const { test, expect } = require( '@playwright/test' );
 
 test.describe(
 	'Customer-role users are blocked from accessing the WP Dashboard.',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.CUSTOMERSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/dashboard-access.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/dashboard-access.spec.js
@@ -1,8 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 
 test.describe(
 	'Customer-role users are blocked from accessing the WP Dashboard.',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.CUSTOMERSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
@@ -1,6 +1,7 @@
-const { test, expect, request, tags } = require( '@playwright/test' );
+const { test, expect, request } = require( '@playwright/test' );
 const { setOption } = require( '../../utils/options' );
 const { activateTheme, DEFAULT_THEME } = require( '../../utils/themes' );
+const { tags } = require( '../../fixtures/fixtures' );
 
 async function runComingSoonTests( themeContext = '' ) {
 	const testSuffix = themeContext ? ` (${ themeContext })` : '';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/launch-your-store.spec.js
@@ -1,4 +1,4 @@
-const { test, expect, request } = require( '@playwright/test' );
+const { test, expect, request, tags } = require( '@playwright/test' );
 const { setOption } = require( '../../utils/options' );
 const { activateTheme, DEFAULT_THEME } = require( '../../utils/themes' );
 
@@ -74,7 +74,7 @@ async function runComingSoonTests( themeContext = '' ) {
 
 test.describe(
 	'Launch Your Store front end - logged out',
-	{ tag: '@skip-on-default-wpcom' },
+	{ tag: tags.SKIP_ON_WPCOM },
 	() => {
 		test.afterAll( async ( { baseURL } ) => {
 			try {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -1,7 +1,3 @@
-const { test, expect } = require( '@playwright/test' );
-const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-const { random } = require( '../../utils/helpers' );
-
 /**
  * External dependencies
  */
@@ -10,6 +6,13 @@ import {
 	getCanvas,
 	goToPageEditor,
 } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { random } = require( '../../utils/helpers' );
 
 const miniCartPageTitle = `Mini Cart ${ random() }`;
 const miniCartPageSlug = miniCartPageTitle.replace( / /gi, '-' ).toLowerCase();
@@ -26,7 +29,7 @@ let productId, countryTaxId, stateTaxId, shippingZoneId;
 
 test.describe(
 	'Mini Cart block page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -29,7 +29,7 @@ let productId, countryTaxId, stateTaxId, shippingZoneId;
 
 test.describe(
 	'Mini Cart block page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-addresses.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-addresses.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -10,7 +14,7 @@ const customer = {
 
 test.describe(
 	'Customer can manage addresses in My Account > Addresses page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-addresses.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-addresses.spec.js
@@ -14,7 +14,7 @@ const customer = {
 
 test.describe(
 	'Customer can manage addresses in My Account > Addresses page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-create-account.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -5,7 +9,7 @@ const customerEmailAddress = `john.doe.${ Date.now() }@example.com`;
 
 test.describe(
 	'Shopper My Account Create Account',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-create-account.spec.js
@@ -9,7 +9,7 @@ const customerEmailAddress = `john.doe.${ Date.now() }@example.com`;
 
 test.describe(
 	'Shopper My Account Create Account',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-downloads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-downloads.spec.js
@@ -18,7 +18,7 @@ const product = {
 
 test.describe(
 	'Customer can manage downloadable file in My Account > Downloads page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		let productId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-downloads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-downloads.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -14,7 +18,7 @@ const product = {
 
 test.describe(
 	'Customer can manage downloadable file in My Account > Downloads page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		let productId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-pay-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-pay-order.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -10,7 +14,7 @@ const customer = {
 
 test.describe(
 	'Customer can pay for their order through My Account',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		let productId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-pay-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-pay-order.spec.js
@@ -14,7 +14,7 @@ const customer = {
 
 test.describe(
 	'Customer can pay for their order through My Account',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		let productId, orderId;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account.spec.js
@@ -1,36 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const { customer } = require( '../../test-data/data' );
 
 const pages = [ 'Orders', 'Downloads', 'Addresses', 'Account details' ];
 
-test.describe( 'My account page', { tag: [ '@payments', '@services' ] }, () => {
-	test.use( { storageState: process.env.CUSTOMERSTATE } );
+test.describe(
+	'My account page',
+	{ tag: [ '@payments', tags.SERVICES ] },
+	() => {
+		test.use( { storageState: process.env.CUSTOMERSTATE } );
 
-	test( 'allows customer to login and navigate', async ( { page } ) => {
-		await page.goto( 'my-account/' );
+		test( 'allows customer to login and navigate', async ( { page } ) => {
+			await page.goto( 'my-account/' );
 
-		await expect(
-			page.getByRole( 'heading', { name: 'My account' } )
-		).toBeVisible();
-		await expect(
-			page.getByText(
-				`Hello ${ customer.first_name } ${ customer.last_name }`
-			)
-		).toBeVisible();
+			await expect(
+				page.getByRole( 'heading', { name: 'My account' } )
+			).toBeVisible();
+			await expect(
+				page.getByText(
+					`Hello ${ customer.first_name } ${ customer.last_name }`
+				)
+			).toBeVisible();
 
-		for ( const accountPage of pages ) {
-			await test.step( `customer can navigate to ${ accountPage } page`, async () => {
-				await page
-					.getByRole( 'link', { name: accountPage, exact: true } )
-					.click();
-				await expect(
-					page.getByRole( 'heading', { name: accountPage } )
-				).toBeVisible();
-			} );
-		}
+			for ( const accountPage of pages ) {
+				await test.step( `customer can navigate to ${ accountPage } page`, async () => {
+					await page
+						.getByRole( 'link', { name: accountPage, exact: true } )
+						.click();
+					await expect(
+						page.getByRole( 'heading', { name: accountPage } )
+					).toBeVisible();
+				} );
+			}
 
-		await expect(
-			page.getByRole( 'link', { name: 'Log out', exact: true } )
-		).toBeVisible();
-	} );
-} );
+			await expect(
+				page.getByRole( 'link', { name: 'Log out', exact: true } )
+			).toBeVisible();
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account.spec.js
@@ -9,7 +9,7 @@ const pages = [ 'Orders', 'Downloads', 'Addresses', 'Account details' ];
 
 test.describe(
 	'My account page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.CUSTOMERSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
@@ -31,7 +31,7 @@ const storeName = 'WooCommerce Core E2E Test Suite';
 
 test.describe(
 	'Shopper Order Email Receiving',
-	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
@@ -1,7 +1,3 @@
-const { test, expect } = require( '@playwright/test' );
-const { customer, storeDetails } = require( '../../test-data/data' );
-const { api } = require( '../../utils' );
-
 /**
  * External dependencies
  */
@@ -9,6 +5,13 @@ import {
 	addAProductToCart,
 	getOrderIdFromUrl,
 } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
+const { test, expect } = require( '@playwright/test' );
+const { customer, storeDetails } = require( '../../test-data/data' );
+const { api } = require( '../../utils' );
 
 let productId, orderId, zoneId;
 
@@ -28,7 +31,7 @@ const storeName = 'WooCommerce Core E2E Test Suite';
 
 test.describe(
 	'Shopper Order Email Receiving',
-	{ tag: [ '@payments', '@services', '@hpos' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@hpos' ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-grouped.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-grouped.spec.js
@@ -13,7 +13,7 @@ let simpleProductId, simpleProduct2Id, groupedProductId;
 
 test.describe(
 	'Grouped Product Page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		const slug = groupedProductName.replace( / /gi, '-' ).toLowerCase();
 		const simpleProduct1 = simpleProductName + ' 1';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-grouped.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-grouped.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -9,7 +13,7 @@ let simpleProductId, simpleProduct2Id, groupedProductId;
 
 test.describe(
 	'Grouped Product Page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		const slug = groupedProductName.replace( / /gi, '-' ).toLowerCase();
 		const simpleProduct1 = simpleProductName + ' 1';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin } = require( '../../test-data/data' );
@@ -10,7 +14,7 @@ let simpleProductId, productCategory1Id, productCategory2Id;
 
 test.describe(
 	'Single Product Page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		const productCategoryName1 = 'Hoodies';
 		const productCategoryName2 = 'Jumpers';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
@@ -14,7 +14,7 @@ let simpleProductId, productCategory1Id, productCategory2Id;
 
 test.describe(
 	'Single Product Page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		const productCategoryName1 = 'Hoodies';
 		const productCategoryName2 = 'Jumpers';

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
@@ -34,7 +34,7 @@ let product1Id,
 
 test.describe(
 	'Browse product tags and attributes from the product page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { getCanvas, goToPageEditor } from '@woocommerce/e2e-utils-playwright';
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect, request } = require( '@playwright/test' );
 const { admin } = require( '../../test-data/data' );
 const pageTitle = 'Product Showcase';
@@ -30,7 +34,7 @@ let product1Id,
 
 test.describe(
 	'Browse product tags and attributes from the product page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -131,7 +135,7 @@ const variations2 = [
 
 test.describe(
 	'Variable Product Page',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		const variableProductName = `Variable single product ${ Date.now() }`;
 		const slug = variableProductName.replace( / /gi, '-' ).toLowerCase();
@@ -243,7 +247,7 @@ test.describe(
 
 test.describe(
 	'Shopper > Update variable product',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		const variableProductName = `Variable single product ${ Date.now() }`;
 		const slug = variableProductName.replace( / /gi, '-' ).toLowerCase();

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
@@ -135,7 +135,7 @@ const variations2 = [
 
 test.describe(
 	'Variable Product Page',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		const variableProductName = `Variable single product ${ Date.now() }`;
 		const slug = variableProductName.replace( / /gi, '-' ).toLowerCase();
@@ -247,7 +247,7 @@ test.describe(
 
 test.describe(
 	'Shopper > Update variable product',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		const variableProductName = `Variable single product ${ Date.now() }`;
 		const slug = variableProductName.replace( / /gi, '-' ).toLowerCase();

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
 const { getInstalledWordPressVersion } = require( '../../utils/wordpress' );
 
@@ -33,8 +33,8 @@ test.describe(
 		tag: [
 			'@payments',
 			'@services',
-			'@skip-on-default-wpcom',
-			'@skip-on-default-pressable',
+			tags.SKIP_ON_WPCOM,
+			tags.SKIP_ON_PRESSABLE,
 		],
 	},
 	() => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -32,7 +32,7 @@ test.describe(
 	{
 		tag: [
 			'@payments',
-			'@services',
+			tags.SERVICES,
 			tags.SKIP_ON_WPCOM,
 			tags.SKIP_ON_PRESSABLE,
 		],

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -31,7 +31,7 @@ test.describe(
 	'Filter items in the shop by product price',
 	{
 		tag: [
-			'@payments',
+			tags.PAYMENTS,
 			tags.SERVICES,
 			tags.SKIP_ON_WPCOM,
 			tags.SKIP_ON_PRESSABLE,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { faker } = require( '@faker-js/faker' );
@@ -16,7 +20,7 @@ let categoryAId, categoryBId, categoryCId, product1Id, product2Id, product3Id;
 
 test.describe(
 	'Search, browse by categories and sort items in the shop',
-	{ tag: [ '@payments', '@services' ] },
+	{ tag: [ '@payments', tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
@@ -20,7 +20,7 @@ let categoryAId, categoryBId, categoryCId, product1Id, product2Id, product3Id;
 
 test.describe(
 	'Search, browse by categories and sort items in the shop',
-	{ tag: [ '@payments', tags.SERVICES ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
 			const api = new wcApi( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 // test case for bug https://github.com/woocommerce/woocommerce/pull/46429
 const test = baseTest.extend( {
@@ -31,7 +31,7 @@ const test = baseTest.extend( {
 
 test(
 	'Check the title of the shop page after the page has been deleted',
-	{ tag: [ '@payments', '@services', '@could-be-lower-level-test' ] },
+	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
 	async ( { page } ) => {
 		await page.goto( 'shop/' );
 		expect( await page.title() ).toBe(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
@@ -31,7 +31,7 @@ const test = baseTest.extend( {
 
 test(
 	'Check the title of the shop page after the page has been deleted',
-	{ tag: [ '@payments', tags.SERVICES, '@could-be-lower-level-test' ] },
+	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.COULD_BE_LOWER_LEVEL_TEST ] },
 	async ( { page } ) => {
 		await page.goto( 'shop/' );
 		expect( await page.title() ).toBe(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
@@ -1,4 +1,4 @@
-const { test: baseTest, expect } = require( '../../fixtures/fixtures' );
+const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 
 const test = baseTest.extend( {
 	storageState: process.env.CUSTOMERSTATE,
@@ -7,11 +7,7 @@ const test = baseTest.extend( {
 test(
 	'logged-in customer can comment on a post',
 	{
-		tag: [
-			'@non-critical',
-			'@skip-on-default-wpcom',
-			'@skip-on-default-pressable',
-		],
+		tag: [ tags.NON_CRITICAL, tags.SKIP_ON_WPCOM, tags.SKIP_ON_PRESSABLE ],
 	},
 	async ( { page } ) => {
 		await page.goto( 'hello-world/' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated the Playwright config files to use the Playwright test tags to include/exclude tests.
Defined the tags in the fixture file and replaced all tags as string with references to this new tags object.

### How to test the changes in this Pull Request:

All tests pass in CI.
List the tests for each environment. Check the list of tests included makes sense. 
Examples:

```
# List all tests that should run for default-pressable
pnpm test:e2e:with-env default-pressable --list

# List all API tests that should run for default-wpcom
pnpm test:e2e:with-env default-wpcom --list --project=api
```
