### PR TITLE
Product Collection: Add support for passing extra attributes like "align" while registering a custom collection

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks-registry/product-collection/register-product-collection.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks-registry/product-collection/register-product-collection.tsx
@@ -375,6 +375,7 @@ export const __experimentalRegisterProductCollection = (
 		example: config.example,
 		scope: config.scope,
 		attributes: {
+			...config.attributes, // Allow users to pass extra attributes.
 			query: {
 				...DEFAULT_QUERY,
 				...( query.offset !== undefined && { offset: query.offset } ),

--- a/plugins/woocommerce-blocks/assets/js/blocks-registry/product-collection/register-product-collection.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks-registry/product-collection/register-product-collection.tsx
@@ -414,9 +414,7 @@ export const __experimentalRegisterProductCollection = (
 					priceRange: query.priceRange,
 				} ),
 			},
-			displayLayout: config.attributes?.displayLayout,
 			hideControls,
-			queryContextIncludes: config.attributes?.queryContextIncludes,
 			// collection should be set to the name of the collection i.e. config.name
 			collection: config.name,
 			// Collections should always have inherit set to false.

--- a/plugins/woocommerce/changelog/53785-fix-53287-product-collection-registerproductcollection-does-not-recognize-align-layout-attributes
+++ b/plugins/woocommerce/changelog/53785-fix-53287-product-collection-registerproductcollection-does-not-recognize-align-layout-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Product Collection: Add support for passing extra attributes like align while registering a custom collection.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53287

While registering a custom collection using `__experimentalRegisterProductCollection`, user [reported](https://github.com/woocommerce/woocommerce/issues/53287) that the align and layout attributes are not passed to the product collection block. After [looking at the code](https://github.com/woocommerce/woocommerce/blob/db81bf0925a4f5802128f7051faf1cab99666070/plugins/woocommerce-blocks/assets/js/blocks-registry/product-collection/register-product-collection.tsx#L377-L423), I can see that we are selectively passing the attributes to the product collection block.

We had two options to fix this issue:
1. Pass only `align` and `layout` attributes selectively to the product collection block as we are doing for all other attributes.
2. Pass all attributes and then override attributes selectively. This way, If we don't override the attributes, they will be passed to the product collection block.

I went with the second option because it will give 3PDs more flexibility to provide any custom attributes to the product collection block and we won't need to maintain selective passing of attributes. Let me know your thoughts.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a new post
2. Run following code in browser console. This will register a new custom collection with title "Just a Test" and align attribute set to "full".
```tsx
wc.wcBlocksRegistry.__experimentalRegisterProductCollection({
  name: "woocommerce/product-collection/just-a-test",
  title: "Just a Test",
  scope: ["block", "inserter"],
  attributes: {
    align: "full",
  },
  innerBlocks: [
    [
      "woocommerce/product-template",
      {},
      [
        [
          "woocommerce/product-image",
          {
            imageSizing: "thumbnail",
            isDescendentOfQueryLoop: true,
          },
          [],
        ],
        [
          "core/post-title",
          {
            textAlign: "center",
            level: 3,
            isLink: true,
            fontSize: "medium",
            __woocommerceNamespace:
              "woocommerce/product-collection/product-title",
          },
          [],
        ],
      ],
    ],
  ],
});
```
3. Add Product Collection block and choose "Just a Test" collection.
4. Verify that the block is displayed full-width as shown in the screenshot below:
![Image](https://github.com/user-attachments/assets/59be86a2-0cbd-4b8a-af89-77a21168fe93)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Product Collection: Add support for passing extra attributes like align while registering a custom collection.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
