### PR TITLE
registerBlockSingleProductTemplate: Refactor to use a BlockRegistrationManager class and Singleton pattern

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -250,16 +250,15 @@ export class BlockRegistrationManager {
 					? [ 'woocommerce/single-product' ]
 					: blockSettings?.ancestor;
 
-				// Only include ancestor if we're not in single-product template
-				// and we're in the site editor
-				const shouldIncludeAncestor =
+				// Only remove ancestor if we're in site editor AND in single-product template
+				const shouldRemoveAncestor =
 					editSiteStore &&
-					! this.currentTemplateId?.includes( 'single-product' );
+					this.currentTemplateId?.includes( 'single-product' );
 
 				// @ts-expect-error - blockMetadata can be either string or object
 				registerBlockType( blockMetadata, {
 					...blockSettings,
-					ancestor: shouldIncludeAncestor ? ancestor : undefined,
+					ancestor: shouldRemoveAncestor ? undefined : ancestor,
 				} );
 			}
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -43,7 +43,7 @@ export class BlockRegistrationManager {
 	/** Map storing block configurations keyed by block name or variation name */
 	private blocks: Map< string, BlockConfig > = new Map();
 	/** Current template ID being edited */
-	private currentTemplateId: string | undefined = '';
+	private currentTemplateId: string | undefined;
 	/** Flag indicating if the manager has been initialized */
 	private initialized = false;
 	/** Flag to prevent recursive registration attempts */

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -128,6 +128,8 @@ export class BlockRegistrationManager {
 			this.blocks.forEach( ( config ) => {
 				this.registerBlock( config );
 			} );
+
+			this.initialized = true;
 		}, 'core/edit-site' );
 
 		// Post Editor Subscription
@@ -140,6 +142,8 @@ export class BlockRegistrationManager {
 			// Only run this once for post editor
 			postEditorUnsubscribe();
 
+			this.initialized = true;
+
 			// Register blocks that are available in post editor
 			this.blocks.forEach( ( config ) => {
 				if ( config.isAvailableOnPostEditor ) {
@@ -150,8 +154,6 @@ export class BlockRegistrationManager {
 				}
 			} );
 		}, 'core/edit-post' );
-
-		this.initialized = true;
 	}
 
 	/**
@@ -288,6 +290,20 @@ export class BlockRegistrationManager {
 	public registerBlockConfig( config: BlockConfig ): void {
 		const key = config.variationName || config.blockName;
 		this.blocks.set( key, config );
+
+		// If we have executed `siteEditorUnsubscribe` and `postEditorUnsubscribe` and initialized already, we can register the block immediately
+		if ( this.initialized ) {
+			const editSiteStore = select( 'core/edit-site' );
+			const editPostStore = select( 'core/edit-post' );
+
+			if ( editSiteStore ) {
+				// Register in site editor context
+				this.registerBlock( config );
+			} else if ( editPostStore && config.isAvailableOnPostEditor ) {
+				// Register in post editor context if available
+				this.registerBlock( config );
+			}
+		}
 	}
 }
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -213,14 +213,10 @@ export class BlockRegistrationManager {
 			isAvailableOnPostEditor,
 		} = config;
 
-		if ( this.hasAttemptedRegistration( blockName ) ) {
-			return;
-		}
-
 		try {
 			// Check if block is already registered
 			const key = variationName || blockName;
-			if ( this.attemptedRegisteredBlocks.has( key ) ) {
+			if ( this.hasAttemptedRegistration( key ) ) {
 				return;
 			}
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -138,6 +138,8 @@ export class BlockRegistrationManager {
 				this.blocks.forEach( ( config ) => {
 					this.registerBlock( config );
 				} );
+
+				this.initialized = true;
 			}
 			// Post Editor Context
 			else if ( editPostStore ) {
@@ -153,9 +155,9 @@ export class BlockRegistrationManager {
 						}
 					}
 				} );
-			}
 
-			this.initialized = true;
+				this.initialized = true;
+			}
 		} );
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -135,7 +135,11 @@ export class BlockRegistrationManager {
 
 	/**
 	 * Handles block registration/unregistration when template context changes.
-	 * Specifically manages transitions to and from single product templates.
+	 *
+	 * Note: This implementation is currently coupled to the 'single-product' template,
+	 * as it's our only use case where blocks need different ancestor constraints.
+	 * If we need to handle more templates in the future, this should be refactored
+	 * to be more generic.
 	 *
 	 * @param {string | undefined} previousTemplateId - The previous template ID
 	 */

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -141,7 +141,7 @@ class BlockRegistrationManager {
 		if ( ! isTransitioningToOrFromSingleProduct ) return;
 
 		// Re-register all blocks with updated context
-		this.blocks.forEach( ( config, key ) => {
+		this.blocks.forEach( ( config ) => {
 			this.unregisterBlock( config );
 			this.registerBlock( config );
 		} );

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -1,140 +1,262 @@
 /**
  * External dependencies
  */
-import { isNumber, isEmpty } from '@woocommerce/types';
 import {
 	BlockAttributes,
 	BlockConfiguration,
 	BlockVariation,
-	getBlockType,
 	registerBlockType,
 	registerBlockVariation,
 	unregisterBlockType,
 	unregisterBlockVariation,
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
+import { isNumber, isEmpty } from '@woocommerce/types';
 
-// Creating a local cache to prevent multiple registration tries.
-// This is needed because the `registerBlockType` call can be invoked multiple times.
-const blockRegistrationAttempts = new Set();
-
-function parseTemplateId( templateId: string | number | undefined ) {
-	// With GB 16.3.0 the return type can be a number: https://github.com/WordPress/gutenberg/issues/53230
-	const parsedTemplateId = isNumber( templateId ) ? undefined : templateId;
-	return parsedTemplateId?.split( '//' )[ 1 ];
-}
-
-const isBlockRegistered = ( blockName: string ) =>
-	Boolean( getBlockType( blockName ) );
-
-export const registerBlockSingleProductTemplate = ( {
-	blockName,
-	blockMetadata,
-	blockSettings,
-	isVariationBlock = false,
-	variationName,
-	isAvailableOnPostEditor,
-}: {
+/**
+ * Configuration object for registering a block.
+ *
+ * @typedef {Object} BlockConfig
+ * @property {string}                               blockName               - The name of the block to register
+ * @property {(string|Partial<BlockConfiguration>)} [blockMetadata]         - Block metadata or name
+ * @property {Partial<BlockConfiguration>}          blockSettings           - Block settings configuration
+ * @property {boolean}                              [isVariationBlock]      - Whether this block is a variation
+ * @property {string}                               [variationName]         - The name of the variation if applicable
+ * @property {boolean}                              isAvailableOnPostEditor - Whether the block should be available in post editor
+ */
+type BlockConfig = {
 	blockName: string;
 	blockMetadata?: string | Partial< BlockConfiguration >;
 	blockSettings: Partial< BlockConfiguration >;
-	isAvailableOnPostEditor: boolean;
 	isVariationBlock?: boolean;
 	variationName?: string;
-} ) => {
-	let currentTemplateId: string | undefined = '';
+	isAvailableOnPostEditor: boolean;
+};
 
-	if ( ! blockMetadata ) {
-		blockMetadata = blockName;
+/**
+ * Manages the registration and unregistration of WooCommerce blocks in different WordPress contexts.
+ *
+ * This class implements the Singleton pattern to ensure only one instance handles all block registrations.
+ * It provides centralized management of blocks between single product templates and other contexts,
+ * handling the different ancestor requirements and registration states efficiently.
+ *
+ * @class BlockRegistrationManager
+ */
+class BlockRegistrationManager {
+	private static instance: BlockRegistrationManager;
+	private blocks: Map< string, BlockConfig > = new Map();
+	private currentTemplateId: string | undefined = '';
+	private initialized = false;
+	private blockRegistrationAttempts = new Set< string >();
+
+	/**
+	 * Private constructor to prevent direct construction calls with the `new` operator.
+	 */
+	private constructor() {
+		this.initializeSubscriptions();
 	}
 
-	const editSiteStore = select( 'core/edit-site' );
-
-	if ( editSiteStore ) {
-		subscribe( () => {
-			const previousTemplateId = currentTemplateId;
-
-			// With GB 16.3.0 the return type can be a number: https://github.com/WordPress/gutenberg/issues/53230
-			currentTemplateId = parseTemplateId(
-				editSiteStore?.getEditedPostId< string | number | undefined >()
-			);
-			const hasChangedTemplate = previousTemplateId !== currentTemplateId;
-
-			if ( ! hasChangedTemplate || ! blockName ) {
-				return;
-			}
-
-			let isRegistered = isBlockRegistered( blockName );
-
-			/**
-			 * We need to unregister the block each time the user visits or leaves the Single Product template.
-			 *
-			 * The Single Product template is the only template where the `ancestor` property is not needed because it provides the context
-			 * for the product blocks. We need to unregister and re-register the block to remove or add the `ancestor` property depending on which
-			 * location (template, post, page, etc.) the user is in.
-			 *
-			 */
-			if (
-				isRegistered &&
-				( currentTemplateId?.includes( 'single-product' ) ||
-					previousTemplateId?.includes( 'single-product' ) )
-			) {
-				if ( isVariationBlock && variationName ) {
-					unregisterBlockVariation( blockName, variationName );
-				} else {
-					unregisterBlockType( blockName );
-				}
-				isRegistered = false;
-			}
-
-			if ( ! isRegistered ) {
-				if ( isVariationBlock ) {
-					// @ts-expect-error: `registerBlockType` is not typed in WordPress core
-					registerBlockVariation( blockName, blockSettings );
-				} else {
-					const ancestor = isEmpty( blockSettings?.ancestor )
-						? [ 'woocommerce/single-product' ]
-						: blockSettings?.ancestor;
-					// @ts-expect-error: `registerBlockType` is not typed in WordPress core
-					registerBlockType( blockMetadata, {
-						...blockSettings,
-						ancestor: ! currentTemplateId?.includes(
-							'single-product'
-						)
-							? ancestor
-							: undefined,
-					} );
-				}
-			}
-		}, 'core/edit-site' );
+	/**
+	 * Gets the singleton instance of the BlockRegistrationManager.
+	 *
+	 * @return {BlockRegistrationManager} The singleton instance
+	 */
+	public static getInstance(): BlockRegistrationManager {
+		if ( ! BlockRegistrationManager.instance ) {
+			BlockRegistrationManager.instance = new BlockRegistrationManager();
+		}
+		return BlockRegistrationManager.instance;
 	}
 
-	if ( isAvailableOnPostEditor ) {
-		subscribe( () => {
-			const isRegistered = Boolean( variationName )
-				? blockRegistrationAttempts.has( variationName )
-				: blockRegistrationAttempts.has( blockName ) ||
-				  isBlockRegistered( blockName );
-			// This subscribe callback could be invoked with the core/blocks store
-			// which would cause infinite registration loops because of the `registerBlockType` call.
-			// This local cache helps prevent that.
-			if (
-				! isRegistered &&
-				isAvailableOnPostEditor &&
-				! editSiteStore
-			) {
-				if ( isVariationBlock ) {
-					blockRegistrationAttempts.add( variationName );
-					registerBlockVariation(
-						blockName,
-						blockSettings as BlockVariation< BlockAttributes >
-					);
-				} else {
-					blockRegistrationAttempts.add( blockName );
-					// @ts-expect-error: `registerBlockType` is typed in WordPress core
-					registerBlockType( blockMetadata, blockSettings );
+	/**
+	 * Parses a template ID from various possible formats.
+	 * Handles both string and number inputs due to Gutenberg 16.3.0 changes.
+	 *
+	 * @private
+	 * @param {string | number | undefined} templateId - The template ID to parse
+	 * @return {string | undefined} The parsed template ID
+	 */
+	private parseTemplateId(
+		templateId: string | number | undefined
+	): string | undefined {
+		const parsedTemplateId = isNumber( templateId )
+			? undefined
+			: templateId;
+		return parsedTemplateId?.split( '//' )[ 1 ];
+	}
+
+	/**
+	 * Initializes the subscription system for both site editor and post editor contexts.
+	 * Sets up listeners for template changes and post editor state.
+	 *
+	 * @private
+	 */
+	private initializeSubscriptions(): void {
+		if ( this.initialized ) return;
+
+		const editSiteStore = select( 'core/edit-site' );
+
+		// Set up site editor subscription
+		if ( editSiteStore ) {
+			subscribe( () => {
+				const previousTemplateId = this.currentTemplateId;
+				this.currentTemplateId = this.parseTemplateId(
+					editSiteStore?.getEditedPostId<
+						string | number | undefined
+					>()
+				);
+
+				if ( previousTemplateId === this.currentTemplateId ) {
+					return;
 				}
+
+				this.handleTemplateChange( previousTemplateId );
+			}, 'core/edit-site' );
+		}
+
+		// Set up post editor subscription
+		subscribe( () => {
+			if ( ! editSiteStore ) {
+				this.handlePostEditorRegistrations();
 			}
 		}, 'core/edit-post' );
+
+		this.initialized = true;
 	}
+
+	/**
+	 * Handles block registration/unregistration when template context changes.
+	 * Specifically manages transitions to and from single product templates.
+	 *
+	 * @private
+	 * @param {string | undefined} previousTemplateId - The previous template ID
+	 */
+	private handleTemplateChange(
+		previousTemplateId: string | undefined
+	): void {
+		const isTransitioningToOrFromSingleProduct =
+			this.currentTemplateId?.includes( 'single-product' ) ||
+			previousTemplateId?.includes( 'single-product' );
+
+		if ( ! isTransitioningToOrFromSingleProduct ) return;
+
+		// Re-register all blocks with updated context
+		this.blocks.forEach( ( config, key ) => {
+			this.unregisterBlock( config );
+			this.registerBlock( config );
+		} );
+	}
+
+	/**
+	 * Handles block registration specifically for the post editor context.
+	 * Ensures blocks are only registered once and only if they should be available in the post editor.
+	 *
+	 * @private
+	 */
+	private handlePostEditorRegistrations(): void {
+		this.blocks.forEach( ( config ) => {
+			if ( ! config.isAvailableOnPostEditor ) return;
+
+			const registrationKey = config.variationName || config.blockName;
+			if ( this.blockRegistrationAttempts.has( registrationKey ) ) return;
+
+			this.registerBlock( config );
+			this.blockRegistrationAttempts.add( registrationKey );
+		} );
+	}
+
+	/**
+	 * Unregisters a block or block variation based on its configuration.
+	 *
+	 * @private
+	 * @param {BlockConfig} config - The configuration of the block to unregister
+	 */
+	private unregisterBlock( config: BlockConfig ): void {
+		const { blockName, isVariationBlock, variationName } = config;
+
+		if ( isVariationBlock && variationName ) {
+			unregisterBlockVariation( blockName, variationName );
+		} else {
+			unregisterBlockType( blockName );
+		}
+	}
+
+	/**
+	 * Registers a block or block variation based on its configuration.
+	 * Handles different registration requirements for single product templates vs other contexts.
+	 *
+	 * @private
+	 * @param {BlockConfig} config - The configuration of the block to register
+	 */
+	private registerBlock( config: BlockConfig ): void {
+		const {
+			blockName,
+			blockMetadata = blockName,
+			blockSettings,
+			isVariationBlock,
+		} = config;
+
+		if ( isVariationBlock ) {
+			registerBlockVariation(
+				blockName,
+				blockSettings as BlockVariation< BlockAttributes >
+			);
+		} else {
+			const ancestor = isEmpty( blockSettings?.ancestor )
+				? [ 'woocommerce/single-product' ]
+				: blockSettings?.ancestor;
+
+			// @ts-expect-error blockMetadata is a string or Partial<BlockConfiguration> which is compatible with registerBlockType
+			registerBlockType( blockMetadata, {
+				...blockSettings,
+				ancestor: ! this.currentTemplateId?.includes( 'single-product' )
+					? ancestor
+					: undefined,
+			} );
+		}
+	}
+
+	/**
+	 * Public method to register a new block configuration with the manager.
+	 * This is the main entry point for adding new blocks to be managed.
+	 *
+	 * @public
+	 * @param {BlockConfig} config - The configuration for the block to register
+	 */
+	public registerBlockConfig( config: BlockConfig ): void {
+		const key = config.variationName || config.blockName;
+		this.blocks.set( key, config );
+
+		// Handle immediate registration for post editor context
+		const editSiteStore = select( 'core/edit-site' );
+		if ( ! editSiteStore && config.isAvailableOnPostEditor ) {
+			this.registerBlock( config );
+			this.blockRegistrationAttempts.add( key );
+		}
+	}
+}
+
+/**
+ * Registers a block for use in single product templates and optionally in the post editor.
+ * This is the main export and public API for the block registration system.
+ *
+ * @example
+ * ```typescript
+ * registerBlockSingleProductTemplate({
+ *     blockName: 'woocommerce/product-price',
+ *     blockSettings: {
+ *         title: 'Product Price',
+ *         icon: 'dollar',
+ *         category: 'woocommerce',
+ *     },
+ *     isAvailableOnPostEditor: true
+ * });
+ * ```
+ *
+ * @param {BlockConfig} config - The configuration object for the block
+ */
+export const registerBlockSingleProductTemplate = (
+	config: BlockConfig
+): void => {
+	BlockRegistrationManager.getInstance().registerBlockConfig( config );
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -193,13 +193,15 @@ export class BlockRegistrationManager {
 		} = config;
 
 		// Prevent recursive registration
-		if ( this.isRegistering ) return;
+		if ( this.isRegistering ) {
+			return;
+		}
 
 		try {
 			this.isRegistering = true;
 
 			// Check if block is already registered
-			if ( getBlockType( blockName ) ) {
+			if ( getBlockType( blockName ) && ! isVariationBlock ) {
 				// eslint-disable-next-line no-console
 				console.debug( `Block ${ blockName } is already registered.` );
 				return;

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -3,12 +3,13 @@
  */
 import {
 	BlockAttributes,
-	BlockConfiguration,
 	BlockVariation,
 	registerBlockType,
 	registerBlockVariation,
 	unregisterBlockType,
 	unregisterBlockVariation,
+	getBlockType,
+	BlockConfiguration,
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
 import { isNumber, isEmpty } from '@woocommerce/types';
@@ -34,23 +35,24 @@ type BlockConfig = {
 };
 
 /**
- * Manages the registration and unregistration of WooCommerce blocks in different WordPress contexts.
- *
- * This class implements the Singleton pattern to ensure only one instance handles all block registrations.
- * It provides centralized management of blocks between single product templates and other contexts,
- * handling the different ancestor requirements and registration states efficiently.
- *
- * @class BlockRegistrationManager
+ * Manages block registration and unregistration for WordPress blocks in different contexts.
+ * Implements the Singleton pattern to ensure consistent block management across the application.
  */
-class BlockRegistrationManager {
+export class BlockRegistrationManager {
+	/** Singleton instance of the manager */
 	private static instance: BlockRegistrationManager;
+	/** Map storing block configurations keyed by block name or variation name */
 	private blocks: Map< string, BlockConfig > = new Map();
+	/** Current template ID being edited */
 	private currentTemplateId: string | undefined = '';
+	/** Flag indicating if the manager has been initialized */
 	private initialized = false;
-	private blockRegistrationAttempts = new Set< string >();
+	/** Flag to prevent recursive registration attempts */
+	private isRegistering = false;
 
 	/**
-	 * Private constructor to prevent direct construction calls with the `new` operator.
+	 * Private constructor to enforce singleton pattern.
+	 * Initializes subscriptions for template changes.
 	 */
 	private constructor() {
 		this.initializeSubscriptions();
@@ -58,6 +60,7 @@ class BlockRegistrationManager {
 
 	/**
 	 * Gets the singleton instance of the BlockRegistrationManager.
+	 * Creates the instance if it doesn't exist.
 	 *
 	 * @return {BlockRegistrationManager} The singleton instance
 	 */
@@ -70,9 +73,8 @@ class BlockRegistrationManager {
 
 	/**
 	 * Parses a template ID from various possible formats.
-	 * Handles both string and number inputs due to Gutenberg 16.3.0 changes.
+	 * Handles both string and number inputs due to Gutenberg changes.
 	 *
-	 * @private
 	 * @param {string | number | undefined} templateId - The template ID to parse
 	 * @return {string | undefined} The parsed template ID
 	 */
@@ -86,18 +88,24 @@ class BlockRegistrationManager {
 	}
 
 	/**
-	 * Initializes the subscription system for both site editor and post editor contexts.
-	 * Sets up listeners for template changes and post editor state.
-	 *
-	 * @private
+	 * Initializes subscriptions for template changes and block registration.
+	 * Sets up listeners for the site editor and handles initial block registration.
 	 */
 	private initializeSubscriptions(): void {
-		if ( this.initialized ) return;
+		if ( this.initialized ) {
+			return;
+		}
 
-		const editSiteStore = select( 'core/edit-site' );
+		const unsubscribe = subscribe( () => {
+			const editSiteStore = select( 'core/edit-site' );
+			if ( ! editSiteStore ) {
+				return;
+			}
 
-		// Set up site editor subscription
-		if ( editSiteStore ) {
+			// Only run this once
+			unsubscribe();
+
+			// Set up the template change listener
 			subscribe( () => {
 				const previousTemplateId = this.currentTemplateId;
 				this.currentTemplateId = this.parseTemplateId(
@@ -106,29 +114,24 @@ class BlockRegistrationManager {
 					>()
 				);
 
-				if ( previousTemplateId === this.currentTemplateId ) {
-					return;
+				if ( previousTemplateId !== this.currentTemplateId ) {
+					this.handleTemplateChange( previousTemplateId );
 				}
+			} );
 
-				this.handleTemplateChange( previousTemplateId );
-			}, 'core/edit-site' );
-		}
+			// Initial registration of blocks
+			this.blocks.forEach( ( config ) => {
+				this.registerBlock( config );
+			} );
 
-		// Set up post editor subscription
-		subscribe( () => {
-			if ( ! editSiteStore ) {
-				this.handlePostEditorRegistrations();
-			}
-		}, 'core/edit-post' );
-
-		this.initialized = true;
+			this.initialized = true;
+		} );
 	}
 
 	/**
 	 * Handles block registration/unregistration when template context changes.
 	 * Specifically manages transitions to and from single product templates.
 	 *
-	 * @private
 	 * @param {string | undefined} previousTemplateId - The previous template ID
 	 */
 	private handleTemplateChange(
@@ -138,55 +141,47 @@ class BlockRegistrationManager {
 			this.currentTemplateId?.includes( 'single-product' ) ||
 			previousTemplateId?.includes( 'single-product' );
 
-		if ( ! isTransitioningToOrFromSingleProduct ) return;
+		if ( ! isTransitioningToOrFromSingleProduct ) {
+			return;
+		}
 
-		// Re-register all blocks with updated context
 		this.blocks.forEach( ( config ) => {
-			this.unregisterBlock( config );
-			this.registerBlock( config );
+			if ( ! this.isRegistering ) {
+				this.unregisterBlock( config );
+				this.registerBlock( config );
+			}
 		} );
 	}
 
 	/**
-	 * Handles block registration specifically for the post editor context.
-	 * Ensures blocks are only registered once and only if they should be available in the post editor.
+	 * Unregisters a block or block variation.
+	 * Handles both regular blocks and variations with error handling.
 	 *
-	 * @private
-	 */
-	private handlePostEditorRegistrations(): void {
-		this.blocks.forEach( ( config ) => {
-			if ( ! config.isAvailableOnPostEditor ) return;
-
-			const registrationKey = config.variationName || config.blockName;
-			if ( this.blockRegistrationAttempts.has( registrationKey ) ) return;
-
-			this.registerBlock( config );
-			this.blockRegistrationAttempts.add( registrationKey );
-		} );
-	}
-
-	/**
-	 * Unregisters a block or block variation based on its configuration.
-	 *
-	 * @private
-	 * @param {BlockConfig} config - The configuration of the block to unregister
+	 * @param {BlockConfig} config - Configuration of the block to unregister
 	 */
 	private unregisterBlock( config: BlockConfig ): void {
 		const { blockName, isVariationBlock, variationName } = config;
 
-		if ( isVariationBlock && variationName ) {
-			unregisterBlockVariation( blockName, variationName );
-		} else {
-			unregisterBlockType( blockName );
+		try {
+			if ( isVariationBlock && variationName ) {
+				unregisterBlockVariation( blockName, variationName );
+			} else {
+				unregisterBlockType( blockName );
+			}
+		} catch ( error ) {
+			console.debug(
+				`Failed to unregister block ${ blockName }:`,
+				error
+			);
 		}
 	}
 
 	/**
-	 * Registers a block or block variation based on its configuration.
-	 * Handles different registration requirements for single product templates vs other contexts.
+	 * Registers a block or block variation.
+	 * Handles different registration requirements for various contexts.
+	 * Includes checks to prevent recursive registration.
 	 *
-	 * @private
-	 * @param {BlockConfig} config - The configuration of the block to register
+	 * @param {BlockConfig} config - Configuration of the block to register
 	 */
 	private registerBlock( config: BlockConfig ): void {
 		const {
@@ -196,49 +191,64 @@ class BlockRegistrationManager {
 			isVariationBlock,
 		} = config;
 
-		if ( isVariationBlock ) {
-			registerBlockVariation(
-				blockName,
-				blockSettings as BlockVariation< BlockAttributes >
-			);
-		} else {
-			const ancestor = isEmpty( blockSettings?.ancestor )
-				? [ 'woocommerce/single-product' ]
-				: blockSettings?.ancestor;
+		// Prevent recursive registration
+		if ( this.isRegistering ) return;
 
-			// @ts-expect-error blockMetadata is a string or Partial<BlockConfiguration> which is compatible with registerBlockType
-			registerBlockType( blockMetadata, {
-				...blockSettings,
-				ancestor: ! this.currentTemplateId?.includes( 'single-product' )
-					? ancestor
-					: undefined,
-			} );
+		try {
+			this.isRegistering = true;
+
+			// Check if block is already registered
+			if ( getBlockType( blockName ) ) {
+				console.debug( `Block ${ blockName } is already registered.` );
+				return;
+			}
+
+			if ( isVariationBlock ) {
+				registerBlockVariation(
+					blockName,
+					blockSettings as BlockVariation< BlockAttributes >
+				);
+			} else {
+				const ancestor = isEmpty( blockSettings?.ancestor )
+					? [ 'woocommerce/single-product' ]
+					: blockSettings?.ancestor;
+
+				registerBlockType( blockMetadata, {
+					...blockSettings,
+					ancestor: ! this.currentTemplateId?.includes(
+						'single-product'
+					)
+						? ancestor
+						: undefined,
+				} );
+			}
+		} catch ( error ) {
+			console.error( `Failed to register block ${ blockName }:`, error );
+		} finally {
+			this.isRegistering = false;
 		}
 	}
 
 	/**
-	 * Public method to register a new block configuration with the manager.
-	 * This is the main entry point for adding new blocks to be managed.
+	 * Registers a new block configuration with the manager.
+	 * Main entry point for adding new blocks to be managed.
 	 *
-	 * @public
-	 * @param {BlockConfig} config - The configuration for the block to register
+	 * @param {BlockConfig} config - Configuration for the block to register
 	 */
 	public registerBlockConfig( config: BlockConfig ): void {
 		const key = config.variationName || config.blockName;
 		this.blocks.set( key, config );
 
-		// Handle immediate registration for post editor context
-		const editSiteStore = select( 'core/edit-site' );
-		if ( ! editSiteStore && config.isAvailableOnPostEditor ) {
+		// Only attempt registration if we're initialized
+		if ( this.initialized && ! this.isRegistering ) {
 			this.registerBlock( config );
-			this.blockRegistrationAttempts.add( key );
 		}
 	}
 }
 
 /**
  * Registers a block for use in single product templates and optionally in the post editor.
- * This is the main export and public API for the block registration system.
+ * Main export and public API for the block registration system.
  *
  * @example
  * ```typescript
@@ -246,17 +256,21 @@ class BlockRegistrationManager {
  *     blockName: 'woocommerce/product-price',
  *     blockSettings: {
  *         title: 'Product Price',
- *         icon: 'dollar',
  *         category: 'woocommerce',
  *     },
  *     isAvailableOnPostEditor: true
  * });
  * ```
  *
- * @param {BlockConfig} config - The configuration object for the block
+ * @param {BlockConfig} config - Configuration object for the block
  */
 export const registerBlockSingleProductTemplate = (
 	config: BlockConfig
 ): void => {
+	if ( ! config.blockName ) {
+		console.error( 'Block name is required for registration' );
+		return;
+	}
+
 	BlockRegistrationManager.getInstance().registerBlockConfig( config );
 };

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -8,7 +8,6 @@ import {
 	registerBlockVariation,
 	unregisterBlockType,
 	unregisterBlockVariation,
-	getBlockType,
 	BlockConfiguration,
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
@@ -218,6 +217,7 @@ export class BlockRegistrationManager {
 			blockSettings,
 			isVariationBlock,
 			variationName,
+			isAvailableOnPostEditor,
 		} = config;
 
 		if ( this.isRegistering ) {
@@ -233,13 +233,19 @@ export class BlockRegistrationManager {
 				return;
 			}
 
+			const editSiteStore = select( 'core/edit-site' );
+
+			// Don't register if we're in post editor context and block isn't available there
+			if ( ! editSiteStore && ! isAvailableOnPostEditor ) {
+				return;
+			}
+
 			if ( isVariationBlock ) {
 				registerBlockVariation(
 					blockName,
 					blockSettings as BlockVariation< BlockAttributes >
 				);
 			} else {
-				const editSiteStore = select( 'core/edit-site' );
 				const ancestor = isEmpty( blockSettings?.ancestor )
 					? [ 'woocommerce/single-product' ]
 					: blockSettings?.ancestor;

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -169,6 +169,7 @@ export class BlockRegistrationManager {
 				unregisterBlockType( blockName );
 			}
 		} catch ( error ) {
+			// eslint-disable-next-line no-console
 			console.debug(
 				`Failed to unregister block ${ blockName }:`,
 				error
@@ -199,6 +200,7 @@ export class BlockRegistrationManager {
 
 			// Check if block is already registered
 			if ( getBlockType( blockName ) ) {
+				// eslint-disable-next-line no-console
 				console.debug( `Block ${ blockName } is already registered.` );
 				return;
 			}
@@ -213,6 +215,7 @@ export class BlockRegistrationManager {
 					? [ 'woocommerce/single-product' ]
 					: blockSettings?.ancestor;
 
+				// @ts-expect-error - This can be either a string or an object.
 				registerBlockType( blockMetadata, {
 					...blockSettings,
 					ancestor: ! this.currentTemplateId?.includes(
@@ -223,6 +226,7 @@ export class BlockRegistrationManager {
 				} );
 			}
 		} catch ( error ) {
+			// eslint-disable-next-line no-console
 			console.error( `Failed to register block ${ blockName }:`, error );
 		} finally {
 			this.isRegistering = false;
@@ -268,6 +272,7 @@ export const registerBlockSingleProductTemplate = (
 	config: BlockConfig
 ): void => {
 	if ( ! config.blockName ) {
+		// eslint-disable-next-line no-console
 		console.error( 'Block name is required for registration' );
 		return;
 	}

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -142,8 +142,6 @@ export class BlockRegistrationManager {
 			// Only run this once for post editor
 			postEditorUnsubscribe();
 
-			this.initialized = true;
-
 			// Register blocks that are available in post editor
 			this.blocks.forEach( ( config ) => {
 				if ( config.isAvailableOnPostEditor ) {
@@ -153,6 +151,8 @@ export class BlockRegistrationManager {
 					}
 				}
 			} );
+
+			this.initialized = true;
 		}, 'core/edit-post' );
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -98,12 +98,17 @@ export class BlockRegistrationManager {
 		// Site Editor Subscription
 		const siteEditorUnsubscribe = subscribe( () => {
 			const editSiteStore = select( 'core/edit-site' );
-			if ( ! editSiteStore ) {
+			const postId = editSiteStore?.getEditedPostId();
+
+			if ( ! editSiteStore || postId === undefined ) {
 				return;
 			}
 
 			// Only run this once for site editor
 			siteEditorUnsubscribe();
+
+			// Set initial template ID
+			this.currentTemplateId = this.parseTemplateId( postId as string );
 
 			// Set up the template change listener
 			subscribe( () => {
@@ -139,9 +144,8 @@ export class BlockRegistrationManager {
 			this.blocks.forEach( ( config ) => {
 				if ( config.isAvailableOnPostEditor ) {
 					const key = config.variationName || config.blockName;
-					if ( ! this.registeredBlocks.has( key ) ) {
+					if ( ! this.hasAttemptedRegistration( key ) ) {
 						this.registerBlock( config );
-						this.registeredBlocks.add( key );
 					}
 				}
 			} );
@@ -284,11 +288,6 @@ export class BlockRegistrationManager {
 	public registerBlockConfig( config: BlockConfig ): void {
 		const key = config.variationName || config.blockName;
 		this.blocks.set( key, config );
-
-		// Only attempt registration if we're initialized
-		if ( this.initialized && ! this.hasAttemptedRegistration( key ) ) {
-			this.registerBlock( config );
-		}
 	}
 }
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -48,8 +48,8 @@ export class BlockRegistrationManager {
 	private initialized = false;
 	/** Flag to prevent recursive registration attempts */
 	private isRegistering = false;
-	/** Set to track registered blocks and prevent duplicates */
-	private registeredBlocks: Set< string > = new Set();
+	/** Set to track block registration attempts to prevent duplicate registration attempts */
+	private attemptedRegisteredBlocks: Set< string > = new Set();
 
 	/**
 	 * Private constructor to enforce singleton pattern.
@@ -174,10 +174,10 @@ export class BlockRegistrationManager {
 		try {
 			if ( isVariationBlock && variationName ) {
 				unregisterBlockVariation( blockName, variationName );
-				this.registeredBlocks.delete( variationName );
+				this.attemptedRegisteredBlocks.delete( variationName );
 			} else {
 				unregisterBlockType( blockName );
-				this.registeredBlocks.delete( blockName );
+				this.attemptedRegisteredBlocks.delete( blockName );
 			}
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
@@ -214,7 +214,7 @@ export class BlockRegistrationManager {
 
 			// Check if block is already registered
 			const key = variationName || blockName;
-			if ( this.registeredBlocks.has( key ) ) {
+			if ( this.attemptedRegisteredBlocks.has( key ) ) {
 				return;
 			}
 
@@ -247,7 +247,7 @@ export class BlockRegistrationManager {
 				} );
 			}
 
-			this.registeredBlocks.add( key );
+			this.attemptedRegisteredBlocks.add( key );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( `Failed to register block ${ blockName }:`, error );

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -97,17 +97,11 @@ export class BlockRegistrationManager {
 			return;
 		}
 
-		// Site Editor Subscription
-		const siteEditorUnsubscribe = subscribe( () => {
-			const editSiteStore = select( 'core/edit-site' );
-			if ( ! editSiteStore ) {
-				return;
-			}
+		const editSiteStore = select( 'core/edit-site' );
+		const editPostStore = select( 'core/edit-post' );
 
-			// Only run this once for site editor
-			siteEditorUnsubscribe();
-
-			// Set up the template change listener
+		if ( editSiteStore ) {
+			// Set up site editor subscription directly
 			subscribe( () => {
 				const previousTemplateId = this.currentTemplateId;
 				this.currentTemplateId = this.parseTemplateId(
@@ -121,33 +115,20 @@ export class BlockRegistrationManager {
 				}
 			}, 'core/edit-site' );
 
-			// Initial registration of blocks for site editor
+			// Initial registration for site editor
 			this.blocks.forEach( ( config ) => {
 				this.registerBlock( config );
 			} );
-		}, 'core/edit-site' );
+		}
 
-		// Post Editor Subscription
-		const postEditorUnsubscribe = subscribe( () => {
-			const editPostStore = select( 'core/edit-post' );
-			if ( ! editPostStore ) {
-				return;
-			}
-
-			// Only run this once for post editor
-			postEditorUnsubscribe();
-
-			// Register blocks that are available in post editor
+		if ( editPostStore ) {
+			// Post editor registration
 			this.blocks.forEach( ( config ) => {
 				if ( config.isAvailableOnPostEditor ) {
-					const key = config.variationName || config.blockName;
-					if ( ! this.registeredBlocks.has( key ) ) {
-						this.registerBlock( config );
-						this.registeredBlocks.add( key );
-					}
+					this.registerBlock( config );
 				}
 			} );
-		}, 'core/edit-post' );
+		}
 
 		this.initialized = true;
 	}

--- a/plugins/woocommerce/changelog/update-register-block-single-product-template
+++ b/plugins/woocommerce/changelog/update-register-block-single-product-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Significant refactor of our block registration system registerBlockSingleProductTemplate for single product templates, specifically addressing performance concerns with the current implementation


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a significant refactor of our block registration system for single product templates, specifically addressing performance concerns with the current implementation.

**The problem:**
Currently, each block that uses `registerBlockSingleProductTemplate` creates its own subscription via WP's `subscribe` method. This leads to:
- Multiple redundant subscriptions (one per block)
- Increased memory usage
- Potential performance degradation as more blocks are added
- Harder to maintain and debug registration state

**The solution:**
Implemented a new `BlockRegistrationManager` using the Singleton pattern that:
- Single subscription for all blocks, rather than one per block.
- Centralizes block registration state management.
- Maintains backward compatibility - no changes needed to existing block implementations

**Next steps:**
The next steps to this PR is to rename the function name so it better reflects its responsibility. I plan to do this in a separate PR.

Closes https://github.com/woocommerce/woocommerce/issues/47736

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify blocks using `registerBlockSingleProductTemplate` register correctly in both single product templates and post/page editor
2. Check transitions between templates using both the command UI (CMD+K) and manual navigation maintain correct block behavior
3. Verify existing block implementations continue to work without changes

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
