### PR TITLE
Product Gallery: unlock blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/edit.tsx
@@ -16,7 +16,6 @@ import { useSelect } from '@wordpress/data';
  */
 import {
 	moveInnerBlocksToPosition,
-	getInnerBlocksLockAttributes,
 	getClassNameByNextPreviousButtonsPosition,
 } from './utils';
 import { ProductGalleryBlockSettings } from './block-settings/index';
@@ -36,10 +35,7 @@ const TEMPLATE: InnerBlockTemplate[] = [
 			},
 		},
 		[
-			[
-				'woocommerce/product-gallery-thumbnails',
-				getInnerBlocksLockAttributes( 'lock' ),
-			],
+			[ 'woocommerce/product-gallery-thumbnails' ],
 			[
 				'core/group',
 				{
@@ -55,12 +51,11 @@ const TEMPLATE: InnerBlockTemplate[] = [
 					metadata: {
 						name: 'Large Image and Navigation',
 					},
-					...getInnerBlocksLockAttributes( 'lock' ),
 				},
 				[
 					[
 						'woocommerce/product-gallery-large-image',
-						getInnerBlocksLockAttributes( 'lock' ),
+						{},
 						[
 							[
 								'woocommerce/product-sale-badge',
@@ -76,7 +71,6 @@ const TEMPLATE: InnerBlockTemplate[] = [
 											},
 										},
 									},
-									lock: { move: true },
 								},
 							],
 							[
@@ -86,15 +80,11 @@ const TEMPLATE: InnerBlockTemplate[] = [
 										type: 'flex',
 										verticalAlignment: 'bottom',
 									},
-									lock: { move: true, remove: true },
 								},
 							],
 						],
 					],
-					[
-						'woocommerce/product-gallery-pager',
-						{ lock: { move: true, remove: true } },
-					],
+					[ 'woocommerce/product-gallery-pager' ],
 				],
 			],
 		],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { BlockAttributes, BlockInstance } from '@wordpress/blocks';
+import { BlockAttributes } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
 import { findBlock } from '@woocommerce/utils';
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
@@ -35,25 +35,6 @@ export const getGroupLayoutAttributes = (
 };
 
 /**
- * Returns inner block lock attributes based on provided action.
- *
- * @param {string} action - The action to take on the inner blocks ('lock' or 'unlock').
- * @return {{lock: {move?: boolean, remove?: boolean}}} - An object representing lock attributes for inner blocks.
- */
-export const getInnerBlocksLockAttributes = (
-	action: string
-): { lock: { move?: boolean; remove?: boolean } } => {
-	switch ( action ) {
-		case 'lock':
-			return { lock: { move: true, remove: true } };
-		case 'unlock':
-			return { lock: {} };
-		default:
-			return { lock: {} };
-	}
-};
-
-/**
  * Updates block attributes based on provided attributes.
  *
  * @param {BlockAttributes}             attributesToUpdate - The new attributes to set on the block.
@@ -76,28 +57,6 @@ export const updateBlockAttributes = (
 			block.clientId,
 			updatedBlock
 		);
-	}
-};
-
-const controlBlocksLockAttribute = ( {
-	blocks,
-	lockBlocks,
-}: {
-	blocks: BlockInstance[];
-	lockBlocks: boolean;
-} ) => {
-	for ( const block of blocks ) {
-		if ( lockBlocks ) {
-			updateBlockAttributes(
-				getInnerBlocksLockAttributes( 'lock' ),
-				block
-			);
-		} else {
-			updateBlockAttributes(
-				getInnerBlocksLockAttributes( 'unlock' ),
-				block
-			);
-		}
 	}
 };
 
@@ -175,11 +134,6 @@ export const moveInnerBlocksToPosition = (
 			largeImageParentBlockIndex !== -1 &&
 			thumbnailsBlockIndex !== -1
 		) {
-			controlBlocksLockAttribute( {
-				blocks: [ thumbnailsBlock, largeImageParentBlock ],
-				lockBlocks: false,
-			} );
-
 			const { thumbnailsPosition } = attributes;
 			setGroupBlockLayoutByThumbnailsPosition(
 				thumbnailsPosition,
@@ -218,11 +172,6 @@ export const moveInnerBlocksToPosition = (
 					largeImageParentBlockIndex
 				);
 			}
-
-			controlBlocksLockAttribute( {
-				blocks: [ thumbnailsBlock, largeImageParentBlock ],
-				lockBlocks: true,
-			} );
 		}
 	}
 };

--- a/plugins/woocommerce/changelog/fix-product-gallery-unlock-blocks
+++ b/plugins/woocommerce/changelog/fix-product-gallery-unlock-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Gallery: Stop locking the blocks


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product Gallery and its inner blocks were locked when inserted. There's no specific reason except for "protecting users" from breaking the block. But at the same time, there's huge granularity of blocks to provide flexibility which is essentially taken away by locking blocks.

If user "breaks" the block, they can reinsert it as an easy way back.

Discussed in https://github.com/woocommerce/woocommerce/issues/42222#issuecomment-2548629422

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Editor > Single Product template.
2. Replace the Product Image Gallery block with the Product Gallery (beta) block.
3. **Expected:** Make sure Product Galler and inner blocks are not locked (no lock icon)
4. Try to move the block somewhere else
5. **Expected:** No crashes or issues

Before | After
-- | --
<img width="354" alt="image" src="https://github.com/user-attachments/assets/62cd9c61-6642-43f7-9746-7ba39bf2026a" /> | <img width="355" alt="image" src="https://github.com/user-attachments/assets/b56d6496-dc91-4c1f-96b0-48359d9ed347" />


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
