### PR TITLE
Fix an undefined property warning on user_email population

### DIFF
--- a/plugins/woocommerce/changelog/fix-php-undefined-prop-warning
+++ b/plugins/woocommerce/changelog/fix-php-undefined-prop-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP warnings when user_email is not populated on my-account page.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -340,7 +340,7 @@ class WC_Form_Handler {
 
 			if ( $customer ) {
 				// Keep billing data in sync if data changed.
-				if ( is_email( $user->user_email ) && $current_email !== $user->user_email ) {
+				if ( isset( $user->user_email ) && is_email( $user->user_email ) && $current_email !== $user->user_email ) {
 					$customer->set_billing_email( $user->user_email );
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The property `user_email` of `$user` will only be populated if `$account_email` is set. Otherwise, it will trigger PHP warnings.

Adding an `isset` check ensures the property is set before using it.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this as a `mu-plugin` (see use case [here](https://github.com/woocommerce/woocommerce/pull/53670#issuecomment-2539335573))
```php
<?php
add_filter( 'woocommerce_save_account_details_required_fields',
	function( $fields ) {
		unset( $fields['account_email'] );
		return $fields;
	},
	10,
	1
);
```
2. Go to /my-account/edit-account/, empty the e-mail field and click Save
3. Observe logs.
Expected: `PHP Warning:  Undefined property: stdClass::$user_email` should not appear

<!-- End testing instructions -->
