### PR TITLE
[Accessibility] Add filter by attribute, stock and rating screen reader labels

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/attribute-filter/block.tsx
@@ -670,6 +670,11 @@ const AttributeFilterBlock = ( {
 						isLoading={ isLoading }
 						disabled={ getIsApplyButtonDisabled() }
 						onClick={ () => onSubmit( checked ) }
+						screenReaderLabel={ sprintf(
+							/* translators: %s is the attribute label */
+							__( 'Apply attribute filter: %s', 'woocommerce' ),
+							attributeObject.label
+						) }
 					/>
 				) }
 			</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/rating-filter/block.tsx
@@ -485,6 +485,10 @@ const RatingFilterBlock = ( {
 							isLoading={ isLoading }
 							disabled={ isLoading || isDisabled }
 							onClick={ () => onSubmit( checked ) }
+							screenReaderLabel={ __(
+								'Apply rating filter',
+								'woocommerce'
+							) }
 						/>
 					) }
 				</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/block.tsx
@@ -528,6 +528,10 @@ const StockStatusFilterBlock = ( {
 							isLoading={ isLoading }
 							disabled={ isLoading || isDisabled }
 							onClick={ () => onSubmit( checked ) }
+							screenReaderLabel={ __(
+								'Apply stock filter',
+								'woocommerce'
+							) }
 						/>
 					) }
 				</div>

--- a/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/test/__snapshots__/block.tsx.snap
+++ b/plugins/woocommerce-blocks/assets/js/blocks/stock-filter/test/__snapshots__/block.tsx.snap
@@ -233,7 +233,7 @@ exports[`Filter by Stock block renders the stock filter block with the filter bu
       <span
         class="screen-reader-text"
       >
-        Apply filter
+        Apply stock filter
       </span>
     </button>
   </div>

--- a/plugins/woocommerce/changelog/fix-52089
+++ b/plugins/woocommerce/changelog/fix-52089
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add filter by attribute, stock and rating screen reader labels


### PR DESCRIPTION
### Submission Review Guidelines:

- * I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- * I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- * I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- * Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #52089 .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- Browse to a shop page with blocks:
  - "Filter by Attribute"
  - "Filter by Rating"
  - "Filter by Stock"
- Enable "Show 'Apply filters' button" for each block.

**"Filter by Attribute"**
- On the frontend, inspecting the "Apply" button should have the following screen reader text: "Apply attribute filter: $ATTRIBUTE_NAME"

**"Filter by Rating"**
- On the frontend, inspecting the "Apply" button should have the following screen reader text: "Apply rating filter"

**"Filter by Stock"**
- On the frontend, inspecting the "Apply" button should have the following screen reader text: "Apply stock filter"

### Changelog entry

- * [ ] Automatically create a changelog entry from the details below.
- * [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance
#### Type

</details>
