### PR TITLE
Fix `registerBlockSingleProductTemplate` not respecting `isAvailableOnPostEditor` flag

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -17,10 +17,11 @@ const blockData: BlockData = {
 test.describe( `${ blockData.name } Block`, () => {
 	test( "can't be added in the Post Editor", async ( { admin, editor } ) => {
 		await admin.createNewPost();
-		await editor.insertBlock( { name: blockData.slug } );
 		await expect(
-			await editor.getBlockByName( blockData.slug )
-		).toBeHidden();
+			editor.insertBlock( { name: blockData.slug } )
+		).rejects.toThrow(
+			new RegExp( `Block type '${ blockData.slug }' is not registered.` )
+		);
 	} );
 
 	test( "can't be added in the Product Catalog Template", async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -18,10 +18,11 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 	} ) => {
 		await admin.createNewPost();
-		await editor.insertBlock( { name: blockData.slug } );
 		await expect(
-			await editor.getBlockByName( blockData.slug )
-		).toBeHidden();
+			editor.insertBlock( { name: blockData.slug } )
+		).rejects.toThrow(
+			new RegExp( `Block type '${ blockData.slug }' is not registered.` )
+		);
 	} );
 
 	test( 'block can be inserted in the Site Editor', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { test, expect, Editor } from '@woocommerce/e2e-utils';
+
+const insertSingleProductBlock = async (
+	blockName: string,
+	editor: Editor
+) => {
+	await editor.insertBlockUsingGlobalInserter( 'Single Product' );
+	await editor.canvas.getByText( 'Album' ).click();
+	await editor.canvas.getByText( 'Done' ).click();
+	const singleProductBlock = await editor.getBlockByName(
+		'woocommerce/single-product'
+	);
+	const singleProductClientId =
+		( await singleProductBlock.getAttribute( 'data-block' ) ) ?? '';
+	return singleProductClientId;
+};
+
+const insertInSingleProductTemplate = async (
+	blockName: string,
+	editor: Editor,
+	admin: Admin
+) => {
+	await admin.visitSiteEditor( {
+		postId: `woocommerce/woocommerce//single-product`,
+		postType: 'wp_template',
+		canvas: 'edit',
+	} );
+	await editor.setContent( '' );
+	await editor.insertBlock( { name: blockName } );
+};
+
+test.describe( 'registerBlockSingleProductTemplate registers', () => {
+	test( 'block available on posts, e.g. Product Price', async ( {
+		admin,
+		editor,
+	} ) => {
+		const blockName = 'woocommerce/product-price';
+
+		await test.step( 'Unavailable in post globally', async () => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: blockName } );
+			await expect(
+				await editor.getBlockByName( blockName )
+			).toHaveCount( 0 );
+		} );
+
+		await test.step( 'Available in post within Single Product block', async () => {
+			const singleProductClientId = await insertSingleProductBlock(
+				blockName,
+				editor
+			);
+			// One from the global inserter, one from the single product block
+			await editor.insertBlock(
+				{ name: blockName },
+				{ clientId: singleProductClientId }
+			);
+			await expect(
+				await editor.getBlockByName( blockName )
+			).toHaveCount( 2 );
+		} );
+
+		await test.step( 'Available in Single Product template globally', async () => {
+			await insertInSingleProductTemplate( blockName, editor, admin );
+			await expect(
+				await editor.getBlockByName( blockName )
+			).toHaveCount( 1 );
+		} );
+	} );
+
+	test( 'block unavailable on posts, e.g. Product Details', async ( {
+		admin,
+		editor,
+	} ) => {
+		const blockName = 'woocommerce/product-details';
+
+		await test.step( 'Unavailable in post, also within Single Product block', async () => {
+			await admin.createNewPost();
+			const singleProductClientId = await insertSingleProductBlock(
+				blockName,
+				editor
+			);
+			await expect(
+				editor.insertBlock(
+					{ name: blockName },
+					{ clientId: singleProductClientId }
+				)
+			).rejects.toThrow(
+				new RegExp( `Block type '${ blockName }' is not registered.` )
+			);
+		} );
+
+		await test.step( 'Available in Single Product template globally', async () => {
+			await insertInSingleProductTemplate( blockName, editor, admin );
+			await expect(
+				await editor.getBlockByName( blockName )
+			).toHaveCount( 1 );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-53604
+++ b/plugins/woocommerce/changelog/fix-53604
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blocks registration through registerBlockSingleProductTemplate


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Due to changes in https://github.com/woocommerce/woocommerce/pull/53217, util didn't respect the `isAvailableOnPostEditor` flag and registered blocks in posts nevertheless.

Closes https://github.com/woocommerce/woocommerce/issues/53604

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Blocks - In posts

1. Create new post
2. Try inserting:
    - Product Price - should be unavailable (✖️)
    - Product Details - should be unavailable (✖️)
3. Insert Single Product block and choose some products
4. Within Single Product block try inserting:
    - Product Price - should be available (☑️)
    - Product Details - should be unavailable (✖️)

### Blocks - in Single Product Template

2. Go to Single Product template
2. Anywhere on the template, try inserting :
    - Product Price - should be available (☑️)
    - Product Details - should be available (☑️)

### Below steps are for developers only!

1. Allow Related Products in the inserter by replacing [this line](https://github.com/woocommerce/woocommerce/blob/b0bb52897a0bbe47a6866d5b5be9147a32bf986d/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/related-products.tsx#L143) with

```
scope: [ 'block', 'inserter' ],
```

In addition, pass the `isAvailableOnPostEditor: false,` flag in [line 146](https://github.com/woocommerce/woocommerce/blob/b0bb52897a0bbe47a6866d5b5be9147a32bf986d/plugins/woocommerce-blocks/assets/js/blocks/product-query/variations/related-products.tsx#L145).

#### Variation - disallowed in post

1. Create new post
2. Try inserting:
    - Related Products Controls - should be unavailable (✖️)
3. Insert Single Product block and choose some products
4. Within Single Product block try inserting:
    - Related Products Controls - should be unavailable (✖️)

#### Variation - allowed in post

0. Change the `isAvailableOnPostEditor` flag from `false` to `true`.
1. Create new post
2. Try inserting:
    - Related Products Controls - should be available (☑️)
3. Insert Single Product block and choose some products
4. Within Single Product block try inserting:
    - Related Products Controls - should be available (☑️)

> [!NOTE]  
> The last scenario is just a hypothetical and block itself will crash on the frontend as it's not meant to be used in this context. The key point is to check whether it appears or not in inserter based on the flag.
> Also, for some reason the block cannot be used as a direct child of Single Product block. This is also unrelated to this PR and like I said, block is not even meant to be used in that context hence it doesn't require investigation or fixing.

#### Variation - in Single Product Template

1. Go to Single Product template
2. Anywhere on the template, try inserting :
    - Related Products Controls - should be available (☑️)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
