### PR TITLE
Fix warning on dependant plugins on the Plugins page

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/53789-beta-tester-warnings
+++ b/plugins/woocommerce-beta-tester/changelog/53789-beta-tester-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix warnings on the Plugins page when a plugin requires another plugin

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester.php
@@ -301,6 +301,8 @@ class WC_Beta_Tester {
 			return $response;
 		}
 
+		$warning = '';
+
 		if ( $this->is_beta_version( $new_version ) ) {
 			$warning = __( '<h1><span>&#9888;</span>This is a beta release<span>&#9888;</span></h1>', 'woocommerce-beta-tester' );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix warnings on the Plugins page when searching for a plugin and it requires a different plugin to be installed first. 

<img width="1788" alt="Image" src="https://github.com/user-attachments/assets/d8b95e05-655c-45e0-a485-ac6abe706818" />

Closes #53789.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `WP_DEBUG` mode (e.g., by installing the `WP Debugging` plugin).
2. Ensure WooCommerce is not installed. 
3. Got to **Plugins > Add New Plugin** page and search for `woocommerce`.
4. Observe warnings.

<!-- End testing instructions -->
