### PR TITLE
Generate subject for email preview and test email

### DIFF
--- a/plugins/woocommerce/changelog/53575-email-preview-subject
+++ b/plugins/woocommerce/changelog/53575-email-preview-subject
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Experimental: generate subject for email preview

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -21,9 +21,7 @@ import { EmailPreviewType } from './settings-email-preview-type';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
-export type EmailType = SelectControl.Option & {
-	subject: string;
-};
+export type EmailType = SelectControl.Option;
 
 type EmailPreviewFillProps = {
 	emailTypes: EmailType[];

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -67,10 +67,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 				<div
 					className={ `wc-settings-email-preview wc-settings-email-preview-${ deviceType }` }
 				>
-					<EmailPreviewHeader
-						emailTypes={ emailTypes }
-						emailType={ emailType }
-					/>
+					<EmailPreviewHeader emailType={ emailType } />
 					<iframe
 						src={ finalPreviewUrl }
 						title={ __( 'Email preview frame', 'woocommerce' ) }

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -146,6 +146,11 @@ $wc-setting-email-preview-gap: 16px;
 	font-weight: normal;
 	line-height: 21px;
 	margin: 0 0 $wc-setting-email-preview-gap;
+
+	&::before {
+		// Zero-width space to prevent jumping when subject is async loaded
+		content: "\200b";
+	}
 }
 
 .wc-settings-email-preview-header-data {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -631,7 +631,6 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			$email_types[] = array(
 				'label'   => $email->get_title(),
 				'value'   => $type,
-				'subject' => $email->get_default_subject(),
 			);
 		}
 		?>

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -210,7 +210,7 @@ class WC_Email extends WC_Settings_API {
 	 *
 	 * @var array
 	 */
-	protected $placeholders = array();
+	public $placeholders = array();
 
 	/**
 	 * Strings to find in subjects/headings.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -29,11 +29,11 @@ class EmailPreview {
 	private string $email_type = self::DEFAULT_EMAIL_TYPE;
 
 	/**
-	 * List of available email types.
+	 * The email object.
 	 *
-	 * @var array
+	 * @var WC_Email|null
 	 */
-	private array $email_types = array();
+	private ?WC_Email $email = null;
 
 	/**
 	 * The single instance of the class.
@@ -62,10 +62,24 @@ class EmailPreview {
 	 * @throws \InvalidArgumentException When the email type is invalid.
 	 */
 	public function set_email_type( string $email_type ) {
-		if ( ! in_array( $email_type, $this->get_email_types(), true ) ) {
+		$emails = WC()->mailer()->get_emails();
+		if ( ! in_array( $email_type, array_keys( $emails ), true ) ) {
 			throw new \InvalidArgumentException( 'Invalid email type' );
 		}
 		$this->email_type = $email_type;
+		$this->email      = $emails[ $email_type ];
+
+		$order = $this->get_dummy_order();
+		$this->email->set_object( $order );
+
+		/**
+		 * Allow to modify the email object before rendering the preview to add additional data.
+		 *
+		 * @param WC_Email $email The email object.
+		 *
+		 * @since 9.6.0
+		 */
+		$this->email = apply_filters( 'woocommerce_prepare_email_for_preview', $this->email );
 	}
 
 	/**
@@ -91,18 +105,6 @@ class EmailPreview {
 			return $product;
 		}
 		return $this->get_dummy_product();
-	}
-
-	/**
-	 * Get the list of available email types.
-	 *
-	 * @return array
-	 */
-	private function get_email_types() {
-		if ( empty( $this->email_types ) ) {
-			$this->email_types = array_keys( WC()->mailer()->get_emails() );
-		}
-		return $this->email_types;
 	}
 
 	/**
@@ -141,27 +143,12 @@ class EmailPreview {
 	private function render_preview_email() {
 		$this->set_up_filters();
 
-		$emails = WC()->mailer()->get_emails();
-		$email  = $emails[ $this->email_type ];
-
-		$order = $this->get_dummy_order();
-		$email->set_object( $order );
-
-		/**
-		 * Allow to modify the email object before rendering the preview to add additional data.
-		 *
-		 * @param WC_Email $email The email object.
-		 *
-		 * @since 9.6.0
-		 */
-		$email = apply_filters( 'woocommerce_prepare_email_for_preview', $email );
-
-		$content = $email->get_content_html();
+		$content = $this->email->get_content_html();
 
 		$this->clean_up_filters();
 
 		/** This filter is documented in src/Internal/Admin/EmailPreview/EmailPreview.php */
-		return apply_filters( 'woocommerce_mail_content', $email->style_inline( $content ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		return apply_filters( 'woocommerce_mail_content', $this->email->style_inline( $content ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -113,7 +113,7 @@ class EmailPreview {
 	/**
 	 * Return a dummy product when the product is not set in email classes.
 	 *
-	 * @param WC_Product $product Order item product.
+	 * @param WC_Product|null $product Order item product.
 	 * @return WC_Product
 	 */
 	public function get_dummy_product_when_not_set( $product ) {

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -71,6 +71,10 @@ class EmailPreview {
 
 		$order = $this->get_dummy_order();
 		$this->email->set_object( $order );
+		$this->email->placeholders = array_merge(
+			$this->email->placeholders,
+			$this->get_placeholders( $order )
+		);
 
 		/**
 		 * Allow to modify the email object before rendering the preview to add additional data.
@@ -235,6 +239,24 @@ class EmailPreview {
 		 * @since 9.6.0
 		 */
 		return apply_filters( 'woocommerce_email_preview_dummy_address', $address, $this->email_type );
+	}
+
+	/**
+	 * Get the placeholders for the email preview.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @return array
+	 */
+	private function get_placeholders( $order ) {
+		$placeholders = array();
+
+		if ( is_a( $order, 'WC_Order' ) ) {
+			$placeholders['{order_date}']              = wc_format_datetime( $order->get_date_created() );
+			$placeholders['{order_number}']            = $order->get_order_number();
+			$placeholders['{order_billing_full_name}'] = $order->get_formatted_billing_full_name();
+		}
+
+		return $placeholders;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -256,7 +256,15 @@ class EmailPreview {
 			$placeholders['{order_billing_full_name}'] = $order->get_formatted_billing_full_name();
 		}
 
-		return $placeholders;
+		/**
+		 * Placeholders for email preview.
+		 *
+		 * @param WC_Order $placeholders Placeholders for email subject.
+		 * @param string   $email_type The email type to preview.
+		 *
+		 * @since 9.6.0
+		 */
+		return apply_filters( 'woocommerce_email_preview_placeholders', $placeholders, $this->email_type );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -99,6 +99,18 @@ class EmailPreview {
 	}
 
 	/**
+	 * Get the preview email content.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		if ( ! $this->email ) {
+			return '';
+		}
+		return $this->email->get_subject();
+	}
+
+	/**
 	 * Return a dummy product when the product is not set in email classes.
 	 *
 	 * @param WC_Product $product Order item product.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -24,9 +24,9 @@ class EmailPreview {
 	/**
 	 * The email type to preview.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	private string $email_type = self::DEFAULT_EMAIL_TYPE;
+	private ?string $email_type = null;
 
 	/**
 	 * The email object.
@@ -142,6 +142,10 @@ class EmailPreview {
 	 */
 	private function render_preview_email() {
 		$this->set_up_filters();
+
+		if ( ! $this->email_type ) {
+			$this->set_email_type( self::DEFAULT_EMAIL_TYPE );
+		}
 
 		$content = $this->email->get_content_html();
 

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -79,6 +79,25 @@ class EmailPreviewRestController extends RestApiControllerBase {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/preview-subject',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->get_preview_subject( $request ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'type' => array(
+							'description' => __( 'The email type to get subject for.', 'woocommerce' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -125,6 +144,29 @@ class EmailPreviewRestController extends RestApiControllerBase {
 			'woocommerce_rest_email_preview_not_sent',
 			__( 'Error sending test email. Please try again.', 'woocommerce' ),
 			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Handle the GET /settings/email/preview-subject.
+	 *
+	 * @param WP_REST_Request $request The received request.
+	 * @return array|WP_Error Request response or an error.
+	 */
+	public function get_preview_subject( WP_REST_Request $request ) {
+		$email_type = $request->get_param( 'type' );
+		try {
+			$this->email_preview->set_email_type( $email_type );
+		} catch ( \InvalidArgumentException $e ) {
+			return new WP_Error(
+				'woocommerce_rest_invalid_email_type',
+				__( 'Invalid email type.', 'woocommerce' ),
+				array( 'status' => 400 ),
+			);
+		}
+
+		return array(
+			'subject' => $this->email_preview->get_subject(),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -97,8 +97,9 @@ class EmailPreviewRestController extends RestApiControllerBase {
 
 		$email_address = $request->get_param( 'email' );
 		$email_content = $email_preview->render();
+		$email_subject = $email_preview->get_subject();
 		$email         = new \WC_Emails();
-		$sent          = $email->send( $email_address, 'test', $email_content );
+		$sent          = $email->send( $email_address, $email_subject, $email_content );
 
 		if ( $sent ) {
 			return array(

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -13,6 +13,14 @@ use WP_REST_Request;
 class EmailPreviewRestController extends RestApiControllerBase {
 
 	/**
+	 * Holds the EmailPreview instance for rendering email previews.
+	 *
+	 * @var EmailPreview
+	 */
+	private EmailPreview $email_preview;
+
+
+	/**
 	 * The root namespace for the JSON REST API endpoints.
 	 *
 	 * @var string
@@ -33,6 +41,13 @@ class EmailPreviewRestController extends RestApiControllerBase {
 	 */
 	protected function get_rest_api_namespace(): string {
 		return 'wc-admin-email';
+	}
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->email_preview = wc_get_container()->get( EmailPreview::class );
 	}
 
 	/**
@@ -83,10 +98,9 @@ class EmailPreviewRestController extends RestApiControllerBase {
 	 * @return array|WP_Error Request response or an error.
 	 */
 	public function send_email_preview( WP_REST_Request $request ) {
-		$email_preview = wc_get_container()->get( EmailPreview::class );
-		$email_type    = $request->get_param( 'type' );
+		$email_type = $request->get_param( 'type' );
 		try {
-			$email_preview->set_email_type( $email_type );
+			$this->email_preview->set_email_type( $email_type );
 		} catch ( \InvalidArgumentException $e ) {
 			return new WP_Error(
 				'woocommerce_rest_invalid_email_type',
@@ -96,8 +110,8 @@ class EmailPreviewRestController extends RestApiControllerBase {
 		}
 
 		$email_address = $request->get_param( 'email' );
-		$email_content = $email_preview->render();
-		$email_subject = $email_preview->get_subject();
+		$email_content = $this->email_preview->render();
+		$email_subject = $this->email_preview->get_subject();
 		$email         = new \WC_Emails();
 		$sent          = $email->send( $email_address, $email_subject, $email_content );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\EmailPreview;
 
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use WC_Emails;
+use WC_Order;
+use WC_Product;
 use WC_Unit_Test_Case;
 
 /**
@@ -13,6 +15,13 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview
  */
 class EmailPreviewTest extends WC_Unit_Test_Case {
+	/**
+	 * Site title.
+	 *
+	 * @var string
+	 */
+	const SITE_TITLE = 'Test Blog';
+
 	/**
 	 * "System Under Test", an instance of the class to be tested.
 	 *
@@ -25,6 +34,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
 		$this->sut = new EmailPreview();
 		new WC_Emails();
 	}
@@ -39,10 +49,9 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests that it returns legacy email preview when feature flag is disabled.
-	 *
-	 * @return void
 	 */
 	public function test_it_returns_legacy_email_preview_by_default() {
+		update_option( 'woocommerce_feature_email_improvements_enabled', 'no' );
 		$message        = $this->sut->render();
 		$legacy_title   = 'HTML email template';
 		$legacy_content = 'Lorem ipsum dolor sit amet';
@@ -52,11 +61,8 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests that it returns processing order email preview when feature flag is enabled.
-	 *
-	 * @return void
 	 */
 	public function test_it_returns_order_email_preview_under_feature_flag() {
-		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
 		$message       = $this->sut->render();
 		$order_title   = 'Thank you for your order';
 		$order_content = "Just to let you know — we've received your order #12345, and it is now being processed:";
@@ -64,5 +70,155 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( $order_title, $message );
 		$this->assertStringContainsString( $order_content, $message );
 		$this->assertStringContainsString( $order_product, $message );
+	}
+
+	/**
+	 * Test handling of invalid email type.
+	 */
+	public function test_invalid_email_type() {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->sut->set_email_type( 'Invalid_Email_Type' );
+	}
+
+	/**
+	 * Test setting the email type.
+	 */
+	public function test_set_email_type() {
+		$this->expectNotToPerformAssertions();
+		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
+	}
+
+	/**
+	 * Test that get_subject() returns empty when no email is set.
+	 */
+	public function test_get_subject_without_email() {
+		$this->assertEmpty( $this->sut->get_subject() );
+	}
+
+	/**
+	 * Test that get_subject() returns a subject when email is set.
+	 */
+	public function test_get_subject_with_email_set() {
+		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
+		$subject = $this->sut->get_subject();
+		$this->assertNotEmpty( $subject );
+		$this->assertEquals( 'Your ' . self::SITE_TITLE . ' order has been received!', $subject );
+	}
+
+	/**
+	 * Test that placeholders are replaced in the subject.
+	 */
+	public function test_placeholder_replacement_in_subject() {
+		$this->sut->set_email_type( 'WC_Email_Cancelled_Order' );
+		$subject = $this->sut->get_subject();
+		// {site_title} placeholder
+		$this->assertStringContainsString( self::SITE_TITLE, $subject );
+		// {order_number} placeholder
+		$this->assertStringContainsString( '12345', $subject );
+
+		$this->sut->set_email_type( 'WC_Email_Customer_Note' );
+		$subject = $this->sut->get_subject();
+		// {order_date} placeholder
+		$this->assertStringContainsString( wc_format_datetime( new \WC_DateTime() ), $subject );
+	}
+
+	/**
+	 * Test get_dummy_product_when_not_set returns dummy product if null is passed.
+	 */
+	public function test_get_dummy_product_when_not_set() {
+		$dummy_product = $this->sut->get_dummy_product_when_not_set( null );
+		$this->assertInstanceOf( WC_Product::class, $dummy_product );
+		$this->assertEquals( 'Dummy Product', $dummy_product->get_name() );
+	}
+
+	/**
+	 * Test dummy product filter - woocommerce_email_preview_dummy_product
+	 */
+	public function test_dummy_product_filter() {
+		$product_filter = function ( $product ) {
+			$product->set_name( 'Filtered Product' );
+			$product->set_price( 99 );
+			return $product;
+		};
+		add_filter( 'woocommerce_email_preview_dummy_product', $product_filter, 10, 1 );
+
+		$content = $this->sut->render();
+		$this->assertStringContainsString( 'Filtered Product', $content );
+		$this->assertStringContainsString( '99', $content );
+		$this->assertStringNotContainsString( 'Dummy Product', $content );
+		$this->assertStringNotContainsString( '25', $content );
+
+		remove_filter( 'woocommerce_email_preview_dummy_product', $product_filter, 10 );
+	}
+
+	/**
+	 * Test dummy order filter - woocommerce_email_preview_dummy_order
+	 */
+	public function test_dummy_order_filter() {
+		$order_filter = function ( $order ) {
+			$order->set_total( 500 );
+			return $order;
+		};
+		add_filter( 'woocommerce_email_preview_dummy_order', $order_filter, 10, 1 );
+
+		$content = $this->sut->render();
+		$this->assertStringContainsString( '500.00', $content );
+		$this->assertStringNotContainsString( '100.00', $content );
+
+		remove_filter( 'woocommerce_email_preview_dummy_order', $order_filter, 10 );
+	}
+
+	/**
+	 * Test dummy address filter - woocommerce_email_preview_dummy_address
+	 */
+	public function test_dummy_address_filter() {
+		$address_filter = function ( $address ) {
+			$address['first_name'] = 'Jane';
+			$address['last_name']  = 'Smith';
+			return $address;
+		};
+		add_filter( 'woocommerce_email_preview_dummy_address', $address_filter, 10, 1 );
+
+		$content = $this->sut->render();
+		$this->assertStringContainsString( 'Jane Smith', $content );
+		$this->assertStringNotContainsString( 'John Doe', $content );
+
+		remove_filter( 'woocommerce_email_preview_dummy_address', $address_filter, 10 );
+	}
+
+	/**
+	 * Test that placeholders can be modified via `woocommerce_email_preview_placeholders`.
+	 */
+	public function test_placeholder_filter() {
+		$placeholders_filter = function ( $placeholders ) {
+			$placeholders['{order_number}'] = '98765';
+			return $placeholders;
+		};
+		add_filter( 'woocommerce_email_preview_placeholders', $placeholders_filter, 10, 1 );
+
+		$this->sut->set_email_type( 'WC_Email_Cancelled_Order' );
+		$subject = $this->sut->get_subject();
+		$this->assertStringContainsString( '98765', $subject );
+		$this->assertStringNotContainsString( '12345', $subject );
+
+		remove_filter( 'woocommerce_email_preview_placeholders', $placeholders_filter, 10 );
+	}
+
+	/**
+	 * Test that the `woocommerce_prepare_email_for_preview` filter is applied.
+	 */
+	public function test_prepare_email_for_preview_filter() {
+		$email_filter = function ( $email ) {
+			$email->settings['subject'] = 'Filtered Subject {order_number}';
+			return $email;
+		};
+		add_filter( 'woocommerce_prepare_email_for_preview', $email_filter, 10, 1 );
+
+		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
+		$subject = $this->sut->get_subject();
+		$this->assertStringContainsString( 'Filtered Subject 12345', $subject );
+		$this->assertStringNotContainsString( 'Your ' . self::SITE_TITLE . ' order has been received!', $subject );
+
+		remove_filter( 'woocommerce_prepare_email_for_preview', $email_filter, 10 );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. This PR uses the backend to generate an email subject for email preview and when sending a test email. It also adds a new `woocommerce_email_preview_placeholders` filter.

Closes #53575.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Subject line**
1. Enable `email_improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
2. Go to **WooCommerce > Settings > Emails**.
3. Verify that the email preview has a subject line.
4. Change the email type in the email preview and verify that the subject line has changed.
5. Verify that placeholders (such as `{order_number}` or `{site_title}`) are replaced with actual values.
6. If your test site can send emails, send a test email and check that the subject line is also correct. 

**New filter**
1. Enable `email_improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
2. Go to **WooCommerce > Settings > Emails**.
3. Manage any email and add a new custom placeholder to a subject line (e.g., `{my_custom_placeholder}`).
4. Add a new filter to replace your placeholder (e.g., into your `functions.php` file):
```php
add_filter( 'woocommerce_email_preview_placeholders', function ( $placeholders ) {
	$placeholders['{my_custom_placeholder}'] = 'Hello, world!';
	return $placeholders;
}, 10, 1 );
```
5. Check that the placeholder is replaced in the email preview. 

<!-- End testing instructions -->
