### PR TITLE
registerBlockSingleProductTemplate: Fix template switching

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -183,10 +183,10 @@ export class BlockRegistrationManager {
 		}
 
 		this.blocks.forEach( ( config ) => {
-			if ( ! this.hasAttemptedRegistration( config.blockName ) ) {
-				this.unregisterBlock( config );
-				this.registerBlock( config );
-			}
+			// When the template changes, we need to unregister and register all blocks that are available on the new template
+			// Unregistering the block will remove it from the `hasAttemptedRegistration` set, so we can register it again
+			this.unregisterBlock( config );
+			this.registerBlock( config );
 		} );
 	}
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -94,7 +94,11 @@ test.describe( 'registerBlockSingleProductTemplate registers', () => {
 
 		await test.step( 'Switch to Single Product template via command palette', async () => {
 			// Open command palette
-			await page.keyboard.press( 'Meta+K' );
+			if ( process.platform === 'darwin' ) {
+				await page.keyboard.press( 'Meta+K' );
+			} else {
+				await page.keyboard.press( 'Control+K' );
+			}
 
 			const searchInput = page.getByRole( 'combobox', {
 				name: 'Search',

--- a/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -70,6 +70,62 @@ test.describe( 'registerBlockSingleProductTemplate registers', () => {
 		} );
 	} );
 
+	test( 'blocks are registered correctly when switching templates via command palette', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		const blockName = 'woocommerce/product-price';
+
+		await test.step( 'Blocks not available in non-product template', async () => {
+			// Visit site editor with a non-product template
+			await admin.visitSiteEditor( {
+				postId: 'woocommerce/woocommerce//coming-soon',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+
+			// Try to insert the block
+			await editor.insertBlock( { name: blockName } );
+			await expect(
+				await editor.getBlockByName( blockName )
+			).toHaveCount( 0 );
+		} );
+
+		await test.step( 'Switch to Single Product template via command palette', async () => {
+			// Open command palette
+			await page.keyboard.press( 'Meta+K' );
+
+			// Wait for command palette to be visible
+			const searchInput = page.getByRole( 'combobox', {
+				name: 'Search',
+			} );
+			await expect( searchInput ).toBeVisible();
+
+			// Search for and select Single Product template
+			await searchInput.fill( 'Single Product' );
+			const templateOption = page.getByRole( 'option', {
+				name: /Single Product/i,
+			} );
+			await expect( templateOption ).toBeVisible();
+			await templateOption.click();
+
+			await expect(
+				await editor.getBlockByName( 'core/post-title' )
+			).toBeVisible();
+		} );
+
+		await test.step( 'Blocks available after switching to Single Product template', async () => {
+			// Try to insert the block
+			await editor.insertBlock( { name: blockName } );
+
+			// Verify block is now available
+			await expect(
+				await editor.getBlockByName( blockName )
+			).toHaveCount( 1 );
+		} );
+	} );
+
 	test( 'block unavailable on posts, e.g. Product Details', async ( {
 		admin,
 		editor,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -76,7 +76,7 @@ test.describe( 'registerBlockSingleProductTemplate registers', () => {
 		page,
 	} ) => {
 		const blockName = 'woocommerce/product-price';
-
+		const blockTitle = 'Product Price';
 		await test.step( 'Blocks not available in non-product template', async () => {
 			// Visit site editor with a non-product template
 			await admin.visitSiteEditor( {
@@ -96,13 +96,11 @@ test.describe( 'registerBlockSingleProductTemplate registers', () => {
 			// Open command palette
 			await page.keyboard.press( 'Meta+K' );
 
-			// Wait for command palette to be visible
 			const searchInput = page.getByRole( 'combobox', {
 				name: 'Search',
 			} );
 			await expect( searchInput ).toBeVisible();
 
-			// Search for and select Single Product template
 			await searchInput.fill( 'Single Product' );
 			const templateOption = page.getByRole( 'option', {
 				name: /Single Product/i,
@@ -116,10 +114,11 @@ test.describe( 'registerBlockSingleProductTemplate registers', () => {
 		} );
 
 		await test.step( 'Blocks available after switching to Single Product template', async () => {
-			// Try to insert the block
-			await editor.insertBlock( { name: blockName } );
+			await editor.setContent( '' );
 
-			// Verify block is now available
+			// Product Price is available in the global inserter. For some reason, using await editor.insertBlock( { name: blockName } ); does not work here.
+			await editor.insertBlockUsingGlobalInserter( blockTitle );
+
 			await expect(
 				await editor.getBlockByName( blockName )
 			).toHaveCount( 1 );

--- a/plugins/woocommerce/changelog/fix-register-product-blocks-on-template-switch
+++ b/plugins/woocommerce/changelog/fix-register-product-blocks-on-template-switch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the issue with product specific blocks being unavailable when using the command palette to switch between templates


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When switching from a non-Woo template as an entry point, to the Single Product template via the command palette the product blocks were not registered correctly. This is because we had a guard around unregistering/registering them which shouldn't have been present. This PR fixes that issue by removing the guard.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure E2E tests pass
2. Load Site Editor on a template that isn't a WooCommerce one, use CMD+K to switch to the Single Product template
3. Ensure the product blocks are available
4. Load a post, ensure they are still available to insert into the Single Product block

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
