### PR TITLE
Product Gallery: Limit the blank space around images

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/utils.ts
@@ -26,7 +26,6 @@ export const getNextPreviousImagesWithClassName = (
 				classname: 'outside-image',
 			};
 		case 'off':
-			return null;
 		default:
 			return null;
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -129,11 +129,11 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 		aspect-ratio: 1 / 1;
 		flex-shrink: 0;
 		max-width: 100%;
+		overflow: hidden;
 		width: 100%;
 		display: flex;
 		align-items: center;
 		scroll-snap-align: none center;
-		overflow: hidden;
 	}
 
 	#{$gallery-next-previous-inside-image} & .wc-block-product-gallery-large-image__image-element {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -109,6 +109,7 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 	#{$gallery-next-previous-outside-image} & .wc-block-product-gallery-large-image__image-element {
 		margin-right: auto;
 		margin-left: auto;
+		width: 100%;
 		max-width: $outside-image-max-width;
 	}
 
@@ -132,6 +133,7 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 		display: flex;
 		align-items: center;
 		scroll-snap-align: none center;
+		overflow: hidden;
 	}
 
 	#{$gallery-next-previous-inside-image} & .wc-block-product-gallery-large-image__image-element {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -128,7 +128,6 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 		aspect-ratio: 1 / 1;
 		flex-shrink: 0;
 		max-width: 100%;
-		overflow: hidden;
 		width: 100%;
 		display: flex;
 		align-items: center;
@@ -151,6 +150,7 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 		transition: all 0.1s linear;
 		aspect-ratio: 1 / 1;
 		object-fit: contain;
+		width: 100%;
 
 		// Keep the order in this way. The hoverZoom class should override the full-screen-on-click class when both are applied.
 		&.wc-block-woocommerce-product-gallery-large-image__image--full-screen-on-click {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/style.scss
@@ -73,7 +73,7 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 		#{$large-image} {
 			img {
 				max-height: $full-height-desktop;
-				width: auto;
+				width: 100%;
 			}
 
 			.wc-block-product-gallery-large-image__container {
@@ -135,7 +135,7 @@ $full-height-mobile-admin-bar: calc($full-height-desktop - $admin-bar-mobile-hei
 	}
 
 	#{$gallery-next-previous-inside-image} & .wc-block-product-gallery-large-image__image-element {
-		width: fit-content;
+		width: 100%;
 		overflow: hidden;
 		margin-right: auto;
 		margin-left: auto;

--- a/plugins/woocommerce/changelog/fix-52982
+++ b/plugins/woocommerce/changelog/fix-52982
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: Make vertical and horizontal images take more space available


### PR DESCRIPTION
z### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was unnecessary blank space around images in Product Gallery block. This PR limits this allowing images to expand.

> [!NOTE]  
> I marked it closes https://github.com/woocommerce/woocommerce/issues/47569 but it's not fully addressing the issue raised in there. This PR only allows expanding images but preserving the size of Product Gallery so within the block boundaries.

Part of https://github.com/woocommerce/woocommerce/issues/47569

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Prepare a product which has a vertical, square-ish and horizontal images
1. Go to Editor > Single Product Template.
2. Replace Product Image Gallery with Product Gallery (Beta) block
3. Turn off thumbnails to see the difference the most
4. Save and go to frontend to product prepared in step 0.
5. **Expected:** Verify the images occupies the available space preserving the size of Product Gallery block (check screenshots for better explanation)
6. Click the image to open full size gallery
7. **Expected:** Verify the images occupies the available space preserving the size of Product Gallery block (check screenshots for better explanation)
8. Go back to editor and change the "Next/Prev buttons" to Outside and repeat steps 3 to 6. The same for "Off"
<img width="276" alt="image" src="https://github.com/user-attachments/assets/c12ed1dc-9f9a-49b6-b094-59762323f893" />

Screenshots:
- 🟢 - Improvement
- ⏸️ - No regressions

#### Next/Prev Buttons INSIDE image

Scenario | Before | After
-- | -- | --
🟢 Default view - vertical img | <img width="1373" alt="image" src="https://github.com/user-attachments/assets/975f9e23-a47f-4483-aaaf-cfecfc302d9b" /> | <img width="1366" alt="image" src="https://github.com/user-attachments/assets/e819b8c4-6f9f-45bb-88d7-04ee5bf946de" />
⏸️ Default view - square-ish img | <img width="1401" alt="image" src="https://github.com/user-attachments/assets/c933c5e7-1795-43cd-a5d1-56eeb1ea7b38" /> | <img width="1413" alt="image" src="https://github.com/user-attachments/assets/6306b6ed-6475-4cbe-a53a-ec41fdb1bb96" />
⏸️ Default view - horizontal img | <img width="1378" alt="image" src="https://github.com/user-attachments/assets/311f6c8b-4fd3-4a2e-befd-0dcdeb5b33bd" /> | <img width="1402" alt="image" src="https://github.com/user-attachments/assets/e675c45f-1cbf-401f-961e-05dc2ee8fd7d" />
⏸️ Full page view - vertical img | <img width="1671" alt="image" src="https://github.com/user-attachments/assets/b0bdf096-f580-4c9c-9ec9-f18316559578" /> | <img width="1676" alt="image" src="https://github.com/user-attachments/assets/41f4d65e-8b56-41e9-9643-943ff493b3e7" />
⏸️ Full page view - square-ish img | <img width="1672" alt="image" src="https://github.com/user-attachments/assets/7673fdfd-9545-4332-86a0-46941efd7fe6" /> | <img width="1673" alt="image" src="https://github.com/user-attachments/assets/56d8cde8-c203-40f5-a0d3-6b8e06cbbd59" />
🟢 Full page view - horizontal img | <img width="1672" alt="image" src="https://github.com/user-attachments/assets/f0d06199-ac8f-4de5-92b9-c925270b5ccc" /> | <img width="1672" alt="image" src="https://github.com/user-attachments/assets/1778e54f-b39e-4a2e-acf0-84a0f39f6e9f" />

#### Next/Prev Buttons OUTSIDE image

Scenario | Before | After
-- | -- | --
🟢 Default view - vertical img | <img width="1383" alt="image" src="https://github.com/user-attachments/assets/b7c5008a-1326-4613-be3e-5cc0339faed3" /> | <img width="1404" alt="image" src="https://github.com/user-attachments/assets/640b135a-7ee7-468f-a6c2-a08c46ac4d9a" />
⏸️ Default view - square-ish img | <img width="1401" alt="image" src="https://github.com/user-attachments/assets/f5372f26-4921-46c6-8336-44ec65ddcc66" /> | <img width="1379" alt="image" src="https://github.com/user-attachments/assets/ff643d04-75f4-496c-bf1f-971848eb4350" />
⏸️ Default view - horizontal img |  <img width="1373" alt="image" src="https://github.com/user-attachments/assets/2dc57920-93fa-45e6-80b0-7b2e2f341e4c" /> | <img width="1376" alt="image" src="https://github.com/user-attachments/assets/8b7e656b-e146-4368-8265-b1ef5f74d75b" />
⏸️ Full page view - vertical img |  <img width="1673" alt="image" src="https://github.com/user-attachments/assets/712061af-c170-48d1-b3bc-3cf23a14ab3b" /> | <img width="1671" alt="image" src="https://github.com/user-attachments/assets/a495a40c-d2fa-49bf-b48e-a14c2d8fbe62" />
⏸️ Full page view - square-ish img | <img width="1674" alt="image" src="https://github.com/user-attachments/assets/c6e58628-0a14-426f-9fd7-09307958a581" /> | <img width="1673" alt="image" src="https://github.com/user-attachments/assets/0c7b1c95-09a3-4a9b-bf9a-8aa8a11721d3" />
🟢 Full page view - horizontal img | <img width="1669" alt="image" src="https://github.com/user-attachments/assets/06659389-53be-49c6-afb6-d4499e59ff32" /> | <img width="1672" alt="image" src="https://github.com/user-attachments/assets/59e6ed35-cf92-4e89-bdac-6168e22cc492" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
