### PR TITLE
[Experimental] Add mechanism to upgrade/downgrade between Add to Cart with Options block versions

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
+import { createBlock } from '@wordpress/blocks';
+import { dispatch, select } from '@wordpress/data';
+import { findBlock } from '@woocommerce/utils';
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../../block.json';
+
+const downgradeToClassicAddtoCartWithOptions = () => {
+	const blocks = select( 'core/block-editor' ).getBlocks();
+	const foundBlock = findBlock( {
+		blocks,
+		findCondition: ( block ) => block.name === metadata.name,
+	} );
+
+	if ( ! foundBlock ) {
+		return;
+	}
+
+	const foundQuantitySelectorBlock = findBlock( {
+		blocks,
+		findCondition: ( block ) =>
+			block.name ===
+			'woocommerce/add-to-cart-with-options-quantity-selector',
+	} );
+
+	const newBlock = createBlock( 'woocommerce/add-to-cart-form', {
+		quantitySelectorStyle:
+			foundQuantitySelectorBlock?.attributes?.quantitySelectorStyle ||
+			'input',
+	} );
+
+	dispatch( 'core/block-editor' ).replaceBlock(
+		foundBlock.clientId,
+		newBlock
+	);
+};
+
+export const DowngradeNotice = () => {
+	const notice = __(
+		'Switch back to the classic Add to Cart with Options block.',
+		'woocommerce'
+	);
+
+	const buttonLabel = __(
+		'Switch back to the classic Add to Cart with Options block.',
+		'woocommerce'
+	);
+
+	const handleClick = () => {
+		downgradeToClassicAddtoCartWithOptions();
+		recordEvent( 'blocks_add_to_cart_with_options_migration', {
+			transform_to: 'legacy',
+		} );
+	};
+
+	return (
+		<Notice isDismissible={ false }>
+			<>{ notice }</>
+			<br />
+			<br />
+			<Button variant="link" onClick={ handleClick }>
+				{ buttonLabel }
+			</Button>
+		</Notice>
+	);
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -22,7 +22,7 @@ const downgradeToClassicAddtoCartWithOptions = ( blockClientId: string ) => {
 	} );
 
 	if ( ! foundBlock ) {
-		return;
+		return false;
 	}
 
 	const foundQuantitySelectorBlock = findBlock( {
@@ -42,6 +42,8 @@ const downgradeToClassicAddtoCartWithOptions = ( blockClientId: string ) => {
 		foundBlock.clientId,
 		newBlock
 	);
+
+	return true;
 };
 
 export const DowngradeNotice = ( {
@@ -56,11 +58,15 @@ export const DowngradeNotice = ( {
 
 	const buttonLabel = __( 'Switch back', 'woocommerce' );
 
-	const handleClick = () => {
-		downgradeToClassicAddtoCartWithOptions( blockClientId );
-		recordEvent( 'blocks_add_to_cart_with_options_migration', {
-			transform_to: 'legacy',
-		} );
+	const handleClick = async () => {
+		const downgraded = await downgradeToClassicAddtoCartWithOptions(
+			blockClientId
+		);
+		if ( downgraded ) {
+			recordEvent( 'blocks_add_to_cart_with_options_migration', {
+				transform_to: 'legacy',
+			} );
+		}
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Notice, Button } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { createBlock } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
@@ -14,11 +13,12 @@ import { findBlock } from '@woocommerce/utils';
  */
 import metadata from '../../block.json';
 
-const downgradeToClassicAddtoCartWithOptions = () => {
+const downgradeToClassicAddtoCartWithOptions = ( blockClientId: string ) => {
 	const blocks = select( 'core/block-editor' ).getBlocks();
 	const foundBlock = findBlock( {
 		blocks,
-		findCondition: ( block ) => block.name === metadata.name,
+		findCondition: ( block ) =>
+			block.name === metadata.name && block.clientId === blockClientId,
 	} );
 
 	if ( ! foundBlock ) {
@@ -44,19 +44,20 @@ const downgradeToClassicAddtoCartWithOptions = () => {
 	);
 };
 
-export const DowngradeNotice = () => {
+export const DowngradeNotice = ( {
+	blockClientId,
+}: {
+	blockClientId: string;
+} ) => {
 	const notice = __(
 		'Switch back to the classic Add to Cart with Options block.',
 		'woocommerce'
 	);
 
-	const buttonLabel = __(
-		'Switch back to the classic Add to Cart with Options block.',
-		'woocommerce'
-	);
+	const buttonLabel = __( 'Switch back', 'woocommerce' );
 
 	const handleClick = () => {
-		downgradeToClassicAddtoCartWithOptions();
+		downgradeToClassicAddtoCartWithOptions( blockClientId );
 		recordEvent( 'blocks_add_to_cart_with_options_migration', {
 			transform_to: 'legacy',
 		} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -13,7 +13,7 @@ import { findBlock } from '@woocommerce/utils';
  */
 import metadata from '../../block.json';
 
-const downgradeToClassicAddtoCartWithOptions = ( blockClientId: string ) => {
+const downgradeToClassicAddToCartWithOptions = ( blockClientId: string ) => {
 	const blocks = select( 'core/block-editor' ).getBlocks();
 	const foundBlock = findBlock( {
 		blocks,
@@ -59,7 +59,7 @@ export const DowngradeNotice = ( {
 	const buttonLabel = __( 'Switch back', 'woocommerce' );
 
 	const handleClick = async () => {
-		const downgraded = await downgradeToClassicAddtoCartWithOptions(
+		const downgraded = await downgradeToClassicAddToCartWithOptions(
 			blockClientId
 		);
 		if ( downgraded ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -5,11 +5,11 @@ import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
 	InnerBlocks,
+	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import type { InnerBlockTemplate } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -17,6 +17,8 @@ import type { InnerBlockTemplate } from '@wordpress/blocks';
 import { useIsDescendentOfSingleProductBlock } from '../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { AddToCartOptionsSettings } from './settings';
 import ToolbarProductTypeGroup from './components/toolbar-type-product-selector-group';
+import { DowngradeNotice } from './components/downgrade-notice';
+import getInnerBlocksTemplate from './utils/get-inner-blocks-template';
 import useProductTypeSelector from './hooks/use-product-type-selector';
 
 export interface Attributes {
@@ -31,26 +33,6 @@ export type FeaturesProps = {
 };
 
 export type UpdateFeaturesType = ( key: FeaturesKeys, value: boolean ) => void;
-
-const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
-	[
-		'core/heading',
-		{
-			level: 2,
-			content: __( 'Add to Cart', 'woocommerce' ),
-		},
-	],
-	[ 'woocommerce/add-to-cart-with-options-variation-selector' ],
-	[ 'woocommerce/product-stock-indicator' ],
-	[ 'woocommerce/add-to-cart-with-options-quantity-selector' ],
-	[
-		'woocommerce/product-button',
-		{
-			textAlign: 'center',
-			fontSize: 'small',
-		},
-	],
-];
 
 const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
@@ -80,12 +62,16 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 		unregisterListener,
 	] );
 
+	const innerBlocksTemplate = getInnerBlocksTemplate();
+
 	return (
 		<>
+			<InspectorControls>
+				<DowngradeNotice />
+			</InspectorControls>
 			<BlockControls>
 				<ToolbarProductTypeGroup />
 			</BlockControls>
-
 			<AddToCartOptionsSettings
 				features={ {
 					isBlockifiedAddToCart: true,
@@ -93,7 +79,7 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 			/>
 
 			<div { ...blockProps }>
-				<InnerBlocks template={ INNER_BLOCKS_TEMPLATE } />
+				<InnerBlocks template={ innerBlocksTemplate } />
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -9,7 +9,6 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -67,7 +67,7 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	return (
 		<>
 			<InspectorControls>
-				<DowngradeNotice />
+				<DowngradeNotice blockClientId={ props?.clientId } />
 			</InspectorControls>
 			<BlockControls>
 				<ToolbarProductTypeGroup />

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -25,10 +25,10 @@ const isBlockifiedAddToCart = getSettingWithCoercion(
 	isBoolean
 );
 
-export const shouldBlockifiedAddtoCartWithOptionsBeRegistered =
+export const shouldBlockifiedAddToCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
-if ( shouldBlockifiedAddtoCartWithOptionsBeRegistered ) {
+if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	registerStore();
 
 	// Register a plugin that adds a product type selector to the template sidebar.

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -25,10 +25,10 @@ const isBlockifiedAddToCart = getSettingWithCoercion(
 	isBoolean
 );
 
-export const shouldRegisterBlock =
+export const shouldBlockifiedAddtoCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
-if ( shouldRegisterBlock ) {
+if ( shouldBlockifiedAddtoCartWithOptionsBeRegistered ) {
 	registerStore();
 
 	// Register a plugin that adds a product type selector to the template sidebar.

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
@@ -9,12 +9,12 @@ import { Icon, button } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import AddToCartWithOptionsQuantitySelectorEdit from './edit';
-import { shouldRegisterBlock } from '..';
+import { shouldBlockifiedAddtoCartWithOptionsBeRegistered } from '..';
 import '../../../base/components/quantity-selector/style.scss';
 import './style.scss';
 import './editor.scss';
 
-if ( shouldRegisterBlock ) {
+if ( shouldBlockifiedAddtoCartWithOptionsBeRegistered ) {
 	registerBlockType( metadata, {
 		edit: AddToCartWithOptionsQuantitySelectorEdit,
 		attributes: metadata.attributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/index.tsx
@@ -9,12 +9,12 @@ import { Icon, button } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import AddToCartWithOptionsQuantitySelectorEdit from './edit';
-import { shouldBlockifiedAddtoCartWithOptionsBeRegistered } from '..';
+import { shouldBlockifiedAddToCartWithOptionsBeRegistered } from '..';
 import '../../../base/components/quantity-selector/style.scss';
 import './style.scss';
 import './editor.scss';
 
-if ( shouldBlockifiedAddtoCartWithOptionsBeRegistered ) {
+if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	registerBlockType( metadata, {
 		edit: AddToCartWithOptionsQuantitySelectorEdit,
 		attributes: metadata.attributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -2,3 +2,5 @@ export type ProductTypeProps = {
 	slug: string;
 	label: string;
 };
+
+export type QuantitySelectorStyleProps = 'input' | 'stepper';

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-inner-blocks-template/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/utils/get-inner-blocks-template/index.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { InnerBlockTemplate } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { QuantitySelectorStyleProps } from '../../types';
+
+const getInnerBlocksTemplate = (
+	quantitySelectorStyle: QuantitySelectorStyleProps = 'input'
+) => {
+	const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
+		[
+			'core/heading',
+			{
+				level: 2,
+				content: __( 'Add to Cart', 'woocommerce' ),
+			},
+		],
+		[ 'woocommerce/add-to-cart-with-options-variation-selector' ],
+		[ 'woocommerce/product-stock-indicator' ],
+		[
+			'woocommerce/add-to-cart-with-options-quantity-selector',
+			{
+				quantitySelectorStyle,
+			},
+		],
+		[
+			'woocommerce/product-button',
+			{
+				textAlign: 'center',
+				fontSize: 'small',
+			},
+		],
+	];
+
+	return INNER_BLOCKS_TEMPLATE;
+};
+
+export default getInnerBlocksTemplate;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/index.tsx
@@ -9,11 +9,11 @@ import { Icon, button } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import AddToCartWithOptionsVariationSelectorEdit from './edit';
-import { shouldRegisterBlock } from '..';
+import { shouldBlockifiedAddToCartWithOptionsBeRegistered } from '..';
 import './style.scss';
 import './editor.scss';
 
-if ( shouldRegisterBlock ) {
+if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	registerBlockType( metadata, {
 		edit: AddToCartWithOptionsVariationSelectorEdit,
 		attributes: metadata.attributes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
+import { dispatch, select } from '@wordpress/data';
+import { findBlock } from '@woocommerce/utils';
+import {
+	createBlock,
+	// @ts-expect-error Type definitions for this function are missing in Gutenberg
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../../block.json';
+import getInnerBlocksTemplate from '../../../../add-to-cart-with-options/utils/get-inner-blocks-template';
+
+const upgradeToBlockifiedAddtoCartWithOptions = async () => {
+	const blocks = select( 'core/block-editor' ).getBlocks();
+	const foundBlock = findBlock( {
+		blocks,
+		findCondition: ( block ) => block.name === metadata.name,
+	} );
+
+	if ( ! foundBlock ) {
+		return;
+	}
+
+	const newBlock = createBlock(
+		'woocommerce/add-to-cart-with-options',
+		{
+			isDescendentOfSingleProductBlock:
+				foundBlock.attributes.isDescendentOfSingleProductBlock,
+		},
+		createBlocksFromInnerBlocksTemplate(
+			getInnerBlocksTemplate(
+				foundBlock.attributes.quantitySelectorStyle
+			)
+		)
+	);
+	dispatch( 'core/block-editor' ).replaceBlock(
+		foundBlock.clientId,
+		newBlock
+	);
+};
+
+export const UpgradeNotice = () => {
+	const notice = createInterpolateElement(
+		__(
+			'Upgrade Add to Cart with Options blocks on this page to <strongText /> for more features!',
+			'woocommerce'
+		),
+		{
+			strongText: (
+				<strong>
+					{ __( `a new blockified experience`, 'woocommerce' ) }
+				</strong>
+			),
+		}
+	);
+
+	const buttonLabel = __(
+		'Upgrade to the blockified Add to Cart with Options block',
+		'woocommerce'
+	);
+
+	const handleClick = () => {
+		upgradeToBlockifiedAddtoCartWithOptions();
+		recordEvent( 'blocks_add_to_cart_with_options_migration', {
+			transform_to: 'blockified',
+		} );
+	};
+
+	return (
+		<Notice isDismissible={ false }>
+			<>{ notice }</>
+			<br />
+			<br />
+			<Button variant="link" onClick={ handleClick }>
+				{ buttonLabel }
+			</Button>
+		</Notice>
+	);
+};

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -30,7 +30,7 @@ const upgradeToBlockifiedAddtoCartWithOptions = async (
 	} );
 
 	if ( ! foundBlock ) {
-		return;
+		return false;
 	}
 
 	const newBlock = createBlock(
@@ -49,6 +49,8 @@ const upgradeToBlockifiedAddtoCartWithOptions = async (
 		foundBlock.clientId,
 		newBlock
 	);
+
+	return true;
 };
 
 export const UpgradeNotice = ( {
@@ -75,11 +77,15 @@ export const UpgradeNotice = ( {
 		'woocommerce'
 	);
 
-	const handleClick = () => {
-		upgradeToBlockifiedAddtoCartWithOptions( blockClientId );
-		recordEvent( 'blocks_add_to_cart_with_options_migration', {
-			transform_to: 'blockified',
-		} );
+	const handleClick = async () => {
+		const upgraded = await upgradeToBlockifiedAddtoCartWithOptions(
+			blockClientId
+		);
+		if ( upgraded ) {
+			recordEvent( 'blocks_add_to_cart_with_options_migration', {
+				transform_to: 'blockified',
+			} );
+		}
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -19,7 +19,7 @@ import {
 import metadata from '../../block.json';
 import getInnerBlocksTemplate from '../../../../add-to-cart-with-options/utils/get-inner-blocks-template';
 
-const upgradeToBlockifiedAddtoCartWithOptions = async (
+const upgradeToBlockifiedAddToCartWithOptions = async (
 	blockClientId: string
 ) => {
 	const blocks = select( 'core/block-editor' ).getBlocks();
@@ -78,7 +78,7 @@ export const UpgradeNotice = ( {
 	);
 
 	const handleClick = async () => {
-		const upgraded = await upgradeToBlockifiedAddtoCartWithOptions(
+		const upgraded = await upgradeToBlockifiedAddToCartWithOptions(
 			blockClientId
 		);
 		if ( upgraded ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -19,11 +19,14 @@ import {
 import metadata from '../../block.json';
 import getInnerBlocksTemplate from '../../../../add-to-cart-with-options/utils/get-inner-blocks-template';
 
-const upgradeToBlockifiedAddtoCartWithOptions = async () => {
+const upgradeToBlockifiedAddtoCartWithOptions = async (
+	blockClientId: string
+) => {
 	const blocks = select( 'core/block-editor' ).getBlocks();
 	const foundBlock = findBlock( {
 		blocks,
-		findCondition: ( block ) => block.name === metadata.name,
+		findCondition: ( block ) =>
+			block.name === metadata.name && block.clientId === blockClientId,
 	} );
 
 	if ( ! foundBlock ) {
@@ -48,10 +51,14 @@ const upgradeToBlockifiedAddtoCartWithOptions = async () => {
 	);
 };
 
-export const UpgradeNotice = () => {
+export const UpgradeNotice = ( {
+	blockClientId,
+}: {
+	blockClientId: string;
+} ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade Add to Cart with Options blocks on this page to <strongText /> for more features!',
+			'Upgrade the Add to Cart with Options block to <strongText /> for more features!',
 			'woocommerce'
 		),
 		{
@@ -69,7 +76,7 @@ export const UpgradeNotice = () => {
 	);
 
 	const handleClick = () => {
-		upgradeToBlockifiedAddtoCartWithOptions();
+		upgradeToBlockifiedAddtoCartWithOptions( blockClientId );
 		recordEvent( 'blocks_add_to_cart_with_options_migration', {
 			transform_to: 'blockified',
 		} );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Skeleton } from '@woocommerce/base-components/skeleton';
 import { BlockEditProps } from '@wordpress/blocks';
@@ -18,6 +18,8 @@ import { isBoolean } from '@woocommerce/types';
 import './editor.scss';
 import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { QuantitySelectorStyle, AddToCartFormSettings } from './settings';
+import { shouldBlockifiedAddtoCartWithOptionsBeRegistered } from '../../add-to-cart-with-options';
+import { UpgradeNotice } from './components/upgrade-notice';
 
 export interface Attributes {
 	className?: string;
@@ -78,6 +80,11 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 
 	return (
 		<>
+			{ shouldBlockifiedAddtoCartWithOptionsBeRegistered && (
+				<InspectorControls>
+					<UpgradeNotice />
+				</InspectorControls>
+			) }
 			<AddToCartFormSettings
 				quantitySelectorStyle={ props.attributes.quantitySelectorStyle }
 				setAttributes={ setAttributes }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -82,7 +82,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 		<>
 			{ shouldBlockifiedAddtoCartWithOptionsBeRegistered && (
 				<InspectorControls>
-					<UpgradeNotice />
+					<UpgradeNotice blockClientId={ props?.clientId } />
 				</InspectorControls>
 			) }
 			<AddToCartFormSettings

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -18,7 +18,7 @@ import { isBoolean } from '@woocommerce/types';
 import './editor.scss';
 import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { QuantitySelectorStyle, AddToCartFormSettings } from './settings';
-import { shouldBlockifiedAddtoCartWithOptionsBeRegistered } from '../../add-to-cart-with-options';
+import { shouldBlockifiedAddToCartWithOptionsBeRegistered } from '../../add-to-cart-with-options';
 import { UpgradeNotice } from './components/upgrade-notice';
 
 export interface Attributes {
@@ -80,7 +80,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 
 	return (
 		<>
-			{ shouldBlockifiedAddtoCartWithOptionsBeRegistered && (
+			{ shouldBlockifiedAddToCartWithOptionsBeRegistered && (
 				<InspectorControls>
 					<UpgradeNotice blockClientId={ props?.clientId } />
 				</InspectorControls>

--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -500,9 +500,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		);
 		await editor.selectBlocks( addToCartWithOptionsBlock );
 
-		await page
-			.getByRole( 'button', { name: 'Switch back to the classic' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Switch back' } ).click();
 
 		await expect(
 			editor.canvas.getByLabel(

--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -463,4 +463,51 @@ test.describe( `${ blockData.name } Block`, () => {
 			expect( eventFired ).toBeUndefined();
 		} );
 	} );
+
+	test( 'can be migrated to the blockified Add to Cart with Options block', async ( {
+		page,
+		editor,
+		blockUtils,
+		admin,
+		requestUtils,
+	} ) => {
+		await requestUtils.setFeatureFlag( 'experimental-blocks', true );
+		await requestUtils.setFeatureFlag( 'blockified-add-to-cart', true );
+
+		await admin.createNewPost();
+		await editor.insertBlock( { name: 'woocommerce/single-product' } );
+
+		const productName = 'Hoodie with Logo';
+		await blockUtils.configureSingleProductBlock( productName );
+
+		const addToCartFormBlock = await editor.getBlockByName(
+			'woocommerce/add-to-cart-form'
+		);
+		await editor.selectBlocks( addToCartFormBlock );
+
+		await page
+			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.click();
+
+		await expect(
+			editor.canvas.getByLabel(
+				'Block: Quantity Selector (Experimental)'
+			)
+		).toBeVisible();
+
+		const addToCartWithOptionsBlock = await editor.getBlockByName(
+			'woocommerce/add-to-cart-with-options'
+		);
+		await editor.selectBlocks( addToCartWithOptionsBlock );
+
+		await page
+			.getByRole( 'button', { name: 'Switch back to the classic' } )
+			.click();
+
+		await expect(
+			editor.canvas.getByLabel(
+				'Block: Quantity Selector (Experimental)'
+			)
+		).toBeHidden();
+	} );
 } );

--- a/plugins/woocommerce/changelog/fix-53208-upgrade-downgrade
+++ b/plugins/woocommerce/changelog/fix-53208-upgrade-downgrade
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add mechanism to upgrade/downgrade between Add to Cart with Options block versions
+
+


### PR DESCRIPTION
Closes #53208.

### How to test the changes in this Pull Request:

1. Install and activate the `WooCommerce Beta Tester` plugin
2. Go to `WooCommerce Admin Test Helper` -> `Features` and enable `blockified-add-to-cart` and `add-to-cart-with-options-stepper-layout`.
2. Create a post or page and add the Single Product block.
3. Select the existing _Add to Cart with Options_ block.
4. Verify in the sidebar there is a notice with a button to update. Click on it and verify it switches the block to the blockified version.
5. Do the same to switch back.
6. Try changing the display style to "Stepper" mode and verify it's preserved.
