### PR TITLE
[e2e tests] Update test tags in page-loads spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-tags-in-page-loads-spec
+++ b/plugins/woocommerce/changelog/e2e-update-tags-in-page-loads-spec
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: updated tags used in page-loads spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -110,7 +110,7 @@ const wcPages = [
 for ( const currentPage of wcPages ) {
 	test.describe(
 		`WooCommerce Page Load > Load ${ currentPage.name } sub pages`,
-		{ tag: [ '@gutenberg', '@services' ] },
+		{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
 		() => {
 			const product = getFakeProduct();
 			const customer = getFakeCustomer();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some tags in the page-loads spec file were reverted by mistake while solving a merge conflict in #53594.
This fixes that.

### How to test the changes in this Pull Request:

CI green.
