### PR TITLE
Live email preview when email settings are changed

### DIFF
--- a/plugins/woocommerce/changelog/52424-email-preview-live-changes
+++ b/plugins/woocommerce/changelog/52424-email-preview-live-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Experimental: live preview email styles changes without saving settings

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-functions.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-functions.tsx
@@ -53,29 +53,20 @@ export const areColorsChanged = ( colors: DefaultColors ): boolean => {
 export const addListeners = ( listener: () => void ) => {
 	// Input listeners
 	for ( const inputId of Object.keys( colorFieldMap ) ) {
-		const inputElement = document.getElementById(
-			inputId
-		) as HTMLInputElement;
-		inputElement.addEventListener( 'change', listener );
+		const field = jQuery( `#${ inputId }` );
+		if ( field.length ) {
+			// Using jQuery events due to iris (color picker) usage
+			field.on( 'change', listener );
+		}
 	}
-	// Color picker listeners
-	const $colorPickers = document.querySelectorAll( '.iris-picker' );
-	$colorPickers.forEach( ( item: Element ) =>
-		item.addEventListener( 'click', listener )
-	);
 };
 
 export const removeListeners = ( listener: () => void ) => {
 	// Input listeners
 	for ( const inputId of Object.keys( colorFieldMap ) ) {
-		const inputElement = document.getElementById(
-			inputId
-		) as HTMLInputElement;
-		inputElement.removeEventListener( 'change', listener );
+		const field = jQuery( `#${ inputId }` );
+		if ( field.length ) {
+			field.off( 'change', listener );
+		}
 	}
-	// Color picker listeners
-	const $colorPickers = document.querySelectorAll( '.iris-picker' );
-	$colorPickers.forEach( ( item: Element ) =>
-		item.removeEventListener( 'click', listener )
-	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { useEffect } from 'react';
 
 type EmailPreviewIframeProps = {
@@ -16,12 +17,22 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 	settingsIds,
 } ) => {
 	useEffect( () => {
-		const handleFieldChange = async () => {
+		const handleFieldChange = async ( event: Event ) => {
+			const target = event.target as HTMLInputElement;
+			const key = target.id;
+			const value = target.value;
+
 			setIsLoading( true );
 
-			setTimeout( () => {
+			try {
+				await apiFetch( {
+					path: 'wc-admin-email/settings/email/save-transient',
+					method: 'POST',
+					data: { key, value },
+				} );
+			} finally {
 				setIsLoading( false );
-			}, 1000 );
+			}
 		};
 
 		// Set up listeners

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+type EmailPreviewIframeProps = {
+	src: string;
+	setIsLoading: ( isLoading: boolean ) => void;
+};
+export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
+	src,
+	setIsLoading,
+} ) => {
+	return (
+		<iframe
+			src={ src }
+			title={ __( 'Email preview frame', 'woocommerce' ) }
+			onLoad={ () => setIsLoading( false ) }
+		/>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -34,7 +34,6 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 					data: { key, value },
 				} );
 			} finally {
-				setIsLoading( false );
 				setCounter( ( prevCounter ) => prevCounter + 1 );
 			}
 		};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -20,7 +20,7 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 	const [ counter, setCounter ] = useState( 0 );
 
 	useEffect( () => {
-		const handleFieldChange = debounce( async ( event: Event ) => {
+		const handleFieldChange = async ( event: Event ) => {
 			const target = event.target as HTMLInputElement;
 			const key = target.id;
 			const value = target.value;
@@ -37,14 +37,14 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 				setIsLoading( false );
 				setCounter( ( prevCounter ) => prevCounter + 1 );
 			}
-		}, 400 );
+		};
 
 		// Set up listeners
 		settingsIds.forEach( ( id ) => {
 			const field = jQuery( `#${ id }` );
 			if ( field.length ) {
 				// Using jQuery events due to select2 and iris (color picker) usage
-				field.on( 'change', handleFieldChange );
+				field.on( 'change', debounce( handleFieldChange, 400 ) );
 			}
 		} );
 

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { debounce } from 'lodash';
 
 type EmailPreviewIframeProps = {
@@ -17,6 +17,8 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 	setIsLoading,
 	settingsIds,
 } ) => {
+	const [ counter, setCounter ] = useState( 0 );
+
 	useEffect( () => {
 		const handleFieldChange = debounce( async ( event: Event ) => {
 			const target = event.target as HTMLInputElement;
@@ -33,6 +35,7 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 				} );
 			} finally {
 				setIsLoading( false );
+				setCounter( ( prevCounter ) => prevCounter + 1 );
 			}
 		}, 400 );
 
@@ -54,11 +57,11 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 				}
 			} );
 		};
-	}, [ setIsLoading, settingsIds ] );
+	}, [ setIsLoading, settingsIds, setCounter ] );
 
 	return (
 		<iframe
-			src={ src }
+			src={ `${ src }&hash=${ counter }` }
 			title={ __( 'Email preview frame', 'woocommerce' ) }
 			onLoad={ () => setIsLoading( false ) }
 		/>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect } from 'react';
+import { debounce } from 'lodash';
 
 type EmailPreviewIframeProps = {
 	src: string;
@@ -17,7 +18,7 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 	settingsIds,
 } ) => {
 	useEffect( () => {
-		const handleFieldChange = async ( event: Event ) => {
+		const handleFieldChange = debounce( async ( event: Event ) => {
 			const target = event.target as HTMLInputElement;
 			const key = target.id;
 			const value = target.value;
@@ -33,7 +34,7 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 			} finally {
 				setIsLoading( false );
 			}
-		};
+		}, 400 );
 
 		// Set up listeners
 		settingsIds.forEach( ( id ) => {

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -2,15 +2,48 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 
 type EmailPreviewIframeProps = {
 	src: string;
 	setIsLoading: ( isLoading: boolean ) => void;
+	settingsIds: string[];
 };
+
 export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 	src,
 	setIsLoading,
+	settingsIds,
 } ) => {
+	useEffect( () => {
+		const handleFieldChange = async () => {
+			setIsLoading( true );
+
+			setTimeout( () => {
+				setIsLoading( false );
+			}, 1000 );
+		};
+
+		// Set up listeners
+		settingsIds.forEach( ( id ) => {
+			const field = jQuery( `#${ id }` );
+			if ( field.length ) {
+				// Using jQuery events due to select2 and iris (color picker) usage
+				field.on( 'change', handleFieldChange );
+			}
+		} );
+
+		return () => {
+			// Remove listeners
+			settingsIds.forEach( ( id ) => {
+				const field = jQuery( `#${ id }` );
+				if ( field.length ) {
+					field.off( 'change' );
+				}
+			} );
+		};
+	}, [ setIsLoading, settingsIds ] );
+
 	return (
 		<iframe
 			src={ src }

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -26,11 +26,13 @@ export type EmailType = SelectControl.Option;
 type EmailPreviewFillProps = {
 	emailTypes: EmailType[];
 	previewUrl: string;
+	settingsIds: string[];
 };
 
 const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	emailTypes,
 	previewUrl,
+	settingsIds,
 } ) => {
 	const [ deviceType, setDeviceType ] =
 		useState< string >( DEVICE_TYPE_DESKTOP );
@@ -74,6 +76,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 					<EmailPreviewIframe
 						src={ finalPreviewUrl }
 						setIsLoading={ setIsLoading }
+						settingsIds={ settingsIds }
 					/>
 				</div>
 			</div>
@@ -96,12 +99,20 @@ export const registerSettingsEmailPreviewFill = () => {
 	try {
 		emailTypes = JSON.parse( emailTypesData || '' );
 	} catch ( e ) {}
+	const settingsIdsData = slotElement.getAttribute(
+		'data-email-settings-ids'
+	);
+	let settingsIds: string[] = [];
+	try {
+		settingsIds = JSON.parse( settingsIdsData || '' );
+	} catch ( e ) {}
 
 	registerPlugin( 'woocommerce-admin-settings-email-preview', {
 		// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
 		scope: 'woocommerce-email-preview-settings',
 		render: () => (
 			<EmailPreviewFill
+				settingsIds={ settingsIds }
 				emailTypes={ emailTypes }
 				previewUrl={ previewUrl }
 			/>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -3,7 +3,6 @@
  */
 import { createSlotFill, SelectControl, Spinner } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 
 /**
@@ -16,6 +15,7 @@ import {
 	DEVICE_TYPE_DESKTOP,
 } from './settings-email-preview-device-type';
 import { EmailPreviewHeader } from './settings-email-preview-header';
+import { EmailPreviewIframe } from './settings-email-preview-iframe';
 import { EmailPreviewSend } from './settings-email-preview-send';
 import { EmailPreviewType } from './settings-email-preview-type';
 
@@ -71,10 +71,9 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 					className={ `wc-settings-email-preview wc-settings-email-preview-${ deviceType }` }
 				>
 					<EmailPreviewHeader emailType={ emailType } />
-					<iframe
+					<EmailPreviewIframe
 						src={ finalPreviewUrl }
-						title={ __( 'Email preview frame', 'woocommerce' ) }
-						onLoad={ () => setIsLoading( false ) }
+						setIsLoading={ setIsLoading }
 					/>
 				</div>
 			</div>

--- a/plugins/woocommerce/client/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings.js
@@ -51,10 +51,14 @@
 		$( '.colorpick' )
 			.iris( {
 				change: function ( event, ui ) {
-					$( this )
+					const $this = $( this );
+					$this
 						.parent()
 						.find( '.colorpickpreview' )
 						.css( { backgroundColor: ui.color.toString() } );
+					setTimeout( function () {
+						$this.trigger( 'change' );
+					} );
 				},
 				hide: true,
 				border: true,

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -629,7 +629,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * Creates the React mount point for the email preview.
 	 */
 	public function email_preview() {
-		//Deletes transient with email settings used for live preview. This is to
+		// Deletes transient with email settings used for live preview. This is to
 		// prevent conflicts where the preview would show values from previous session.
 		foreach ( EmailPreview::EMAIL_SETTINGS_IDS as $id ) {
 			delete_transient( $id );

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -647,6 +647,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			id="wc_settings_email_preview_slotfill"
 			data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
 			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
+			data-email-settings-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::EMAIL_SETTINGS_IDS ) ); ?>"
 		></div>
 		<?php
 	}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -6,6 +6,7 @@
  * @version 2.1.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\BrandingController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
@@ -628,6 +629,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * Creates the React mount point for the email preview.
 	 */
 	public function email_preview() {
+		//Deletes transient with email settings used for live preview. This is to
+		// prevent conflicts where the preview would show values from previous session.
+		foreach ( EmailPreview::EMAIL_SETTINGS_IDS as $id ) {
+			delete_transient( $id );
+		}
 		$emails      = WC()->mailer()->get_emails();
 		$email_types = array();
 		foreach ( $emails as $type => $email ) {

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -21,6 +21,18 @@ defined( 'ABSPATH' ) || exit;
 class EmailPreview {
 	const DEFAULT_EMAIL_TYPE = 'WC_Email_Customer_Processing_Order';
 
+	const EMAIL_SETTINGS_IDS = array(
+		'woocommerce_email_background_color',
+		'woocommerce_email_base_color',
+		'woocommerce_email_body_background_color',
+		'woocommerce_email_font_family',
+		'woocommerce_email_footer_text',
+		'woocommerce_email_footer_text_color',
+		'woocommerce_email_header_alignment',
+		'woocommerce_email_header_image',
+		'woocommerce_email_text_color',
+	);
+
 	/**
 	 * The email type to preview.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -164,11 +164,12 @@ class EmailPreview {
 		}
 
 		$content = $this->email->get_content_html();
+		$inlined = $this->email->style_inline( $content );
 
 		$this->clean_up_filters();
 
 		/** This filter is documented in src/Internal/Admin/EmailPreview/EmailPreview.php */
-		return apply_filters( 'woocommerce_mail_content', $this->email->style_inline( $content ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		return apply_filters( 'woocommerce_mail_content', $inlined ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
@@ -288,6 +289,8 @@ class EmailPreview {
 		// Email templates fetch product from the database to show additional information, which are not
 		// saved in WC_Order_Item_Product. This filter enables fetching that data also in email preview.
 		add_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10, 1 );
+		// Enable email preview mode - this way transient values are fetched for live preview.
+		add_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
 	}
 
 	/**
@@ -296,6 +299,7 @@ class EmailPreview {
 	private function clean_up_filters() {
 		remove_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
 		remove_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10 );
+		remove_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
 	}
 
 	/**
@@ -305,6 +309,16 @@ class EmailPreview {
 	 * @return true
 	 */
 	public function enable_shipping_address() {
+		return true;
+	}
+
+	/**
+	 * Enable preview mode to use transient values in email-styles.php. Not using __return_true
+	 * so we don't accidentally remove the same filter used by other plugin or theme.
+	 *
+	 * @return true
+	 */
+	public function enable_preview_mode() {
 		return true;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -19,7 +19,6 @@ class EmailPreviewRestController extends RestApiControllerBase {
 	 */
 	private EmailPreview $email_preview;
 
-
 	/**
 	 * The root namespace for the JSON REST API endpoints.
 	 *
@@ -98,6 +97,43 @@ class EmailPreviewRestController extends RestApiControllerBase {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/save-transient',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->save_transient( $request ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'key'   => array(
+							'required'          => true,
+							'type'              => 'string',
+							'description'       => 'The key for the transient. Must be one of the allowed options.',
+							'validate_callback' => function ( $key ) {
+								if ( ! in_array( $key, EmailPreview::EMAIL_SETTINGS_IDS, true ) ) {
+									return new \WP_Error(
+										'woocommerce_rest_not_allowed_key',
+										sprintf( 'The provided key "%s" is not allowed.', $key ),
+										array( 'status' => 400 ),
+									);
+								}
+								return true;
+							},
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'value' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'description'       => 'The value to be saved for the transient.',
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -167,6 +203,29 @@ class EmailPreviewRestController extends RestApiControllerBase {
 
 		return array(
 			'subject' => $this->email_preview->get_subject(),
+		);
+	}
+
+	/**
+	 * Handle the POST /settings/email/save-transient.
+	 *
+	 * @param WP_REST_Request $request The received request.
+	 * @return array|WP_Error Request response or an error.
+	 */
+	public function save_transient( WP_REST_Request $request ) {
+		$key    = $request->get_param( 'key' );
+		$value  = $request->get_param( 'value' );
+		$is_set = set_transient( $key, $value, HOUR_IN_SECONDS );
+		if ( ! $is_set ) {
+			return new WP_Error(
+				'woocommerce_rest_transient_not_set',
+				__( 'Error saving transient. Please try again.', 'woocommerce' ),
+				array( 'status' => 500 )
+			);
+		}
+		return array(
+			// translators: %s: Email settings color key, e.g., "woocommerce_email_base_color".
+			'message' => sprintf( __( 'Transient saved for key %s.', 'woocommerce' ), $key ),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -128,7 +128,13 @@ class EmailPreviewRestController extends RestApiControllerBase {
 							'type'              => 'string',
 							'description'       => 'The value to be saved for the transient.',
 							'validate_callback' => 'rest_validate_request_arg',
-							'sanitize_callback' => 'sanitize_text_field',
+							'sanitize_callback' => function ( $value, $request ) {
+								$key = $request->get_param( 'key' );
+								if ( 'woocommerce_email_footer_text' === $key ) {
+									return sanitize_textarea_field( $value );
+								}
+								return sanitize_text_field( $value );
+							},
 						),
 					),
 				),

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -131,7 +131,7 @@ class EmailPreviewRestController extends RestApiControllerBase {
 							'sanitize_callback' => function ( $value, $request ) {
 								$key = $request->get_param( 'key' );
 								if ( 'woocommerce_email_footer_text' === $key ) {
-									return sanitize_textarea_field( $value );
+									return wp_kses_post( trim( $value ) );
 								}
 								return sanitize_text_field( $value );
 							},

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -299,7 +299,6 @@ class FeaturesController {
 						'Enable modern email design and live preview for transactional emails',
 						'woocommerce'
 					),
-					'disable_ui'  => true,
 				),
 			);
 

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -49,7 +49,7 @@ defined( 'ABSPATH' ) || exit;
 															 */
 															if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
 																$text_transient    = get_transient( 'woocommerce_email_footer_text' );
-																$email_footer_text = $text_transient ? $text_transient : $email_footer_text;
+																$email_footer_text = false !== $text_transient ? $text_transient : $email_footer_text;
 															}
 															echo wp_kses_post(
 																wpautop(

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 7.4.0
+ * @version 9.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -41,6 +41,16 @@ defined( 'ABSPATH' ) || exit;
 													<tr>
 														<td colspan="2" valign="middle" id="credit">
 															<?php
+															$email_footer_text = get_option( 'woocommerce_email_footer_text' );
+															/**
+															 * This filter is documented in templates/emails/email-styles.php
+															 *
+															 * @since 9.6.0
+															 */
+															if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
+																$text_transient    = get_transient( 'woocommerce_email_footer_text' );
+																$email_footer_text = $text_transient ? $text_transient : $email_footer_text;
+															}
 															echo wp_kses_post(
 																wpautop(
 																	wptexturize(
@@ -51,7 +61,7 @@ defined( 'ABSPATH' ) || exit;
 																		 *
 																		 * @param string $email_footer_text
 																		 */
-																		apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) )
+																		apply_filters( 'woocommerce_email_footer_text', $email_footer_text )
 																	)
 																)
 															);

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 7.4.0
+ * @version 9.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -39,6 +39,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<div id="template_header_image">
 										<?php
 										$img = get_option( 'woocommerce_email_header_image' );
+										/**
+										 * This filter is documented in templates/emails/email-styles.php
+										 *
+										 * @since 9.6.0
+										 */
+										if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
+											$img_transient = get_transient( 'woocommerce_email_header_image' );
+											$img           = $img_transient ? $img_transient : $img;
+										}
 
 										if ( $img ) {
 											echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( get_bloginfo( 'name', 'display' ) ) . '" /></p>';

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 										 */
 										if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
 											$img_transient = get_transient( 'woocommerce_email_header_image' );
-											$img           = $img_transient ? $img_transient : $img;
+											$img           = false !== $img_transient ? $img_transient : $img;
 										}
 
 										if ( $img ) {

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -23,10 +23,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 $bg               = get_option( 'woocommerce_email_background_color' );
 $body             = get_option( 'woocommerce_email_body_background_color' );
 $base             = get_option( 'woocommerce_email_base_color' );
-$base_text        = wc_light_or_dark( $base, '#202020', '#ffffff' );
 $text             = get_option( 'woocommerce_email_text_color' );
 $footer_text      = get_option( 'woocommerce_email_footer_text_color' );
 $header_alignment = get_option( 'woocommerce_email_header_alignment' );
+
+/**
+ * Check if we are in preview mode (WooCommerce > Settings > Emails).
+ *
+ * @since 9.6.0
+ * @param bool $is_email_preview Whether the email is being previewed.
+ */
+$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
+
+if ( $is_email_preview ) {
+	$bg_transient               = get_transient( 'woocommerce_email_background_color' );
+	$body_transient             = get_transient( 'woocommerce_email_body_background_color' );
+	$base_transient             = get_transient( 'woocommerce_email_base_color' );
+	$text_transient             = get_transient( 'woocommerce_email_text_color' );
+	$footer_text_transient      = get_transient( 'woocommerce_email_footer_text_color' );
+	$header_alignment_transient = get_transient( 'woocommerce_email_header_alignment' );
+
+	$bg               = $bg_transient ? $bg_transient : $bg;
+	$body             = $body_transient ? $body_transient : $body;
+	$base             = $base_transient ? $base_transient : $base;
+	$text             = $text_transient ? $text_transient : $text;
+	$footer_text      = $footer_text_transient ? $footer_text_transient : $footer_text;
+	$header_alignment = $header_alignment_transient ? $header_alignment_transient : $header_alignment;
+}
+
+$base_text = wc_light_or_dark( $base, '#202020', '#ffffff' );
 
 // Pick a contrasting color for links.
 $link_color = wc_hex_is_light( $base ) ? $base : $base_text;

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -118,6 +118,70 @@ test.describe( 'WooCommerce Email Settings', () => {
 		expect( sender ).toContain( newFromAddress );
 	} );
 
+	test( 'Live preview when changing email settings', async ( {
+		page,
+		baseURL,
+	} ) => {
+		await setFeatureFlag( baseURL, 'yes' );
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
+
+		// Wait for the iframe content to load
+		const iframeSelector = '#wc_settings_email_preview_slotfill iframe';
+		const iframeElement = page.locator( iframeSelector );
+
+		const iframeContainsHtml = async ( code ) => {
+			const iframe = page.frameLocator( iframeSelector );
+			const content = await iframe.locator( 'html' ).innerHTML();
+			return content.includes( code );
+		};
+
+		// Define colors and corresponding fields
+		const emailFields = [
+			{ id: 'woocommerce_email_background_color', value: '#012345' },
+			{ id: 'woocommerce_email_base_color', value: '#6789ab' },
+			{ id: 'woocommerce_email_body_background_color', value: '#cdef01' },
+			{ id: 'woocommerce_email_footer_text_color', value: '#234567' },
+			// This color is ligtened in styles and not used with this specific value so can't be tested
+			// { id: 'woocommerce_email_text_color', value: '#89abcd' },
+			{ id: 'woocommerce_email_footer_text', value: 'New footer value' },
+		];
+
+		let iframeSrc = await iframeElement.getAttribute( 'src' );
+
+		for ( const { id, value } of emailFields ) {
+			await page.fill( `#${ id }`, value );
+			await page.evaluate( ( inputId ) => {
+				const input = document.getElementById( inputId );
+				input.blur();
+			}, id );
+
+			// I've tried many ways to wait for the iframe to reload, but none of them
+			// worked consistently because of debounce, so I'm using a simple retry loop
+			let retries = 0;
+			let newIframeSrc = null;
+			while ( retries < 10 ) {
+				newIframeSrc = await iframeElement.getAttribute( 'src' );
+				// eslint-disable-next-line playwright/no-conditional-in-test
+				if ( newIframeSrc !== iframeSrc ) {
+					break;
+				}
+				await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
+				retries++;
+			}
+			await expect( newIframeSrc ).not.toEqual( iframeSrc );
+			iframeSrc = newIframeSrc;
+
+			// Check that the iframe contains the new value
+			await expect( await iframeContainsHtml( value ) ).toBeTruthy();
+		}
+
+		// Check that the iframe does not contain any of the new values after page reload
+		await page.reload();
+		for ( const { value } of emailFields ) {
+			await expect( await iframeContainsHtml( value ) ).toBeFalsy();
+		}
+	} );
+
 	test( 'Send email preview', async ( { page, baseURL } ) => {
 		await setFeatureFlag( baseURL, 'yes' );
 		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -240,4 +240,123 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_query_params( $params );
 		return $request;
 	}
+
+	/**
+	 * Test saving transient without required arguments
+	 */
+	public function test_save_transient_without_args() {
+		$request  = $this->get_save_transient_request();
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): key, value', $response->get_data()['message'] );
+
+		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0] );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): value', $response->get_data()['message'] );
+
+		$request  = $this->get_save_transient_request( null, 'value' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): key', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test saving transient with invalid arguments
+	 */
+	public function test_save_transient_with_invalid_args() {
+		$request  = $this->get_save_transient_request( 'non-allowed-key', 'value' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Invalid parameter(s): key', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test saving transient by a user without the needed capabilities.
+	 */
+	public function test_save_transient_by_user_without_caps() {
+		$filter_callback = fn() => array(
+			'manage_woocommerce' => false,
+		);
+		add_filter( 'user_has_cap', $filter_callback );
+
+		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
+
+		remove_filter( 'user_has_cap', $filter_callback );
+	}
+
+	/**
+	 * Test saving transient with a successful saving.
+	 */
+	public function test_save_transient_success_response() {
+		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Transient saved for key ' . EmailPreview::EMAIL_SETTINGS_IDS[0] . '.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Test saving transient with different sanitization logic.
+	 */
+	public function test_save_transient_sanitization_logic_with_newlines() {
+		$textarea_key            = 'woocommerce_email_footer_text';
+		$textarea_value          = "Line 1\nLine 2\nLine 3";
+		$expected_textarea_value = "Line 1\nLine 2\nLine 3";
+
+		$request  = $this->get_save_transient_request( $textarea_key, $textarea_value );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Transient saved for key ' . $textarea_key . '.', $response->get_data()['message'] );
+		$this->assertEquals( $expected_textarea_value, get_transient( $textarea_key ) );
+
+		$text_key            = 'woocommerce_email_header_image';
+		$text_value          = "Line 1\nLine 2\nLine 3";
+		$expected_text_value = 'Line 1 Line 2 Line 3';
+
+		$request  = $this->get_save_transient_request( $text_key, $text_value );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Transient saved for key ' . $text_key . '.', $response->get_data()['message'] );
+		$this->assertEquals( $expected_text_value, get_transient( $text_key ) );
+	}
+
+	/**
+	 * Test saving transient with a failed saving.
+	 */
+	public function test_save_transient_error_response() {
+		set_transient( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value', HOUR_IN_SECONDS );
+
+		// Saving the transient will fail because the transient key is already set to the same value.
+		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 500, $response->get_status() );
+		$this->assertEquals( 'Error saving transient. Please try again.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Helper method to construct a request to save transient value.
+	 *
+	 * @param string|null $key Transient key.
+	 * @param string|null $value Transient value.
+	 * @return WP_REST_Request
+	 */
+	private function get_save_transient_request( ?string $key = null, ?string $value = null ) {
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/save-transient' );
+		$params  = array();
+		if ( $key ) {
+			$params['key'] = $key;
+		}
+		if ( $value ) {
+			$params['value'] = $value;
+		}
+		$request->set_body_params( $params );
+		return $request;
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -221,4 +221,18 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_prepare_email_for_preview', $email_filter, 10 );
 	}
+
+	/**
+	 * Test that transient values are applied in email preview
+	 */
+	public function test_transient_values_in_preview() {
+		update_option( EmailPreview::EMAIL_SETTINGS_IDS[0], 'option_value' );
+		set_transient( EmailPreview::EMAIL_SETTINGS_IDS[0], 'transient_value', HOUR_IN_SECONDS );
+
+		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
+		$content = $this->sut->render();
+
+		$this->assertStringNotContainsString( 'option_value', $content );
+		$this->assertStringContainsString( 'transient_value', $content );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -226,6 +226,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 * Test that transient values are applied in email preview
 	 */
 	public function test_transient_values_in_preview() {
+		$original_value = get_option( EmailPreview::EMAIL_SETTINGS_IDS[0] );
 		update_option( EmailPreview::EMAIL_SETTINGS_IDS[0], 'option_value' );
 		set_transient( EmailPreview::EMAIL_SETTINGS_IDS[0], 'transient_value', HOUR_IN_SECONDS );
 
@@ -234,5 +235,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 		$this->assertStringNotContainsString( 'option_value', $content );
 		$this->assertStringContainsString( 'transient_value', $content );
+
+		update_option( EmailPreview::EMAIL_SETTINGS_IDS[0], $original_value );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. This PR adds option to see live changes in email preview when email settings are changed without needing to save settings. 

Closes #52424.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Advanced > Features** and enable `Email improvements` experimental feature.
2. Go to **WooCommerce > Settings > Emails**.
3. Observe that the email preview is loaded.
4. Change (one by one) Logo, Header alignment, Footer text, and all five colors and observe that each change is reflected in the email preview. 
5. If your test website can send emails, check that the changes are also reflected in the email.
6. Reload the page and observe that the email preview is back to original values.
7. Test, that unless settings are saved, these styles are only applied in the email preview and not in real emails sent to customers.
    - This can be tested by changing the email styles, leaving settings tab open, and in a new tab resending an order email from order detail page. 

<!-- End testing instructions -->
