### PR TITLE
Bump WP requirement to 6.6 on release/9.6 branch

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, woocommerce, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1, claudiulodro, tiagonoronha, ryelle, levinmedia, aljullu, nerrad, joshuawold, assassinateur, haszari, mppfeiffer, nielslange, opr18, ralucastn, tjcafferkey, danielwrobert, patriciahillebrandt, albarin, dinhtungdu, imanish003, karolmanijak, sunyatasattva, alexandrelara, gigitux, danieldudzic, samueljseay, alexflorisca, opr18, tarunvijwani, pauloarromba, saadtarhi, bor0, kloon, coreymckrill, jorgeatorres, leifsinger
 Tags: online store, ecommerce, shop, shopping cart, sell online
-Requires at least: 6.5
+Requires at least: 6.6
 Tested up to: 6.7
 Requires PHP: 7.4
 Stable tag: 9.5.1

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP: 7.4
  *
  * @package WooCommerce


### PR DESCRIPTION
Per our L-1 policy and given WP 6.7 is stable.