### PR TITLE
[Delayed Account Creation] Update password nag text

### DIFF
--- a/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
+++ b/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update password nag text on order confirmation page so it makes sense after placing multiple orders.

--- a/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
+++ b/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update password nag text on order confirmation page so it makes sense after placing multiple orders.

--- a/plugins/woocommerce/changelog/fix-53117-password-nag
+++ b/plugins/woocommerce/changelog/fix-53117-password-nag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update password nag text on order confirmation page so it makes sense after placing multiple orders.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -171,7 +171,7 @@ class Status extends AbstractOrderConfirmationBlock {
 				return wc_print_notice(
 					sprintf(
 						// translators: %s: site name.
-						__( 'Your account with %s has been successfully created. We emailed you a link to set your account password.', 'woocommerce' ),
+						__( 'Your account with %s was created but needs to be confirmed. We emailed you a link to set your account password.', 'woocommerce' ),
 						esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
 					),
 					'notice',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -171,7 +171,7 @@ class Status extends AbstractOrderConfirmationBlock {
 				return wc_print_notice(
 					sprintf(
 						// translators: %s: site name.
-						__( 'Your account with %s was created but needs to be confirmed. We emailed you a link to set your account password.', 'woocommerce' ),
+						__( 'Your account with %s was created and we emailed you a link to set your account password.', 'woocommerce' ),
 						esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
 					),
 					'notice',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rewords account creation notice to be more generic.

> Your account with %s has been successfully created. We emailed you a link to set your account password.

^ Sounds like it just happened.

> Your account with %s was created and we emailed you a link to set your account password.

^ Past tense. Call to action. User needs to click the link even if they didn't just register.

![Screenshot 2024-12-18 at 12 48 05](https://github.com/user-attachments/assets/1c0e14fa-73ef-4e45-965b-039d079e2e08)

Closes #53117

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to /wp-admin/admin.php?page=wc-settings&tab=account
2. Enable delayed account creation and auto generate passwords
3. Place order with new email address as guest
4. Create account on order confirmation page
5. Force refresh the page
6. Notice is visible

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
