### PR TITLE
[e2e tests] Fix flakiness in shop-search-browse spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-shop-search-browse-sort-home-category
+++ b/plugins/woocommerce/changelog/e2e-fix-shop-search-browse-sort-home-category
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix flakiness in shop-search-browse-sort spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
@@ -1,117 +1,86 @@
 /**
  * Internal dependencies
  */
-import { tags } from '../../fixtures/fixtures';
-const { test, expect } = require( '@playwright/test' );
-const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-const { faker } = require( '@faker-js/faker' );
-
-const singleProductPrice1 = '979.99';
-const singleProductPrice2 = '989.99';
-const singleProductPrice3 = '999.99';
-
-const simpleProductName = faker.commerce.productName();
-
-const categoryA = faker.commerce.department();
-const categoryB = faker.commerce.department();
-const categoryC = faker.commerce.department();
-
-let categoryAId, categoryBId, categoryCId, product1Id, product2Id, product3Id;
+import { test, expect, tags } from '../../fixtures/fixtures';
+import { getFakeCategory, getFakeProduct } from '../../utils/data';
 
 test.describe(
 	'Search, browse by categories and sort items in the shop',
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
-		test.beforeAll( async ( { baseURL } ) => {
-			const api = new wcApi( {
-				url: baseURL,
-				consumerKey: process.env.CONSUMER_KEY,
-				consumerSecret: process.env.CONSUMER_SECRET,
-				version: 'wc/v3',
-			} );
-			// add product categories
+		let categories = [];
+		let products = [];
+
+		test.beforeAll( async ( { api } ) => {
 			await api
-				.post( 'products/categories', {
-					name: categoryA,
+				.post( 'products/categories/batch', {
+					create: [
+						getFakeCategory(),
+						getFakeCategory(),
+						getFakeCategory(),
+					],
 				} )
 				.then( ( response ) => {
-					categoryAId = response.data.id;
-				} );
-			await api
-				.post( 'products/categories', {
-					name: categoryB,
+					categories = response.data.create;
 				} )
-				.then( ( response ) => {
-					categoryBId = response.data.id;
-				} );
-			await api
-				.post( 'products/categories', {
-					name: categoryC,
-				} )
-				.then( ( response ) => {
-					categoryCId = response.data.id;
+				.catch( ( error ) => {
+					console.error( error.response );
 				} );
 
-			// add products
 			await api
-				.post( 'products', {
-					name: simpleProductName + ' 1',
-					type: 'simple',
-					regular_price: singleProductPrice1,
-					categories: [ { id: categoryAId } ],
+				.post( 'products/batch', {
+					create: [
+						{
+							...getFakeProduct( { regular_price: '979.99' } ),
+							categories: [ { id: categories[ 0 ].id } ],
+						},
+						{
+							...getFakeProduct( { regular_price: '989.99' } ),
+							categories: [ { id: categories[ 1 ].id } ],
+						},
+						{
+							...getFakeProduct( { regular_price: '999.99' } ),
+							categories: [ { id: categories[ 2 ].id } ],
+						},
+					],
 				} )
 				.then( ( response ) => {
-					product1Id = response.data.id;
-				} );
-			await api
-				.post( 'products', {
-					name: simpleProductName + ' 2',
-					type: 'simple',
-					regular_price: singleProductPrice2,
-					categories: [ { id: categoryBId } ],
+					products = response.data.create;
 				} )
-				.then( ( response ) => {
-					product2Id = response.data.id;
-				} );
-			await api
-				.post( 'products', {
-					name: simpleProductName + ' 3',
-					type: 'simple',
-					regular_price: singleProductPrice3,
-					categories: [ { id: categoryCId } ],
-				} )
-				.then( ( response ) => {
-					product3Id = response.data.id;
+				.catch( ( error ) => {
+					console.error( error.response );
 				} );
 		} );
 
-		test.afterAll( async ( { baseURL } ) => {
-			const api = new wcApi( {
-				url: baseURL,
-				consumerKey: process.env.CONSUMER_KEY,
-				consumerSecret: process.env.CONSUMER_SECRET,
-				version: 'wc/v3',
-			} );
+		test.afterAll( async ( { api } ) => {
 			await api.post( 'products/batch', {
-				delete: [ product1Id, product2Id, product3Id ],
+				delete: [
+					products[ 0 ].id,
+					products[ 1 ].id,
+					products[ 2 ].id,
+				],
 			} );
 			await api.post( 'products/categories/batch', {
-				delete: [ categoryAId, categoryBId, categoryCId ],
+				delete: [
+					categories[ 0 ].id,
+					categories[ 1 ].id,
+					categories[ 2 ].id,
+				],
 			} );
 		} );
 
 		// default theme doesn't have a search box, but can simulate a search by visiting the search URL
 		test( 'should let user search the store', async ( { page } ) => {
 			await test.step( 'Go to the shop and perform the search', async () => {
-				await page.goto( `shop/?s=${ simpleProductName }%201` );
+				await page.goto( `shop/?s=${ products[ 0 ].name }%201` );
 
 				await expect(
 					page.getByRole( 'heading', {
-						name: `${ simpleProductName } 1`,
+						name: `${ products[ 0 ].name }`,
 					} )
 				).toBeVisible();
 				await expect( page.getByLabel( 'Breadcrumb' ) ).toContainText(
-					`${ simpleProductName } 1`
+					`${ products[ 0 ].name }`
 				);
 			} );
 		} );
@@ -119,28 +88,31 @@ test.describe(
 		test( 'should let user browse products by categories', async ( {
 			page,
 		} ) => {
-			await test.step( 'Go to the shop and browse by the Audio category', async () => {
+			await test.step( 'Go to the shop and browse by the category', async () => {
 				await page.goto( 'shop/' );
-				await page.locator( `text=${ simpleProductName } 2` ).click();
+				await page.locator( `text=${ products[ 1 ].name }` ).click();
 				await page
 					.getByLabel( 'Breadcrumb' )
-					.getByRole( 'link', { name: categoryB } )
+					.getByRole( 'link', {
+						name: categories[ 1 ].name,
+						exact: true,
+					} )
 					.click();
 			} );
 
-			await test.step( 'Ensure the Audio category page contains all the relevant products', async () => {
+			await test.step( 'Ensure the category page contains all the relevant products', async () => {
 				await expect(
-					page.getByRole( 'heading', { name: categoryB } )
+					page.getByRole( 'heading', { name: categories[ 1 ].name } )
 				).toBeVisible();
 				await expect(
 					page.getByRole( 'heading', {
-						name: simpleProductName + ' 2',
+						name: products[ 1 ].name,
 					} )
 				).toBeVisible();
-				await page.locator( `text=${ simpleProductName } 2` ).click();
+				await page.locator( `text=${ products[ 1 ].name }` ).click();
 				await expect(
 					page.getByRole( 'heading', {
-						name: simpleProductName + ' 2',
+						name: products[ 1 ].name,
 					} )
 				).toBeVisible();
 			} );
@@ -152,7 +124,7 @@ test.describe(
 			await test.step( 'Go to the shop and sort by price high to low', async () => {
 				await page.goto( 'shop/' );
 				await expect(
-					page.getByLabel( `Add to cart: “${ simpleProductName } 1”` )
+					page.getByLabel( `Add to cart: “${ products[ 0 ].name }”` )
 				).toBeVisible();
 
 				// sort by price high to low
@@ -171,10 +143,10 @@ test.describe(
 					.getByRole( 'heading' )
 					.allInnerTexts();
 				const highToLow_index_priciest = highToLowList.indexOf(
-					`${ simpleProductName } 3`
+					`${ products[ 2 ].name }`
 				);
 				const highToLow_index_cheapest = highToLowList.indexOf(
-					`${ simpleProductName } 1`
+					`${ products[ 0 ].name }`
 				);
 				expect( highToLow_index_priciest ).toBeLessThan(
 					highToLow_index_cheapest
@@ -184,7 +156,7 @@ test.describe(
 			await test.step( 'Go to the shop and sort by price low to high', async () => {
 				await page.goto( 'shop/' );
 				await expect(
-					page.getByLabel( `Add to cart: “${ simpleProductName } 1”` )
+					page.getByLabel( `Add to cart: “${ products[ 0 ].name }”` )
 				).toBeVisible();
 
 				// sort by price low to high
@@ -201,10 +173,10 @@ test.describe(
 					.getByRole( 'heading' )
 					.allInnerTexts();
 				const lowToHigh_index_priciest = lowToHighList.indexOf(
-					`${ simpleProductName } 3`
+					`${ products[ 2 ].name }`
 				);
 				const lowToHigh_index_cheapest = lowToHighList.indexOf(
-					`${ simpleProductName } 1`
+					`${ products[ 0 ].name }`
 				);
 				expect( lowToHigh_index_cheapest ).toBeLessThan(
 					lowToHigh_index_priciest

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
@@ -15,13 +15,17 @@ test.describe(
 			await api
 				.post( 'products/categories/batch', {
 					create: [
-						getFakeCategory(),
-						getFakeCategory(),
-						getFakeCategory(),
+						getFakeCategory( { extraRandomTerm: true } ),
+						getFakeCategory( { extraRandomTerm: true } ),
+						getFakeCategory( { extraRandomTerm: true } ),
 					],
 				} )
 				.then( ( response ) => {
 					categories = response.data.create;
+
+					if ( categories.map( ( c ) => c.id ).includes( 0 ) ) {
+						console.log( JSON.stringify( response.data ) );
+					}
 				} )
 				.catch( ( error ) => {
 					console.error( error.response );

--- a/plugins/woocommerce/tests/e2e-pw/utils/data.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/data.js
@@ -56,9 +56,11 @@ function getFakeProduct( options = {} ) {
 	};
 }
 
-function getFakeCategory() {
+function getFakeCategory( options = { extraRandomTerm: false } ) {
 	return {
-		name: `${ faker.commerce.productMaterial() } ${ faker.commerce.department() } `,
+		name: `${ faker.commerce.productMaterial() } ${ faker.commerce.department() } ${
+			options.extraRandomTerm ? faker.string.alphanumeric( 5 ) : ''
+		}`.trim(),
 	};
 }
 

--- a/plugins/woocommerce/tests/e2e-pw/utils/data.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/data.js
@@ -45,16 +45,25 @@ function getFakeCustomer() {
 	return getFakeUser( 'customer' );
 }
 
-function getFakeProduct() {
+function getFakeProduct( options = {} ) {
 	return {
 		name: `${ faker.commerce.productName() }`,
 		description: faker.commerce.productDescription(),
-		regular_price: faker.commerce.price(),
+		regular_price: options.regular_price
+			? options.regular_price
+			: faker.commerce.price(),
 		type: 'simple',
+	};
+}
+
+function getFakeCategory() {
+	return {
+		name: `${ faker.commerce.productMaterial() } ${ faker.commerce.department() } `,
 	};
 }
 
 module.exports = {
 	getFakeCustomer,
 	getFakeProduct,
+	getFakeCategory,
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53510

There are 2 different issues causing the test to be flaky, both related to the randomly generated categories names:
1. The test uses 3 categories, and sometimes 2 of the 3 randomly generated categories were the same. This caused the api call that creates the second duplicated category to fail.
3. Sometimes the generated category was 'Home' which is similar to the 'Home' breadcrumb resulting in a strict mode violation.

Both were fixed by making the category name out of multiple terms, decreasing the change of duplication and making sure the category named 'Home' will never be generated.
Using 2 words categories and running the test multiple runs of 500 repeats each it still failed 3 times on average, because the category already exists. Adding the 3rd word in the category name removed that possibility, and the test passed each time.

I refactored the entire `beforeAll` hook and how the test data is generated.

### How to test the changes in this Pull Request:

```
pnpm test:e2e shop-search-browse-sort.spec.js --repeat-each=100
```
