### PR TITLE
Update reference to "invoice", replace with "order details".

### DIFF
--- a/plugins/woocommerce/changelog/fix-53889-invoice-vs-order-details
+++ b/plugins/woocommerce/changelog/fix-53889-invoice-vs-order-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update some of the language in our order emails to reference 'order details' instead of 'invoice'.

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.6.0
+ * @version 9.7.0
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
@@ -52,7 +52,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		printf(
 			wp_kses(
 			/* translators: %1$s Site title, %2$s Order pay link */
-				__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
+				__( 'An order has been created for you on %1$s. Your order details are below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
 				array(
 					'a' => array(
 						'href' => array(),

--- a/plugins/woocommerce/templates/emails/plain/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.6.0
+ * @version 9.7.0
  */
 
 // phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found, Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed -- Plain text output needs specific spacing without tabs
@@ -42,7 +42,7 @@ if ( $order->needs_payment() ) {
 		echo wp_kses_post(
 			sprintf(
 				/* translators: %1$s: Site title, %2$s: Order pay link */
-				__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
+				__( 'An order has been created for you on %1$s. Your order details are below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
 				esc_html( get_bloginfo( 'name', 'display' ) ),
 				esc_url( $order->get_checkout_payment_url() )
 			)


### PR DESCRIPTION
As @webdados highlighed, we previously updated the language we use in various locations to prefer generic terms like *'order details'* instead of *'invoice'* (since the latter has a specific legal meaning in some geographies that we may not have been satisfying).

However, there are some spots that we missed, such as in the `customer-invoice` email. To that end, we are changing the following sentence:

```
An order has been created for you on <blogname>. Your invoice is below, with a link to make payment when you’re ready: <url>
```

To:

```
An order has been created for you on <blogname>. Your order details are below, with a link to make payment when you’re ready: <url>
```

Note that this wording had already been adopted within the same template, but for cases where the order failed. So, this further update is really just for consistency.

Closes #53889.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

To test this, you will need a suitable tool or plugin that allows you to "catch" and view any emails that have been sent. There are lots of good options out there, but if in doubt you can check out [Email Log](https://wordpress.org/plugins/email-log/).

1. Start with an existing order, or create a new one.
2. Modify it if necessary, so that the status is **pending payment**.
3. Trigger the `customer-invoice` email by selecting **send order details to customer** from the order actions menu:

![order-email-setup](https://github.com/user-attachments/assets/01408644-a45e-4bae-8a95-15fc5d7dfaca)

4. Review the email that was sent. It should not include any references to an invoice:

<div align="center"><img src="https://github.com/user-attachments/assets/94ae35e5-c811-42d2-9a78-073039572519" alt="Updated customer invoice email" width="600"></div>

5. Note that there are both plain text and HTML versions of the email, so please verify that the change to the wording is present in both.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
