### PR TITLE
Align variation selector labels and selects

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-selector-alignment
+++ b/plugins/woocommerce/changelog/fix-variation-selector-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Align variation selector labels and selects in the Single Product template of block themes

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -164,10 +164,14 @@
 	* Product variations
 	*/
 	table.variations {
+		display: block;
+
 		tr {
-			// Limit variation dropdown width and add block gap.
-			display: block;
-			margin-bottom: var(--wp--style--block-gap);
+			th,
+			td {
+				padding-bottom: var(--wp--style--block-gap);
+				text-align: left;
+			}
 
 			th {
 				// Ensure variation label doesn't stick to dropdown.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces some CSS changes to make sure the selects of the variation selector are correctly aligned between them, like in a table/grid layout. This PR only affects block themes and I tried to keep CSS changes to the minimum, to decrease the risk of backwards compatibility issues.

See p1733479099772339-slack-C02FL3X7KR6 for extra context.

### How to test the changes in this Pull Request:

1. Go to the frontend page of a variable product with more than one attribute.
2. Verify the selects are aligned between them and the labels take the same width, no matter how long the text is.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/45d4b6f8-ea48-4ba5-aa6d-505d664141b8) | ![imatge](https://github.com/user-attachments/assets/fd907c3f-8363-423e-ab4e-6ab28bd47ecc)