### PR TITLE
Avoid crash widget area when Product Collection is rendered

### DIFF
--- a/plugins/woocommerce/changelog/53638-fix-widget-area-product-collection-crash
+++ b/plugins/woocommerce/changelog/53638-fix-widget-area-product-collection-crash
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Avoid crash widget area when Product Collection is rendered

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -477,8 +477,8 @@ final class BlockTypesController {
 					'Cart',
 					'Checkout',
 					'ProductGallery',
-					'ProductCollection\Controller',
-					'ProductCollection\NoResults',
+					'ProductCollection',
+					'ProductCollectionNoResults',
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -477,6 +477,8 @@ final class BlockTypesController {
 					'Cart',
 					'Checkout',
 					'ProductGallery',
+					'ProductCollection\Controller',
+					'ProductCollection\NoResults',
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR fixes crashes in the widget area when any product collection variation appears in the inserter search results by disabling the registration of the block in the widget area.

This change does not “remove” any feature because, even in WooCommerce 9.4, the block crashes, but it doesn't impact the entire widget area.





| WooCommerce 9.4 | WooCommerce 9.5 |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/3a1ed4b2-6720-4931-8813-2f5975b74a79" /> | <video src="https://github.com/user-attachments/assets/90bb28cc-7a0f-4106-967b-4afbaf4cec7e" /> | 

### Why this happen

This issue occurs because most blocks used by the Product Collection (e.g., `core/post-title`) aren't registered in the widget area, causing `createBlocksFromInnerBlocksTemplate` to throw an unhandled error.

Before [woocommerce/woocommerce#52209](https://github.com/woocommerce/woocommerce/pull/52209) (that it will be shipped with WooCommerce 9.5), the Product Collection initially rendered the Collection Chooser, and only after the user clicked did the actual block instance load and `createBlocksFromInnerBlocksTemplate` get invoked. Now, the variations are visible in the inserter, so the actual block loads immediately and `createBlocksFromInnerBlocksTemplate` is invoked throwing the unhandled error that causes the crash.







<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53639 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable a Classic theme like Storefront.
2. Visit `wp-admin/widgets.php`.
3. Add a new widget.
4. Search `Product Collection`.
5. Ensure that it is not appear in the search results.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Avoid crash widget area when Product Collection is rendered

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
