### PR TITLE
[Settings]: configure TS to avoid importing React lib

### DIFF
--- a/packages/js/settings-editor/changelog/update-ts-config-add-react
+++ b/packages/js/settings-editor/changelog/update-ts-config-add-react
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Comment: configure tsconfig to avoid importing React lib

--- a/packages/js/settings-editor/src/components/header/index.tsx
+++ b/packages/js/settings-editor/src/components/header/index.tsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import classnames from 'classnames';
 import {
 	// @ts-expect-error missing types.
 	__experimentalHeading as Heading,
+
 	// @ts-expect-error missing types.
 	__experimentalHStack as HStack,
+
 	// @ts-expect-error missing types.
 	__experimentalVStack as VStack,
 } from '@wordpress/components';

--- a/packages/js/settings-editor/src/components/section-tabs/index.tsx
+++ b/packages/js/settings-editor/src/components/section-tabs/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createElement, Fragment } from '@wordpress/element';
 import { TabPanel } from '@wordpress/components';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 /* eslint-disable @woocommerce/dependency-group */

--- a/packages/js/settings-editor/src/components/sidebar/index.tsx
+++ b/packages/js/settings-editor/src/components/sidebar/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 /* eslint-disable @woocommerce/dependency-group */
 // @ts-expect-error missing type.
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis

--- a/packages/js/settings-editor/src/components/sidebar/setting-item.tsx
+++ b/packages/js/settings-editor/src/components/sidebar/setting-item.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import classNames from 'classnames';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';

--- a/packages/js/settings-editor/src/legacy/content.tsx
+++ b/packages/js/settings-editor/src/legacy/content.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/packages/js/settings-editor/src/route.tsx
+++ b/packages/js/settings-editor/src/route.tsx
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	useEffect,
-	useMemo,
-	useState,
-	useRef,
-} from '@wordpress/element';
+import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	addAction,

--- a/packages/js/settings-editor/src/tests/route.test.tsx
+++ b/packages/js/settings-editor/src/tests/route.test.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { renderHook } from '@testing-library/react-hooks';
 import { screen, render } from '@testing-library/react';
 import { addAction, applyFilters, didFilter } from '@wordpress/hooks';

--- a/packages/js/settings-editor/tsconfig.json
+++ b/packages/js/settings-editor/tsconfig.json
@@ -11,10 +11,12 @@
 			"./typings",
 			"./node_modules/@types"
 		],
-		"jsx": "react-jsx",
+	"jsx": "react-jsx",
+	"jsxFactory": null,
+	"jsxFragmentFactory": null
 	},
 	"include": [
 		"typings/**/*",
-		"src/**/*",
-	],
+		"src/**/*"
+	]
 }

--- a/packages/js/settings-editor/tsconfig.json
+++ b/packages/js/settings-editor/tsconfig.json
@@ -10,7 +10,8 @@
 		"typeRoots": [
 			"./typings",
 			"./node_modules/@types"
-		]
+		],
+		"jsx": "react-jsx",
 	},
 	"include": [
 		"typings/**/*",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request focuses on updating the TypeScript configuration to avoid importing the React library and removing unnecessary `createElement` imports from various components in the `settings-editor` package. The most important changes include configuring `tsconfig` to use `react-jsx` and cleaning up imports in multiple files.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Apply these changes
2. Confirm TS doesn't complain when using React components


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
