### PR TITLE
Experiment: Render classic on sale badge if filter is in use

### DIFF
--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSaleBadge.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSaleBadge.php
@@ -97,6 +97,13 @@ class ProductSaleBadge extends AbstractBlock {
 			return $content;
 		}
 
+		// Check if woocommerce_sale_flash filter is in use
+		if ( has_filter( 'woocommerce_sale_flash' ) ) {
+			ob_start();
+			wc_get_template( 'single-product/sale-flash.php' );
+			return ob_get_clean();
+		}
+
 		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : '';
 		$product = wc_get_product( $post_id );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In scope of https://github.com/woocommerce/woocommerce/issues/52982 we discussed with @roykho a possibility to rely on classic content if the hooks is in use.

In this case we're talking On Sale Badge and `woocommerce_sale_flash` filter that many plugins and themes rely on.

In this very little (but powerful and controversial) POC I'm wondering if we could:
- check if filter is in use
    - if YES: render classic sale-flash which automatically takes into account the `woocommerce_sale_flash` hook
    - if NO: render block as normal.

It's not ideal and solution has lots of downsides:
- changes doesn't get reflected on the Editor
- it provides an uncertainty and confusion - as a user you may no exactly know what to expect on the frontend and why it changed out of nowhere
- styling issues. We may need to include CSS changes and maintain the classic badge with new block. Not ideal.
- alignment or global styles from Editor are not reflected in here (we could mimic this with custom CSS but that implies technical debt)
- it gets applied in other cases and may be applied incorrectly..
    - Here's On Sale Badge used in Product Collection block. Due to lack of position relative on the container, sale gets positions at the top left corner of the page. Again, could be addressed with custom defensive CSS as well but again, it increases the maintenance cost.
    - Also, Product Image has its own internal hardcoded badge which is not impacted. We'd have to migrate it to use On Sale Badge block for consistency

![Screen Shot 2024-12-18 at 19 22 51 PM](https://github.com/user-attachments/assets/8d9dd446-bb2d-4b6d-bebf-c890a265217f)

On the other hand:
- it would allow for plugins to keep working normally if we updated Product Image Gallery block with Product Gallery.

While I'm rather convinced it's NOT a way to go, I wanted to mention this possibility anyway as we discussed that with @roykho. cc: @gigitux.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Editor > Single Product template.
2. Replace the Product Image Gallery block with the Product Gallery (beta) block.
3. Go to frontend
4. See the regular On Sale Badge block (right side in the image)

<img width="1398" alt="image" src="https://github.com/user-attachments/assets/9c5a97e7-2c18-4c75-bd2a-cdea5bd95a1d" />

6. Include this code in your `functions.php`:

```
add_filter( 'woocommerce_sale_flash', 'my_custom_sale_flash' );
function my_custom_sale_flash( $text ) {
	return '<span class="onsale">-20%</span>';
}
```

7. Visit the product page again
8. See there's "classic" badge with -20% text on it

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/40f6c07b-1504-4a0b-99e4-6449f0ce989c" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
