### PR TITLE
Fix: Styling issues in Product Editor around featured product star and variation dimensions spacing

### DIFF
--- a/plugins/woocommerce/changelog/53707-fix-53524-minor-issues-in-woocommerce
+++ b/plugins/woocommerce/changelog/53707-fix-53524-minor-issues-in-woocommerce
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Styling issues in Product Editor around featured product star and variation dimensions spacing

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5888,6 +5888,17 @@ img.help_tip {
 	}
 }
 
+.woocommerce_variation .woocommerce_variable_attributes .dimensions_field.form-row {
+	.wrap {
+		display: flex;
+		gap: 12px;
+
+		input {
+			width: 33.33%;
+		}
+	}
+}
+
 .woocommerce_attribute,
 .woocommerce_variation {
 	h3 .sort {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3653,6 +3653,10 @@ table.wp-list-table {
 	.column-product_type {
 		width: 48px;
 		text-align: left !important;
+
+		a:focus {
+			box-shadow: none;
+		}
 	}
 
 	.column-customer_message,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53524

This PR fixes two minor issues in WooCommerce:
1. When we click on the star for add to the featured product, two dots appear around it and are clickable.
![Image](https://github.com/user-attachments/assets/0233b898-1ce3-4716-8e2a-602f213ba0d0)

2. While editing a variation of a variable product, the 3 dimensions fields are stuck together as shown in the screenshot below.
![Image](https://github.com/user-attachments/assets/23e45f07-7a13-48ec-bb52-c28fa9d18727)

This PR fixes both of these issues. I tried to keep scope of CSS changes to minimum.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

### Case 1: Clicking on start in All products table

1. Go to All products page.
2. Click on any star inside Star column
3. Verify that two dots doesn't appear around the star.

### Case 2: Editing a variation of a variable product

1. Edit any variable product
2. Go to variations tab
3. Click on any variation to edit it.
4. Verify that 3 dimensions fields are not stuck together as shown in the screenshot below.
![Image](https://github.com/user-attachments/assets/2ed07557-9832-4867-8f82-48d4d188283f)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Styling issues in Product Editor around featured product star and variation dimensions spacing
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
