### PR TITLE
[dev] Fix: Debugging link when the workflow fails

### DIFF
--- a/.github/workflows/new-cfe-cherry-pick.yml
+++ b/.github/workflows/new-cfe-cherry-pick.yml
@@ -240,7 +240,7 @@ jobs:
               run: |
                   gh pr comment $HTML_URL --body "IMPORTANT: Merging this PR to the appropriate branches is critical to the release process and ensures that the bug does not cause regressions in the future releases.
 
-                  Cherry picking failed for the trunk. Please bring this to release team's attention. Workflow link for debugging: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/new-cfe-cherry-pick.yml"
+                  Cherry picking failed for the trunk. Please bring this to release team's attention. Workflow link for debugging: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
               env:
                 GH_TOKEN: ${{ github.token }}
                 HTML_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/new-prr-cherry-pick.yml
+++ b/.github/workflows/new-prr-cherry-pick.yml
@@ -280,7 +280,7 @@ jobs:
               run: |
                   gh pr comment $HTML_URL --body "IMPORTANT: Merging this PR to the appropriate branches is critical to the release process and ensures that the bug does not cause regressions in the future releases.
 
-                  Cherry picking failed for the frozen release: $FROZEN_RELEASE_BRANCH. Please bring this to release team's attention. Workflow link for debugging:https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/new-prr-cherry-pick.yml"
+                  Cherry picking failed for the frozen release: $FROZEN_RELEASE_BRANCH. Please bring this to release team's attention. Workflow link for debugging: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
               env:
                 GH_TOKEN: ${{ github.token }}
                 HTML_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Whenever the cherry-pick workflow fails, the bot comments on GitHub, but at present, the link throws a `404` due to the presence of an extra slug.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with [this guide](https://woocorerelease.wordpress.com/2024/10/22/point-release-request-prr-end-to-end-flow-and-testing-instructions/) to setup, don't go into testing yet. You can skip slack setup.
3. Now make some changes in the release branch of your choice and open a PRR (make sure a frozen branch is present)
4. Make similar changes in the trunk and frozen release branch to simulate a merge conflict.
5. Now approve the PRR, wait for the approve comment on github.
6. Merge your change.
7. This should trigger the workflow to pick changes, but it should fail due to conflicts.
8. Observe that the comment has now correct debug link.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
