### PR TITLE
[Delayed Account Creation] Move password nag from the order confirmation to the my account page

### DIFF
--- a/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
+++ b/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update password nag text on order confirmation page so it makes sense after placing multiple orders.

--- a/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
+++ b/packages/js/e2e-utils-playwright/changelog/fix-53117-password-nag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update password nag text on order confirmation page so it makes sense after placing multiple orders.

--- a/plugins/woocommerce/changelog/fix-53117-password-nag
+++ b/plugins/woocommerce/changelog/fix-53117-password-nag
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Update password nag text on order confirmation page so it makes sense after placing multiple orders.
+Moved password nag from the order confirmation page to the my account page.

--- a/plugins/woocommerce/changelog/fix-53117-password-nag
+++ b/plugins/woocommerce/changelog/fix-53117-password-nag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update password nag text on order confirmation page so it makes sense after placing multiple orders.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -89,6 +89,19 @@ class WC_Shortcode_My_Account {
 			/* translators: %s: logout url */
 			wc_add_notice( sprintf( __( 'Are you sure you want to log out? <a href="%s">Confirm and log out</a>', 'woocommerce' ), wc_logout_url() ) );
 		}
+
+		if ( get_user_option( 'default_password_nag' ) ) {
+			wc_add_notice(
+				sprintf(
+					// translators: %s: site name.
+					__( 'Your account with %s is using a temporary password. We emailed you a link to set your account password.', 'woocommerce' ),
+					esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
+				),
+				'notice',
+				array(),
+				true
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -90,7 +90,7 @@ class WC_Shortcode_My_Account {
 			wc_add_notice( sprintf( __( 'Are you sure you want to log out? <a href="%s">Confirm and log out</a>', 'woocommerce' ), wc_logout_url() ) );
 		}
 
-		if ( get_user_option( 'default_password_nag' ) ) {
+		if ( get_user_option( 'default_password_nag' ) && wc_is_current_account_menu_item( 'dashboard' ) ) {
 			wc_add_notice(
 				sprintf(
 					// translators: %s: site name.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -90,7 +90,7 @@ class WC_Shortcode_My_Account {
 			wc_add_notice( sprintf( __( 'Are you sure you want to log out? <a href="%s">Confirm and log out</a>', 'woocommerce' ), wc_logout_url() ) );
 		}
 
-		if ( get_user_option( 'default_password_nag' ) && wc_is_current_account_menu_item( 'dashboard' ) ) {
+		if ( get_user_option( 'default_password_nag' ) && ( wc_is_current_account_menu_item( 'dashboard' ) || wc_is_current_account_menu_item( 'edit-account' ) ) ) {
 			wc_add_notice(
 				sprintf(
 					// translators: %s: site name.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -94,7 +94,7 @@ class WC_Shortcode_My_Account {
 			wc_add_notice(
 				sprintf(
 					// translators: %s: site name.
-					__( 'Your account with %s is using a temporary password. We emailed you a link to set your account password.', 'woocommerce' ),
+					__( 'Your account with %s is using a temporary password. We emailed you a link to change your password.', 'woocommerce' ),
 					esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
 				),
 				'notice',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -40,16 +40,6 @@ class Status extends AbstractOrderConfirmationBlock {
 			return '';
 		}
 
-		$account_notice = $this->render_account_notice( $order );
-
-		if ( $account_notice ) {
-			$block = sprintf(
-				'<div class="wc-block-order-confirmation-status-notices %1$s">%2$s</div>',
-				esc_attr( trim( $classname ) ),
-				$account_notice
-			) . $block;
-		}
-
 		$additional_content = $this->render_confirmation_notice( $order );
 
 		if ( $additional_content ) {
@@ -154,33 +144,6 @@ class Status extends AbstractOrderConfirmationBlock {
 	protected function render_content_fallback() {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		return '<p>' . esc_html__( 'Please check your email for the order confirmation.', 'woocommerce' ) . '</p>';
-	}
-
-	/**
-	 * If the user associated with the order needs to set a password (new account) show a notice.
-	 *
-	 * @param \WC_Order|null $order Order object.
-	 * @return string
-	 */
-	protected function render_account_notice( $order = null ) {
-		if ( $order && $order->get_customer_id() && 'store-api' === $order->get_created_via() ) {
-			$nag      = get_user_option( 'default_password_nag', $order->get_customer_id() );
-			$generate = filter_var( get_option( 'woocommerce_registration_generate_password', 'no' ), FILTER_VALIDATE_BOOLEAN );
-
-			if ( $nag && $generate ) {
-				return wc_print_notice(
-					sprintf(
-						// translators: %s: site name.
-						__( 'Your account with %s was created and we emailed you a link to set your account password.', 'woocommerce' ),
-						esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
-					),
-					'notice',
-					array(),
-					true
-				);
-			}
-		}
-		return '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -171,7 +171,7 @@ class Status extends AbstractOrderConfirmationBlock {
 				return wc_print_notice(
 					sprintf(
 						// translators: %s: site name.
-						__( 'Your account with %s has been successfully created. We emailed you a link to set your account password.', 'woocommerce' ),
+						__( 'Your account with %s was created but needs to be confirmed. We emailed you a link to set your account password.', 'woocommerce' ),
 						esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
 					),
 					'notice',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -171,7 +171,7 @@ class Status extends AbstractOrderConfirmationBlock {
 				return wc_print_notice(
 					sprintf(
 						// translators: %s: site name.
-						__( 'Your account with %s was created but needs to be confirmed. We emailed you a link to set your account password.', 'woocommerce' ),
+						__( 'Your account with %s was created and we emailed you a link to set your account password.', 'woocommerce' ),
 						esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) )
 					),
 					'notice',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the password nag from the order confirmation page to the my account page. 

![Screenshot 2024-12-18 at 16 14 13](https://github.com/user-attachments/assets/0a014fa2-20b6-41e7-ba9a-3eaf1e742b58)

Closes #53117

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to /wp-admin/admin.php?page=wc-settings&tab=account
2. Enable delayed account creation and auto generate passwords
3. Place order with new email address as guest
4. On the order confirmation page, create an account.
5. Refresh the page. No notice is shown regarding the password.
6. Go to the My Account page.
7. See the notice at the top of the dashboard.
8. Use the link in the email you received the set the password.
9. Notice is removed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
