### PR TITLE
Update e2e checks CI configs to not run all daily checks in PRs

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-the-extra-e2e-checks-for-prs
+++ b/plugins/woocommerce/changelog/e2e-remove-the-extra-e2e-checks-for-prs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update some e2e CI jobs to not run on PRs

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -239,11 +239,8 @@
 						"--shard=3/4",
 						"--shard=4/4"
 					],
-					"changes": [ 
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -266,11 +263,8 @@
 						"--shard=3/4",
 						"--shard=4/4"
 					],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -288,11 +282,8 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env woocommerce-payments",
 					"shardingArguments": [],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -310,11 +301,8 @@
 					"testType": "e2e",
 					"command": "test:e2e:with-env woocommerce-paypal-payments",
 					"shardingArguments": [],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -335,11 +323,8 @@
 						"--shard=1/2",
 						"--shard=2/2"
 					],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -388,9 +373,7 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -398,7 +381,6 @@
 						}
 					},
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -419,9 +401,7 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -429,7 +409,6 @@
 						}
 					},
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],
@@ -450,9 +429,7 @@
 						"--shard=4/5",
 						"--shard=5/5"
 					],
-					"changes": [
-						"tests/e2e-pw/**"
-					],
+					"changes": [],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -460,7 +437,6 @@
 						}
 					},
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks"
 					],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a partial revert of https://github.com/woocommerce/woocommerce/pull/53756
Running all those extra e2e checks on PRs probably take too much CI run time. We'll revisit this later with https://github.com/woocommerce/woocommerce/issues/53582 if context changes.

### How to test the changes in this Pull Request:

1. Create a new branch based on this one
2. Update a test in the `tests/e2e-pw/**` path
3. Run the ci-jobs utility with this branch as the baseRef

```
pnpm utils ci-jobs --base-ref=e2e/remove-the-extra-e2e-checks-for-prs --event=pull_request
```

The jobs updated by this PR should not be in the list of jobs
