### PR TITLE
Limit core profiler extensions to 8

### DIFF
--- a/plugins/woocommerce/changelog/update-53364-limit-core-profiler-extensions-8-maximum
+++ b/plugins/woocommerce/changelog/update-53364-limit-core-profiler-extensions-8-maximum
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Limit core profiler extensions to 8 maximum

--- a/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/actions/tracks.tsx
@@ -150,6 +150,7 @@ const recordTracksPluginsInstallationRequest = ( {
 		shown: event.payload.pluginsShown || [],
 		selected: event.payload.pluginsSelected || [],
 		unselected: event.payload.pluginsUnselected || [],
+		truncated: event.payload.pluginsTruncated || [],
 	} );
 };
 

--- a/plugins/woocommerce/client/admin/client/core-profiler/events.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/events.tsx
@@ -77,6 +77,7 @@ export type PluginsInstallationRequestedEvent = {
 		pluginsShown: string[];
 		pluginsSelected: string[];
 		pluginsUnselected: string[];
+		pluginsTruncated: string[];
 	};
 };
 

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -113,6 +113,7 @@ export type CoreProfilerStateMachineContext = {
 		sellingPlatforms?: SellingPlatform[] | null;
 	} & Partial< ProfileItems >;
 	pluginsAvailable: ExtensionList[ 'plugins' ] | [];
+	pluginsTruncated: string[];
 	pluginsSelected: string[]; // extension slugs
 	pluginsInstallationErrors: PluginInstallError[];
 	geolocatedLocation: GeolocationResponse | undefined;
@@ -626,7 +627,16 @@ const handlePlugins = assign( {
 	}: {
 		event: DoneActorEvent< Extension[] >;
 	} ) => {
-		return event.output;
+		return event.output.slice( 0, 8 );
+	},
+	pluginsTruncated: ( {
+		event,
+	}: {
+		event: DoneActorEvent< Extension[] >;
+	} ) => {
+		return event.output
+			.slice( 8 )
+			.map( ( plugin ) => plugin.key.replace( ':alt', '' ) );
 	},
 } );
 
@@ -798,6 +808,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 		countries: [] as CountryStateOption[],
 		pluginsAvailable: [],
 		pluginsInstallationErrors: [],
+		pluginsTruncated: [],
 		pluginsSelected: [],
 		loader: {},
 		onboardingProfile: {} as OnboardingProfile,

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -627,7 +627,7 @@ const handlePlugins = assign( {
 	}: {
 		event: DoneActorEvent< Extension[] >;
 	} ) => {
-		return event.output.slice( 0, 8 );
+		return event.output.slice( 0, 8 ); // in lieu of a plugin display priority system, we're only showing the first 8 plugins in the recommendations list
 	},
 	pluginsTruncated: ( {
 		event,

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -602,14 +602,11 @@ const getPlugins = fromPromise( async () => {
 	const extensionsBundles = await resolveSelect(
 		ONBOARDING_STORE_NAME
 	).getFreeExtensions();
-	const coreProfilerPlugins =
+	return (
 		extensionsBundles.find(
 			( bundle ) => bundle.key === 'obw/core-profiler'
-		)?.plugins || [];
-	// We can only show 8 plugins.
-	return Array.isArray( coreProfilerPlugins )
-		? coreProfilerPlugins.slice( 0, 8 )
-		: [];
+		)?.plugins || []
+	);
 } );
 
 /** Special callback that is used to trigger a navigation event if the user uses the browser's back or forward buttons */

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -602,11 +602,14 @@ const getPlugins = fromPromise( async () => {
 	const extensionsBundles = await resolveSelect(
 		ONBOARDING_STORE_NAME
 	).getFreeExtensions();
-	return (
+	const coreProfilerPlugins =
 		extensionsBundles.find(
 			( bundle ) => bundle.key === 'obw/core-profiler'
-		)?.plugins || []
-	);
+		)?.plugins || [];
+	// We can only show 8 plugins.
+	return Array.isArray( coreProfilerPlugins )
+		? coreProfilerPlugins.slice( 0, 8 )
+		: [];
 } );
 
 /** Special callback that is used to trigger a navigation event if the user uses the browser's back or forward buttons */

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
@@ -89,7 +89,10 @@ export const Plugins = ( {
 }: {
 	context: Pick<
 		CoreProfilerStateMachineContext,
-		'pluginsAvailable' | 'pluginsInstallationErrors' | 'pluginsSelected'
+		| 'pluginsAvailable'
+		| 'pluginsInstallationErrors'
+		| 'pluginsSelected'
+		| 'pluginsTruncated'
 	>;
 	sendEvent: (
 		payload:
@@ -147,6 +150,7 @@ export const Plugins = ( {
 				pluginsShown,
 				pluginsSelected: selectedPluginSlugs,
 				pluginsUnselected,
+				pluginsTruncated: context.pluginsTruncated,
 			},
 		} );
 	};

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
@@ -25,7 +25,7 @@ export const PluginErrorBanner = ( {
 		case pluginsInstallationPermissionsFailure:
 		case pluginsInstallationErrors?.some(
 			// it really shouldn't get here since permissions are pre-checked. but we'll check for 403 just to be safe.
-			( e ) => e.errorDetails?.data.data.status === 403 // 403 is the code representing rest_authorization_required_code()
+			( e ) => e.errorDetails?.data?.data?.status === 403 // 403 is the code representing rest_authorization_required_code()
 		):
 			installationErrorMessage = __(
 				'You do not have permissions to install plugins. Please contact your site administrator.',

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
@@ -64,6 +64,7 @@ describe( 'Plugins Component', () => {
 		],
 		pluginsSelected: [],
 		pluginsInstallationErrors: [],
+		pluginsTruncated: [],
 	};
 	const navigationProgress = 80;
 

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
@@ -111,6 +111,7 @@ describe( 'Plugins Component', () => {
 				pluginsSelected: [ 'plugin1' ],
 				pluginsShown: [ 'plugin1', 'plugin2', 'plugin3', 'plugin4' ],
 				pluginsUnselected: [ 'plugin3', 'plugin4' ],
+				pluginsTruncated: [],
 			},
 		} );
 	} );

--- a/plugins/woocommerce/client/admin/client/core-profiler/stories/Plugins.story.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/stories/Plugins.story.tsx
@@ -54,6 +54,7 @@ export const Basic = () => (
 			pluginsAvailable: plugins,
 			pluginsSelected: [],
 			pluginsInstallationErrors: [],
+			pluginsTruncated: [],
 		} }
 	/>
 );
@@ -79,6 +80,7 @@ export const InstallationError = () => (
 					error: 'Installation failed',
 				},
 			],
+			pluginsTruncated: [],
 		} }
 	/>
 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partially addresses #53364

- Adds 8 hard limit to number of core profiler extensions

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate Code Snippets plugin
2. Activate the following code snippet: <br> 
```php
function filter_free_extensions_response($response) {
    $plugins = array();
    for($i = 1; $i <= 9; $i++) {
        $plugins[] = array(
            "name" => "WooPlugin " . $i,
            "description" => "Plugin " . $i . " description",
            "is_visible" => true,
            "is_built_by_wc" => true,
            "key" => "woo-plugin-" . strtolower($i),
            "label" => "Plugin " . $i . " Label",
            "image_url" => "https://woocommerce.com/wp-content/plugins/wccom-plugins/obw-free-extensions/images/core-profiler/logo-woo.svg",
            "learn_more_link" => "https://woocommerce.com",
            "install_priority" => $i,
            "is_installed" => false,
            "is_activated" => false
        );
    }

    return array(
        array(
            "key" => "obw/core-profiler",
            "title" => "Grow your store",
            "plugins" => $plugins
        )
    );
}

add_filter('rest_pre_echo_response', function($response, $object, $request) {
    if ($request->get_route() === '/wc-admin/onboarding/free-extensions') {
        return filter_free_extensions_response($response);
    }
    return $response;
}, 10, 3);
```
4. In JS console, run `localStorage.setItem( 'debug', 'wc-admin:*' );`
4. Go through core profiler until the extensions step
5. Observe it shows 8 extensions despite having 9 extensions
6. Click next to attempt installation
7. Observe the track `wcadmin_coreprofiler_store_extensions_continue` is fired with 1 truncated plugin

<img width="1049" alt="image" src="https://github.com/user-attachments/assets/11abd1ec-eeb4-4338-9338-48a81289b736" />

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/175bfe18-554b-4890-8c84-ce9a1baee9cc" />


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
