### PR TITLE
fix: core profiler not showing jetpack auth step when pre-installed

### DIFF
--- a/plugins/woocommerce/changelog/fix-core-profiler-jetpack-auth-not-showing
+++ b/plugins/woocommerce/changelog/fix-core-profiler-jetpack-auth-not-showing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed core profiler not showing jetpack auth step when pre-installed

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -1650,6 +1650,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 										target: '#isJetpackConnected',
 										guard: or( [
 											'hasJpcRequiredPluginSelected',
+											'hasJpcRequiredPluginActivated',
 										] ),
 									},
 									{ actions: 'redirectToWooHome' },
@@ -1676,7 +1677,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 								onDone: [
 									{
 										target: '#isJetpackConnected',
-										guard: 'hasJetpackActivated',
+										guard: 'hasJpcRequiredPluginActivated',
 									},
 									{ actions: 'redirectToWooHome' },
 								],
@@ -1794,7 +1795,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 									{
 										type: 'hasJpcRequiredPluginSelected',
 									},
-									{ type: 'hasJetpackActivated' },
+									{ type: 'hasJpcRequiredPluginActivated' },
 								] )
 							)
 						) {
@@ -1872,11 +1873,11 @@ export const CoreProfilerController = ( {
 						return pluginDetails?.requires_jpc === true;
 					} );
 				},
-				hasJetpackActivated: ( { context } ) => {
+				hasJpcRequiredPluginActivated: ( { context } ) => {
 					return (
 						context.pluginsAvailable.find(
 							( plugin: Extension ) =>
-								plugin.key === 'jetpack' && plugin.is_activated
+								plugin.requires_jpc && plugin.is_activated
 						) !== undefined
 					);
 				},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a bug where Jetpack connection required plugins was not triggering the jetpack auth redirect after the core profiler

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

For the below, a "JPC plugin" (jetpack required connection plugin) is either "WooPayments" or "Jetpack"

Scenarios:
1. JPC plugin pre-installed and some plugins selected for installation, continue clicked
2. JPC plugin pre-installed and all plugins deselected for installation, continue clicked
3. JPC plugin not pre-installed and JPC plugin selected for installation, continue clicked
4. JPC plugin not pre-installed and JPC plugin not selected for installation, with other plugins selected, continue clicked
5. JPC plugin pre-installed and skip link clicked
6. JPC plugin not pre-installed and skip link clicked
7. JPC plugin installed and connected, no other plugins selected, continue clicked (you can reuse scenarios 1/2/3 for this)
8. JPC plugin installed and connected, some other plugins selected, continue clicked (you can reuse scenarios 1/2/3 for this)

(3 and 4 are identical code paths so it's not really necessary to test them both)

Testing instructions:
1. Spin up a JN site with JPC plugin pre-installed or not, depending on the scenario you are testing
2. Go through the Core Profiler, until the Plugin installation screen
3. Execute according to the scenarios above
4. Scenarios 1, 2, 3 should see the Jetpack connection screen, but not in 4, 5, 6, 7, 8

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
