### PR TITLE
Enable remote logging UI and mark feature as stable in FeaturesController

### DIFF
--- a/plugins/woocommerce/changelog/update-remote-logging-feature
+++ b/plugins/woocommerce/changelog/update-remote-logging-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Enable remote logging UI and mark feature as stable in FeaturesController

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -280,7 +280,7 @@ class FeaturesController {
 						'woocommerce'
 					),
 					'enabled_by_default' => true,
-					'disable_ui'         => true,
+					'disable_ui'         => false,
 
 					/*
 					 * This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),
@@ -291,7 +291,7 @@ class FeaturesController {
 					 * @see https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959
 					 */
 					'is_legacy'          => true,
-					'is_experimental'    => true,
+					'is_experimental'    => false,
 				),
 				'email_improvements'     => array(
 					'name'        => __( 'Email improvements', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We got some feedback from the community (https://developer.woocommerce.com/2024/09/23/recent-updates-to-error-handling-and-optional-remote-error-logging/) that they want a simple way to toggle the remote logging feature on and off. This PR enables the UI for the feature and marks it as stable since it's been released for a while now.

![Screenshot 2024-12-12 at 12 22 44](https://github.com/user-attachments/assets/b489ee65-fed0-4091-b8e4-7ebd328b9129)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Confirm that the "Remote logging" feature is visible and you can toggle it on and off

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
