### PR TITLE
[Experimental] Prevent two unnecessary dispatches to Product Type store

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -3,7 +3,6 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
-import { dispatch } from '@wordpress/data';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
@@ -12,9 +11,8 @@ import { isBoolean } from '@woocommerce/types';
 /**
  * Internal dependencies
  */
-import registerStore, { store as woocommerceTemplateStateStore } from './store';
+import registerStore from './store';
 import ProductTypeSelectorPlugin from './plugins';
-import getProductTypeOptions from './utils/get-product-types';
 import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import save from './save';
@@ -31,16 +29,7 @@ export const shouldRegisterBlock =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
 if ( shouldRegisterBlock ) {
-	// Register the store
 	registerStore();
-
-	// loads the product types
-	dispatch( woocommerceTemplateStateStore ).setProductTypes(
-		getProductTypeOptions()
-	);
-
-	// Select Simple product type
-	dispatch( woocommerceTemplateStateStore ).switchProductType( 'simple' );
 
 	// Register a plugin that adds a product type selector to the template sidebar.
 	const PLUGIN_NAME = 'document-settings-template-selector-pane';

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/store/index.ts
@@ -14,6 +14,7 @@ import {
 	STORE_NAME,
 } from './constants';
 import type { ProductTypeProps } from '../types';
+import getProductTypeOptions from '../utils/get-product-types';
 
 type StoreState = {
 	productTypes: {
@@ -34,10 +35,12 @@ type Actions = {
 	listener?: string;
 };
 
+const productTypeOptions = getProductTypeOptions();
+
 const DEFAULT_STATE = {
 	productTypes: {
-		list: [],
-		current: undefined,
+		list: productTypeOptions,
+		current: productTypeOptions[ 0 ]?.slug,
 	},
 	listeners: [],
 };

--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-store-dispatches
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-store-dispatches
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent two unnecessary dispatches to Product Type store
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Small PR that optimizes the usage of the Product Type store in the new _Add to Cart with Options_ block. It does so by setting the default values on store creation, instead of when the React component is mounted. This way we avoid calling `dispatch` twice. It also makes it so if `simple` is not one of the available product types, we default to the next one.

### How to test the changes in this Pull Request:

1. Install and activate the `WooCommerce Beta Tester` plugin
2. Go to `WooCommerce Admin Test Helper` -> `Features` and enable `blockified-add-to-cart`.
3. Go to Appearance > Editor > Template > Single Product.
4. Add the _Add to Cart with Options (Experimental)_ block.
5. Verify you can switch the product type using the toolbar selector and by default `Simple Product` was selected.
6. Add this PHP code snippet:

```PHP
add_filter(
	'product_type_selector',
	function ( $product_types ) {
		// Remove simple product type.
		unset( $product_types['simple'] );
		return $product_types;
	}
);
```

7. Reload the Site Editor and verify by default there is another product type selected, instead of `Simple Product`.