### PR TITLE
Add email preview when managing specific email

### DIFF
--- a/plugins/woocommerce/changelog/52293-preview-specific-email
+++ b/plugins/woocommerce/changelog/52293-preview-specific-email
@@ -1,0 +1,3 @@
+Significance: patch
+Type: add
+Comment: Add specific email preview in email settings. Behind a hidden experimental feature, not yet for public use

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -34,8 +34,11 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 } ) => {
 	const [ deviceType, setDeviceType ] =
 		useState< string >( DEVICE_TYPE_DESKTOP );
+	const isSingleEmail = emailTypes.length === 1;
 	const [ emailType, setEmailType ] = useState< string >(
-		'WC_Email_Customer_Processing_Order'
+		isSingleEmail
+			? emailTypes[ 0 ].value
+			: 'WC_Email_Customer_Processing_Order'
 	);
 	const [ isLoading, setIsLoading ] = useState< boolean >( false );
 	const finalPreviewUrl = `${ previewUrl }&type=${ emailType }`;
@@ -44,14 +47,16 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 		<Fill>
 			<div className="wc-settings-email-preview-container">
 				<div className="wc-settings-email-preview-controls">
-					<EmailPreviewType
-						emailTypes={ emailTypes }
-						emailType={ emailType }
-						setEmailType={ ( newEmailType: string ) => {
-							setIsLoading( true );
-							setEmailType( newEmailType );
-						} }
-					/>
+					{ ! isSingleEmail && (
+						<EmailPreviewType
+							emailTypes={ emailTypes }
+							emailType={ emailType }
+							setEmailType={ ( newEmailType: string ) => {
+								setIsLoading( true );
+								setEmailType( newEmailType );
+							} }
+						/>
+					) }
 					<div className="wc-settings-email-preview-spinner">
 						{ isLoading && <Spinner /> }
 					</div>

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -49,6 +49,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		add_action( 'woocommerce_admin_field_email_image_url', array( $this, 'email_image_url' ) );
 		add_action( 'woocommerce_admin_field_email_font_family', array( $this, 'email_font_family' ) );
 		add_action( 'woocommerce_admin_field_email_color_palette', array( $this, 'email_color_palette' ) );
+		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+			add_action( 'woocommerce_email_settings_after', array( $this, 'email_preview_single' ) );
+		}
 		parent::__construct();
 	}
 
@@ -629,8 +632,8 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$email_types = array();
 		foreach ( $emails as $type => $email ) {
 			$email_types[] = array(
-				'label'   => $email->get_title(),
-				'value'   => $type,
+				'label' => $email->get_title(),
+				'value' => $type,
 			);
 		}
 		?>
@@ -639,6 +642,35 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
 			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
 		></div>
+		<?php
+	}
+
+	/**
+	 * Creates the React mount point for the single email preview.
+	 *
+	 * @param object $email The email object to run the method on.
+	 */
+	public function email_preview_single( $email ) {
+		// Email types array should have a single entry for current email.
+		$email_types = array(
+			array(
+				'label' => $email->get_title(),
+				'value' => get_class( $email ),
+			),
+		);
+		?>
+		<h2><?php echo esc_html( __( 'Email preview', 'woocommerce' ) ); ?></h2>
+
+		<p><?php echo esc_html( __( 'Preview your email template. You can also test on different devices and send yourself a test email.', 'woocommerce' ) ); ?></p>
+		<div>
+			<div
+				id="wc_settings_email_preview_slotfill"
+				data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
+				data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
+			></div>
+			<input type="hidden" id="woocommerce_email_from_name" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_name' ) ); ?>" />
+			<input type="hidden" id="woocommerce_email_from_address" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_address' ) ); ?>" />
+		</div>
 		<?php
 	}
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -458,13 +458,23 @@ test.describe( 'WooCommerce Email Settings', () => {
 			page.locator( '#woocommerce_email_footer_text_color' )
 		).not.toHaveValue( dummyColor );
 
-		// Undo resetting
+		// Change colors to make sure Undo button is active
+		await page.fill( '#woocommerce_email_base_color', dummyColor );
+		await page.fill( '#woocommerce_email_background_color', dummyColor );
+		await page.fill(
+			'#woocommerce_email_body_background_color',
+			dummyColor
+		);
+		await page.fill( '#woocommerce_email_text_color', dummyColor );
+		await page.fill( '#woocommerce_email_footer_text_color', dummyColor );
+
+		// Undo changes
 		await page
 			.locator( resetButtonElement )
 			.getByText( 'Undo changes', { exact: true } )
 			.click();
 
-		// Verify colors are back to the state before resetting
+		// Verify changes are undone
 		await expect(
 			page.locator( '#woocommerce_email_base_color' )
 		).not.toHaveValue( dummyColor );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is part of https://github.com/woocommerce/woocommerce/issues/52228, behind a hidden experimental feature flag. This PR adds a specific email preview where a merchant can go to the settings of any email and see its preview on the same page.

Closes #52293.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Without the `email-improvements` experimental flag enabled, there should be no changes on the specific email settings page.
2. Enable the `email-improvements` experimental flag (in DB, set `woocommerce_feature_email_improvements_enabled` option to `yes`).
3. On the **WooCommerce > Settings > Email** page select any email in the **Email notifications** table, before the HTML template section you should see a preview of the selected email.
4. You should be able to toggle between desktop and mobile view.
5. You should not be able to change email type in preview.
6. The sender name and email should correspond to those set in the Email sender options section. Note that you need to save the settings to see the changes.

<!-- End testing instructions -->