### PR TITLE
Live preview changes on Manage email page

### DIFF
--- a/plugins/woocommerce/changelog/53696-live-preview-manage-email
+++ b/plugins/woocommerce/changelog/53696-live-preview-manage-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Experimental: add live preview for subject, heading, and additional content when managing specific email

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -69,6 +69,9 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 		fromAddressEl.addEventListener( 'change', handleFromAddressChange );
 
 		return () => {
+			if ( ! fromNameEl || ! fromAddressEl ) {
+				return;
+			}
 			fromNameEl.removeEventListener( 'change', handleFromNameChange );
 			fromAddressEl.removeEventListener(
 				'change',
@@ -93,6 +96,9 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 		subjectEl.addEventListener( 'transient-saved', fetchSubject );
 
 		return () => {
+			if ( ! subjectEl ) {
+				return;
+			}
 			subjectEl.removeEventListener( 'transient-saved', fetchSubject );
 		};
 	}, [ fetchSubject ] );

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -24,6 +24,7 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 	const [ fromName, setFromName ] = useState( '' );
 	const [ fromAddress, setFromAddress ] = useState( '' );
 	const [ subject, setSubject ] = useState( '' );
+	let subjectEl: Element | null = null;
 
 	const fetchSubject = useCallback( async () => {
 		try {
@@ -31,6 +32,9 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 				path: `wc-admin-email/settings/email/preview-subject?type=${ emailType }`,
 			} );
 			setSubject( response.subject );
+			if ( subjectEl ) {
+				subjectEl.dispatchEvent( new Event( 'subject-updated' ) );
+			}
 		} catch ( e ) {
 			setSubject( '' );
 		}
@@ -78,7 +82,7 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 	}, [ emailType, fetchSubject ] );
 
 	useEffect( () => {
-		const subjectEl = document.querySelector(
+		subjectEl = document.querySelector(
 			'[id^="woocommerce_"][id$="_subject"]'
 		);
 

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -34,6 +34,7 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 					data: { key, value },
 				} );
 			} finally {
+				target.dispatchEvent( new Event( 'transient-saved' ) );
 				setCounter( ( prevCounter ) => prevCounter + 1 );
 			}
 		};

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -674,6 +674,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				id="wc_settings_email_preview_slotfill"
 				data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
 				data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
+				data-email-settings-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::get_email_content_settings_ids( $email->id ) ) ); ?>"
 			></div>
 			<input type="hidden" id="woocommerce_email_from_name" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_name' ) ); ?>" />
 			<input type="hidden" id="woocommerce_email_from_address" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_address' ) ); ?>" />

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -631,7 +631,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	public function email_preview() {
 		// Deletes transient with email settings used for live preview. This is to
 		// prevent conflicts where the preview would show values from previous session.
-		foreach ( EmailPreview::EMAIL_SETTINGS_IDS as $id ) {
+		foreach ( EmailPreview::get_email_style_settings_ids() as $id ) {
 			delete_transient( $id );
 		}
 		$emails      = WC()->mailer()->get_emails();
@@ -647,7 +647,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			id="wc_settings_email_preview_slotfill"
 			data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
 			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
-			data-email-settings-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::EMAIL_SETTINGS_IDS ) ); ?>"
+			data-email-settings-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::get_email_style_settings_ids() ) ); ?>"
 		></div>
 		<?php
 	}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -629,11 +629,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * Creates the React mount point for the email preview.
 	 */
 	public function email_preview() {
-		// Deletes transient with email settings used for live preview. This is to
-		// prevent conflicts where the preview would show values from previous session.
-		foreach ( EmailPreview::get_email_style_settings_ids() as $id ) {
-			delete_transient( $id );
-		}
+		$this->delete_transient_email_settings( null );
 		$emails      = WC()->mailer()->get_emails();
 		$email_types = array();
 		foreach ( $emails as $type => $email ) {
@@ -658,6 +654,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * @param object $email The email object to run the method on.
 	 */
 	public function email_preview_single( $email ) {
+		$this->delete_transient_email_settings( $email->id );
 		// Email types array should have a single entry for current email.
 		$email_types = array(
 			array(
@@ -680,6 +677,22 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			<input type="hidden" id="woocommerce_email_from_address" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_address' ) ); ?>" />
 		</div>
 		<?php
+	}
+
+	/**
+	 * Deletes transient with email settings used for live preview. This is to
+	 * prevent conflicts where the preview would show values from previous session.
+	 *
+	 * @param string|null $email_id Email ID.
+	 */
+	private function delete_transient_email_settings( ?string $email_id ) {
+		$setting_ids = array_merge(
+			EmailPreview::get_email_style_settings_ids(),
+			EmailPreview::get_email_content_settings_ids( $email_id ),
+		);
+		foreach ( $setting_ids as $id ) {
+			delete_transient( $id );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -425,6 +425,15 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_subject() {
+		/**
+		 * Provides an opportunity to inspect and modify subject for the email.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param string      $subject Subject of the email.
+		 * @param object|bool $object  The object (ie, product or order) this email relates to, if any.
+		 * @param WC_Email    $email   WC_Email instance managing the email.
+		 */
 		return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->get_option_or_transient( 'subject', $this->get_default_subject() ) ), $this->object, $this );
 	}
 
@@ -434,6 +443,15 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_heading() {
+		/**
+		 * Provides an opportunity to inspect and modify heading for the email.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param string      $heading Heading to be added to the email.
+		 * @param object|bool $object  The object (ie, product or order) this email relates to, if any.
+		 * @param WC_Email    $email   WC_Email instance managing the email.
+		 */
 		return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->get_option_or_transient( 'heading', $this->get_default_heading() ) ), $this->object, $this );
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -416,7 +416,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param object|bool $object             The object (ie, product or order) this email relates to, if any.
 		 * @param WC_Email    $email              WC_Email instance managing the email.
 		 */
-		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option_or_transient( 'additional_content' ) ), $this->object, $this );
 	}
 
 	/**
@@ -425,7 +425,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_subject() {
-		return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->get_option( 'subject', $this->get_default_subject() ) ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->get_option_or_transient( 'subject', $this->get_default_subject() ) ), $this->object, $this );
 	}
 
 	/**
@@ -434,7 +434,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_heading() {
-		return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->get_option( 'heading', $this->get_default_heading() ) ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->get_option_or_transient( 'heading', $this->get_default_heading() ) ), $this->object, $this );
 	}
 
 	/**
@@ -1198,5 +1198,32 @@ class WC_Email extends WC_Settings_API {
 		if ( $phpmailer instanceof PHPMailer\PHPMailer\PHPMailer ) {
 			$phpmailer->AltBody = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
+	}
+
+	/**
+	 * Get an option or transient for email preview.
+	 *
+	 * @param string $key Option key.
+	 * @param mixed  $empty_value Value to use when option is empty.
+	 */
+	private function get_option_or_transient( string $key, $empty_value = null ) {
+		$option = $this->get_option( $key, $empty_value );
+
+		/**
+		 * This filter is documented in templates/emails/email-styles.php
+		 *
+		 * @since 9.6.0
+		 * @param bool $is_email_preview Whether the email is being previewed.
+		 */
+		$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
+		if ( $is_email_preview ) {
+			$email_id  = $this->id;
+			$transient = get_transient( "woocommerce_${email_id}_${key}" );
+			if ( false !== $transient ) {
+				$option = $transient ? $transient : $empty_value;
+			}
+		}
+
+		return $option;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -39,6 +39,20 @@ class EmailPreview {
 	);
 
 	/**
+	 * All fields IDs that can customize specific email content in Settings.
+	 *
+	 * @var array
+	 */
+	private static array $email_content_settings_ids = array();
+
+	/**
+	 * Whether the email settings IDs are initialized.
+	 *
+	 * @var bool
+	 */
+	private static bool $email_settings_ids_initialized = false;
+
+	/**
 	 * The email type to preview.
 	 *
 	 * @var string|null
@@ -74,6 +88,28 @@ class EmailPreview {
 	/**
 	 * Get all email settings IDs.
 	 */
+	public static function get_all_email_settings_ids() {
+		if ( ! self::$email_settings_ids_initialized ) {
+			self::$email_settings_ids_initialized = true;
+
+			$emails = WC()->mailer()->get_emails();
+			foreach ( $emails as $email ) {
+				self::$email_content_settings_ids = array_merge(
+					self::$email_content_settings_ids,
+					self::get_email_content_settings_ids( $email->id )
+				);
+			}
+			self::$email_content_settings_ids = array_unique( self::$email_content_settings_ids );
+		}
+		return array_merge(
+			self::$email_style_settings_ids,
+			self::$email_content_settings_ids,
+		);
+	}
+
+	/**
+	 * Get email style settings IDs.
+	 */
 	public static function get_email_style_settings_ids() {
 		return self::$email_style_settings_ids;
 	}
@@ -81,9 +117,12 @@ class EmailPreview {
 	/**
 	 * Get email content settings IDs for specific email.
 	 *
-	 * @param string $email_id Email ID.
+	 * @param string|null $email_id Email ID.
 	 */
-	public static function get_email_content_settings_ids( string $email_id ) {
+	public static function get_email_content_settings_ids( ?string $email_id ) {
+		if ( ! $email_id ) {
+			return array();
+		}
 		return array(
 			"woocommerce_${email_id}_subject",
 			"woocommerce_${email_id}_heading",

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -79,6 +79,19 @@ class EmailPreview {
 	}
 
 	/**
+	 * Get email content settings IDs for specific email.
+	 *
+	 * @param string $email_id Email ID.
+	 */
+	public static function get_email_content_settings_ids( string $email_id ) {
+		return array(
+			"woocommerce_${email_id}_subject",
+			"woocommerce_${email_id}_heading",
+			"woocommerce_${email_id}_additional_content",
+		);
+	}
+
+	/**
 	 * Set the email type to preview.
 	 *
 	 * @param string $email_type Email type.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -21,7 +21,12 @@ defined( 'ABSPATH' ) || exit;
 class EmailPreview {
 	const DEFAULT_EMAIL_TYPE = 'WC_Email_Customer_Processing_Order';
 
-	const EMAIL_SETTINGS_IDS = array(
+	/**
+	 * All fields IDs that can customize email styles in Settings.
+	 *
+	 * @var array
+	 */
+	private static array $email_style_settings_ids = array(
 		'woocommerce_email_background_color',
 		'woocommerce_email_base_color',
 		'woocommerce_email_body_background_color',
@@ -64,6 +69,13 @@ class EmailPreview {
 			static::$instance = new static();
 		}
 		return static::$instance;
+	}
+
+	/**
+	 * Get all email settings IDs.
+	 */
+	public static function get_email_style_settings_ids() {
+		return self::$email_style_settings_ids;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class EmailPreview {
 	const DEFAULT_EMAIL_TYPE = 'WC_Email_Customer_Processing_Order';
+	const DEFAULT_EMAIL_ID   = 'customer_processing_order';
 
 	/**
 	 * All fields IDs that can customize email styles in Settings.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -183,7 +183,10 @@ class EmailPreview {
 		if ( ! $this->email ) {
 			return '';
 		}
-		return $this->email->get_subject();
+		$this->set_up_filters();
+		$subject = $this->email->get_subject();
+		$this->clean_up_filters();
+		return $subject;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -130,7 +130,10 @@ class EmailPreviewRestController extends RestApiControllerBase {
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => function ( $value, $request ) {
 								$key = $request->get_param( 'key' );
-								if ( 'woocommerce_email_footer_text' === $key ) {
+								if (
+									'woocommerce_email_footer_text' === $key
+									|| preg_match( '/_additional_content$/', $key )
+								) {
 									return wp_kses_post( trim( $value ) );
 								}
 								return sanitize_text_field( $value );

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -112,7 +112,7 @@ class EmailPreviewRestController extends RestApiControllerBase {
 							'type'              => 'string',
 							'description'       => 'The key for the transient. Must be one of the allowed options.',
 							'validate_callback' => function ( $key ) {
-								if ( ! in_array( $key, EmailPreview::EMAIL_SETTINGS_IDS, true ) ) {
+								if ( ! in_array( $key, EmailPreview::get_email_style_settings_ids(), true ) ) {
 									return new \WP_Error(
 										'woocommerce_rest_not_allowed_key',
 										sprintf( 'The provided key "%s" is not allowed.', $key ),

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -112,7 +112,7 @@ class EmailPreviewRestController extends RestApiControllerBase {
 							'type'              => 'string',
 							'description'       => 'The key for the transient. Must be one of the allowed options.',
 							'validate_callback' => function ( $key ) {
-								if ( ! in_array( $key, EmailPreview::get_email_style_settings_ids(), true ) ) {
+								if ( ! in_array( $key, EmailPreview::get_all_email_settings_ids(), true ) ) {
 									return new \WP_Error(
 										'woocommerce_rest_not_allowed_key',
 										sprintf( 'The provided key "%s" is not allowed.', $key ),

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -263,6 +263,33 @@ test.describe( 'WooCommerce Email Settings', () => {
 			await expect( page.getByLabel( 'Email preview type' ) ).toHaveCount(
 				0
 			);
+
+			// Change subject and observed it's changed in the preview
+			const newSubject = 'New subject';
+			const subjectId = 'woocommerce_customer_processing_order_subject';
+
+			await page.fill( `#${ subjectId }`, newSubject );
+			await page.evaluate( async ( inputId ) => {
+				const input = document.getElementById( inputId );
+				input.blur();
+
+				await new Promise( ( resolve ) => {
+					input.addEventListener(
+						'transient-saved',
+						() => resolve(),
+						{ once: true }
+					);
+				} );
+
+				return new Promise( ( resolve ) => {
+					input.addEventListener(
+						'subject-updated',
+						() => resolve(),
+						{ once: true }
+					);
+				} );
+			}, subjectId );
+			await expect( await getSubject() ).toContain( 'New subject' );
 		}
 	);
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -264,7 +264,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 				0
 			);
 
-			// Change subject and observed it's changed in the preview
+			// Change subject and observe it's changed in the preview
 			const newSubject = 'New subject';
 			const subjectId = 'woocommerce_customer_processing_order_subject';
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -250,7 +250,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'Missing parameter(s): key, value', $response->get_data()['message'] );
 
-		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0] );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0] );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'Missing parameter(s): value', $response->get_data()['message'] );
@@ -280,7 +280,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		add_filter( 'user_has_cap', $filter_callback );
 
-		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value' );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0], 'value' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
@@ -292,11 +292,11 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test saving transient with a successful saving.
 	 */
 	public function test_save_transient_success_response() {
-		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value' );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0], 'value' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'Transient saved for key ' . EmailPreview::EMAIL_SETTINGS_IDS[0] . '.', $response->get_data()['message'] );
+		$this->assertEquals( 'Transient saved for key ' . EmailPreview::get_email_style_settings_ids()[0] . '.', $response->get_data()['message'] );
 	}
 
 	/**
@@ -330,10 +330,10 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test saving transient with a failed saving.
 	 */
 	public function test_save_transient_error_response() {
-		set_transient( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value', HOUR_IN_SECONDS );
+		set_transient( EmailPreview::get_email_style_settings_ids()[0], 'value', HOUR_IN_SECONDS );
 
 		// Saving the transient will fail because the transient key is already set to the same value.
-		$request  = $this->get_save_transient_request( EmailPreview::EMAIL_SETTINGS_IDS[0], 'value' );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0], 'value' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 500, $response->get_status() );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -272,6 +272,33 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test saving transient for an unregistered email fails
+	 */
+	public function test_save_transient_with_unregistered_email() {
+		$keys = EmailPreview::get_email_content_settings_ids( 'unregistered_email_id' );
+		foreach ( $keys as $key ) {
+			$request  = $this->get_save_transient_request( $key, 'value' );
+			$response = $this->server->dispatch( $request );
+			$this->assertEquals( 400, $response->get_status() );
+			$this->assertEquals( 'Invalid parameter(s): key', $response->get_data()['message'] );
+		}
+	}
+
+	/**
+	 * Test saving transient for registered email
+	 */
+	public function test_save_transient_with_registered_email() {
+		$keys = EmailPreview::get_email_content_settings_ids( EmailPreview::DEFAULT_EMAIL_ID );
+		foreach ( $keys as $key ) {
+			$request  = $this->get_save_transient_request( $key, 'value' );
+			$response = $this->server->dispatch( $request );
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertEquals( 'Transient saved for key ' . $key . '.', $response->get_data()['message'] );
+			$this->assertEquals( 'value', get_transient( $key ) );
+		}
+	}
+
+	/**
 	 * Test saving transient by a user without the needed capabilities.
 	 */
 	public function test_save_transient_by_user_without_caps() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -226,9 +226,9 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 * Test that transient values are applied in email preview
 	 */
 	public function test_transient_values_in_preview() {
-		$original_value = get_option( EmailPreview::EMAIL_SETTINGS_IDS[0] );
-		update_option( EmailPreview::EMAIL_SETTINGS_IDS[0], 'option_value' );
-		set_transient( EmailPreview::EMAIL_SETTINGS_IDS[0], 'transient_value', HOUR_IN_SECONDS );
+		$original_value = get_option( EmailPreview::get_email_style_settings_ids()[0] );
+		update_option( EmailPreview::get_email_style_settings_ids()[0], 'option_value' );
+		set_transient( EmailPreview::get_email_style_settings_ids()[0], 'transient_value', HOUR_IN_SECONDS );
 
 		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
 		$content = $this->sut->render();
@@ -236,6 +236,6 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString( 'option_value', $content );
 		$this->assertStringContainsString( 'transient_value', $content );
 
-		update_option( EmailPreview::EMAIL_SETTINGS_IDS[0], $original_value );
+		update_option( EmailPreview::get_email_style_settings_ids()[0], $original_value );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -209,8 +209,9 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 */
 	public function test_prepare_email_for_preview_filter() {
 		$email_filter = function ( $email ) {
-			$email->settings['subject'] = 'Filtered Subject {order_number}';
-			return $email;
+			$new_email                      = clone $email;
+			$new_email->settings['subject'] = 'Filtered Subject {order_number}';
+			return $new_email;
 		};
 		add_filter( 'woocommerce_prepare_email_for_preview', $email_filter, 10, 1 );
 
@@ -237,5 +238,46 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'transient_value', $content );
 
 		update_option( EmailPreview::get_email_style_settings_ids()[0], $original_value );
+	}
+
+	/**
+	 * Test that transient values are applied in subject
+	 */
+	public function test_transient_values_in_subject() {
+		$email_id = EmailPreview::DEFAULT_EMAIL_ID;
+		$key      = "woocommerce_${email_id}_subject";
+
+		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
+		$this->assertEquals( $this->sut->get_subject(), 'Your ' . self::SITE_TITLE . ' order has been received!' );
+
+		set_transient( $key, 'transient_subject', HOUR_IN_SECONDS );
+		$this->assertEquals( $this->sut->get_subject(), 'transient_subject' );
+	}
+
+	/**
+	 * Test that transient values are applied in email content
+	 */
+	public function test_transient_values_in_email_content() {
+		$email_id         = EmailPreview::DEFAULT_EMAIL_ID;
+		$heading_key      = "woocommerce_${email_id}_heading";
+		$additional_key   = "woocommerce_${email_id}_additional_content";
+		$heading_value    = get_option( $heading_key );
+		$additional_value = get_option( $additional_key );
+
+		update_option( $heading_key, 'option_value_heading' );
+		set_transient( $heading_key, 'transient_value_heading', HOUR_IN_SECONDS );
+		update_option( $additional_key, 'option_value_additional' );
+		set_transient( $additional_key, 'transient_value_additional', HOUR_IN_SECONDS );
+
+		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
+		$content = $this->sut->render();
+
+		$this->assertStringNotContainsString( 'option_value_heading', $content );
+		$this->assertStringNotContainsString( 'option_value_additional', $content );
+		$this->assertStringContainsString( 'transient_value_heading', $content );
+		$this->assertStringContainsString( 'transient_value_additional', $content );
+
+		update_option( $heading_key, $heading_value );
+		update_option( $additional_key, $additional_value );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -238,6 +238,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'transient_value', $content );
 
 		update_option( EmailPreview::get_email_style_settings_ids()[0], $original_value );
+		delete_transient( EmailPreview::get_email_style_settings_ids()[0] );
 	}
 
 	/**
@@ -252,6 +253,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 		set_transient( $key, 'transient_subject', HOUR_IN_SECONDS );
 		$this->assertEquals( $this->sut->get_subject(), 'transient_subject' );
+		delete_transient( $key );
 	}
 
 	/**
@@ -279,5 +281,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 
 		update_option( $heading_key, $heading_value );
 		update_option( $additional_key, $additional_value );
+		delete_transient( $heading_key );
+		delete_transient( $additional_key );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of #52228. Adds live preview when managing a specific email.

Closes #53696.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable **Email improvements** feature in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Email**.
3. Click **Manage** on any email.
4. Update the **Subject** field and check that the subject is updated in the email preview.
5. Update the **Email heading** field and check that the heading is updated in the email preview.
6. Update the **Additional content** field and check that it's updated in the email preview.

<!-- End testing instructions -->
