### PR TITLE
Run the build step in CI for release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         id: 'install-monorepo'
         with:
           install: '${{ matrix.projectName }}...'
-          build: ${{ ( github.ref_type == 'tag' && 'false' ) || matrix.projectName }}
+          build: ${{ matrix.projectName }}
           build-type: ${{ ( matrix.testType == 'unit:php' && 'backend' ) || 'full' }}
           pull-playwright-cache: ${{ matrix.testEnv.shouldCreate && ( matrix.testType == 'e2e' || matrix.testType == 'performance' ) }}
           pull-package-deps: '${{ matrix.projectName }}'

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -5,7 +5,7 @@ const testsRootPath = __dirname;
 const testsResultsPath = `${ testsRootPath }/test-results`;
 
 if ( ! process.env.BASE_URL ) {
-	console.log( 'BASE_URL is not set. Using default.' );
+	console.log( 'BASE_URL is not set. Using default' );
 	process.env.BASE_URL = 'http://localhost:8086';
 }
 

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -5,7 +5,7 @@ const testsRootPath = __dirname;
 const testsResultsPath = `${ testsRootPath }/test-results`;
 
 if ( ! process.env.BASE_URL ) {
-	console.log( 'BASE_URL is not set. Using default' );
+	console.log( 'BASE_URL is not set. Using default.' );
 	process.env.BASE_URL = 'http://localhost:8086';
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Core e2e checks for the release package for `9.6 Beta 1` failed because of a missing build step.

The release checks are not building the plugin, because they use the already packaged woocommerce zip from the Github releases. 
The e2e tests did not need a build to run. But since we started using the `e2e-utils-playwright` package a build is necessary for this package.


### How to test the changes in this Pull Request:

Check e2e tests jobs in CI, the `Install Monorepo` step:
1. check [the value for the build input for the step](https://github.com/woocommerce/woocommerce/actions/runs/12411642462/job/34649782604?pr=53880#step:3:11). It should be `build: @woocommerce/plugin-woocommerce`
2. check the step log and make sure the [build](https://github.com/woocommerce/woocommerce/actions/runs/12411642462/job/34649782604?pr=53880#step:3:390) is performed right after the install
