### PR TITLE
[Experimental] Set Add to Cart with Options as the parent of the Quantity Selector block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -38,6 +38,7 @@ const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 			content: __( 'Add to Cart', 'woocommerce' ),
 		},
 	],
+	[ 'woocommerce/add-to-cart-with-options-quantity-selector' ],
 	[
 		'woocommerce/product-button',
 		{

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -13,6 +13,7 @@
 	},
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "postId" ],
+	"ancestor": [ "woocommerce/add-to-cart-with-options" ],
 	"textdomain": "woocommerce",
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
+import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
 
 /**
@@ -14,28 +14,20 @@ import '../../../base/components/quantity-selector/style.scss';
 import './style.scss';
 import './editor.scss';
 
-const blockSettings = {
-	edit: AddToCartWithOptionsQuantitySelectorEdit,
-	attributes: metadata.attributes,
-	icon: {
-		src: (
-			<Icon
-				icon={ button }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
-	ancestor: [ 'woocommerce/single-product' ],
-	save() {
-		return null;
-	},
-};
-
 if ( shouldRegisterBlock ) {
-	registerBlockSingleProductTemplate( {
-		blockName: metadata.name,
-		blockMetadata: metadata,
-		blockSettings,
-		isAvailableOnPostEditor: true,
+	registerBlockType( metadata, {
+		edit: AddToCartWithOptionsQuantitySelectorEdit,
+		attributes: metadata.attributes,
+		icon: {
+			src: (
+				<Icon
+					icon={ button }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+		save() {
+			return null;
+		},
 	} );
 }

--- a/plugins/woocommerce/changelog/fix-quantity-selector-parent
+++ b/plugins/woocommerce/changelog/fix-quantity-selector-parent
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Set Add to Cart with Options as the parent of the Quantity Selector block
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR that makes it so the Quantity Selector block can only be added inside the Add to Cart with Options block. It also adds it to the default template.

![imatge](https://github.com/user-attachments/assets/d7c3fde5-3249-459f-b14e-eb2fc7cc9b86)

### How to test the changes in this Pull Request:

1. Create a post or page and add the Single Product block.
2. Add the _Add to Cart with Options (Experimental)_ block.
3. Verify it contains the Quantity Selector block.
4. Verify you can add the _Quantity Selector_ inside the _Add to Cart with Options (Experimental)_ block.
5. Verify you can't add the _Quantity Selector_ block outside the _Add to Cart with Options (Experimental)_ block.
