### PR TITLE
Fix: Stepper input style is broken when form has additional fields

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -64,7 +64,7 @@
 // Stepper CSS
 div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 	form.cart {
-		div.wc-block-components-quantity-selector {
+		div.wc-block-components-quantity-selector.quantity {
 			display: inline-flex;
 			width: unset;
 			background-color: #fff;

--- a/plugins/woocommerce/changelog/53782-fix-53359-stepper-input-style-is-corrupted-when-form-has-additional-fields
+++ b/plugins/woocommerce/changelog/53782-fix-53359-stepper-input-style-is-corrupted-when-form-has-additional-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Stepper input style is broken when form has additional fields


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53359

This PR fixes the issue where "Input Stepper" style is corrupted when form has additional fields. I tried to keep scope of the fix as small as possible.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a simple product and enable "Name Your Price" feature for it (Note: You will need to install [Name Your Price](https://woocommerce.com/products/name-your-price/) plugin)
2. Create a new post and add a "Single Product" block to it
3. Select product created in step 1
4. Publish the post and view it on the frontend
5. Verify that the quantity stepper inputs are displayed correctly (Note: "Stepper" option is not enabled by default and you need to toggle it on "Add to Cart Options")
![image](https://github.com/user-attachments/assets/0e21e2fa-016d-41f8-98a3-8b3d5d540d0b)

**Test for regressions:**

Do some smoke testing to make sure there are no regressions after this change. Make sure "Add to Cart with Options" looks good:
- Test with different product types i.e. simple, variable, grouped, external/affiliate, etc.
- Test on Single Product Template
- Change Quantity Selector type: Input vs Stepper


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Stepper input style is broken when form has additional fields
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
