### PR TITLE
Enable "coming soon" and "store only"options by default for new installation

### DIFF
--- a/plugins/woocommerce/changelog/update-default-coming-soon-value
+++ b/plugins/woocommerce/changelog/update-default-coming-soon-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Enable "coming soon" option by default in WooCommerce installation

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -998,14 +998,15 @@ class WC_Install {
 	}
 
 	/**
-	 * Add the woocommerce_coming_soon option for new shops.
+	 * Add the coming soon options for new shops.
 	 *
-	 * Ensure that the option is set for all shops, even if core profiler is disabled on the host.
+	 * Ensure that the options are set for all shops for performance even if core profiler is disabled on the host.
 	 *
 	 * @since 9.3.0
 	 */
 	public static function add_coming_soon_option() {
 		add_option( 'woocommerce_coming_soon', 'yes' );
+		add_option( 'woocommerce_store_pages_only', 'yes' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1005,7 +1005,7 @@ class WC_Install {
 	 * @since 9.3.0
 	 */
 	public static function add_coming_soon_option() {
-		add_option( 'woocommerce_coming_soon', 'no' );
+		add_option( 'woocommerce_coming_soon', 'yes' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/API/LaunchYourStore.php
@@ -117,7 +117,7 @@ class LaunchYourStore {
 	}
 
 	/**
-	 * Initializes options for coming soon. Does not override if options exist.
+	 * Initializes options for coming soon. Overwrites existing coming soon status but keeps the private link and share key.
 	 *
 	 * @return bool|void
 	 */
@@ -134,7 +134,7 @@ class LaunchYourStore {
 		$share_key        = wp_generate_password( 32, false );
 
 		update_option( 'woocommerce_coming_soon', $coming_soon );
-		add_option( 'woocommerce_store_pages_only', $store_pages_only );
+		update_option( 'woocommerce_store_pages_only', $store_pages_only );
 		add_option( 'woocommerce_private_link', $private_link );
 		add_option( 'woocommerce_share_key', $share_key );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/basic.spec.js
@@ -1,14 +1,10 @@
-const { test, expect, request } = require( '@playwright/test' );
+const { test, expect } = require( '@playwright/test' );
 const { logIn } = require( '../utils/login' );
 const { admin, customer } = require( '../test-data/data' );
-const { setOption } = require( '../utils/options' );
+const { setComingSoon } = require( '../utils/coming-soon' );
 
 test.beforeAll( async ( { baseURL } ) => {
-	try {
-		await setOption( request, baseURL, 'woocommerce_coming_soon', 'no' );
-	} catch ( error ) {
-		console.log( error );
-	}
+	await setComingSoon( { baseURL, enabled: 'no' } );
 } );
 
 test( 'Load the home page', async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const maynePostal = 'V0N 2J0';
 const shippingZoneNameUSRegion = 'USA Zone';
 const shippingZoneNameFlatRate = 'Canada with Flat rate';
@@ -396,6 +396,8 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 	let productId, shippingFreeId, shippingFlatId, shippingLocalId;
 
 	test.beforeAll( async ( { baseURL } ) => {
+		await setComingSoon( { baseURL, enabled: 'no' } );
+
 		// need to add a product to the store so that we can order it and check shipping options
 		const api = new wcApi( {
 			url: baseURL,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-create-simple.spec.js
@@ -1,5 +1,5 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const productData = {
 	virtual: {
 		name: `Virtual product ${ Date.now() }`,
@@ -67,7 +67,7 @@ for ( const productType of Object.keys( productData ) ) {
 	test(
 		`can create a simple ${ productType } product`,
 		{ tag: [ tags.GUTENBERG, tags.SERVICES ] },
-		async ( { page, category, product } ) => {
+		async ( { page, category, product, baseURL } ) => {
 			await test.step( 'add new product', async () => {
 				await page.goto( 'wp-admin/post-new.php?post_type=product' );
 			} );
@@ -300,6 +300,8 @@ for ( const productType of Object.keys( productData ) ) {
 			} );
 
 			await test.step( 'shopper can add the product to cart', async () => {
+				await setComingSoon( { baseURL, enabled: 'no' } );
+
 				// logout admin user
 				await page.context().clearCookies();
 				await page.reload();

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/account-email-receiving.spec.js
@@ -2,7 +2,7 @@
 
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { admin, customer } = require( '../../test-data/data' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const emailContent = '#wp-mail-logging-modal-content-body-content';
 const emailContentHtml = '#wp-mail-logging-modal-format-html';
 
@@ -27,6 +27,10 @@ test.describe(
 	'Shopper Account Email Receiving',
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
+		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+		} );
+
 		test.beforeEach( async ( { page, user } ) => {
 			await page.goto(
 				`wp-admin/tools.php?page=wpml_plugin_log&s=${ encodeURIComponent(

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/add-to-cart.spec.js
@@ -6,6 +6,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
  * External dependencies
  */
 import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 const productName = `Cart product test ${ Date.now() }`;
 const productPrice = '13.99';
@@ -17,6 +18,8 @@ test.describe(
 		let productId;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-calculate-shipping.spec.js
@@ -1,5 +1,6 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 /**
  * External dependencies
@@ -45,7 +46,9 @@ test.describe(
 	() => {
 		let product1Id, product2Id, shippingZoneNLId, shippingZonePTId;
 
-		test.beforeAll( async ( { api } ) => {
+		test.beforeAll( async ( { api, baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			// make sure the currency is USD
 			await api.put( 'settings/general/woocommerce_currency', {
 				value: 'USD',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block-coupons.spec.js
@@ -1,6 +1,6 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 /**
  * External dependencies
  */
@@ -65,7 +65,8 @@ test.describe(
 	() => {
 		const couponBatchId = [];
 
-		test.beforeAll( async ( { api } ) => {
+		test.beforeAll( async ( { api, baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			// make sure the currency is USD
 			await api.put( 'settings/general/woocommerce_currency', {
 				value: 'USD',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-block.spec.js
@@ -1,6 +1,6 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { fillPageTitle } = require( '../../utils/editor' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 /**
  * External dependencies
  */
@@ -34,7 +34,8 @@ test.describe(
 	'Cart Block page',
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
-		test.beforeAll( async ( { api } ) => {
+		test.beforeAll( async ( { api, baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			// make sure the currency is USD
 			await api.put( 'settings/general/woocommerce_currency', {
 				value: 'USD',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
@@ -7,6 +7,7 @@ import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
@@ -33,6 +34,7 @@ test.describe(
 		let firstProductId, secondProductId, shippingZoneDEId, shippingZoneFRId;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-block-calculate-tax.spec.js
@@ -12,7 +12,7 @@ import {
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { fillPageTitle } = require( '../../utils/editor' );
@@ -58,6 +58,8 @@ test.describe(
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-calculate-tax.spec.js
@@ -6,7 +6,7 @@ import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const { test, expect, request } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { customer } = require( '../../test-data/data' );
@@ -43,6 +43,8 @@ test.describe.serial(
 	},
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-coupons.spec.js
@@ -7,7 +7,7 @@ import { addAProductToCart } from '@woocommerce/e2e-utils-playwright';
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -41,6 +41,8 @@ test.describe(
 		const couponBatchId = [];
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-checkout-restricted-coupons.spec.js
@@ -11,7 +11,7 @@ import {
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const includedProductName = 'Included test product';
 const excludedProductName = 'Excluded test product';
 const includedCategoryName = 'Included Category';
@@ -60,6 +60,7 @@ test.describe(
 		const couponBatchId = [];
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-redirection.spec.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
@@ -21,6 +21,8 @@ test.describe(
 		const productName = 'A redirect product test';
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const productName = `Cart product test ${ Date.now() }`;
 const productPrice = '13.99';
 const twoProductPrice = +productPrice * 2;
@@ -14,6 +14,8 @@ test.describe( 'Cart page', { tag: [ tags.PAYMENTS, tags.SERVICES ] }, () => {
 	let productId, product2Id, product3Id;
 
 	test.beforeAll( async ( { baseURL } ) => {
+		await setComingSoon( { baseURL, enabled: 'no' } );
+
 		const api = new wcApi( {
 			url: baseURL,
 			consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block-coupons.spec.js
@@ -10,7 +10,7 @@ import {
 const { fillPageTitle } = require( '../../utils/editor' );
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { random } = require( '../../utils/helpers' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const simpleProductName = `Checkout Coupons Product ${ random() }`;
 const singleProductFullPrice = '110.00';
 const singleProductSalePrice = '55.00';
@@ -65,7 +65,8 @@ test.describe(
 	() => {
 		const couponBatchId = [];
 
-		test.beforeAll( async ( { api } ) => {
+		test.beforeAll( async ( { api, baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			// make sure the currency is USD
 			await api.put( 'settings/general/woocommerce_currency', {
 				value: 'USD',

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -7,6 +7,7 @@ const { admin, customer } = require( '../../test-data/data' );
 const { logIn } = require( '../../utils/login' );
 const { setFilterValue, clearFilters } = require( '../../utils/filters' );
 const { setOption } = require( '../../utils/options' );
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 /**
  * External dependencies
@@ -64,6 +65,8 @@ test.describe(
 	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS, tags.SKIP_ON_WPCOM ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
@@ -5,14 +5,15 @@ import {
 	addAProductToCart,
 	getOrderIdFromUrl,
 } from '@woocommerce/e2e-utils-playwright';
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+
 /**
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
-const { test, expect } = require( '@playwright/test' );
-const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin } = require( '../../test-data/data' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const billingEmail = 'marge-test-account@example.com';
 
 test.describe(
@@ -22,6 +23,7 @@ test.describe(
 		let productId, orderId, shippingZoneId;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
@@ -7,6 +7,7 @@ import {
 } from '@woocommerce/e2e-utils-playwright';
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
 const { getFakeCustomer, getFakeProduct } = require( '../../utils/data' );
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 const test = baseTest.extend( {
 	page: async ( { page, api }, use ) => {
@@ -111,6 +112,9 @@ test.describe(
 	'Shopper Checkout Login Account',
 	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.HPOS ] },
 	() => {
+		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+		} );
 		//todo audit follow-up: this is a variation of a checkout/placing an order flow,
 		// should be part of another spec maybe. See checkout.spec.js
 		test( 'can login to an existing account during checkout', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -3,7 +3,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin, customer } = require( '../../test-data/data' );
 const { setFilterValue, clearFilters } = require( '../../utils/filters' );
 const { setOption } = require( '../../utils/options' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 /**
  * External dependencies
  */
@@ -31,6 +31,7 @@ test.describe(
 		let guestOrderId, customerOrderId, productId, shippingZoneId;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/dashboard-access.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/dashboard-access.spec.js
@@ -3,11 +3,15 @@
  */
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 test.describe(
 	'Customer-role users are blocked from accessing the WP Dashboard.',
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
+		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+		} );
 		test.use( { storageState: process.env.CUSTOMERSTATE } );
 
 		const dashboardScreens = {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -13,7 +13,7 @@ import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { random } = require( '../../utils/helpers' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const miniCartPageTitle = `Mini Cart ${ random() }`;
 const miniCartPageSlug = miniCartPageTitle.replace( / /gi, '-' ).toLowerCase();
 const miniCartButton = 'main .wc-block-mini-cart__button';
@@ -34,6 +34,7 @@ test.describe(
 		test.use( { storageState: process.env.ADMINSTATE } );
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-addresses.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-addresses.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const randomNum = new Date().getTime().toString();
 const customer = {
 	username: `customer${ randomNum }`,
@@ -17,6 +17,7 @@ test.describe(
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-create-account.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const customerEmailAddress = `john.doe.${ Date.now() }@example.com`;
 
 test.describe(
@@ -12,6 +12,7 @@ test.describe(
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-downloads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-downloads.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const randomNum = new Date().getTime().toString();
 const customer = {
 	username: `customer${ randomNum }`,
@@ -23,6 +23,7 @@ test.describe(
 		let productId, orderId;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-pay-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account-pay-order.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const randomNum = new Date().getTime().toString();
 const customer = {
 	username: `customer${ randomNum }`,
@@ -19,6 +19,7 @@ test.describe(
 		let productId, orderId;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/my-account.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const { customer } = require( '../../test-data/data' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const pages = [ 'Orders', 'Downloads', 'Addresses', 'Account details' ];
 
 test.describe(
@@ -12,6 +12,10 @@ test.describe(
 	{ tag: [ tags.PAYMENTS, tags.SERVICES ] },
 	() => {
 		test.use( { storageState: process.env.CUSTOMERSTATE } );
+
+		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
+		} );
 
 		test( 'allows customer to login and navigate', async ( { page } ) => {
 			await page.goto( 'my-account/' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
@@ -12,6 +12,7 @@ import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const { customer, storeDetails } = require( '../../test-data/data' );
 const { api } = require( '../../utils' );
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 let productId, orderId, zoneId;
 
@@ -36,7 +37,8 @@ test.describe(
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 
-		test.beforeAll( async () => {
+		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			productId = await api.create.product( product );
 			await api.update.enableCashOnDelivery();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-grouped.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-grouped.spec.js
@@ -4,7 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const productPrice = '18.16';
 const simpleProductName = 'Simple single product';
 const groupedProductName = 'Grouped single product';
@@ -20,6 +20,7 @@ test.describe(
 		const simpleProduct2 = simpleProductName + ' 2';
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-simple.spec.js
@@ -5,7 +5,7 @@ import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { admin } = require( '../../test-data/data' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const productPrice = '18.16';
 const simpleProductName = 'Simple single product';
 const simpleProductSlug = simpleProductName.replace( / /gi, '-' ).toLowerCase();
@@ -28,6 +28,7 @@ test.describe(
 			'<ol><li>Test numbered item</li></ol>';
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-tags-attributes.spec.js
@@ -10,7 +10,7 @@ const { test, expect, request } = require( '@playwright/test' );
 const { admin } = require( '../../test-data/data' );
 const pageTitle = 'Product Showcase';
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const singleProductPrice1 = '5.00';
 const singleProductPrice2 = '10.00';
 const singleProductPrice3 = '15.00';
@@ -39,6 +39,7 @@ test.describe(
 		test.use( { storageState: process.env.ADMINSTATE } );
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
@@ -4,6 +4,7 @@
 import { tags } from '../../fixtures/fixtures';
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 const productPrice = '18.16';
 const cartDialogMessage =
@@ -142,6 +143,7 @@ test.describe(
 		let variableProductId, totalPrice;
 
 		test.beforeAll( async ( { baseURL } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			const api = new wcApi( {
 				url: baseURL,
 				consumerKey: process.env.CONSUMER_KEY,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-products-filter-by-price.spec.js
@@ -1,4 +1,5 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const { fillPageTitle } = require( '../../utils/editor' );
 const { getInstalledWordPressVersion } = require( '../../utils/wordpress' );
 
@@ -40,7 +41,8 @@ test.describe(
 		],
 	},
 	() => {
-		test.beforeAll( async ( { api } ) => {
+		test.beforeAll( async ( { baseURL, api } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			// add products
 			await api
 				.post( 'products', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
@@ -3,6 +3,7 @@
  */
 import { test, expect, tags } from '../../fixtures/fixtures';
 import { getFakeCategory, getFakeProduct } from '../../utils/data';
+const { setComingSoon } = require( '../../utils/coming-soon' );
 
 test.describe(
 	'Search, browse by categories and sort items in the shop',
@@ -11,7 +12,8 @@ test.describe(
 		let categories = [];
 		let products = [];
 
-		test.beforeAll( async ( { api } ) => {
+		test.beforeAll( async ( { baseURL, api } ) => {
+			await setComingSoon( { baseURL, enabled: 'no' } );
 			await api
 				.post( 'products/categories/batch', {
 					create: [

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-title-after-deletion.spec.js
@@ -1,5 +1,5 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 // test case for bug https://github.com/woocommerce/woocommerce/pull/46429
 const test = baseTest.extend( {
 	storageState: process.env.ADMINSTATE,
@@ -32,7 +32,8 @@ const test = baseTest.extend( {
 test(
 	'Check the title of the shop page after the page has been deleted',
 	{ tag: [ tags.PAYMENTS, tags.SERVICES, tags.COULD_BE_LOWER_LEVEL_TEST ] },
-	async ( { page } ) => {
+	async ( { baseURL, page } ) => {
+		await setComingSoon( { baseURL, enabled: 'no' } );
 		await page.goto( 'shop/' );
 		expect( await page.title() ).toBe(
 			'Shop – WooCommerce Core E2E Test Suite'

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/wordpress-post.spec.js
@@ -1,5 +1,5 @@
 const { test: baseTest, expect, tags } = require( '../../fixtures/fixtures' );
-
+const { setComingSoon } = require( '../../utils/coming-soon' );
 const test = baseTest.extend( {
 	storageState: process.env.CUSTOMERSTATE,
 } );
@@ -9,7 +9,8 @@ test(
 	{
 		tag: [ tags.WP_CORE, tags.SKIP_ON_WPCOM, tags.SKIP_ON_PRESSABLE ],
 	},
-	async ( { page } ) => {
+	async ( { baseURL, page } ) => {
+		await setComingSoon( { baseURL, enabled: 'no' } );
 		await page.goto( 'hello-world/' );
 		await expect(
 			page.getByRole( 'heading', { name: 'Hello world!', exact: true } )

--- a/plugins/woocommerce/tests/e2e-pw/utils/coming-soon.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/coming-soon.js
@@ -1,0 +1,14 @@
+const { request } = require( '@playwright/test' );
+const { setOption } = require( './options' );
+
+const setComingSoon = async ( { baseURL, enabled } ) => {
+	try {
+		await setOption( request, baseURL, 'woocommerce_coming_soon', enabled );
+	} catch ( error ) {
+		console.log( error );
+	}
+};
+
+module.exports = {
+	setComingSoon,
+};

--- a/plugins/woocommerce/tests/e2e-pw/utils/index.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/index.js
@@ -6,6 +6,7 @@ const tours = require( './tours' );
 const login = require( './login' );
 const editor = require( './editor' );
 const helpers = require( './helpers' );
+const comingSoon = require( './coming-soon' );
 
 module.exports = {
 	api,
@@ -16,4 +17,5 @@ module.exports = {
 	login,
 	editor,
 	helpers,
+	comingSoon,
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53036

This PR updates the default behavior of WooCommerce for fresh installations to ensure that stores are set to **Coming Soon** mode when the core profiler is skipped. This change aligns with user expectations and prevents unexpected exposure of the store while it is still being set up.

#### Key Updates:

1. **Default Store Mode**:
   - Sets `coming soon = yes` and `store pages only = yes` as default installation values.
   - Ensures that these defaults are applied regardless of whether the core profiler is completed or skipped.

2. **Core Profiler Logic**:
   - Retains current behavior where the core profiler can override the default values.

3. **E2E Tests**:
   - Disable coming soon mode for shopper related tests. I don't know if there is a better way to do this because we don't want to disable coming soon mode for all tests. Just for shopper related tests.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new site and install WooCommerce (e.g., via JN or a local environment).
2. On the core profiler screen, navigate away by entering a different path in the browser (e.g., `/wp-admin/`) without completing the profiler.
3. Verify the following:
   - The **Live** badge is not shown in the admin top navigation bar.
	 - The home page is displayed normally.
   - Visiting the shop page in a incognito window displays the **Coming Soon** page instead of the shop.
   - The `coming soon` and `store pages only` options are set to `yes` in the database.
4. Complete the core profiler
5. Visit the home page and the shop page in a incognito window.
6. Verify that the home page displays the coming soon page

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
