### PR TITLE
fix: Warning: Undefined property: stdClass::$items_sold

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -587,6 +587,10 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$sparkline_data = array();
 			$total          = 0;
 			foreach ( $data as $d ) {
+				if ( ! isset( $d['subtotals']->$meta_key ) ) {
+					continue;
+                }
+				
 				$total += $d['subtotals']->$meta_key;
 				array_push( $sparkline_data, array( strval( strtotime( $d['interval'] ) * 1000 ), $d['subtotals']->$meta_key ) );
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We make use of Sentry.io which is reporting the following warning:

`Warning: Undefined property: stdClass::$items_sold`

Im not quite sure why `$items_sold` is undefined, but this pull request should prevent triggering that warning, by checking if the property exists.
