### PR TITLE
Add extra e2e checks in CI for PRs updating the tests

### DIFF
--- a/plugins/woocommerce/changelog/ci-run-extra-e2e-checks-for-e2e-tests-updates
+++ b/plugins/woocommerce/changelog/ci-run-extra-e2e-checks-for-e2e-tests-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI config: run extra e2e checks for different envs in PRs updating e2e tests

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -234,11 +234,10 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env gutenberg-stable",
 					"shardingArguments": [
-						"--shard=1/5",
-						"--shard=2/5",
-						"--shard=3/5",
-						"--shard=4/5",
-						"--shard=5/5"
+						"--shard=1/4",
+						"--shard=2/4",
+						"--shard=3/4",
+						"--shard=4/4"
 					],
 					"changes": [ 
 						"tests/e2e-pw/**"
@@ -262,11 +261,10 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env gutenberg-nightly",
 					"shardingArguments": [
-						"--shard=1/5",
-						"--shard=2/5",
-						"--shard=3/5",
-						"--shard=4/5",
-						"--shard=5/5"
+						"--shard=1/4",
+						"--shard=2/4",
+						"--shard=3/4",
+						"--shard=4/4"
 					],
 					"changes": [
 						"tests/e2e-pw/**"
@@ -333,7 +331,10 @@
 					"name": "Core e2e tests - WooCommerce Shipping & Tax",
 					"testType": "e2e",
 					"command": "test:e2e:with-env woocommerce-services",
-					"shardingArguments": [],
+					"shardingArguments": [
+						"--shard=1/2",
+						"--shard=2/2"
+					],
 					"changes": [
 						"tests/e2e-pw/**"
 					],

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -240,8 +240,11 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [],
+					"changes": [ 
+						"tests/e2e-pw/**"
+					],
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -265,8 +268,11 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -284,8 +290,11 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env woocommerce-payments",
 					"shardingArguments": [],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -303,8 +312,11 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env woocommerce-paypal-payments",
 					"shardingArguments": [],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -322,8 +334,11 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env woocommerce-services",
 					"shardingArguments": [],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -340,8 +355,11 @@
 					"name": "Core e2e tests - HPOS disabled",
 					"testType": "e2e",
 					"command": "test:e2e:with-env default-hpos-disabled --project=ui",
-					"shardingArguments": [],
+					"shardingArguments": [
+						"tests/e2e-pw/**"
+					],
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -369,7 +387,9 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -377,6 +397,7 @@
 						}
 					},
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -397,7 +418,9 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -405,6 +428,7 @@
 						}
 					},
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -425,7 +449,9 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [],
+					"changes": [
+						"tests/e2e-pw/**"
+					],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -433,6 +459,7 @@
 						}
 					},
 					"events": [
+						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53582

Update the CI config for `@woocommerce/plugin-woocommerce` to run more checks when updating the e2e tests. 
The `pull_request` event and only the `tests/e2e-pw/**` path in the changes list ensures that when updating anything in the e2e tests path all these checks will run.

The reason for this change is to make sure we don't introduce breaking test changes to these jobs, as they are only running daily.

I also rebalanced the core e2e shards by removing one shard from the Gutenberg jobs and adding one to the Services job.

### How to test the changes in this Pull Request:

1. Create a new branch based on this one
2. Update a file outside of the `tests/e2e-pw/**` path, but in a path that triggers checks (e.g. `src/**/*.php`)
3. Run the ci-jobs utility with this branch as the baseRef

```
pnpm utils ci-jobs --base-ref=ci/run-extra-e2e-checks-for-e2e-tests-updates --event=pull_request
```

All the jobs updated by this PR should not be part of the list of jobs

5. Update a test in the `tests/e2e-pw/**` path
6. Run the ci-jobs utility with this branch as the baseRef

All the jobs updated by this PR are expected in the list of jobs