### PR TITLE
Remove changelog entries for CFEs in 9.5

### DIFF
--- a/packages/js/ai/changelog/52961-update-dompurify
+++ b/packages/js/ai/changelog/52961-update-dompurify
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Update dompurify to 2.5.7

--- a/plugins/woocommerce/changelog/52081-nullable
+++ b/plugins/woocommerce/changelog/52081-nullable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Fix implicit nullable deprecation warning when running on PHP 8.4.

--- a/plugins/woocommerce/changelog/52971-fix-52879-analytics-scroll
+++ b/plugins/woocommerce/changelog/52971-fix-52879-analytics-scroll
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix horizontal scrolling on Analytics pages.

--- a/plugins/woocommerce/changelog/53026-fix-escape-attribute
+++ b/plugins/woocommerce/changelog/53026-fix-escape-attribute
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-StyleAttributesUtils: escape className attribute

--- a/plugins/woocommerce/changelog/53051-fix-52990-use-payment-method-instead-of-intent
+++ b/plugins/woocommerce/changelog/53051-fix-52990-use-payment-method-instead-of-intent
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: This PR does not require a changelog entry, as it is an alteration of https://github.com/woocommerce/woocommerce/pull/52173, a PR that has not been released yet.
-

--- a/plugins/woocommerce/changelog/53085-dev-9.5-revert-52044
+++ b/plugins/woocommerce/changelog/53085-dev-9.5-revert-52044
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Checkout: Revert #52044 Add loading placeholder and payment method toggle.

--- a/plugins/woocommerce/changelog/53126-fix-52910-reports_charts-filter
+++ b/plugins/woocommerce/changelog/53126-fix-52910-reports_charts-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix `woocommerce_reports_charts` filter

--- a/plugins/woocommerce/changelog/53192-update-refactor-merged-packages-activation
+++ b/plugins/woocommerce/changelog/53192-update-refactor-merged-packages-activation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: A fix related to enable Brands to 5%, which hasn't been released.
-

--- a/plugins/woocommerce/changelog/53277-fix-use-correct-option-type
+++ b/plugins/woocommerce/changelog/53277-fix-use-correct-option-type
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Correctly respect the generate password option for accounts created post Checkout.

--- a/plugins/woocommerce/changelog/cfe-fix-52699
+++ b/plugins/woocommerce/changelog/cfe-fix-52699
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Product Elements: fix the issue that some product elements like price or rating were not available in Patterns

--- a/plugins/woocommerce/changelog/cfe-fix-plugin-search
+++ b/plugins/woocommerce/changelog/cfe-fix-plugin-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix search in Installed Plugins page

--- a/plugins/woocommerce/changelog/fix-52812-payments-menu-item-linking-to-blank-page
+++ b/plugins/woocommerce/changelog/fix-52812-payments-menu-item-linking-to-blank-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the Payments main menu item linking to a blank page when onboarding tasks are hidden.

--- a/plugins/woocommerce/changelog/fix-cys-router
+++ b/plugins/woocommerce/changelog/fix-cys-router
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add new required props to RouterProvider

--- a/plugins/woocommerce/changelog/fix-delayed-account-mobile-styles-52717
+++ b/plugins/woocommerce/changelog/fix-delayed-account-mobile-styles-52717
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix mobile styles for delayed account creation.

--- a/plugins/woocommerce/changelog/fix-offer-metadata-missing-price
+++ b/plugins/woocommerce/changelog/fix-offer-metadata-missing-price
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix "missing 'price' property in 'offers'" error in Google Search Console

--- a/plugins/woocommerce/changelog/fix-paymentinfo-uncaught-exception
+++ b/plugins/woocommerce/changelog/fix-paymentinfo-uncaught-exception
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: This modifies some other code introduced in 9.5 that has not been released yet, so no separate changelog entry is necessary.
-
-

--- a/plugins/woocommerce/changelog/pr-52817
+++ b/plugins/woocommerce/changelog/pr-52817
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the registration of routes in controllers inheriting from RestApiControllerBase


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Some CFEs already merged both into `release/9.5` _and_ `trunk` still have lingering changelog files in `trunk`, which can be problematic in the future. This PR removes those files. In particular, it covers the following CFE in 9.5:

|Changelog file|Merged into `release/9.5` via...|Merged into `trunk` via...|
|---|----|---|
|`[...]/52081-nullable`|https://github.com/woocommerce/woocommerce/pull/53465|https://github.com/woocommerce/woocommerce/pull/53606|
|`[...]/fix-52812-payments-menu-item-linking-to-blank-page`|https://github.com/woocommerce/woocommerce/pull/52900|https://github.com/woocommerce/woocommerce/pull/52916|
|`[...]/fix-offer-metadata-missing-price`|https://github.com/woocommerce/woocommerce/pull/52871|https://github.com/woocommerce/woocommerce/pull/53200|
|`[...]/52961-update-dompurify`|https://github.com/woocommerce/woocommerce/pull/53043|https://github.com/woocommerce/woocommerce/pull/52961|
|`[...]/cfe-fix-52699`|https://github.com/woocommerce/woocommerce/pull/53077|https://github.com/woocommerce/woocommerce/pull/53108|
|`[...]/53085-dev-9.5-revert-52044`|https://github.com/woocommerce/woocommerce/pull/53085|https://github.com/woocommerce/woocommerce/pull/53115|
|`[...]/53192-update-refactor-merged-packages-activation`|https://github.com/woocommerce/woocommerce/pull/53192|https://github.com/woocommerce/woocommerce/pull/53246|
|`[...]/fix-cys-router`|https://github.com/woocommerce/woocommerce/pull/53433|https://github.com/woocommerce/woocommerce/pull/53444|
|`[...]/pr-52817`|https://github.com/woocommerce/woocommerce/pull/52817|https://github.com/woocommerce/woocommerce/pull/52851|
|`[...]/fix-delayed-account-mobile-styles-52717`|https://github.com/woocommerce/woocommerce/pull/52736|https://github.com/woocommerce/woocommerce/pull/53038|
|`[...]/52971-fix-52879-analytics-scroll`|https://github.com/woocommerce/woocommerce/pull/52971|https://github.com/woocommerce/woocommerce/pull/53067|
|`[...]/53026-fix-escape-attribute`|https://github.com/woocommerce/woocommerce/pull/53026|https://github.com/woocommerce/woocommerce/pull/53099|
|`[...]/53051-fix-52990-use-payment-method-instead-of-intent`|https://github.com/woocommerce/woocommerce/pull/53051|https://github.com/woocommerce/woocommerce/pull/53118|
|`[...]/53126-fix-52910-reports_charts-filter`|https://github.com/woocommerce/woocommerce/pull/53126|https://github.com/woocommerce/woocommerce/pull/53225|
|`[...]/53277-fix-use-correct-option-type`|https://github.com/woocommerce/woocommerce/pull/53277|https://github.com/woocommerce/woocommerce/pull/53280|
|`[...]/cfe-fix-plugin-search`|https://github.com/woocommerce/woocommerce/pull/53438|https://github.com/woocommerce/woocommerce/pull/53446|
|`[...]/fix-paymentinfo-uncaught-exception`|https://github.com/woocommerce/woocommerce/pull/53585|https://github.com/woocommerce/woocommerce/pull/53607|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

N/A.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
