### PR TITLE
Fix @version bump requirement when it's already set to the expected value

### DIFF
--- a/plugins/woocommerce/changelog/53646-highlight-template-changes-fix
+++ b/plugins/woocommerce/changelog/53646-highlight-template-changes-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix @version bump requirement when it's already set to the expected value

--- a/plugins/woocommerce/changelog/53646-highlight-template-changes-fix
+++ b/plugins/woocommerce/changelog/53646-highlight-template-changes-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix @version bump requirement when it's already set to the expected value


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes `@version` bump requirement when it's already set to the expected value by a previous pull request within the same milestone. 

I've tested locally different scenarios for modifying/deleting templates and changing or not changing `@version` and it seems that everything is working as expected.

```
::warning file=/plugins/woocommerce/templates/emails/email-addresses.php,line=1,title=TEMPLATES::This template may require a version bump! Expected 9.6.0
::warning file=/plugins/woocommerce/templates/emails/email-footer.php,line=1,title=TEMPLATES::This template may require a version bump! Expected 9.6.0
::notice file=/plugins/woocommerce/templates/emails/email-header.php,line=1,title=TEMPLATES::Version bump found
::notice file=/plugins/woocommerce/templates/emails/email-order-items.php,line=1,title=TEMPLATES::Template deleted
::notice file=/plugins/woocommerce/templates/emails/email-styles.php,line=1,title=TEMPLATES::Version matches the expected version
```

Closes #53646.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a PR to update a template and bump the `@version` tag.
2. Merge the PR.
3. Create 2nd PR to update the same template, but don't bump the `@version` because it's already set to the right version (next WC version).
4. Observer that the `Highlight Template Changes` job will fail. 

<!-- End testing instructions -->