### PR TITLE
Fix deprecation warnings in email preview in PHP 8.3 (#53787)

### DIFF
--- a/plugins/woocommerce/changelog/email-preview-deprecation-warning
+++ b/plugins/woocommerce/changelog/email-preview-deprecation-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix deprecation warnings in PHP 8.3 in email preview classes

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1236,7 +1236,7 @@ class WC_Email extends WC_Settings_API {
 		$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
 		if ( $is_email_preview ) {
 			$email_id  = $this->id;
-			$transient = get_transient( "woocommerce_${email_id}_${key}" );
+			$transient = get_transient( "woocommerce_{$email_id}_{$key}" );
 			if ( false !== $transient ) {
 				$option = $transient ? $transient : $empty_value;
 			}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -125,9 +125,9 @@ class EmailPreview {
 			return array();
 		}
 		return array(
-			"woocommerce_${email_id}_subject",
-			"woocommerce_${email_id}_heading",
-			"woocommerce_${email_id}_additional_content",
+			"woocommerce_{$email_id}_subject",
+			"woocommerce_{$email_id}_heading",
+			"woocommerce_{$email_id}_additional_content",
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -246,7 +246,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 */
 	public function test_transient_values_in_subject() {
 		$email_id = EmailPreview::DEFAULT_EMAIL_ID;
-		$key      = "woocommerce_${email_id}_subject";
+		$key      = "woocommerce_{$email_id}_subject";
 
 		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
 		$this->assertEquals( $this->sut->get_subject(), 'Your ' . self::SITE_TITLE . ' order has been received!' );
@@ -261,8 +261,8 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 */
 	public function test_transient_values_in_email_content() {
 		$email_id         = EmailPreview::DEFAULT_EMAIL_ID;
-		$heading_key      = "woocommerce_${email_id}_heading";
-		$additional_key   = "woocommerce_${email_id}_additional_content";
+		$heading_key      = "woocommerce_{$email_id}_heading";
+		$additional_key   = "woocommerce_{$email_id}_additional_content";
 		$heading_value    = get_option( $heading_key );
 		$additional_value = get_option( $additional_key );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduced in #53718. Fixes deprecation notice on PHP 8.3. Fixes #53871.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install `WooCommerce 9.6 beta 1` via WooCommerce Beta Tester.
2. Enable `WP_DEBUG` mode (e.g., by installing the `WP Debugging` plugin). 
3. Observe that there is a deprecation notice on every admin page:
```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /srv/htdocs/wp-content/plugins/wc_beta_tester_live_branch_9.7.0-dev-12361349351-g8792124/includes/emails/class-wc-email.php on line 1239
```
4. Install the version from this PR. 
5. Observe that no deprecation notice is present. 

<!-- End testing instructions -->
