### PR TITLE
Fix the capitalization of "privacy policy" and "terms and conditions"

### DIFF
--- a/plugins/woocommerce/changelog/pr-53883
+++ b/plugins/woocommerce/changelog/pr-53883
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Fix the capitalization of "privacy policy" and "terms and conditions"

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -961,8 +961,8 @@ function wc_privacy_policy_text( $type = 'checkout' ) {
 function wc_replace_policy_page_link_placeholders( $text ) {
 	$privacy_page_id = wc_privacy_policy_page_id();
 	$terms_page_id   = wc_terms_and_conditions_page_id();
-	$privacy_link    = $privacy_page_id ? '<a href="' . esc_url( get_permalink( $privacy_page_id ) ) . '" class="woocommerce-privacy-policy-link" target="_blank">' . __( 'Privacy policy', 'woocommerce' ) . '</a>' : __( 'Privacy policy', 'woocommerce' );
-	$terms_link      = $terms_page_id ? '<a href="' . esc_url( get_permalink( $terms_page_id ) ) . '" class="woocommerce-terms-and-conditions-link" target="_blank">' . __( 'Terms and conditions', 'woocommerce' ) . '</a>' : __( 'Terms and conditions', 'woocommerce' );
+	$privacy_link    = $privacy_page_id ? '<a href="' . esc_url( get_permalink( $privacy_page_id ) ) . '" class="woocommerce-privacy-policy-link" target="_blank">' . __( 'privacy policy', 'woocommerce' ) . '</a>' : __( 'privacy policy', 'woocommerce' );
+	$terms_link      = $terms_page_id ? '<a href="' . esc_url( get_permalink( $terms_page_id ) ) . '" class="woocommerce-terms-and-conditions-link" target="_blank">' . __( 'terms and conditions', 'woocommerce' ) . '</a>' : __( 'terms and conditions', 'woocommerce' );
 
 	$find_replace = array(
 		'[terms]'          => $terms_link,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a revert of https://github.com/woocommerce/woocommerce/pull/52218. As pointed out in https://github.com/woocommerce/woocommerce/pull/52218#issuecomment-2549793322, the "privacy policy" and "terms and conditions" strings must actually be in lower case because they are used inside other strings.


### How to test the changes in this Pull Request:

Run `pnpm run build` in the command line to rebuild the translations, then run the following:

```
wp eval "add_filter('woocommerce_privacy_policy_page_id', fn() => 0);  add_filter('woocommerce_terms_and_conditions_page_id', fn() => 0); echo wc_replace_policy_page_link_placeholders('I understand the [privacy_policy] and agree to the [terms].');"
```

You should get (note the case):

```
I understand the privacy policy and agree to the terms and conditions.
```

Now run this:

```
wp eval "add_filter('woocommerce_privacy_policy_page_id', fn() => 1);  add_filter('woocommerce_terms_and_conditions_page_id', fn() => 1); echo wc_replace_policy_page_link_placeholders('I understand the [privacy_policy] and agree to the [terms].');"
```

And you should get:

```
I understand the <a href="http://localhost/hello-world/" class="woocommerce-privacy-policy-link" target="_blank">privacy policy</a> and agree to the <a href="http://localhost/hello-world/" class="woocommerce-terms-and-conditions-link" target="_blank">terms and conditions</a>.
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
