### PR TITLE
PaymentInfo: Abstract the exception handler

### DIFF
--- a/plugins/woocommerce/changelog/fix-paymentinfo-uncaught-exception
+++ b/plugins/woocommerce/changelog/fix-paymentinfo-uncaught-exception
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This modifies some other code introduced in 9.5 that has not been released yet, so no separate changelog entry is necessary.
+
+

--- a/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
+++ b/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
@@ -118,9 +118,8 @@ class PaymentInfo {
 			}
 
 			try {
-				$payment_details = \WC_Payments::get_payments_api_client()
-					->get_payment_method( $payment_method_id );
-			} catch ( Exception $ex ) {
+				$payment_details = \WC_Payments::get_payments_api_client()->get_payment_method( $payment_method_id );
+			} catch ( \Throwable $ex ) {
 				$order_id = $order->get_id();
 				$message  = $ex->getMessage();
 				wc_get_logger()->error(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In `get_wcpay_card_info` we use some code from the WooPayments extension. That code can potentially throw an exception, but it might not be a standard Exception. It might be an API_Exception. We don't need to differentiate our catch code between exception types, so it's better for us to just use the abstract Throwable type, which will catch all exceptions.

### How to test the changes in this Pull Request:

TBD
