### PR TITLE
Accept an error message from payment methods or convert notices for failure only

### DIFF
--- a/plugins/woocommerce/changelog/53671-add-errors-to-process-payments
+++ b/plugins/woocommerce/changelog/53671-add-errors-to-process-payments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Accept a `message` in the payment result when processing payment, as well as convert error notices on failure.

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -343,11 +343,6 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function process_payment( $order_id ) {
-		wc_add_notice( __( 'Cash on delivery is not available for this order, but a notice.', 'woocommerce' ), 'error' );
-		return array(
-			'result'  => 'failure',
-			'message' => __( 'Cash on delivery is not available for this order.', 'woocommerce' ),
-		);
 		$order = wc_get_order( $order_id );
 
 		if ( $order->get_total() > 0 ) {

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -343,6 +343,11 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function process_payment( $order_id ) {
+		wc_add_notice( __( 'Cash on delivery is not available for this order, but a notice.', 'woocommerce' ), 'error' );
+		return array(
+			'result'  => 'failure',
+			'message' => __( 'Cash on delivery is not available for this order.', 'woocommerce' ),
+		);
 		$order = wc_get_order( $order_id );
 
 		if ( $order->get_total() > 0 ) {

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -56,20 +56,20 @@ class Legacy {
 		// Restore $_POST data.
 		$_POST = $post_data;
 
-		// Handle result. If status was not returned we consider this invalid and return failure.
-		$result_status = $gateway_result['result'] ?? 'failure';
-		// These are the same statuses supported by the API and indicate processing status. This is not the same as order status.
-		$valid_status = array( 'success', 'failure', 'pending', 'error' );
-		$result->set_status( in_array( $result_status, $valid_status, true ) ? $result_status : 'failure' );
-
 		// If the payment failed with a message, throw an exception.
-		if ( 'failure' === $result_status ) {
+		if ( 'failure' === $gateway_result['result'] ) {
 			if ( isset( $gateway_result['message'] ) ) {
 				throw new RouteException( 'woocommerce_rest_payment_error', wp_strip_all_tags( $gateway_result['message'] ), 400 );
 			} else {
 				NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
 			}
 		}
+
+		// Handle result. If status was not returned we consider this invalid and return failure.
+		$result_status = $gateway_result['result'] ?? 'failure';
+		// These are the same statuses supported by the API and indicate processing status. This is not the same as order status.
+		$valid_status = array( 'success', 'failure', 'pending', 'error' );
+		$result->set_status( in_array( $result_status, $valid_status, true ) ? $result_status : 'failure' );
 
 		// If `process_payment` added notices but didn't set the status to failure, clear them. Notices are not displayed from the API unless status is failure.
 		wc_clear_notices();

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -5,7 +5,7 @@ use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use Automattic\WooCommerce\StoreApi\Utilities\NoticeHandler;
 use Automattic\WooCommerce\Blocks\Package;
-
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 /**
  * Legacy class.
  */
@@ -56,15 +56,23 @@ class Legacy {
 		// Restore $_POST data.
 		$_POST = $post_data;
 
-		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
-		// and a generic notice will be shown instead if payment failed.
-		wc_clear_notices();
-
 		// Handle result. If status was not returned we consider this invalid and return failure.
 		$result_status = $gateway_result['result'] ?? 'failure';
 		// These are the same statuses supported by the API and indicate processing status. This is not the same as order status.
 		$valid_status = array( 'success', 'failure', 'pending', 'error' );
 		$result->set_status( in_array( $result_status, $valid_status, true ) ? $result_status : 'failure' );
+
+		// If the payment failed with a message, throw an exception.
+		if ( 'failure' === $result_status ) {
+			if ( isset( $gateway_result['message'] ) ) {
+				throw new RouteException( 'woocommerce_rest_payment_error', wp_strip_all_tags( $gateway_result['message'] ), 400 );
+			} else {
+				NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
+			}
+		}
+
+		// If `process_payment` added notices but didn't set the status to failure, clear them. Notices are not displayed from the API unless status is failure.
+		wc_clear_notices();
 
 		// set payment_details from result.
 		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -57,7 +57,7 @@ class Legacy {
 		$_POST = $post_data;
 
 		// If the payment failed with a message, throw an exception.
-		if ( 'failure' === $gateway_result['result'] ) {
+		if ( isset( $gateway_result['result'] ) && 'failure' === $gateway_result['result'] ) {
 			if ( isset( $gateway_result['message'] ) ) {
 				throw new RouteException( 'woocommerce_rest_payment_error', wp_strip_all_tags( $gateway_result['message'] ), 400 );
 			} else {

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -61,7 +61,7 @@ class Legacy {
 		// If the payment failed with a message, throw an exception.
 		if ( isset( $gateway_result['result'] ) && 'failure' === $gateway_result['result'] ) {
 			if ( isset( $gateway_result['message'] ) ) {
-				throw new RouteException( 'woocommerce_rest_payment_error', wp_strip_all_tags( $gateway_result['message'] ), 400 );
+				throw new RouteException( 'woocommerce_rest_payment_error', esc_html( wp_strip_all_tags( $gateway_result['message'] ) ), 400 );
 			} else {
 				NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
 			}

--- a/plugins/woocommerce/src/StoreApi/Legacy.php
+++ b/plugins/woocommerce/src/StoreApi/Legacy.php
@@ -23,6 +23,8 @@ class Legacy {
 	 *
 	 * @param PaymentContext $context Holds context for the payment.
 	 * @param PaymentResult  $result  Result of the payment.
+	 *
+	 * @throws RouteException If the gateway returns an explicit error message.
 	 */
 	public function process_legacy_payment( PaymentContext $context, PaymentResult &$result ) {
 		if ( $result->status ) {


### PR DESCRIPTION
### Submission Review Guidelines:

This PR is a third spin on https://github.com/woocommerce/woocommerce-blocks/pull/4700 and https://github.com/woocommerce/woocommerce-blocks/pull/4871

This for me, addresses the concerns in those 2 previous issues, by only converting error notices to exception if the payment gateway explicitly returned a failure status, and didn't return a message with the payment result.

Otherwise, this adds support for returning a message with failure status which will be used instead of notices.

I tried to expand this to shortcode Checkout but was a bit finicky.
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/51272

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Using this requires modifying code to modify a core payment method.

1. Modify COD class `process_payment` method and return this at the top of the file:
```php
return array(
	'result' => 'failure',
	'message' => __( 'Cash on delivery is not available for this order.', 'woocommerce' ),
);
```
2. On Checkout block, place an order using COD, ensure that it doesn't pass and you get that error.
3. Remove the `message` part of the error, try placing again. Ensure you get a generic error `Something went wrong. Please contact us to get assistance.`
4. Add a notice before the return:
```php
wc_add_notice( __( 'Cash on delivery is not available for this order, but a notice.', 'woocommerce' ), 'error' );
```
5. On placing the order, ensure you get that error.
6. Now, leave both the message and the notice and try to place an order, only the one from the array (without `, but with a notice`) should be shown.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Accept a `message` in the payment result when processing payment, as well as convert error notices on failure.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
