### PR TITLE
Enable required checkboxes in Additional Checkout Fields API

### DIFF
--- a/docs/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -256,7 +256,7 @@ You can set a placeholder to be shown on the select by passing a `placeholder` v
 |-----|-----|-----|----------------|--------------|
 | `options` | An array of options to show in the select input. Each options must be an array containing a `label` and `value` property. Each entry must have a unique `value`. Any duplicate options will be removed. The `value` is what gets submitted to the server during checkout and the `label` is simply a user-friendly representation of this value. It is not transmitted to the server in any way. | Yes | see below | No default - this must be provided. |
 | `required` | If this is `true` then the shopper _must_ provide a value for this field during the checkout process. | No | `true` | `false` |
-| `placeholder` | If this value is set, the shopper will see this option in the select. If the select is required, the shopper cannot select this option. | No | `Select a role | Select a $label |
+| `placeholder` | If this value is set, the shopper will see this option in the select. If the select is required, the shopper cannot select this option. | No | `Select a role` | Select a $label |
 
 ##### Example of `options` value
 
@@ -280,7 +280,12 @@ You can set a placeholder to be shown on the select by passing a `placeholder` v
 
 #### Options for `checkbox` fields
 
-The checkbox field type does not have any specific options, however `required` will always be `false` for a checkbox field. Making a checkbox field required is not supported.
+As well as the options above, checkbox fields also support a `required` option. If this is `true` then the shopper _must_ check this box to place the order.
+
+| Option name     | Description                                                                  | Required? | Example                                                      | Default value |
+|-----------------|------------------------------------------------------------------------------|-----------|--------------------------------------------------------------|---|
+| `required`      | If this is `true` then the shopper _must_ check this box to place the order. | No | `true`                                                       | `false` |
+| `error_message` | A custom message to show if the box is unchecked.                            | No | `You must confirm you are over 18 before placing the order.` | `Please check this box if you want to proceed.` |
 
 ### Attributes
 

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -195,7 +195,7 @@
           "menu_title": "Additional Checkout Fields",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/additional-checkout-fields.md",
-          "hash": "aa38325787bc1a130bfa301209fbdd27544d9ed474c85bbbe761bf2106bf9e97",
+          "hash": "8336fc88a08df2b41ec20234f7475ddc94b8605fdd7db9577e96c93dad716fee",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/additional-checkout-fields.md",
           "id": "cb5dd8d59043a4e53929121b45da7b33b1661ab8"
         }
@@ -1915,5 +1915,5 @@
       "categories": []
     }
   ],
-  "hash": "123ddfa050df61ec619604dd059bf25271eeb424725df2a70cf5009059784b7a"
+  "hash": "0a49132d17aa2f1d245e8f981d56efa0535dc24f3181a444d6a073533c2afaed"
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -210,8 +210,8 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 						return (
 							<ValidatedCheckboxControl
 								key={ field.key }
-								{ ...( field.error_message
-									? field.error_message
+								{ ...( field.errorMessage
+									? { errorMessage: field.errorMessage }
 									: {} ) }
 								{ ...checkboxProps }
 							/>

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -210,6 +210,9 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 						return (
 							<ValidatedCheckboxControl
 								key={ field.key }
+								{ ...( field.error_message
+									? field.error_message
+									: {} ) }
 								{ ...checkboxProps }
 							/>
 						);

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -5,6 +5,7 @@ import {
 	ValidatedTextInput,
 	type ValidatedTextInputHandle,
 	CheckboxControl,
+	ValidatedCheckboxControl,
 } from '@woocommerce/blocks-components';
 import {
 	BillingCountryInput,
@@ -195,19 +196,29 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 				}
 
 				if ( field.type === 'checkbox' ) {
+					const checkboxProps = {
+						checked: Boolean( values[ field.key as keyof T ] ),
+						onChange: ( checked: boolean ) => {
+							onChange( {
+								...values,
+								[ field.key ]: checked,
+							} );
+						},
+						...checkboxFieldProps,
+					};
+					if ( field.required ) {
+						return (
+							<ValidatedCheckboxControl
+								key={ field.key }
+								{ ...checkboxProps }
+							/>
+						);
+					}
+
 					return (
 						<CheckboxControl
 							key={ field.key }
-							checked={ Boolean(
-								values[ field.key as keyof T ]
-							) }
-							onChange={ ( checked: boolean ) => {
-								onChange( {
-									...values,
-									[ field.key ]: checked,
-								} );
-							} }
-							{ ...checkboxFieldProps }
+							{ ...checkboxProps }
 						/>
 					);
 				}

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -52,7 +52,7 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 	values,
 	children,
 	isEditing,
-	ariaDescribedBy,
+	ariaDescribedBy = '',
 }: AddressFormProps< T > ): JSX.Element => {
 	const instanceId = useInstanceId( Form );
 	const isFirstRender = useRef( true );

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/types.ts
@@ -27,7 +27,7 @@ export interface AddressFormProps< T > {
 	// Type of form (billing or shipping).
 	addressType?: FormType;
 	// aria-describedby attribute to add to the input.
-	ariaDescribedBy?: string | undefined;
+	ariaDescribedBy?: string;
 	// Array of fields in form.
 	fields: ( keyof FormFields )[];
 	// Called with the new address data when the address form changes. This is only called when all required fields are filled and there are no validation errors.

--- a/plugins/woocommerce-blocks/packages/checkout/utils/validation/get-validity-message-for-input.ts
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/validation/get-validity-message-for-input.ts
@@ -46,7 +46,7 @@ const defaultValidityMessage =
 const getValidityMessageForInput = (
 	label: string | undefined,
 	inputElement: HTMLInputElement,
-	customValidityMessage?: ( validity: ValidityState ) => string | undefined
+	customValidityMessage?: ( validity: ValidityState ) => string
 ): string => {
 	// No errors, or custom error - return early.
 	if ( inputElement.validity.valid || inputElement.validity.customError ) {

--- a/plugins/woocommerce-blocks/packages/checkout/utils/validation/get-validity-message-for-input.ts
+++ b/plugins/woocommerce-blocks/packages/checkout/utils/validation/get-validity-message-for-input.ts
@@ -4,7 +4,7 @@
 import { __, sprintf, getLocaleData } from '@wordpress/i18n';
 
 const defaultValidityMessage =
-	( label: string | undefined ) =>
+	( label: string | undefined, inputElement: HTMLInputElement ) =>
 	( validity: ValidityState ): string | undefined => {
 		const localeData = getLocaleData();
 		const shouldKeepOriginalCase = [ 'de', 'de_AT', 'de_CH' ].includes(
@@ -15,11 +15,18 @@ const defaultValidityMessage =
 			? label
 			: label?.toLocaleLowerCase() || __( 'field', 'woocommerce' );
 
-		const invalidFieldMessage = sprintf(
+		let invalidFieldMessage = sprintf(
 			/* translators: %s field label */
 			__( 'Please enter a valid %s', 'woocommerce' ),
 			fieldLabel
 		);
+
+		if ( inputElement.type === 'checkbox' ) {
+			invalidFieldMessage = __(
+				'Please check this box if you want to proceed.',
+				'woocommerce'
+			);
+		}
 
 		if (
 			validity.valueMissing ||
@@ -47,7 +54,7 @@ const getValidityMessageForInput = (
 	}
 
 	const validityMessageCallback =
-		customValidityMessage || defaultValidityMessage( label );
+		customValidityMessage || defaultValidityMessage( label, inputElement );
 
 	return (
 		validityMessageCallback( inputElement.validity ) ||

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -3,6 +3,7 @@
  */
 import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,10 +24,15 @@ export type CheckboxControlProps = {
 /**
  * Component used to show a checkbox control with styles.
  */
-export const CheckboxControl = ( {
-	className,
-	label,
-	id,
+export const CheckboxControl = forwardRef<
+	HTMLInputElement,
+	CheckboxControlProps
+>(
+	(
+		{
+			className,
+			label,
+			id,
 	onChange,
 	children,
 	hasError = false,
@@ -35,7 +41,9 @@ export const CheckboxControl = ( {
 	errorId,
 	errorMessage,
 	...rest
-}: CheckboxControlProps & Record< string, unknown > ): JSX.Element => {
+		}: CheckboxControlProps & Record< string, unknown >,
+		forwardedRef
+	): JSX.Element => {
 	const instanceId = useInstanceId( CheckboxControl );
 	const checkboxId = id || `checkbox-control-${ instanceId }`;
 
@@ -51,6 +59,7 @@ export const CheckboxControl = ( {
 		>
 			<label htmlFor={ checkboxId }>
 				<input
+						ref={ forwardedRef }
 					id={ checkboxId }
 					className="wc-block-components-checkbox__input"
 					type="checkbox"
@@ -77,6 +86,7 @@ export const CheckboxControl = ( {
 			</label>
 		</div>
 	);
-};
+	}
+);
 
 export default CheckboxControl;

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -15,6 +15,7 @@ export type CheckboxControlProps = {
 	className?: string;
 	label?: string | React.ReactNode;
 	id?: string;
+	ariaDescribedBy?: string | undefined;
 	onChange: ( value: boolean ) => void;
 	children?: ReactNode | null | undefined;
 	feedback?: ReactNode | null;

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -3,6 +3,7 @@
  */
 import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
+import type { ReactNode } from 'react';
 import { forwardRef } from '@wordpress/element';
 
 /**
@@ -15,7 +16,8 @@ export type CheckboxControlProps = {
 	label?: string | React.ReactNode;
 	id?: string;
 	onChange: ( value: boolean ) => void;
-	children?: React.ReactChildren;
+	children?: ReactNode | null | undefined;
+	feedback?: ReactNode | null;
 	hasError?: boolean;
 	checked?: boolean;
 	disabled?: string | boolean | undefined;
@@ -38,6 +40,7 @@ export const CheckboxControl = forwardRef<
 	hasError = false,
 	checked = false,
 	disabled = false,
+			feedback,
 	errorId,
 	errorMessage,
 	...rest
@@ -84,6 +87,7 @@ export const CheckboxControl = forwardRef<
 				) }
 				{ children }
 			</label>
+				{ feedback }
 		</div>
 	);
 	}

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -36,61 +36,63 @@ export const CheckboxControl = forwardRef<
 			className,
 			label,
 			id,
-	onChange,
-	children,
-	hasError = false,
-	checked = false,
-	disabled = false,
+			onChange,
+			children,
+			hasError = false,
+			checked = false,
+			disabled = false,
 			feedback,
-	errorId,
-	errorMessage,
-	...rest
+			errorId,
+			errorMessage,
+			...rest
 		}: CheckboxControlProps & Record< string, unknown >,
 		forwardedRef
 	): JSX.Element => {
-	const instanceId = useInstanceId( CheckboxControl );
-	const checkboxId = id || `checkbox-control-${ instanceId }`;
+		const instanceId = useInstanceId( CheckboxControl );
+		const checkboxId = id || `checkbox-control-${ instanceId }`;
 
-	return (
-		<div
-			className={ clsx(
-				'wc-block-components-checkbox',
-				{
-					'has-error': hasError,
-				},
-				className
-			) }
-		>
-			<label htmlFor={ checkboxId }>
-				<input
-						ref={ forwardedRef }
-					id={ checkboxId }
-					className="wc-block-components-checkbox__input"
-					type="checkbox"
-					onChange={ ( event ) => onChange( event.target.checked ) }
-					aria-invalid={ hasError === true }
-					checked={ checked }
-					disabled={ !! disabled }
-					{ ...rest }
-				/>
-				<svg
-					className="wc-block-components-checkbox__mark"
-					aria-hidden="true"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 20"
-				>
-					<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
-				</svg>
-				{ label && (
-					<span className="wc-block-components-checkbox__label">
-						{ label }
-					</span>
+		return (
+			<div
+				className={ clsx(
+					'wc-block-components-checkbox',
+					{
+						'has-error': hasError,
+					},
+					className
 				) }
-				{ children }
-			</label>
+			>
+				<label htmlFor={ checkboxId }>
+					<input
+						ref={ forwardedRef }
+						id={ checkboxId }
+						className="wc-block-components-checkbox__input"
+						type="checkbox"
+						onChange={ ( event ) =>
+							onChange( event.target.checked )
+						}
+						aria-invalid={ hasError === true }
+						checked={ checked }
+						disabled={ !! disabled }
+						{ ...rest }
+					/>
+					<svg
+						className="wc-block-components-checkbox__mark"
+						aria-hidden="true"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 20"
+					>
+						<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+					</svg>
+					{ label && (
+						<span className="wc-block-components-checkbox__label">
+							{ label }
+						</span>
+					) }
+					{ children }
+				</label>
 				{ feedback }
-		</div>
-	);
+			</div>
+		);
 	}
 );
 

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -18,7 +18,6 @@ export type CheckboxControlProps = {
 	ariaDescribedBy?: string | undefined;
 	onChange: ( value: boolean ) => void;
 	children?: ReactNode | null | undefined;
-	feedback?: ReactNode | null;
 	hasError?: boolean;
 	checked?: boolean;
 	disabled?: string | boolean | undefined;
@@ -41,7 +40,6 @@ export const CheckboxControl = forwardRef<
 			hasError = false,
 			checked = false,
 			disabled = false,
-			feedback,
 			errorId,
 			errorMessage,
 			...rest
@@ -90,7 +88,6 @@ export const CheckboxControl = forwardRef<
 					) }
 					{ children }
 				</label>
-				{ feedback }
 			</div>
 		);
 	}

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/stories/index.stories.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/stories/index.stories.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Story, Meta } from '@storybook/react';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,12 +15,23 @@ export default {
 	args: {
 		instanceId: 'my-checkbox-id',
 		label: 'Check me out',
+		checked: false,
 	},
 } as Meta< CheckboxControlProps >;
 
-const Template: Story< CheckboxControlProps > = ( args ) => (
-	<CheckboxControl { ...args } />
-);
+const Template: Story< CheckboxControlProps > = ( args ) => {
+	const [ checked, setChecked ] = useState( args.checked );
+	useEffect( () => {
+		setChecked( args.checked );
+	}, [ args.checked ] );
+	return (
+		<CheckboxControl
+			{ ...args }
+			onChange={ ( value ) => setChecked( value ) }
+			checked={ checked }
+		/>
+	);
+};
 
 export const Default = Template.bind( {} );
 Default.args = {};

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/style.scss
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/style.scss
@@ -4,6 +4,17 @@
 	margin-top: em($gap);
 	line-height: 1;
 
+	// Validated checkbox is set to grid because we need to display the validation error below the checkbox, the flex
+	// layout doesn't allow for that without extra markup.
+	&.wc-block-components-validated-checkbox-control label {
+		display: grid;
+		grid-template-columns: auto 1fr;
+
+		.wc-block-components-validation-error {
+			grid-column: 1 / -1;
+		}
+	}
+
 	label {
 		align-items: flex-start;
 		display: inline-flex;

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -1,0 +1,244 @@
+/**
+ * External dependencies
+ */
+import {
+	useEffect,
+	useCallback,
+	forwardRef,
+	useImperativeHandle,
+	useRef,
+} from '@wordpress/element';
+import clsx from 'clsx';
+import { isObject } from '@woocommerce/types';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { useInstanceId } from '@wordpress/compose';
+import type { InputHTMLAttributes, ReactElement } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CheckboxControl from './index';
+import './style.scss';
+import { ValidationInputError } from '../validation-input-error';
+import { getValidityMessageForInput } from '../../checkout/utils';
+
+export interface ValidatedCheckboxControlProps
+	extends Omit<
+		InputHTMLAttributes< HTMLInputElement >,
+		'onChange' | 'onBlur' | 'aria-describedby'
+	> {
+	// id to use for the input. If not provided, an id will be generated.
+	id?: string;
+	// Unique instance ID. id will be used instead if provided.
+	instanceId?: string | undefined;
+	// Class name to add to the input.
+	className?: string | undefined;
+	// aria-describedby attribute to add to the input.
+	ariaDescribedBy?: string | undefined;
+	// id to use for the error message. If not provided, an id will be generated.
+	errorId?: string;
+	// Feedback to display alongside the input. May be hidden when validation errors are displayed.
+	feedback?: ReactElement | null;
+	// Callback to run on change which is passed the updated value.
+	onChange: ( newValue: boolean ) => void;
+	// Optional label for the field.
+	label?: string | undefined;
+	// Field value.
+	checked?: boolean | undefined;
+	// If true, validation errors will be shown.
+	showError?: boolean;
+	// Error message to display alongside the field regardless of validation.
+	errorMessage?: string | undefined;
+	// Custom validation function that is run on change. Use setCustomValidity to set an error message.
+	customValidation?:
+		| ( ( inputObject: HTMLInputElement ) => boolean )
+		| undefined;
+	// Custom validation message to display when validity is false. Given the input element. Expected to use inputObject.validity.
+	customValidityMessage?: ( validity: ValidityState ) => undefined | string;
+	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
+	validateOnMount?: boolean | undefined;
+}
+
+export type ValidatedCheckboxControlHandle = {
+	focus?: () => void;
+	revalidate: () => void;
+};
+
+/**
+ * A text based input which validates the input value.
+ */
+const ValidatedCheckboxControl = forwardRef<
+	ValidatedCheckboxControlHandle,
+	ValidatedCheckboxControlProps
+>(
+	(
+		{
+			className,
+			id,
+			ariaDescribedBy,
+			errorId,
+			onChange,
+			showError = true,
+			errorMessage: passedErrorMessage = '',
+			checked = false,
+			customValidation = () => true,
+			customValidityMessage,
+			feedback = null,
+			label,
+			validateOnMount = true,
+			instanceId: preferredInstanceId = '',
+			...rest
+		},
+		forwardedRef
+	): JSX.Element => {
+		// Ref for the input element.
+		const inputRef = useRef< HTMLInputElement >( null );
+
+		const instanceId = useInstanceId(
+			ValidatedCheckboxControl,
+			'',
+			preferredInstanceId
+		);
+		const textInputId =
+			typeof id !== 'undefined' ? id : 'textinput-' + instanceId;
+		const errorIdString = errorId !== undefined ? errorId : textInputId;
+
+		const { setValidationErrors, clearValidationError } =
+			useDispatch( VALIDATION_STORE_KEY );
+
+		// Ref for validation callback.
+		const customValidationRef = useRef( customValidation );
+
+		// Update ref when validation callback changes.
+		useEffect( () => {
+			customValidationRef.current = customValidation;
+		}, [ customValidation ] );
+
+		const { validationError, validationErrorId } = useSelect(
+			( select ) => {
+				const store = select( VALIDATION_STORE_KEY );
+				return {
+					validationError: store.getValidationError( errorIdString ),
+					validationErrorId:
+						store.getValidationErrorId( errorIdString ),
+				};
+			}
+		);
+
+		const validateInput = useCallback(
+			( errorsHidden = true ) => {
+				const inputObject = inputRef.current || null;
+
+				if ( inputObject === null ) {
+					return;
+				}
+
+				if (
+					inputObject.checkValidity() &&
+					customValidationRef.current( inputObject )
+				) {
+					clearValidationError( errorIdString );
+					return;
+				}
+
+				setValidationErrors( {
+					[ errorIdString ]: {
+						message: getValidityMessageForInput(
+							label,
+							inputObject,
+							customValidityMessage
+						),
+						hidden: errorsHidden,
+					},
+				} );
+			},
+			[
+				clearValidationError,
+				errorIdString,
+				setValidationErrors,
+				label,
+				customValidityMessage,
+			]
+		);
+
+		// Allows parent to trigger revalidation.
+		useImperativeHandle(
+			forwardedRef,
+			function () {
+				return {
+					focus() {
+						inputRef.current?.focus();
+					},
+					revalidate() {
+						validateInput( false );
+					},
+				};
+			},
+			[ validateInput ]
+		);
+
+		/**
+		 * Validation on mount.
+		 */
+		useEffect( () => {
+			if ( validateOnMount ) {
+				validateInput( false );
+			}
+		}, [ validateOnMount, validateInput ] );
+
+		// Remove validation errors when unmounted.
+		useEffect( () => {
+			return () => {
+				clearValidationError( errorIdString );
+			};
+		}, [ clearValidationError, errorIdString ] );
+
+		if ( passedErrorMessage !== '' && isObject( validationError ) ) {
+			validationError.message = passedErrorMessage;
+		}
+
+		const hasError = validationError?.message && ! validationError?.hidden;
+
+		return (
+			<CheckboxControl
+				className={ clsx( className, {
+					'has-error': hasError,
+				} ) }
+				aria-invalid={ hasError === true }
+				id={ textInputId }
+				aria-errormessage={
+					// we're using the internal `aria-errormessage` attribute, calculated from the data store.
+					// If a consumer wants to overwrite the attribute, they can pass a prop.
+					showError && hasError && validationErrorId
+						? validationErrorId
+						: undefined
+				}
+				ref={ inputRef }
+				onChange={ ( newValue ) => {
+					validateInput( false );
+					// Push the changes up to the parent component.
+					onChange( newValue );
+				} }
+				ariaDescribedBy={ ariaDescribedBy }
+				checked={ checked }
+				title="" // This prevents the same error being shown on hover.
+				label={ label }
+				feedback={
+					showError && hasError ? (
+						<ValidationInputError
+							errorMessage={ passedErrorMessage }
+							propertyName={ errorIdString }
+							elementId={ errorIdString }
+						/>
+					) : (
+						feedback
+					)
+				}
+				{ ...rest }
+			/>
+		);
+	}
+);
+
+export default ValidatedCheckboxControl;

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -7,12 +7,12 @@ import {
 	forwardRef,
 	useImperativeHandle,
 	useRef,
+	useId,
 } from '@wordpress/element';
 import clsx from 'clsx';
 import { isObject } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
-import { useInstanceId } from '@wordpress/compose';
 import type { InputHTMLAttributes, ReactElement } from 'react';
 
 /**
@@ -84,11 +84,8 @@ const ValidatedCheckboxControl = forwardRef<
 		// Ref for the input element.
 		const inputRef = useRef< HTMLInputElement >( null );
 
-		const instanceId = useInstanceId(
-			ValidatedCheckboxControl,
-			'',
-			preferredInstanceId
-		);
+		const genId = useId();
+		const instanceId = preferredInstanceId || genId;
 		const textInputId = id || `textinput-${ instanceId }`;
 		const errorIdString = errorId || textInputId;
 

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -26,7 +26,7 @@ import { getValidityMessageForInput } from '../../checkout/utils';
 export interface ValidatedCheckboxControlProps
 	extends Omit< InputHTMLAttributes< HTMLInputElement >, 'onChange' > {
 	// Unique instance ID. id will be used instead if provided.
-	instanceId?: string | undefined;
+	instanceId?: string;
 	// id to use for the error message. If not provided, an id will be generated.
 	errorId?: string;
 	// Feedback to display alongside the input. May be hidden when validation errors are displayed.
@@ -34,19 +34,19 @@ export interface ValidatedCheckboxControlProps
 	// Callback to run on change which is passed the updated value.
 	onChange: ( newValue: boolean ) => void;
 	// Optional label for the field.
-	label?: string | undefined;
+	label?: string;
 	// If true, validation errors will be shown.
 	showError?: boolean;
 	// Error message to display alongside the field regardless of validation.
-	errorMessage?: string | undefined;
+	errorMessage?: string;
 	// Custom validation function that is run on change. Use setCustomValidity to set an error message.
 	customValidation?:
 		| ( ( inputObject: HTMLInputElement ) => boolean )
 		| undefined;
 	// Custom validation message to display when validity is false. Given the input element. Expected to use inputObject.validity.
-	customValidityMessage?: ( validity: ValidityState ) => undefined | string;
+	customValidityMessage?: ( validity: ValidityState ) => string;
 	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
-	validateOnMount?: boolean | undefined;
+	validateOnMount?: boolean;
 }
 
 export type ValidatedCheckboxControlHandle = {

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -80,7 +80,7 @@ const ValidatedCheckboxControl = forwardRef<
 			...rest
 		},
 		forwardedRef
-	): JSX.Element => {
+	) => {
 		// Ref for the input element.
 		const inputRef = useRef< HTMLInputElement >( null );
 
@@ -89,9 +89,8 @@ const ValidatedCheckboxControl = forwardRef<
 			'',
 			preferredInstanceId
 		);
-		const textInputId =
-			typeof id !== 'undefined' ? id : 'textinput-' + instanceId;
-		const errorIdString = errorId !== undefined ? errorId : textInputId;
+		const textInputId = id || `textinput-${ instanceId }`;
+		const errorIdString = errorId || textInputId;
 
 		const { setValidationErrors, clearValidationError } =
 			useDispatch( VALIDATION_STORE_KEY );

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -24,18 +24,9 @@ import { ValidationInputError } from '../validation-input-error';
 import { getValidityMessageForInput } from '../../checkout/utils';
 
 export interface ValidatedCheckboxControlProps
-	extends Omit<
-		InputHTMLAttributes< HTMLInputElement >,
-		'onChange' | 'onBlur' | 'aria-describedby'
-	> {
-	// id to use for the input. If not provided, an id will be generated.
-	id?: string;
+	extends Omit< InputHTMLAttributes< HTMLInputElement >, 'onChange' > {
 	// Unique instance ID. id will be used instead if provided.
 	instanceId?: string | undefined;
-	// Class name to add to the input.
-	className?: string | undefined;
-	// aria-describedby attribute to add to the input.
-	ariaDescribedBy?: string | undefined;
 	// id to use for the error message. If not provided, an id will be generated.
 	errorId?: string;
 	// Feedback to display alongside the input. May be hidden when validation errors are displayed.
@@ -44,8 +35,6 @@ export interface ValidatedCheckboxControlProps
 	onChange: ( newValue: boolean ) => void;
 	// Optional label for the field.
 	label?: string | undefined;
-	// Field value.
-	checked?: boolean | undefined;
 	// If true, validation errors will be shown.
 	showError?: boolean;
 	// Error message to display alongside the field regardless of validation.
@@ -76,7 +65,7 @@ const ValidatedCheckboxControl = forwardRef<
 		{
 			className,
 			id,
-			ariaDescribedBy,
+			'aria-describedby': ariaDescribedBy,
 			errorId,
 			onChange,
 			showError = true,

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -205,11 +205,14 @@ const ValidatedCheckboxControl = forwardRef<
 						: undefined
 				}
 				ref={ inputRef }
-				onChange={ ( newValue ) => {
-					validateInput( false );
-					// Push the changes up to the parent component.
-					onChange( newValue );
-				} }
+				onChange={ useCallback(
+					( newValue ) => {
+						validateInput( false );
+						// Push the changes up to the parent component.
+						onChange( newValue );
+					},
+					[ onChange, validateInput ]
+				) }
 				ariaDescribedBy={ ariaDescribedBy }
 				checked={ checked }
 				title="" // This prevents the same error being shown on hover.

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -104,8 +104,6 @@ const ValidatedCheckboxControl = forwardRef<
 			customValidationRef.current = customValidation;
 		}, [ customValidation ] );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore - The second argument is a dependency array, this has no deps it should recalculate all the time.
 		const { validationError, validationErrorId } = useSelect(
 			( select ) => {
 				const store = select( VALIDATION_STORE_KEY );
@@ -114,7 +112,8 @@ const ValidatedCheckboxControl = forwardRef<
 					validationErrorId:
 						store.getValidationErrorId( errorIdString ),
 				};
-			}
+			},
+			[ errorIdString ]
 		);
 
 		const validateInput = useCallback(

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -45,7 +45,7 @@ export interface ValidatedCheckboxControlProps
 		| undefined;
 	// Custom validation message to display when validity is false. Given the input element. Expected to use inputObject.validity.
 	customValidityMessage?: ( validity: ValidityState ) => string;
-	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
+	// Whether validation should run on mount.
 	validateOnMount?: boolean;
 }
 

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -183,7 +183,7 @@ const ValidatedCheckboxControl = forwardRef<
 		 */
 		useEffect( () => {
 			if ( validateOnMount ) {
-				validateInput( false );
+				validateInput( true );
 			}
 		}, [ validateOnMount, validateInput ] );
 

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -115,6 +115,8 @@ const ValidatedCheckboxControl = forwardRef<
 			customValidationRef.current = customValidation;
 		}, [ customValidation ] );
 
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore - The second argument is a dependency array, this has no deps it should recalculate all the time.
 		const { validationError, validationErrorId } = useSelect(
 			( select ) => {
 				const store = select( VALIDATION_STORE_KEY );

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -55,7 +55,7 @@ export type ValidatedCheckboxControlHandle = {
 };
 
 /**
- * A text based input which validates the input value.
+ * A checkbox which validates the input is checked.
  */
 const ValidatedCheckboxControl = forwardRef<
 	ValidatedCheckboxControlHandle,

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -95,11 +95,6 @@ const ValidatedCheckboxControl = forwardRef<
 		// Ref for validation callback.
 		const customValidationRef = useRef( customValidation );
 
-		// Update ref when validation callback changes.
-		useEffect( () => {
-			customValidationRef.current = customValidation;
-		}, [ customValidation ] );
-
 		const { validationError, validationErrorId } = useSelect(
 			( select ) => {
 				const store = select( VALIDATION_STORE_KEY );
@@ -114,6 +109,7 @@ const ValidatedCheckboxControl = forwardRef<
 
 		const validateInput = useCallback(
 			( errorsHidden = true ) => {
+				customValidationRef.current = customValidation;
 				const inputObject = inputRef.current || null;
 
 				if ( inputObject === null ) {
@@ -145,6 +141,7 @@ const ValidatedCheckboxControl = forwardRef<
 				setValidationErrors,
 				label,
 				customValidityMessage,
+				customValidation,
 			]
 		);
 

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -12,7 +12,7 @@ import {
 import clsx from 'clsx';
 import { isObject } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import type { InputHTMLAttributes, ReactElement } from 'react';
 
 /**
@@ -90,14 +90,19 @@ const ValidatedCheckboxControl = forwardRef<
 		const errorIdString = errorId || textInputId;
 
 		const { setValidationErrors, clearValidationError } =
-			useDispatch( VALIDATION_STORE_KEY );
+			useDispatch( validationStore );
 
 		// Ref for validation callback.
 		const customValidationRef = useRef( customValidation );
 
+		// Update ref when validation callback changes.
+		useEffect( () => {
+			customValidationRef.current = customValidation;
+		}, [ customValidation ] );
+
 		const { validationError, validationErrorId } = useSelect(
 			( select ) => {
-				const store = select( VALIDATION_STORE_KEY );
+				const store = select( validationStore );
 				return {
 					validationError: store.getValidationError( errorIdString ),
 					validationErrorId:
@@ -109,7 +114,6 @@ const ValidatedCheckboxControl = forwardRef<
 
 		const validateInput = useCallback(
 			( errorsHidden = true ) => {
-				customValidationRef.current = customValidation;
 				const inputObject = inputRef.current || null;
 
 				if ( inputObject === null ) {
@@ -141,7 +145,6 @@ const ValidatedCheckboxControl = forwardRef<
 				setValidationErrors,
 				label,
 				customValidityMessage,
-				customValidation,
 			]
 		);
 

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx';
 import { isObject } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { validationStore } from '@woocommerce/block-data';
-import type { InputHTMLAttributes, ReactElement } from 'react';
+import type { InputHTMLAttributes } from 'react';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -29,8 +29,6 @@ export interface ValidatedCheckboxControlProps
 	instanceId?: string;
 	// id to use for the error message. If not provided, an id will be generated.
 	errorId?: string;
-	// Feedback to display alongside the input. May be hidden when validation errors are displayed.
-	feedback?: ReactElement | null;
 	// Callback to run on change which is passed the updated value.
 	onChange: ( newValue: boolean ) => void;
 	// Optional label for the field.
@@ -73,7 +71,6 @@ const ValidatedCheckboxControl = forwardRef<
 			checked = false,
 			customValidation = () => true,
 			customValidityMessage,
-			feedback = null,
 			label,
 			validateOnMount = true,
 			instanceId: preferredInstanceId = '',

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -213,19 +213,10 @@ const ValidatedCheckboxControl = forwardRef<
 				checked={ checked }
 				title="" // This prevents the same error being shown on hover.
 				label={ label }
-				feedback={
-					showError && hasError ? (
-						<ValidationInputError
-							errorMessage={ passedErrorMessage }
-							propertyName={ errorIdString }
-							elementId={ errorIdString }
-						/>
-					) : (
-						feedback
-					)
-				}
 				{ ...rest }
-			/>
+			>
+				<ValidationInputError propertyName={ errorIdString } />
+			</CheckboxControl>
 		);
 	}
 );

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -185,9 +185,13 @@ const ValidatedCheckboxControl = forwardRef<
 
 		return (
 			<CheckboxControl
-				className={ clsx( className, {
-					'has-error': hasError,
-				} ) }
+				className={ clsx(
+					'wc-block-components-validated-checkbox-control',
+					className,
+					{
+						'has-error': hasError,
+					}
+				) }
 				aria-invalid={ hasError === true }
 				id={ textInputId }
 				aria-errormessage={

--- a/plugins/woocommerce-blocks/packages/components/index.ts
+++ b/plugins/woocommerce-blocks/packages/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Button } from './button';
 export { default as CheckboxControl } from './checkbox-control';
+export { default as ValidatedCheckboxControl } from './checkbox-control/validated-checkbox-control';
 export { default as CheckboxList } from './checkbox-list';
 export { Chip, RemovableChip } from './chip';
 export { default as FormStep } from './form-step';

--- a/plugins/woocommerce-blocks/packages/components/text-input/types.ts
+++ b/plugins/woocommerce-blocks/packages/components/text-input/types.ts
@@ -9,9 +9,9 @@ export interface ValidatedTextInputProps
 		'onChange' | 'onBlur'
 	> {
 	// Unique instance ID. id will be used instead if provided.
-	instanceId?: string | undefined;
+	instanceId?: string;
 	// aria-describedby attribute to add to the input.
-	ariaDescribedBy?: string | undefined;
+	ariaDescribedBy?: string;
 	// id to use for the error message. If not provided, an id will be generated.
 	errorId?: string;
 	// Feedback to display alongside the input. May be hidden when validation errors are displayed.
@@ -21,19 +21,17 @@ export interface ValidatedTextInputProps
 	// Callback to run on change which is passed the updated value.
 	onChange: ( newValue: string ) => void;
 	// Optional label for the field.
-	label?: string | undefined;
+	label?: string;
 	// If true, validation errors will be shown.
 	showError?: boolean;
 	// Error message to display alongside the field regardless of validation.
-	errorMessage?: string | undefined;
+	errorMessage?: string;
 	// Custom validation function that is run on change. Use setCustomValidity to set an error message.
-	customValidation?:
-		| ( ( inputObject: HTMLInputElement ) => boolean )
-		| undefined;
+	customValidation?: ( inputObject: HTMLInputElement ) => boolean;
 	// Custom validation message to display when validity is false. Given the input element. Expected to use inputObject.validity.
-	customValidityMessage?: ( validity: ValidityState ) => undefined | string;
+	customValidityMessage?: ( validity: ValidityState ) => string;
 	// Custom formatted to format values as they are typed.
 	customFormatter?: ( value: string ) => string;
 	// Whether validation should run when mounted - only has an effect when focusOnMount is also true.
-	validateOnMount?: boolean | undefined;
+	validateOnMount?: boolean;
 }

--- a/plugins/woocommerce-blocks/packages/components/text-input/types.ts
+++ b/plugins/woocommerce-blocks/packages/components/text-input/types.ts
@@ -42,6 +42,6 @@ export interface ValidatedTextInputProps
 	customValidityMessage?: ( validity: ValidityState ) => undefined | string;
 	// Custom formatted to format values as they are typed.
 	customFormatter?: ( value: string ) => string;
-	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
+	// Whether validation should run when mounted - only has an effect when focusOnMount is also true.
 	validateOnMount?: boolean | undefined;
 }

--- a/plugins/woocommerce-blocks/packages/components/text-input/types.ts
+++ b/plugins/woocommerce-blocks/packages/components/text-input/types.ts
@@ -8,14 +8,8 @@ export interface ValidatedTextInputProps
 		InputHTMLAttributes< HTMLInputElement >,
 		'onChange' | 'onBlur'
 	> {
-	// id to use for the input. If not provided, an id will be generated.
-	id?: string;
 	// Unique instance ID. id will be used instead if provided.
 	instanceId?: string | undefined;
-	// Type of input, defaults to text.
-	type?: string | undefined;
-	// Class name to add to the input.
-	className?: string | undefined;
 	// aria-describedby attribute to add to the input.
 	ariaDescribedBy?: string | undefined;
 	// id to use for the error message. If not provided, an id will be generated.
@@ -28,8 +22,6 @@ export interface ValidatedTextInputProps
 	onChange: ( newValue: string ) => void;
 	// Optional label for the field.
 	label?: string | undefined;
-	// Field value.
-	value?: string | undefined;
 	// If true, validation errors will be shown.
 	showError?: boolean;
 	// Error message to display alongside the field regardless of validation.

--- a/plugins/woocommerce-blocks/packages/components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce-blocks/packages/components/text-input/validated-text-input.tsx
@@ -42,7 +42,7 @@ const ValidatedTextInput = forwardRef<
 			className,
 			id,
 			type = 'text',
-			ariaDescribedBy,
+			ariaDescribedBy = '',
 			errorId,
 			focusOnMount = false,
 			onChange,

--- a/plugins/woocommerce-blocks/tests/e2e/plugins/additional-checkout-fields.php
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/additional-checkout-fields.php
@@ -96,6 +96,18 @@ class Additional_Checkout_Fields_Test_Helper {
 				'type'     => 'checkbox',
 			)
 		);
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'            => 'first-plugin-namespace/test-required-checkbox',
+				'label'         => 'Test required checkbox',
+				'location'      => 'contact',
+				'required'      => 'true',
+				'type'          => 'checkbox',
+				'error_message' => 'Please check the box or you will be unable to order',
+			)
+		);
+
 		woocommerce_register_additional_checkout_field(
 			array(
 				'id'       => 'first-plugin-namespace/road-size',

--- a/plugins/woocommerce-blocks/tests/e2e/plugins/additional-checkout-fields.php
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/additional-checkout-fields.php
@@ -102,7 +102,7 @@ class Additional_Checkout_Fields_Test_Helper {
 				'id'            => 'first-plugin-namespace/test-required-checkbox',
 				'label'         => 'Test required checkbox',
 				'location'      => 'contact',
-				'required'      => 'true',
+				'required'      => true,
 				'type'          => 'checkbox',
 				'error_message' => 'Please check the box or you will be unable to order',
 			)

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -71,6 +71,44 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 
 			await checkoutPageObject.placeOrder( false );
 
+			// Test that the required checkbox warning shows up after submitting without interacting.
+			await expect(
+				checkoutPageObject.page.getByText(
+					'Please check the box or you will be unable to order'
+				)
+			).toBeVisible();
+
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
+
+			await expect(
+				checkoutPageObject.page.getByText(
+					'Please check the box or you will be unable to order'
+				)
+			).toBeHidden();
+
+			// Test that unchecking shows and checking again hides the message.
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.uncheck();
+
+			await expect(
+				checkoutPageObject.page.getByText(
+					'Please check the box or you will be unable to order'
+				)
+			).toBeVisible();
+
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
+
+			await expect(
+				checkoutPageObject.page.getByText(
+					'Please check the box or you will be unable to order'
+				)
+			).toBeHidden();
+
 			await expect(
 				checkoutPageObject.page.getByText(
 					'Please enter a valid government id'

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -182,6 +182,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 
 			await checkoutPageObject.waitForCheckoutToFinishUpdating();
 
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
+
 			await checkoutPageObject.placeOrder();
 
 			expect(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.merchant.block_theme.spec.ts
@@ -102,6 +102,10 @@ test.describe( 'Merchant → Additional Checkout Fields', () => {
 			.getByLabel( 'Can a truck fit down your road?' )
 			.uncheck();
 
+		await checkoutPageObject.page
+			.getByLabel( 'Test required checkbox' )
+			.check();
+
 		await checkoutPageObject.placeOrder();
 
 		const orderId = checkoutPageObject.getOrderId();
@@ -237,6 +241,10 @@ test.describe( 'Merchant → Additional Checkout Fields', () => {
 			} )
 			.getByLabel( 'Can a truck fit down your road?' )
 			.uncheck();
+
+		await checkoutPageObject.page
+			.getByLabel( 'Test required checkbox' )
+			.check();
 
 		await checkoutPageObject.placeOrder();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
@@ -87,6 +87,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
 
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
+
 			await checkoutPageObject.placeOrder();
 
 			expect(
@@ -317,6 +321,9 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 					},
 				}
 			);
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
 
 			await checkoutPageObject.waitForCustomerDataUpdate();
 
@@ -417,6 +424,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
+
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
 
 			await checkoutPageObject.placeOrder();
 
@@ -562,6 +573,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
+
 			await checkoutPageObject.placeOrder( false );
 
 			await expect(
@@ -683,6 +698,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
+
+			await checkoutPageObject.page
+				.getByLabel( 'Test required checkbox' )
+				.check();
 
 			await checkoutPageObject.placeOrder();
 

--- a/plugins/woocommerce/changelog/add-additional-required-checkbox
+++ b/plugins/woocommerce/changelog/add-additional-required-checkbox
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add required checkboxes to Additional Checkout Fields API

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -462,6 +462,12 @@ class CheckoutFields {
 			unset( $field_data['error_message'] );
 		}
 
+		// Get the error message property and set it to errorMessage for use in JS.
+		if ( isset( $field_data['error_message'] ) ) {
+			$field_data['errorMessage'] = $field_data['error_message'];
+			unset( $field_data['error_message'] );
+		}
+
 		return $field_data;
 	}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -446,9 +446,11 @@ class CheckoutFields {
 			return false;
 		}
 
-		// Filter the boolean in case the developer added it as a string.
-		$options['required']    = filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
-		$field_data['required'] = $options['required'];
+		if ( isset( $options['required'] ) ) {
+			// Filter the boolean in case the developer added it as a string.
+			$options['required']    = filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+			$field_data['required'] = $options['required'];
+		}
 
 		if ( ( ! isset( $options['required'] ) || false === $options['required'] ) && ! empty( $options['error_message'] ) ) {
 			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -446,6 +446,10 @@ class CheckoutFields {
 			return false;
 		}
 
+		// Filter the boolean in case the developer added it as a string.
+		$options['required']    = filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+		$field_data['required'] = $options['required'];
+
 		if ( ( ! isset( $options['required'] ) || false === $options['required'] ) && ! empty( $options['error_message'] ) ) {
 			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );
 			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -440,12 +440,22 @@ class CheckoutFields {
 	private function process_checkbox_field( $field_data, $options ) {
 		$id = $options['id'];
 
-		// Checkbox fields are always optional. Log a warning if it's set explicitly as true.
-		$field_data['required'] = false;
+		if ( isset( $options['required'] ) && ! is_bool( $options['required'] ) ) {
+			$message = sprintf( 'The required property for field with id: "%s" must be a boolean, you passed %s. The field will not be registered.', $id, gettype( $options['required'] ) );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
+			return false;
+		}
 
-		if ( isset( $options['required'] ) && true === $options['required'] ) {
-			$message = sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+		if ( ( ! isset( $options['required'] ) || false === $options['required'] ) && ! empty( $options['error_message'] ) ) {
+			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
+			unset( $field_data['error_message'] );
+		}
+
+		if ( isset( $options['error_message'] ) && ! is_string( $options['error_message'] ) ) {
+			$message = sprintf( 'The error_message property for field with id: "%s" must be a string, you passed %s. A default message will be shown.', $id, gettype( $options['error_message'] ) );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
+			unset( $field_data['error_message'] );
 		}
 
 		return $field_data;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -442,7 +442,7 @@ class CheckoutFields {
 
 		if ( isset( $options['required'] ) && null === filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
 			$message = sprintf( 'The required property for field with id: "%s" must be a boolean, you passed %s. The field will not be registered.', $id, gettype( $options['required'] ) );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
 			return false;
 		}
 
@@ -454,13 +454,13 @@ class CheckoutFields {
 
 		if ( ( ! isset( $options['required'] ) || false === $options['required'] ) && ! empty( $options['error_message'] ) ) {
 			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
 			unset( $field_data['error_message'] );
 		}
 
 		if ( isset( $options['error_message'] ) && ! is_string( $options['error_message'] ) ) {
 			$message = sprintf( 'The error_message property for field with id: "%s" must be a string, you passed %s. A default message will be shown.', $id, gettype( $options['error_message'] ) );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
 			unset( $field_data['error_message'] );
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -440,7 +440,7 @@ class CheckoutFields {
 	private function process_checkbox_field( $field_data, $options ) {
 		$id = $options['id'];
 
-		if ( isset( $options['required'] ) && ! is_bool( $options['required'] ) ) {
+		if ( isset( $options['required'] ) && null === filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
 			$message = sprintf( 'The required property for field with id: "%s" must be a boolean, you passed %s. The field will not be registered.', $id, gettype( $options['required'] ) );
 			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.6.0' );
 			return false;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -440,16 +440,13 @@ class CheckoutFields {
 	private function process_checkbox_field( $field_data, $options ) {
 		$id = $options['id'];
 
-		if ( isset( $options['required'] ) && null === filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ) {
+		if ( isset( $options['required'] ) && ! is_bool( $options['required'] ) ) {
 			$message = sprintf( 'The required property for field with id: "%s" must be a boolean, you passed %s. The field will not be registered.', $id, gettype( $options['required'] ) );
 			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
 			return false;
 		}
 
-		if ( isset( $options['required'] ) ) {
-			// Filter the boolean in case the developer added it as a string.
-			$field_data['required'] = filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
-		}
+		$field_data['required'] = $options['required'] ?? false;
 
 		if ( ( ! isset( $field_data['required'] ) || false === $field_data['required'] ) && ! empty( $options['error_message'] ) ) {
 			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -448,11 +448,10 @@ class CheckoutFields {
 
 		if ( isset( $options['required'] ) ) {
 			// Filter the boolean in case the developer added it as a string.
-			$options['required']    = filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
-			$field_data['required'] = $options['required'];
+			$field_data['required'] = filter_var( $options['required'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 		}
 
-		if ( ( ! isset( $options['required'] ) || false === $options['required'] ) && ! empty( $options['error_message'] ) ) {
+		if ( ( ! isset( $field_data['required'] ) || false === $field_data['required'] ) && ! empty( $options['error_message'] ) ) {
 			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );
 			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
 			unset( $field_data['error_message'] );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -337,7 +337,6 @@ class CheckoutSchema extends AbstractSchema {
 				$field_schema['enum'][] = true;
 			}
 
-
 			$schema[ $key ] = $field_schema;
 		}
 		return $schema;

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -333,6 +333,11 @@ class CheckoutSchema extends AbstractSchema {
 				$field_schema['type'] = 'boolean';
 			}
 
+			if ( 'checkbox' === $field['type'] && true === $field['required'] ) {
+				$field_schema['enum'][] = true;
+			}
+
+
 			$schema[ $key ] = $field_schema;
 		}
 		return $schema;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1129,7 +1129,7 @@ class AdditionalFields extends MockeryTestCase {
 				'label'    => 'Checkbox Bad Required Value',
 				'location' => 'order',
 				'type'     => 'checkbox',
-				'required' => 'true',
+				'required' => true,
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -45,6 +45,7 @@ class AdditionalFields extends MockeryTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 
 		global $wp_rest_server;
 		$wp_rest_server = new \Spy_REST_Server();
@@ -106,6 +107,7 @@ class AdditionalFields extends MockeryTestCase {
 		WC()->session->destroy_session();
 		remove_all_filters( 'woocommerce_get_country_locale' );
 		remove_all_actions( 'doing_it_wrong_run' );
+		remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 		$this->unregister_fields();
 		parent::tearDown();
 	}
@@ -1046,15 +1048,15 @@ class AdditionalFields extends MockeryTestCase {
 	}
 
 	/**
-	 * Ensure an error is triggered when a checkbox is registered as required.
+	 * Ensure an error is triggered when a checkbox is registered with invalid required property.
 	 */
 	public function test_invalid_required_prop_checkbox() {
-		$id                    = 'plugin-namespace/checkbox-only-optional';
+		$id                    = 'plugin-namespace/checkbox-bad-required-value';
 		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
 				'woocommerce_register_additional_checkout_field',
-				\esc_html( sprintf( 'Registering checkbox fields as required is not supported. "%s" will be registered as optional.', $id ) ),
+				\esc_html( sprintf( 'The required property for field with id: "%s" must be a boolean, you passed string. The field will not be registered.', $id ) ),
 			)
 		)->once();
 
@@ -1071,10 +1073,10 @@ class AdditionalFields extends MockeryTestCase {
 		\woocommerce_register_additional_checkout_field(
 			array(
 				'id'       => $id,
-				'label'    => 'Checkbox Only Optional',
+				'label'    => 'Checkbox Bad Required Value',
 				'location' => 'order',
 				'type'     => 'checkbox',
-				'required' => true,
+				'required' => 'string',
 			)
 		);
 
@@ -1086,16 +1088,194 @@ class AdditionalFields extends MockeryTestCase {
 			)
 		);
 
-		// Fields should still be registered regardless of the error, but with required as optional.
+		// Fields should not be registered.
+		$request  = new \WP_REST_Request( 'OPTIONS', '/wc/store/v1/checkout' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertArrayNotHasKey(
+			$id,
+			$data['schema']['properties']['additional_fields']['properties']
+		);
+
+		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
+
+		// Ensures the field isn't registered.
+		$this->assertFalse( $this->controller->is_field( $id ), \sprintf( '%s is still registered', $id ) );
+	}
+
+	/**
+	 * Ensure no error is triggered when a checkbox is registered with required property that is not boolean, but can be filtered to one.
+	 */
+	public function test_valid_required_prop_checkbox() {
+		$id                    = 'plugin-namespace/checkbox-good-required-value';
+		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
+		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->never();
+
+		add_action(
+			'doing_it_wrong_run',
+			array(
+				$doing_it_wrong_mocker,
+				'doing_it_wrong_run',
+			),
+			10,
+			2
+		);
+
+		\woocommerce_register_additional_checkout_field(
+			array(
+				'id'       => $id,
+				'label'    => 'Checkbox Bad Required Value',
+				'location' => 'order',
+				'type'     => 'checkbox',
+				'required' => 'true',
+			)
+		);
+
+		\remove_action(
+			'doing_it_wrong_run',
+			array(
+				$doing_it_wrong_mocker,
+				'doing_it_wrong_run',
+			)
+		);
+
+		// Fields should not be registered.
 		$request  = new \WP_REST_Request( 'OPTIONS', '/wc/store/v1/checkout' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$data = $response->get_data();
 
 		$this->assertEquals(
+			true,
+			$data['schema']['properties']['additional_fields']['properties'][ $id ]['required']
+		);
+
+		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
+
+		// Ensures the field isn't registered.
+		$this->assertFalse( $this->controller->is_field( $id ), \sprintf( '%s is still registered', $id ) );
+	}
+
+	/**
+	 * Ensure a warning is triggered when a checkbox is registered with an error_message, but it is not required.
+	 */
+	public function test_error_message_non_required_checkbox() {
+		$id                    = 'plugin-namespace/checkbox-non-required-error-message';
+		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
+		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
+			array(
+				'woocommerce_register_additional_checkout_field',
+				\esc_html( sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id ) ),
+			)
+		)->once();
+
+		add_action(
+			'doing_it_wrong_run',
+			array(
+				$doing_it_wrong_mocker,
+				'doing_it_wrong_run',
+			),
+			10,
+			2
+		);
+
+		\woocommerce_register_additional_checkout_field(
+			array(
+				'id'            => $id,
+				'label'         => 'Checkbox Non Required Error message',
+				'location'      => 'order',
+				'type'          => 'checkbox',
+				'required'      => false,
+				'error_message' => 'This field is required.',
+			)
+		);
+
+		\remove_action(
+			'doing_it_wrong_run',
+			array(
+				$doing_it_wrong_mocker,
+				'doing_it_wrong_run',
+			)
+		);
+
+		// Fields should not be registered.
+		$request  = new \WP_REST_Request( 'OPTIONS', '/wc/store/v1/checkout' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertArrayNotHasKey(
+			'error_message',
+			$data['schema']['properties']['additional_fields']['properties'][ $id ]
+		);
+		$this->assertEquals(
 			false,
-			$data['schema']['properties']['additional_fields']['properties'][ $id ]['required'],
-			print_r( $data['schema']['properties']['additional_fields']['properties'][ $id ], true )
+			$data['schema']['properties']['additional_fields']['properties'][ $id ]['required']
+		);
+
+		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
+
+		// Ensures the field isn't registered.
+		$this->assertFalse( $this->controller->is_field( $id ), \sprintf( '%s is still registered', $id ) );
+	}
+
+	/**
+	 * Ensure a warning is triggered when a checkbox is registered with a non-string error_message.
+	 */
+	public function test_non_string_error_message_checkbox() {
+		$id                    = 'plugin-namespace/checkbox-non-string-error-message';
+		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
+		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
+			array(
+				'woocommerce_register_additional_checkout_field',
+				\esc_html( sprintf( 'The error_message property for field with id: "%s" must be a string, you passed boolean. A default message will be shown.', $id ) ),
+			)
+		)->once();
+
+		add_action(
+			'doing_it_wrong_run',
+			array(
+				$doing_it_wrong_mocker,
+				'doing_it_wrong_run',
+			),
+			10,
+			2
+		);
+
+		\woocommerce_register_additional_checkout_field(
+			array(
+				'id'            => $id,
+				'label'         => 'Checkbox Non Required Error message',
+				'location'      => 'order',
+				'type'          => 'checkbox',
+				'required'      => true,
+				'error_message' => false,
+			)
+		);
+
+		\remove_action(
+			'doing_it_wrong_run',
+			array(
+				$doing_it_wrong_mocker,
+				'doing_it_wrong_run',
+			)
+		);
+
+		// Fields should not be registered.
+		$request  = new \WP_REST_Request( 'OPTIONS', '/wc/store/v1/checkout' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertArrayNotHasKey(
+			'error_message',
+			$data['schema']['properties']['additional_fields']['properties'][ $id ]
+		);
+		$this->assertEquals(
+			true,
+			$data['schema']['properties']['additional_fields']['properties'][ $id ]['required']
 		);
 
 		\__internal_woocommerce_blocks_deregister_checkout_field( $id );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Adds a `ValidatedCheckboxControl` component to the `@woocommerce/blocks-components` package.
- Add tests to cover `ValidatedCheckboxControl`
- Support `'required' => true` for checkbox fields in the Additional Checkout Fields API.
- Support custom error messages for required checkbox fields in the Additional Checkout Fields API.
- Bug fix in `CheckboxControl` story. (Will add `ValidatedCheckboxControl` stories in a follow up PR)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #51255

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

## Front-end (shopper) testing
1. Add the following code to your site:

```php
add_action( 'woocommerce_blocks_loaded', function() {
woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'first-plugin-namespace/test-required-field',
				'label'    => 'Test required field',
				'location' => 'contact',
				'required' => true, // boolean, not string
				'type'     => 'checkbox',
				'error_message' => 'Please check the box or you cannot place the order'
			)
		);
} );
```

2. Go to the Checkout block and ensure you see the `Test required field` checkbox.
3. Check it and uncheck it, verify the error message defined above shows up.
4. Try to check out while it's unchecked with the error message visible, ensure checkout cannot proceed while the box is unchecked.
5. Check the box, ensure the error disappears.
6. Reload the page, ensure the error message is not showing.
7. Try to check out while the checkbox is unchecked, but every other field is valid. Ensure the error message displays and you can't check out.
8. Check the box and ensure you can check out.

## Developer testing

1. Take the snippet above, change the value of `required` to `'false'` (as a string, not boolean).
2. Load the Checkout block, ensure the field is optional.
3. Change the value of `required` to an array, load the Checkout block, ensure you get a doing_it_wrong error (use [Query Monitor](https://en-gb.wordpress.org/plugins/query-monitor/) to see these)
4. Remove `required` completely, go to the Checkout block and ensure the field is optional.
5. Change the value of `required` to `true` (boolean), go to the Checkout block and ensure it is required, follow some steps from above, e.g. checking and unchecking the field.
6. Change the value of `error_message` to anything that isn't a string. Ensure you see a doing_it_wrong error in the Checkout block. Check the field is still required, but a generic error message is shown.
7. Change the value of `error_message` back, and then change `required` to `false`. Reload the Checkout block, ensure you see a doing_it_wrong error.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
