### PR TITLE
Skip invalid test scenario in CYS Loading Screen e2e test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-third-test-scenario-in-loading-screen
+++ b/plugins/woocommerce/changelog/e2e-remove-third-test-scenario-in-loading-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-E2E tests: remove the third test scenario in existing e2e test loading-screen as it is not a valid

--- a/plugins/woocommerce/changelog/e2e-remove-third-test-scenario-in-loading-screen
+++ b/plugins/woocommerce/changelog/e2e-remove-third-test-scenario-in-loading-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: remove the third test scenario in existing e2e test loading-screen as it is not a valid

--- a/plugins/woocommerce/changelog/e2e-skip-third-test-scenario-in-loading-screen
+++ b/plugins/woocommerce/changelog/e2e-skip-third-test-scenario-in-loading-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: skip the third test scenario in existing e2e test loading-screen as it is not a valid

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -114,4 +114,39 @@ test.describe( 'Assembler - Loading Page', { tag: tags.GUTENBERG }, () => {
 				)
 		).toBeVisible();
 	} );
+
+	// Skipped due to unconfirmed expected result and paused CYS
+	// This test could also be a good candidate for integration test once confirmed, ref #53663
+	test.skip( 'should hide loading screen and steps on subsequent runs', async ( {
+		pageObject,
+		baseURL,
+		page,
+	} ) => {
+		await pageObject.setupSite( baseURL );
+		await pageObject.waitForLoadingScreenFinish();
+
+		const assembler = await pageObject.getAssembler();
+		await assembler
+			.getByRole( 'button', { name: 'Finish customizing' } )
+			.click();
+		await assembler.getByText( 'Your store looks great!' ).waitFor();
+		// Abort any additional unnecessary requests
+		await page.evaluate( () => window.stop() );
+		await pageObject.setupSite( baseURL );
+
+		const requestToSetupStore = createRequestsToSetupStoreDictionary();
+
+		setupRequestInterceptor( page, requestToSetupStore );
+
+		for ( const step of steps ) {
+			await expect( page.getByText( step ) ).toBeHidden();
+			await expect( page.getByAltText( step ) ).toBeHidden();
+		}
+
+		expect( Object.values( requestToSetupStore ) ).toEqual( [
+			false,
+			false,
+			false,
+		] );
+	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -114,37 +114,4 @@ test.describe( 'Assembler - Loading Page', { tag: tags.GUTENBERG }, () => {
 				)
 		).toBeVisible();
 	} );
-
-	test( 'should hide loading screen and steps on subsequent runs', async ( {
-		pageObject,
-		baseURL,
-		page,
-	} ) => {
-		await pageObject.setupSite( baseURL );
-		await pageObject.waitForLoadingScreenFinish();
-
-		const assembler = await pageObject.getAssembler();
-		await assembler
-			.getByRole( 'button', { name: 'Finish customizing' } )
-			.click();
-		await assembler.getByText( 'Your store looks great!' ).waitFor();
-		// Abort any additional unnecessary requests
-		await page.evaluate( () => window.stop() );
-		await pageObject.setupSite( baseURL );
-
-		const requestToSetupStore = createRequestsToSetupStoreDictionary();
-
-		setupRequestInterceptor( page, requestToSetupStore );
-
-		for ( const step of steps ) {
-			await expect( page.getByText( step ) ).toBeHidden();
-			await expect( page.getByAltText( step ) ).toBeHidden();
-		}
-
-		expect( Object.values( requestToSetupStore ) ).toEqual( [
-			false,
-			false,
-			false,
-		] );
-	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50427

As a consequence of the flaky test report and further investigation, along with discussions on Slack with the Kirigami team regarding the expected behavior of this feature (CYS Loading Screen), we have decided to skip it from the e2e test suite as it is deemed invalid.

If we ever return to this to make the test active again, we should consider transforming it to the integration test.

Slack discussion was here: p1732875096063979-slack-C01BWDDTGKX and here: p1734005818948669-slack-C02FL3X7KR6

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Just a removal. Make sure CI pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
