### PR TITLE
Prevent rendering the Shop loop when the Shop page is defined and used in the front page in block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-53805-shop-loop-when-shop-page-is-defined
+++ b/plugins/woocommerce/changelog/fix-53805-shop-loop-when-shop-page-is-defined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent rendering the Shop loop when the Shop page is defined and used in the front page in block themes

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -334,15 +334,12 @@ class WC_Query {
 			return true;
 		}
 
-		$initial_installed_version = get_option( 'woocommerce_initial_installed_version' );
-		if (
-			! empty( $initial_installed_version ) &&
-			version_compare( $initial_installed_version, '9.5', '>=' )
-		) {
-			$installed_in_95_or_after = true;
-		} else {
-			$installed_in_95_or_after = false;
+		if ( ! wc_current_theme_is_fse_theme() ) {
+			return false;
 		}
+
+		$initial_version          = get_option( 'woocommerce_initial_installed_version' );
+		$installed_in_95_or_after = ! empty( $initial_version ) && version_compare( $initial_version, '9.5', '>=' );
 
 		if (
 			! $installed_in_95_or_after &&
@@ -353,7 +350,7 @@ class WC_Query {
 			return false;
 		}
 
-		return wc_current_theme_supports_woocommerce_or_fse();
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-query.php
+++ b/plugins/woocommerce/includes/class-wc-query.php
@@ -341,11 +341,20 @@ class WC_Query {
 		$initial_version          = get_option( 'woocommerce_initial_installed_version' );
 		$installed_in_95_or_after = ! empty( $initial_version ) && version_compare( $initial_version, '9.5', '>=' );
 
+		if ( $installed_in_95_or_after ) {
+			return true;
+		}
+
+		$shop_page_id          = wc_get_page_id( 'shop' );
+		$current_page_id       = absint( $q->get( 'page_id' ) );
+		$is_shop_page          = $current_page_id === $shop_page_id;
+		$is_shop_front_page    = $this->page_on_front_is( $shop_page_id );
+		$shop_page_has_content = ! empty( get_post_field( 'post_content', $shop_page_id ) );
+
 		if (
-			! $installed_in_95_or_after &&
-			absint( $q->get( 'page_id' ) ) === wc_get_page_id( 'shop' ) &&
-			$this->page_on_front_is( wc_get_page_id( 'shop' ) ) &&
-			! empty( get_post_field( 'post_content', wc_get_page_id( 'shop' ) ) )
+			$is_shop_page &&
+			$is_shop_front_page &&
+			$shop_page_has_content
 		) {
 			return false;
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-query-test.php
@@ -34,6 +34,54 @@ class WC_Query_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Shop page takes priority over template in legacy stores with
+	 * block themes when the shop page is set as the homepage.
+	 */
+	public function test_shop_page_in_home_displays_correctly_in_legacy_stores() {
+		switch_theme( 'twentytwentyfour' );
+
+		// Create a page and use it as the Shop page.
+		$shop_page_id                     = wp_insert_post(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Shop',
+				'post_content' => 'Shop page content',
+			)
+		);
+		$default_woocommerce_shop_page_id = get_option( 'woocommerce_shop_page_id' );
+		update_option( 'woocommerce_shop_page_id', $shop_page_id );
+
+		// Set the Shop page as the homepage.
+		$default_show_on_front = get_option( 'show_on_front' );
+		$default_page_on_front = get_option( 'page_on_front' );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $shop_page_id );
+		update_option( 'woocommerce_initial_installed_version', '9.4.0' );
+
+		// Simulate the main query.
+		$query = new WP_Query(
+			array(
+				'post_type' => 'page',
+				'page_id'   => $shop_page_id,
+			)
+		);
+		global $wp_the_query;
+		$previous_wp_the_query = $wp_the_query;
+		$wp_the_query          = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$query->get_posts();
+
+		$this->assertTrue( ! defined( 'SHOP_IS_ON_FRONT' ) || ! SHOP_IS_ON_FRONT );
+
+		// Reset main query, options and delete the page we created.
+		$wp_the_query = $previous_wp_the_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		update_option( 'woocommerce_shop_page_id', $default_woocommerce_shop_page_id );
+		update_option( 'show_on_front', $default_show_on_front );
+		update_option( 'page_on_front', $default_page_on_front );
+		wp_delete_post( $shop_page_id, true );
+	}
+
+	/**
 	 * @testdox Shop page can be set as the homepage on block themes.
 	 */
 	public function test_shop_page_in_home_displays_correctly() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #53805.

In block themes, we want the _Product Catalog_ template to take priority over the _Shop_ page contents. However, until now, we had a case where this didn't happen: when the _Shop_ page was set as the _Homepage_ (see https://github.com/woocommerce/woocommerce/issues/45477). In order to keep backwards compatibility, in this PR we add a special case for this case in stores installed in 9.4.x or earlier.

The bug was introduced in https://github.com/woocommerce/woocommerce/pull/51626.

### How to test the changes in this Pull Request:

1. Add some contents to the _Shop_ page (ie: _Filter by Attribute_ and _Product Collection_ blocks).
2. Go to `/shop` and verify the contents you added in step 1 are not visible (expected, the template takes precedence).
3. Go to `/wp-admin/options-reading.php` and set your home page as the _Shop_ page.
4. Go to the database and modify the `woocommerce_initial_installed_version` setting between `9.4.3` and `9.5.1`.
5. Go to `/`, when the setting is `9.4.3`, you should see the contents from 1, when the setting is `9.5.1`, you should see the template.
