### PR TITLE
Floating email preview 

### DIFF
--- a/plugins/woocommerce/changelog/52422-floating-email-preview
+++ b/plugins/woocommerce/changelog/52422-floating-email-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Experimental: make email preview floating next to email settings on wide displays

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -46,11 +46,14 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	);
 	const [ isLoading, setIsLoading ] = useState< boolean >( false );
 	const [ isWide, setIsWide ] = useState< boolean >(
-		window.innerWidth > FLOATING_PREVIEW_WIDTH_LIMIT
+		! isSingleEmail && window.innerWidth > FLOATING_PREVIEW_WIDTH_LIMIT
 	);
 	const finalPreviewUrl = `${ previewUrl }&type=${ emailType }`;
 
 	useEffect( () => {
+		if ( isSingleEmail ) {
+			return;
+		}
 		const handleResize = debounce( () => {
 			setIsWide( window.innerWidth > FLOATING_PREVIEW_WIDTH_LIMIT );
 		}, 400 );

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -3,7 +3,8 @@
  */
 import { createSlotFill, SelectControl, Spinner } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	previewUrl,
 	settingsIds,
 } ) => {
+	const FLOATING_PREVIEW_WIDTH_LIMIT = 1550;
 	const [ deviceType, setDeviceType ] =
 		useState< string >( DEVICE_TYPE_DESKTOP );
 	const isSingleEmail = emailTypes.length === 1;
@@ -43,11 +45,28 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 			: 'WC_Email_Customer_Processing_Order'
 	);
 	const [ isLoading, setIsLoading ] = useState< boolean >( false );
+	const [ isWide, setIsWide ] = useState< boolean >(
+		window.innerWidth > FLOATING_PREVIEW_WIDTH_LIMIT
+	);
 	const finalPreviewUrl = `${ previewUrl }&type=${ emailType }`;
+
+	useEffect( () => {
+		const handleResize = debounce( () => {
+			setIsWide( window.innerWidth > FLOATING_PREVIEW_WIDTH_LIMIT );
+		}, 400 );
+		window.addEventListener( 'resize', handleResize );
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+		};
+	}, [] );
 
 	return (
 		<Fill>
-			<div className="wc-settings-email-preview-container">
+			<div
+				className={ `wc-settings-email-preview-container ${
+					isWide ? 'wc-settings-email-preview-container-floating' : ''
+				}` }
+			>
 				<div className="wc-settings-email-preview-controls">
 					{ ! isSingleEmail && (
 						<EmailPreviewType

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -1,4 +1,9 @@
 $wc-setting-email-preview-gap: 16px;
+$wc-setting-email-width: 634px;
+
+#wc_settings_email_preview_slotfill {
+	position: relative;
+}
 
 .wc-settings-email-preview-container {
 	background: $gray-100;
@@ -10,6 +15,12 @@ $wc-setting-email-preview-gap: 16px;
 	height: 960px;
 	padding: $wc-setting-email-preview-gap;
 	width: 652px;
+}
+
+.wc-settings-email-preview-container-floating {
+	bottom: 0;
+	position: absolute;
+	left: $wc-setting-email-width + $wc-setting-email-preview-gap * 2;
 }
 
 .wc-settings-email-preview-controls {
@@ -234,6 +245,12 @@ $wc-setting-email-preview-gap: 16px;
 			box-shadow: none;
 		}
 	}
+}
+
+.wc-settings-email-color-palette-separator {
+	border-bottom: none;
+	margin-left: 0;
+	max-width: $wc-setting-email-width;
 }
 
 .wc-settings-email-color-palette-title {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -793,6 +793,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$default_colors = $this->get_email_default_colors();
 
 		?>
+		<hr class="wc-settings-email-color-palette-separator" />
 		<h2 class="wc-settings-email-color-palette-title"><?php echo esc_html( $value['title'] ); ?></h2>
 		<div
 			class="wc-settings-email-color-palette-buttons"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. On a wide-enough display, make the email preview float next to email settings for an easier live preview when changing settings. 

<img width="1686" alt="Screenshot 2024-12-13 at 10 30 46" src="https://github.com/user-attachments/assets/3365db91-b8ab-4c16-be71-d59cf4b37163" />

Closes #52422.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable **Email improvements** feature in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Email**.
3. When your browser window is wider than 1550px, the email preview should float next to the email settings. Otherwise, it's below email settings.
4. Resize the browser window to observe that the email preview position changes (there is a 400ms debounce, which means the position is recalculated only 400ms after the last resize event - it's not immediate to improve performance). 
5. Check that the preview is not blocking other elements on the page. 

<!-- End testing instructions -->
