### PR TITLE
Fix get paid core task list item behaviour

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -134,14 +134,6 @@ class TaskLists {
 			unset( $tasks[ $store_customisation_task_index ] );
 		}
 
-		// If the React-based Payments settings page is enabled, we don't need the dedicated WooPayments task.
-		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) ) {
-			$key = array_search( 'WooCommercePayments', $tasks, true );
-			if ( false !== $key ) {
-				unset( $tasks[ $key ] );
-			}
-		}
-
 		self::add_list(
 			array(
 				'id'                      => 'setup',

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -101,6 +101,11 @@ class WcPayWelcomePage {
 				'icon'       => $menu_icon,
 			);
 
+			// Put the page under WooCommerce menu item because we have settings payments left nav item if this feature flag is enabled.
+			if ( Features::is_enabled( 'reactify-classic-payments-settings' ) ) {
+				$page_options['parent'] = 'woocommerce';
+			}
+
 			wc_admin_register_page( $page_options );
 
 			$menu_path = PageController::get_instance()->get_path_from_id( $page_id );

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -67,11 +67,6 @@ class WcPayWelcomePage {
 	 * Delayed hook registration.
 	 */
 	public function delayed_register() {
-		// Don't do anything if the feature is enabled.
-		if ( Features::is_enabled( 'reactify-classic-payments-settings' ) ) {
-			return;
-		}
-
 		add_action( 'admin_menu', array( $this, 'register_menu_and_page' ) );
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'shared_settings' ) );
 		add_filter( 'woocommerce_admin_allowed_promo_notes', array( $this, 'allowed_promo_notes' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- allow to access fake incentive page if NOX feature flag is enabled
- core task list item navigates to this page if incentive is enabled

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a new JurassicNinja site with WooCommerce on this PR's live branch and the WooCommerce Beta Tester plugin (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=fix/update-core-get-paid-task-list-behaviour))
2. Go to WP admin > Tools > WCA Test Helper > Features and make sure the `reactify-classic-payments-settings` is enabled
3. Core task list should show incentive and bring merchant to fake connect page with incentive.
4. Payments left nav item should redirect us to Payments -> Settings.
5. Dismiss the incentive. Get back to WooCommerce -> Home.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
