### PR TITLE
[Blueprint] Implement import functionality with confirmation modal and error handling

### DIFF
--- a/plugins/woocommerce/changelog/53869-update-import-blueprint
+++ b/plugins/woocommerce/changelog/53869-update-import-blueprint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: This feature is behind a feature flag and not intended for public use yet.
+

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -21,7 +21,6 @@ import {
 } from 'xstate5';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
-import { Action as WPNoticeAction } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -21,6 +21,7 @@ import {
 } from 'xstate5';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
+import { Action as WPNoticeAction } from '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { Modal, Button, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+
+type OverwriteConfirmationModalProps = {
+	isOpen: boolean;
+	isImporting: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	overwrittenItems: string[];
+};
+
+export const OverwriteConfirmationModal: React.FC<
+	OverwriteConfirmationModalProps
+> = ( { isOpen, isImporting, onClose, onConfirm, overwrittenItems } ) => {
+	if ( ! isOpen ) return null;
+	return (
+		<Modal
+			title={ __(
+				'Your configuration will be overridden',
+				'woocommerce'
+			) }
+			onRequestClose={ onClose }
+			className="woocommerce-blueprint-overwrite-modal"
+		>
+			<p className="woocommerce-blueprint-overwrite-modal__description">
+				{ __(
+					'Importing the file will overwrite the current configuration for the following items in WooCommerce Settings:',
+					'woocommerce'
+				) }
+			</p>
+
+			<ul className="woocommerce-blueprint-overwrite-modal__list">
+				{ overwrittenItems.map( ( item ) => (
+					<li key={ item }>{ item }</li>
+				) ) }
+			</ul>
+
+			<div className="woocommerce-blueprint-overwrite-modal__actions">
+				<Button
+					className="woocommerce-blueprint-overwrite-modal__actions-cancel"
+					variant="tertiary"
+					onClick={ onClose }
+				>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</Button>
+				<Button
+					className={ clsx(
+						'woocommerce-blueprint-overwrite-modal__actions-import',
+						{
+							'is-importing': isImporting,
+						}
+					) }
+					variant="primary"
+					onClick={ onConfirm }
+				>
+					{ isImporting ? (
+						<Spinner />
+					) : (
+						__( 'Import', 'woocommerce' )
+					) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
@@ -185,7 +185,7 @@ const Blueprint = () => {
 			saveButton.style.display = 'none';
 		}
 	} );
-	console.log( queueResponse );
+
 	return (
 		<div className="blueprint-settings-slotfill">
 			{ error && (
@@ -336,7 +336,7 @@ const Blueprint = () => {
 					setIsOverwriteConfirmationModalOpen( false );
 				} }
 				onConfirm={ importBlueprint }
-				overwrittenItems={ queueResponse?.settings_to_override || [] }
+				overwrittenItems={ queueResponse?.settings_to_overwrite || [] }
 			/>
 		</div>
 	);

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
@@ -102,4 +102,79 @@
 	h3 {
 		margin-top: 1.5em;
 	}
+
+	.woocommerce-blueprint-import-button {
+		margin-top: 24px;
+	}
+}
+
+// Show the notice at the bottom right of the screen
+.woocommerce-transient-notices:has(div.woocommerce-blueprint-import-notice) {
+	bottom: 14px;
+	right: 18px;
+	left: initial;
+}
+
+.woocommerce-blueprint-overwrite-modal {
+	max-width: 480px;
+
+	.components-modal__header {
+		padding: 32px 32px 16px 32px;
+		height: 80px;
+
+		.components-modal__header-heading {
+			color: $gray-900;
+			font-size: 20px;
+			font-weight: 500;
+			line-height: 28px; /* 140% */
+		}
+	}
+
+	.components-modal__content {
+		padding: 0 32px 32px;
+	}
+
+	.woocommerce-blueprint-overwrite-modal__description {
+		color: $gray-900;
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 20px; /* 153.846% */
+		margin: 0 0 8px;
+	}
+
+	ul {
+		margin: 0;
+		list-style: disc;
+		list-style-position: inside;
+
+		li {
+			color: $gray-900;
+			font-size: 13px;
+			font-weight: 500;
+			line-height: 20px; /* 153.846% */
+			margin-bottom: 0;
+		}
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 12px;
+		margin-top: 24px;
+
+		button {
+			padding: 8px 16px;
+			font-size: 13px;
+			font-weight: 400;
+			line-height: 20px;
+			height: 40px;
+		}
+
+		&-import.is-importing {
+			padding: 10px 16px;
+			width: 132px;
+			justify-content: center;
+			align-items: center;
+		}
+	}
 }

--- a/plugins/woocommerce/client/admin/client/layout/transient-notices/snackbar/list.js
+++ b/plugins/woocommerce/client/admin/client/layout/transient-notices/snackbar/list.js
@@ -53,7 +53,6 @@ function SnackbarList( {
 		// To be removed when we're no longer using core/notices2.
 		onRemove2( notice.id );
 	};
-
 	return (
 		<div className={ className }>
 			{ children }

--- a/plugins/woocommerce/client/admin/client/layout/transient-notices/snackbar/list.js
+++ b/plugins/woocommerce/client/admin/client/layout/transient-notices/snackbar/list.js
@@ -53,6 +53,7 @@ function SnackbarList( {
 		// To be removed when we're no longer using core/notices2.
 		onRemove2( notice.id );
 	};
+
 	return (
 		<div className={ className }>
 			{ children }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -381,9 +381,9 @@ class RestApi {
 
 		// Same as above, we don't want to sanitize the file name for basename as it expects the raw file name.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$response['reference']            = basename( $_FILES['file']['tmp_name'] . '.' . $extension );
-		$response['process_nonce']        = wp_create_nonce( $response['reference'] );
-		$response['settings_to_override'] = $this->get_settings_to_override( $import_schema->get_schema()->get_steps() );
+		$response['reference']             = basename( $_FILES['file']['tmp_name'] . '.' . $extension );
+		$response['process_nonce']         = wp_create_nonce( $response['reference'] );
+		$response['settings_to_overwrite'] = $this->get_settings_to_overwrite( $import_schema->get_schema()->get_steps() );
 
 		return $response;
 	}
@@ -488,7 +488,7 @@ class RestApi {
 	 * @param array $requested_steps List of steps from the import schema.
 	 * @return array List of settings that will be overridden.
 	 */
-	private function get_settings_to_override( array $requested_steps ): array {
+	private function get_settings_to_overwrite( array $requested_steps ): array {
 		$settings_map = array(
 			'setWCSettings'            => __( 'Settings', 'woocommerce' ),
 			'setWCCoreProfilerOptions' => __( 'Core Profiler Options', 'woocommerce' ),
@@ -525,24 +525,24 @@ class RestApi {
 			'title'      => 'queue',
 			'type'       => 'object',
 			'properties' => array(
-				'reference'            => array(
+				'reference'             => array(
 					'type' => 'string',
 				),
-				'process_nonce'        => array(
+				'process_nonce'         => array(
 					'type' => 'string',
 				),
-				'settings_to_override' => array(
+				'settings_to_overwrite' => array(
 					'type'  => 'array',
 					'items' => array(
 						'type' => 'string',
 					),
 				),
-				'error_type'           => array(
+				'error_type'            => array(
 					'type'    => 'string',
 					'default' => null,
 					'enum'    => array( 'upload', 'schema_validation', 'conflict' ),
 				),
-				'errors'               => array(
+				'errors'                => array(
 					'type'  => 'array',
 					'items' => array(
 						'type' => 'string',

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -369,9 +369,9 @@ class RestApi {
 		// Full validation is performed in the process function.
 		try {
 			if ( 'application/zip' === $mime_type ) {
-				ImportSchema::create_from_zip( $tmp_filepath );
+				$import_schema = ImportSchema::create_from_zip( $tmp_filepath );
 			} else {
-				ImportSchema::create_from_json( $tmp_filepath );
+				$import_schema = ImportSchema::create_from_json( $tmp_filepath );
 			}
 		} catch ( \Exception $e ) {
 			$response['error_type'] = 'schema_validation';
@@ -381,8 +381,9 @@ class RestApi {
 
 		// Same as above, we don't want to sanitize the file name for basename as it expects the raw file name.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$response['reference']     = basename( $_FILES['file']['tmp_name'] . '.' . $extension );
-		$response['process_nonce'] = wp_create_nonce( $response['reference'] );
+		$response['reference']            = basename( $_FILES['file']['tmp_name'] . '.' . $extension );
+		$response['process_nonce']        = wp_create_nonce( $response['reference'] );
+		$response['settings_to_override'] = $this->get_settings_to_override( $import_schema->get_schema()->get_steps() );
 
 		return $response;
 	}
@@ -482,6 +483,38 @@ class RestApi {
 
 
 	/**
+	 * Get list of settings that will be overridden by the import.
+	 *
+	 * @param array $requested_steps List of steps from the import schema.
+	 * @return array List of settings that will be overridden.
+	 */
+	private function get_settings_to_override( array $requested_steps ): array {
+		$settings_map = array(
+			'setWCSettings'            => __( 'Settings', 'woocommerce' ),
+			'setWCCoreProfilerOptions' => __( 'Core Profiler Options', 'woocommerce' ),
+			'setWCPaymentGateways'     => __( 'Payment Gateways', 'woocommerce' ),
+			'setWCShipping'            => __( 'Shipping', 'woocommerce' ),
+			'setWCTaskOptions'         => __( 'Task Options', 'woocommerce' ),
+			'setWCTaxRates'            => __( 'Tax Rates', 'woocommerce' ),
+			'installPlugin'            => __( 'Plugins', 'woocommerce' ),
+			'installTheme'             => __( 'Themes', 'woocommerce' ),
+		);
+
+		$settings = array();
+		foreach ( $requested_steps as $step ) {
+			$step_name = $step->meta->alias ?? $step->step;
+			if ( isset( $settings_map[ $step_name ] )
+			&& ! in_array( $settings_map[ $step_name ], $settings, true ) ) {
+				$settings[] = $settings_map[ $step_name ];
+			}
+		}
+
+		return $settings;
+	}
+
+
+
+	/**
 	 * Get the schema for the queue endpoint.
 	 *
 	 * @return array
@@ -492,18 +525,24 @@ class RestApi {
 			'title'      => 'queue',
 			'type'       => 'object',
 			'properties' => array(
-				'reference'     => array(
+				'reference'            => array(
 					'type' => 'string',
 				),
-				'process_nonce' => array(
+				'process_nonce'        => array(
 					'type' => 'string',
 				),
-				'error_type'    => array(
+				'settings_to_override' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+				'error_type'           => array(
 					'type'    => 'string',
 					'default' => null,
 					'enum'    => array( 'upload', 'schema_validation', 'conflict' ),
 				),
-				'errors'        => array(
+				'errors'               => array(
 					'type'  => 'array',
 					'items' => array(
 						'type' => 'string',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53680

This PR adds an Import button to the blueprint page to run the importer.

Upon clicking the Import button, it will show a confirmation modal to confirm the import. If the importer request returns errors, they are displayed to the user if the importer request returns successfully, a success notice is shown.


https://github.com/user-attachments/assets/49a3713f-e222-49c2-bf3e-a31a2d0bd321


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Turn on the blueprint feature flag using WC Test Helper
2. Go to WooCommerce > Settings > Advanced > Blueprint
3. Observe that there is a Blueprint uploader dropzone
4. Scroll down and export a blueprint
5. Drag blueprint.json into the dropzone
6. Click on Import button
7. Confirm the import
8. Observe the success notice

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This feature is behind a feature flag and not intended for public use yet.

</details>
