### PR TITLE
Link the Payments task to Payments task page when the new Payments settings feature is enabled

### DIFF
--- a/plugins/woocommerce/changelog/update-link-payments-task-to-task-page-when-new-payments-settings-feature-flag
+++ b/plugins/woocommerce/changelog/update-link-payments-task-to-task-page-when-new-payments-settings-feature-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: The Payments task page is not part of the initial entry points for the new Payments settings page.
+
+

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -76,8 +76,10 @@ class Payments extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		// If the React-based Payments settings page is enabled, the task is always visible.
-		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) ) {
+		// If the React-based Payments settings page is enabled, the task is visible
+		// if just the payment-gateway-suggestions feature is also, without checking if WooPayments is supported.
+		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) &&
+			Features::is_enabled( 'payment-gateway-suggestions' )) {
 			return true;
 		}
 
@@ -101,20 +103,5 @@ class Payments extends Task {
 		);
 
 		return ! empty( $enabled_gateways );
-	}
-
-	/**
-	 * The task action URL.
-	 *
-	 * @return string
-	 */
-	public function get_action_url() {
-		// If the React-based Payments settings page is enabled, we want the task to link to the Payments Settings page.
-		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) ) {
-			return admin_url( 'admin.php?page=wc-settings&tab=checkout' );
-		}
-
-		// Otherwise, we want the task behavior to remain unchanged (link to the Payments task page).
-		return '';
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -77,9 +77,9 @@ class Payments extends Task {
 	 */
 	public function can_view() {
 		// If the React-based Payments settings page is enabled, the task is visible
-		// if just the payment-gateway-suggestions feature is also, without checking if WooPayments is supported.
+		// if just the payment-gateway-suggestions feature is also enabled, without checking if WooPayments is supported.
 		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) &&
-			Features::is_enabled( 'payment-gateway-suggestions' )) {
+			Features::is_enabled( 'payment-gateway-suggestions' ) ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -104,4 +104,21 @@ class Payments extends Task {
 
 		return ! empty( $enabled_gateways );
 	}
+
+	/**
+	 * The task action URL.
+	 *
+	 * @return string
+	 */
+	public function get_action_url() {
+		// If the React-based Payments settings page is enabled and the task is complete
+		// we want the task to link to the Payments Settings page.
+		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) &&
+			self::is_complete() ) {
+			return admin_url( 'admin.php?page=wc-settings&tab=checkout' );
+		}
+
+		// Otherwise, we want the task behavior to remain unchanged (link to the Payments task page).
+		return '';
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -715,6 +715,12 @@ class PaymentsRestController extends RestApiControllerBase {
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
+						'dev_mode'    => array(
+							'type'        => 'boolean',
+							'description' => esc_html__( 'Whether the provider is in dev mode.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
 					),
 				),
 				'management'        => array(

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -67,7 +67,7 @@ class WcPayWelcomePage {
 	 * Delayed hook registration.
 	 */
 	public function delayed_register() {
-		// Don't do anything if the feature is not enabled.
+		// Don't do anything if the feature is enabled.
 		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) ) {
 			return;
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
@@ -587,6 +587,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'enabled', $provider['state'], 'Provider (gateway) `state[enabled]` entry is missing' );
 		$this->assertArrayHasKey( 'needs_setup', $provider['state'], 'Provider (gateway) `state[needs_setup]` entry is missing' );
 		$this->assertArrayHasKey( 'test_mode', $provider['state'], 'Provider (gateway) `state[test_mode]` entry is missing' );
+		$this->assertArrayHasKey( 'dev_mode', $provider['state'], 'Provider (gateway) `state[dev_mode]` entry is missing' );
 		$this->assertArrayHasKey( 'management', $provider, 'Provider (gateway) `management` entry is missing' );
 		$this->assertArrayHasKey( 'settings_url', $provider['management'], 'Provider (gateway) `management[settings_url]` entry is missing' );
 		$this->assertArrayHasKey( 'onboarding', $provider, 'Provider (gateway) `onboarding` entry is missing' );
@@ -667,6 +668,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'enabled', $provider['state'], 'Provider (gateway) `state[enabled]` entry is missing' );
 		$this->assertArrayHasKey( 'needs_setup', $provider['state'], 'Provider (gateway) `state[needs_setup]` entry is missing' );
 		$this->assertArrayHasKey( 'test_mode', $provider['state'], 'Provider (gateway) `state[test_mode]` entry is missing' );
+		$this->assertArrayHasKey( 'dev_mode', $provider['state'], 'Provider (gateway) `state[dev_mode]` entry is missing' );
 		$this->assertArrayHasKey( 'management', $provider, 'Provider (gateway) `management` entry is missing' );
 		$this->assertArrayHasKey( 'settings_url', $provider['management'], 'Provider (gateway) `management[settings_url]` entry is missing' );
 		$this->assertArrayHasKey( 'onboarding', $provider, 'Provider (gateway) `onboarding` entry is missing' );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
@@ -958,6 +958,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 					'enabled'     => false,
 					'needs_setup' => false,
 					'test_mode'   => false,
+					'dev_mode'    => false,
 				),
 				'management'  => array(
 					'settings_url' => 'http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs',
@@ -987,6 +988,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 					'enabled'     => false,
 					'needs_setup' => false,
 					'test_mode'   => false,
+					'dev_mode'    => false,
 				),
 				'management'  => array(
 					'settings_url' => 'http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=checkout&section=cheque',
@@ -1016,6 +1018,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 					'enabled'     => false,
 					'needs_setup' => false,
 					'test_mode'   => false,
+					'dev_mode'    => false,
 				),
 				'management'  => array(
 					'settings_url' => 'http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=checkout&section=cod',
@@ -1035,6 +1038,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 					'enabled'     => $enabled_core_paypal_pg,
 					'needs_setup' => false,
 					'test_mode'   => false,
+					'dev_mode'    => false,
 				),
 				'management'  => array(
 					'settings_url' => 'admin.php?page=wc-settings&tab=checkout&section=paypal',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -91,6 +91,7 @@ class PaymentsTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'enabled', $gateway['state'], 'Gateway `state[enabled]` entry is missing' );
 		$this->assertArrayHasKey( 'needs_setup', $gateway['state'], 'Gateway `state[needs_setup]` entry is missing' );
 		$this->assertArrayHasKey( 'test_mode', $gateway['state'], 'Gateway `state[test_mode]` entry is missing' );
+		$this->assertArrayHasKey( 'dev_mode', $gateway['state'], 'Gateway `state[dev_mode]` entry is missing' );
 		$this->assertArrayHasKey( 'management', $gateway, 'Gateway `management` entry is missing' );
 		$this->assertArrayHasKey( 'settings_url', $gateway['management'], 'Gateway `management[settings_url]` entry is missing' );
 		$this->assertArrayHasKey( 'links', $gateway, 'Gateway `links` entry is missing' );
@@ -315,6 +316,7 @@ class PaymentsTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'enabled', $gateway['state'], 'Gateway `state[enabled]` entry is missing' );
 		$this->assertArrayHasKey( 'needs_setup', $gateway['state'], 'Gateway `state[needs_setup]` entry is missing' );
 		$this->assertArrayHasKey( 'test_mode', $gateway['state'], 'Gateway `state[test_mode]` entry is missing' );
+		$this->assertArrayHasKey( 'dev_mode', $gateway['state'], 'Gateway `state[dev_mode]` entry is missing' );
 		$this->assertArrayHasKey( 'management', $gateway, 'Gateway `management` entry is missing' );
 		$this->assertArrayHasKey( 'settings_url', $gateway['management'], 'Gateway `management[settings_url]` entry is missing' );
 		// There are no `plugin` or `links` entries because this is a fake gateway without a plugin.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

To align with the PRD requirements, the Payments task will continue to link to the Payments task page, not the new Payments settings page. The linking introduced in [this PR](https://github.com/woocommerce/woocommerce/pull/53514) was a mistake - we fix it in this PR.

Updates to #53379 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja site with WooCommerce on this PR's live branch and the WooCommerce Beta Tester plugin (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=update/link-payments-task-to-task-page-when-new-payments-settings-feature-flag))
2. Go to WP admin > Tools > WCA Test Helper > Features and make sure the `reactify-classic-payments-settings` is enabled
3. Access the WP admin of the newly created site, click on the WooCommerce menu item, and you should be taken to the WooCommerce profiler. Click "Skip guided setup" and choose `US` as the store's base location country.
4. Go to WooCommerce > Home, and you should see a "Get paid" task. Click on it and you will be taken to the Payments task page:
![Screenshot 2024-12-10 at 16 54 36](https://github.com/user-attachments/assets/5eae5b69-985c-4334-af54-85623d851adf)
5. Go to WooCommerce > Home, click on the Payments menu item (with a red badge notice), and you will be taken to the new Payments settings page:
![Screenshot 2024-12-06 at 16 08 59](https://github.com/user-attachments/assets/ea04942b-8144-4019-9b91-b90beaa29264)
6. Click on Take offline payments and enable "Cash on delivery"
7. Go to WooCommerce > Home, and the "Get paid" task should be marked as completed, the Payments main menu item should not have a red badge notice anymore, and a "Set up additional payment options" task should be visible in the Things to do next list:
![Screenshot 2024-12-06 at 16 14 03](https://github.com/user-attachments/assets/8beaa07b-3811-429f-a48a-0630940ab886)
8. Click on the "Get paid" task and you should be taken to the new Payments settings page.
9. Click on "Take offline payments" and disable "Cash on delivery".
10. Go to WooCommerce > Home, and the "Get paid" task should NOT be marked as completed.
11. Click on "Get started" to install and activate WooPayments:
![394325233-5eae5b69-985c-4334-af54-85623d851adf](https://github.com/user-attachments/assets/9a99ee4c-8ba3-4a68-be32-56c7baf5855b)
12. Click on "Connect" to start the WooPayments onboarding process:
![Screenshot 2024-12-10 at 16 57 43](https://github.com/user-attachments/assets/96153e6b-24b0-4c07-8839-72a370ad25a2)
13. You should be asked to connect your site to WPCOM (if there is not Jetpack connection) and then pointed to the WooPayments onboarding wizard:
![Screenshot 2024-12-10 at 17 05 06](https://github.com/user-attachments/assets/db16d3f0-fb68-47f7-a4cc-ce13369d4f42)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
