### PR TITLE
[Settings] Update Transformer groups

### DIFF
--- a/plugins/woocommerce/changelog/53773-update-settings-transformer-relax-rules
+++ b/plugins/woocommerce/changelog/53773-update-settings-transformer-relax-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Fix Settings data grouping so that undefined ids are matched and group checkboxes are still included in groups when malformed.
+

--- a/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
@@ -308,8 +308,8 @@ class Transformer {
 	 * @param array &$transformed_settings Transformed settings array.
 	 */
 	private function finalize_transformation( array &$transformed_settings ): void {
-		$this->flush_current_group( $transformed_settings );
 		$this->flush_current_checkbox_group( $transformed_settings );
+		$this->flush_current_group( $transformed_settings );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
@@ -200,7 +200,7 @@ class Transformer {
 
 		switch ( $checkboxgroup ) {
 			case 'start':
-				$this->start_checkbox_group( $setting, $transformed_settings );
+				$this->start_checkbox_group( $setting );
 				break;
 
 			case 'end':
@@ -217,9 +217,8 @@ class Transformer {
 	 * Start a new checkbox group.
 	 *
 	 * @param array $setting Setting to add.
-	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private function start_checkbox_group( array $setting, array &$transformed_settings ): void {
+	private function start_checkbox_group( array $setting ): void {
 		// If we already have an open checkbox group, flush it to settings before starting a new one.
 		if ( is_array( $this->current_checkbox_group ) ) {
 			$this->flush_current_checkbox_group();

--- a/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
+++ b/plugins/woocommerce/src/Admin/Features/Settings/Transformer.php
@@ -104,7 +104,7 @@ class Transformer {
 		if ( $this->current_checkbox_group && 'checkbox' !== $type ) {
 			// It's expected that a checkbox group will always be closed before a non-checkbox setting.
 			// If not, it's likely a checkbox group was not closed properly so we flush the current checkbox group and add the setting as-is.
-			$this->flush_current_checkbox_group( $transformed_settings );
+			$this->flush_current_checkbox_group();
 		}
 
 		switch ( $type ) {
@@ -222,7 +222,7 @@ class Transformer {
 	private function start_checkbox_group( array $setting, array &$transformed_settings ): void {
 		// If we already have an open checkbox group, flush it to settings before starting a new one.
 		if ( is_array( $this->current_checkbox_group ) ) {
-			$this->flush_current_checkbox_group( $transformed_settings );
+			$this->flush_current_checkbox_group();
 		}
 
 		$this->current_checkbox_group = array( $setting );
@@ -272,10 +272,8 @@ class Transformer {
 
 	/**
 	 * Flush current checkbox group to transformed settings.
-	 *
-	 * @param array $transformed_settings Transformed settings array.
 	 */
-	private function flush_current_checkbox_group( array &$transformed_settings ): void {
+	private function flush_current_checkbox_group(): void {
 		if ( is_array( $this->current_checkbox_group ) ) {
 			if ( is_array( $this->current_group ) ) {
 				$this->current_group = array_merge( $this->current_group, $this->current_checkbox_group );
@@ -308,7 +306,7 @@ class Transformer {
 	 * @param array &$transformed_settings Transformed settings array.
 	 */
 	private function finalize_transformation( array &$transformed_settings ): void {
-		$this->flush_current_checkbox_group( $transformed_settings );
+		$this->flush_current_checkbox_group();
 		$this->flush_current_group( $transformed_settings );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
@@ -192,6 +192,67 @@ class TransformerTest extends WC_Unit_Test_Case {
 
 
 	/**
+	 * Test group grouping with no ids present.
+	 */
+	public function test_group_grouping_no_ids(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'title' => 'group 1',
+								'desc'  => 'Description 1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting1',
+							),
+							array(
+								'type' => 'text',
+								'id'   => 'setting2',
+							),
+							array(
+								'type' => 'sectionend',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'     => 'group',
+								'title'    => 'group 1',
+								'desc'     => 'Description 1',
+								'settings' => array(
+									array(
+										'type' => 'text',
+										'id'   => 'setting1',
+									),
+									array(
+										'type' => 'text',
+										'id'   => 'setting2',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected group to be transformed' );
+	}
+
+
+	/**
 	 * Test multiple groups in a section.
 	 */
 	public function test_multiple_groups(): void {
@@ -618,9 +679,9 @@ class TransformerTest extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected orphaned end checkbox to remain untransformed' );
 	}
 
-		/**
-		 * Test group with checkbox inside.
-		 */
+	/**
+	 * Test group with checkbox inside.
+	 */
 	public function test_group_with_checkbox_inside(): void {
 		$input = array(
 			'tab1' => array(
@@ -689,5 +750,73 @@ class TransformerTest extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected nested sectionend and checkboxgroup to be transformed' );
+	}
+
+	/**
+	 * Test group with malformed checkboxgroup inside. The checkbox items should still be included in the group.
+	 */
+	public function test_group_with_malformed_checkboxgroup_inside(): void {
+		$input = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'  => 'title',
+								'id'    => 'group_1',
+								'title' => 'group 1',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check1',
+								'title'         => 'Checkbox Group',
+								'checkboxgroup' => 'start',
+							),
+							array(
+								'type'          => 'checkbox',
+								'id'            => 'check2',
+								// Starting a new group without closing the previous one.
+								'checkboxgroup' => 'start',
+							),
+							array(
+								'type' => 'sectionend',
+								'id'   => 'group_1',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'tab1' => array(
+				'sections' => array(
+					'section1' => array(
+						'settings' => array(
+							array(
+								'type'     => 'group',
+								'id'       => 'group_1',
+								'title'    => 'group 1',
+								'settings' => array(
+									array(
+										'type'  => 'checkbox',
+										'id'    => 'check1',
+										'title' => 'Checkbox Group',
+										'checkboxgroup' => 'start',
+									),
+									array(
+										'type' => 'checkbox',
+										'id'   => 'check2',
+										'checkboxgroup' => 'end',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $this->transformer->transform( $input ), 'Expected nested sectionend and malformed checkboxgroup to be transformed' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
@@ -799,14 +799,14 @@ class TransformerTest extends WC_Unit_Test_Case {
 								'title'    => 'group 1',
 								'settings' => array(
 									array(
-										'type'  => 'checkbox',
-										'id'    => 'check1',
-										'title' => 'Checkbox Group',
+										'type'          => 'checkbox',
+										'id'            => 'check1',
+										'title'         => 'Checkbox Group',
 										'checkboxgroup' => 'start',
 									),
 									array(
-										'type' => 'checkbox',
-										'id'   => 'check2',
+										'type'          => 'checkbox',
+										'id'            => 'check2',
 										'checkboxgroup' => 'start',
 									),
 								),

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Settings/TransformerTest.php
@@ -807,7 +807,7 @@ class TransformerTest extends WC_Unit_Test_Case {
 									array(
 										'type' => 'checkbox',
 										'id'   => 'check2',
-										'checkboxgroup' => 'end',
+										'checkboxgroup' => 'start',
 									),
 								),
 							),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2943,7 +2943,7 @@ importers:
         version: 6.3.19(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/edit-site':
         specifier: 6.10.0
-        version: 6.10.0(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
+        version: 6.10.0(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/editor':
         specifier: wp-6.0
         version: 12.5.11(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
@@ -25266,6 +25266,7 @@ packages:
 
   sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   sugarss@2.0.0:
     resolution: {integrity: sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==}
@@ -29235,7 +29236,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.5(@babel/core@7.26.0)
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
@@ -45829,7 +45830,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@wordpress/edit-site@6.10.0(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
+  '@wordpress/edit-site@6.10.0(@emotion/is-prop-valid@1.2.1)(@preact/signals-core@1.5.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@react-spring/web': 9.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -45849,7 +45850,7 @@ snapshots:
       '@wordpress/date': 5.10.0
       '@wordpress/deprecated': 4.10.0
       '@wordpress/dom': 4.10.0
-      '@wordpress/editor': 14.11.0(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
+      '@wordpress/editor': 14.11.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
       '@wordpress/element': 6.10.0
       '@wordpress/escape-html': 3.10.0
       '@wordpress/hooks': 4.10.0
@@ -46028,7 +46029,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@wordpress/editor@14.11.0(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(babel-plugin-macros@3.1.0)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
+  '@wordpress/editor@14.11.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@17.0.71)(react-dom@17.0.2(react@17.0.2))(react-with-direction@1.4.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 3.6.1
@@ -49370,10 +49371,10 @@ snapshots:
 
   babel-eslint@10.1.0(eslint@7.32.0):
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/code-frame': 7.23.5
+      '@babel/parser': 7.23.5
+      '@babel/traverse': 7.23.5
+      '@babel/types': 7.23.5
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.8
@@ -49836,7 +49837,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.23.5):
     dependencies:
-      '@babel/compat-data': 7.26.2
+      '@babel/compat-data': 7.25.2
       '@babel/core': 7.23.5
       '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.23.5)
       semver: 6.3.1
@@ -49845,7 +49846,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.26.0):
     dependencies:
-      '@babel/compat-data': 7.26.2
+      '@babel/compat-data': 7.25.2
       '@babel/core': 7.26.0
       '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.26.0)
       semver: 6.3.1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53682

Changes Settings Transformer such that a `title` with no id subsequently followed by a `sectionend` with no id will match as a group. Another change was made such that flushed checkbox groups don't get immediately added as settings. Instead, they are passed to the current group for further processing. This allows malformed checkbox groups that are part of an input group to still be rendered as part of that group.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure CI passes
2. Add/Enable Gutenberg and turn on the `settings` feature flag
3. Check Advanced Products tab
```js
window.wcSettings.admin.settingsData.products.sections.advanced.settings
```
4. There should be two entries with checkbox groups in `settings`. Although these checkbox groups are malformed, they are still included in in the group

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fix Settings data grouping so that undefined ids are matched and group checkboxes are still included in groups when malformed.

</details>
