### PR TITLE
Update `applyExtensionCartUpdate` to always return response

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -125,6 +125,7 @@ export const applyExtensionCartUpdate =
 				return response;
 			}
 			dispatch.receiveCart( response );
+			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			return Promise.reject( error );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/checkout/checkout-block-extensibility.shopper.block_theme.spec.ts
@@ -41,6 +41,47 @@ test.describe( 'Shopper → Extensibility', () => {
 		await frontendUtils.goToCheckout();
 	} );
 	test.describe( 'extensionCartUpdate', () => {
+		test( 'Response is not undefined in any code path', async ( {
+			checkoutPageObject,
+		} ) => {
+			// With no additional args.
+			let response = await checkoutPageObject.page.evaluate(
+				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update' } ).then( ( response ) => response );"
+			);
+			let resolvedResponse = await Promise.resolve( response );
+			expect( resolvedResponse ).not.toBeUndefined();
+			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
+
+			// With overwriteDirtyCustomerData true.
+			response = await checkoutPageObject.page.evaluate(
+				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: true } ).then( ( response ) => response );"
+			);
+			resolvedResponse = await Promise.resolve( response );
+			expect( resolvedResponse ).not.toBeUndefined();
+			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
+
+			// With overwriteDirtyCustomerData false.
+			response = await checkoutPageObject.page.evaluate(
+				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update', overwriteDirtyCustomerData: false } ).then( ( response ) => response );"
+			);
+			resolvedResponse = await Promise.resolve( response );
+			expect( resolvedResponse ).not.toBeUndefined();
+			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
+
+			// With a dirty customer object.
+			await checkoutPageObject.page
+				.getByLabel( 'Country/Region' )
+				.selectOption( 'United Kingdom (UK)' );
+			await expect(
+				checkoutPageObject.page.getByLabel( 'Country/Region' )
+			).toHaveValue( 'GB' );
+			response = await checkoutPageObject.page.evaluate(
+				"wc.blocksCheckout.extensionCartUpdate( { namespace: 'woocommerce-blocks-test-extension-cart-update' } ).then( ( response ) => response );"
+			);
+			resolvedResponse = await Promise.resolve( response );
+			expect( resolvedResponse ).not.toBeUndefined();
+			expect( resolvedResponse ).toHaveProperty( 'billing_address' );
+		} );
 		test( 'Unpushed data is/is not overwritten depending on arg', async ( {
 			checkoutPageObject,
 		} ) => {

--- a/plugins/woocommerce/changelog/fix-extension-cart-update-args
+++ b/plugins/woocommerce/changelog/fix-extension-cart-update-args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue where extensionCartUpdate would return undefined if not overwriting dirty customer data.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/49311/files#diff-104ed0ccbbe914c26add1fcc3f567985816b8ab4653855eea51dc4247811322dL103 we removed the `return response;` line - this wouldn't have been a problem if the args had `overwriteDirtyCustomerData` set to `true` by default, but in the case that customer data wasn't dirty, response was not returned.

This PR ensures response is always returned.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following code to be executed server-side:

```php
use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
use Automattic\WooCommerce\StoreApi\StoreApi;

add_action(
	'woocommerce_init',
	function () {
		$extend = StoreApi::container()->get( ExtendSchema::class );
		if (
			is_callable(
				array(
					$extend,
					'register_update_callback',
				)
			)
		) {
			$extend->register_update_callback(
				array(
					'namespace' => 'woocommerce-blocks-test-extension-cart-update',
					'callback'  => function ( $data ) {
						if ( ! empty( $data['test-name-change'] ) ) {
							WC()->cart->get_customer()->set_shipping_first_name( 'Mr. Test' );
							WC()->cart->get_customer()->save();
						}
					},
				)
			);
		}
	}
);
```

2. Go to the Checkout block and open the JS console. Execute the following code:

```js
wc.blocksCheckout.extensionCartUpdate( {
        namespace: 'woocommerce-blocks-test-extension-cart-update',
		overwriteDirtyCustomerData: true,
        cartPropsToReceive: [ 'extensions' ],
    } ).then( ( response ) => {
        console.log( { response } );
    } ).catch( ( error ) => {
        console.error( { error } );
    } );
```

3. Ensure the response is logged correctly, and that you don't see `undefined` as the response, the response should contain the cart data.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
