### PR TITLE
[e2e tests] Fix search url in shop test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-search-url-extra-character
+++ b/plugins/woocommerce/changelog/e2e-fix-search-url-extra-character
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix the search direct url in shop test

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/shop-search-browse-sort.spec.js
@@ -78,7 +78,7 @@ test.describe(
 		// default theme doesn't have a search box, but can simulate a search by visiting the search URL
 		test( 'should let user search the store', async ( { page } ) => {
 			await test.step( 'Go to the shop and perform the search', async () => {
-				await page.goto( `shop/?s=${ products[ 0 ].name }%201` );
+				await page.goto( `shop/?s=${ products[ 0 ].name }` );
 
 				await expect(
 					page.getByRole( 'heading', {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53637

The search url contained extra characters (`%201` => ` 1`) that were not part of the product name and can give unexpected results.

### How to test the changes in this Pull Request:

```
pnpm test:e2e shop-search-browse-sort.spec.js
```
