### PR TITLE
[WC Payments NOX] Fix WooPayments PMs logos list

### DIFF
--- a/packages/js/onboarding/changelog/update-woopayments-methods-logos-component
+++ b/packages/js/onboarding/changelog/update-woopayments-methods-logos-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improved the WooPaymentsMethodsLogos component to support provided breakpoints and number of methods shown for those.

--- a/packages/js/onboarding/src/components/WCPayBanner/WCPayBanner.tsx
+++ b/packages/js/onboarding/src/components/WCPayBanner/WCPayBanner.tsx
@@ -13,7 +13,7 @@ import { Text } from '@woocommerce/experimental';
 /**
  * Internal dependencies
  */
-import { WooPaymentMethodsLogos } from '../WooPaymentsMethodsLogos';
+import { WooPaymentsMethodsLogos } from '../WooPaymentsMethodsLogos';
 import { WCPayBannerImage } from './WCPayBannerImage';
 
 export const WCPayBannerFooter: React.VFC< {
@@ -28,7 +28,7 @@ export const WCPayBannerFooter: React.VFC< {
 				) }
 			</Text>
 		</div>
-		<WooPaymentMethodsLogos
+		<WooPaymentsMethodsLogos
 			isWooPayEligible={ isWooPayEligible }
 			maxElements={ 10 }
 		/>

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
@@ -69,7 +69,7 @@ const PaymentMethods = [
 	},
 ];
 
-export const WooPaymentMethodsLogos: React.VFC< {
+export const WooPaymentsMethodsLogos: React.VFC< {
 	isWooPayEligible: boolean;
 	maxElements: number;
 	tabletWidthBreakpoint?: number;

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
@@ -20,7 +20,7 @@ import Affirm from '../../images/payment-methods/affirm';
 import Klarna from '../../images/payment-methods/klarna';
 
 /**
- * Payment methods logos
+ * Payment methods list.
  */
 const PaymentMethods = [
 	{
@@ -69,27 +69,59 @@ const PaymentMethods = [
 	},
 ];
 
-// Maximum number of logos to be displayed on a mobile screen.
-const maxElementsMobile = 5;
-// Maximum number of logos to be displayed on a tablet screen.
-const maxElementsTablet = 7;
-// Maximum number of logos to be displayed on a desktop screen.
-const maxElementsDesktop = 10;
-// Total number of available payment methods from https://woocommerce.com/document/woopayments/payment-methods.
-const totalPaymentMethods = 20;
-
 export const WooPaymentMethodsLogos: React.VFC< {
 	isWooPayEligible: boolean;
 	maxElements: number;
-} > = ( { isWooPayEligible = false, maxElements = maxElementsDesktop } ) => {
+	tabletWidthBreakpoint?: number;
+	maxElementsTablet?: number;
+	mobileWidthBreakpoint?: number;
+	maxElementsMobile?: number;
+	totalPaymentMethods?: number;
+} > = ( {
+	/**
+	 * Whether the store (location) is eligible for WooPay.
+	 * Based on this we will include or not the WooPay logo in the list.
+	 */
+	isWooPayEligible = false,
+	/**
+	 * Maximum number of logos to be displayed (on a desktop screen).
+	 */
+	maxElements = 10,
+	/**
+	 * Breakpoint at which the number of logos to display changes to the tablet layout.
+	 */
+	tabletWidthBreakpoint = 768,
+	/**
+	 * Maximum number of logos to be displayed on a tablet screen.
+	 */
+	maxElementsTablet = 7,
+	/**
+	 * Breakpoint at which the number of logos to display changes to the mobile layout.
+	 */
+	mobileWidthBreakpoint = 480,
+	/**
+	 * Maximum number of logos to be displayed on a mobile screen.
+	 */
+	maxElementsMobile = 5,
+	/**
+	 * Total number of payment methods that WooPayments supports.
+	 * The default is set according to https://woocommerce.com/document/woopayments/payment-methods.
+	 * If not eligible for WooPay, the total number of payment methods is reduced by one.
+	 */
+	totalPaymentMethods = 20,
+} ) => {
 	const [ maxShownElements, setMaxShownElements ] = useState( maxElements );
 
-	// Determine the maximum number of logos to display, taking into account WooPay’s eligibility.
-	const getMaxShownElements = (
-		maxElementsNumber: number,
-		isWooPayAvailable: boolean
-	) => {
-		if ( ! isWooPayAvailable ) {
+	// Reduce the total number of payment methods by one if the store is not eligible for WooPay.
+	const maxSupportedPaymentMethods = isWooPayEligible
+		? totalPaymentMethods
+		: totalPaymentMethods - 1;
+
+	/**
+	 * Determine the maximum number of logos to display, taking into account WooPay’s eligibility.
+	 */
+	const getMaxShownElements = ( maxElementsNumber: number ) => {
+		if ( ! isWooPayEligible ) {
 			return maxElementsNumber + 1;
 		}
 
@@ -98,9 +130,9 @@ export const WooPaymentMethodsLogos: React.VFC< {
 
 	useEffect( () => {
 		const updateMaxElements = () => {
-			if ( window.innerWidth <= 480 ) {
+			if ( window.innerWidth <= mobileWidthBreakpoint ) {
 				setMaxShownElements( maxElementsMobile );
-			} else if ( window.innerWidth <= 768 ) {
+			} else if ( window.innerWidth <= tabletWidthBreakpoint ) {
 				setMaxShownElements( maxElementsTablet );
 			} else {
 				setMaxShownElements( maxElements );
@@ -109,29 +141,38 @@ export const WooPaymentMethodsLogos: React.VFC< {
 
 		updateMaxElements();
 
+		// Update the number of logos to display when the window is resized.
 		window.addEventListener( 'resize', updateMaxElements );
 
+		// Cleanup on unmount.
 		return () => {
 			window.removeEventListener( 'resize', updateMaxElements );
 		};
-	}, [ maxElements ] );
+	}, [
+		maxElements,
+		maxElementsMobile,
+		maxElementsTablet,
+		tabletWidthBreakpoint,
+		mobileWidthBreakpoint,
+	] );
 
 	return (
 		<>
 			<div className="woocommerce-woopayments-payment-methods-logos">
 				{ PaymentMethods.slice(
 					0,
-					getMaxShownElements( maxShownElements, isWooPayEligible )
+					getMaxShownElements( maxShownElements )
 				).map( ( pm ) => {
+					// Do not display the WooPay logo if the store is not eligible for WooPay.
 					if ( ! isWooPayEligible && pm.name === 'woopay' ) {
 						return null;
 					}
 
 					return pm.component;
 				} ) }
-				{ maxShownElements < totalPaymentMethods && (
+				{ maxShownElements < maxSupportedPaymentMethods && (
 					<div className="woocommerce-woopayments-payment-methods-logos-count">
-						+ { totalPaymentMethods - maxShownElements }
+						+ { maxSupportedPaymentMethods - maxShownElements }
 					</div>
 				) }
 			</div>

--- a/packages/js/onboarding/src/index.ts
+++ b/packages/js/onboarding/src/index.ts
@@ -30,4 +30,4 @@ export { WooOnboardingTaskListHeader } from './components/WooOnboardingTaskListH
 export { WooOnboardingTask } from './components/WooOnboardingTask';
 export * from './utils/countries';
 export { Loader } from './components/Loader';
-export { WooPaymentMethodsLogos } from './components/WooPaymentsMethodsLogos';
+export { WooPaymentsMethodsLogos } from './components/WooPaymentsMethodsLogos';

--- a/plugins/woocommerce/changelog/update-nox-fix-woopayments-pms-logos-list
+++ b/plugins/woocommerce/changelog/update-nox-fix-woopayments-pms-logos-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the behavior of the WooPayments PMs logos list on the new Payments settings page.

--- a/plugins/woocommerce/client/admin/client/payments-welcome/banner.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/banner.tsx
@@ -3,7 +3,7 @@
  */
 import { Card, CardBody, Button, CardDivider } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { WooPaymentMethodsLogos } from '@woocommerce/onboarding';
+import { WooPaymentsMethodsLogos } from '@woocommerce/onboarding';
 
 /**
  * Internal dependencies
@@ -76,7 +76,7 @@ const Banner: React.FC< Props > = ( { isSubmitted, handleSetup } ) => {
 			<CardDivider />
 			<CardBody className="woopayments-welcome-page__payments">
 				<p>{ strings.paymentOptions }</p>
-				<WooPaymentMethodsLogos
+				<WooPaymentsMethodsLogos
 					isWooPayEligible={ isWooPayEligible }
 					maxElements={ 10 }
 				/>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
@@ -18,6 +18,7 @@ import {
 	hasIncentive,
 	isActionIncentive,
 	isIncentiveDismissedInContext,
+	isWooPayEligible,
 } from '~/settings-payments/utils';
 import { DefaultDragHandle } from '~/settings-payments/components/sortable';
 import { StatusBadge } from '~/settings-payments/components/status-badge';
@@ -90,7 +91,9 @@ export const PaymentExtensionSuggestionListItem = ( {
 					{ isWooPayments( extension.id ) && (
 						<WooPaymentsMethodsLogos
 							maxElements={ 10 }
-							isWooPayEligible={ true }
+							tabletWidthBreakpoint={ 1080 } // Reduce the number of logos earlier.
+							mobileWidthBreakpoint={ 768 } // Reduce the number of logos earlier.
+							isWooPayEligible={ isWooPayEligible( extension ) }
 						/>
 					) }
 				</div>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
@@ -5,7 +5,7 @@
 import { decodeEntities } from '@wordpress/html-entities';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { WooPaymentMethodsLogos } from '@woocommerce/onboarding';
+import { WooPaymentsMethodsLogos } from '@woocommerce/onboarding';
 import { PaymentExtensionSuggestionProvider } from '@woocommerce/data';
 
 /**
@@ -88,7 +88,7 @@ export const PaymentExtensionSuggestionListItem = ( {
 						) }
 					/>
 					{ isWooPayments( extension.id ) && (
-						<WooPaymentMethodsLogos
+						<WooPaymentsMethodsLogos
 							maxElements={ 10 }
 							isWooPayEligible={ true }
 						/>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -55,11 +55,10 @@ export const PaymentGatewayListItem = ( {
 			return 'needs_setup';
 		}
 		if ( gateway.state.enabled ) {
-			if ( isWcPay ) {
-				if ( gateway.state.test_mode ) {
-					return 'test_mode';
-				}
+			if ( gateway.state.test_mode ) {
+				return 'test_mode';
 			}
+
 			return 'active';
 		}
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -13,7 +13,11 @@ import { Tooltip } from '@wordpress/components';
 import sanitizeHTML from '~/lib/sanitize-html';
 import { StatusBadge } from '~/settings-payments/components/status-badge';
 import { EllipsisMenuWrapper as EllipsisMenu } from '~/settings-payments/components/ellipsis-menu-content';
-import { hasIncentive, isWooPayments } from '~/settings-payments/utils';
+import {
+	hasIncentive,
+	isWooPayEligible,
+	isWooPayments,
+} from '~/settings-payments/utils';
 import { DefaultDragHandle } from '~/settings-payments/components/sortable';
 import { WC_ASSET_URL } from '~/utils/admin-settings';
 import {
@@ -121,7 +125,9 @@ export const PaymentGatewayListItem = ( {
 					{ itemIsWooPayments && (
 						<WooPaymentsMethodsLogos
 							maxElements={ 10 }
-							isWooPayEligible={ true }
+							tabletWidthBreakpoint={ 1080 } // Reduce the number of logos earlier.
+							mobileWidthBreakpoint={ 768 } // Reduce the number of logos earlier.
+							isWooPayEligible={ isWooPayEligible( gateway ) }
 						/>
 					) }
 				</div>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { WooPaymentMethodsLogos } from '@woocommerce/onboarding';
+import { WooPaymentsMethodsLogos } from '@woocommerce/onboarding';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { PaymentGatewayProvider } from '@woocommerce/data';
@@ -117,8 +117,8 @@ export const PaymentGatewayListItem = ( {
 							decodeEntities( gateway.description )
 						) }
 					/>
-					{ isWcPay && (
-						<WooPaymentMethodsLogos
+					{ itemIsWooPayments && (
+						<WooPaymentsMethodsLogos
 							maxElements={ 10 }
 							isWooPayEligible={ true }
 						/>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -33,7 +33,7 @@ export const PaymentGatewayListItem = ( {
 	acceptIncentive,
 	...props
 }: PaymentGatewayItemProps ) => {
-	const isWcPay = isWooPayments( gateway.id );
+	const itemIsWooPayments = isWooPayments( gateway.id );
 	const incentive = hasIncentive( gateway ) ? gateway._incentive : null;
 	const shouldHighlightIncentive =
 		incentive && ! incentive?.promo_id.includes( '-action-' );
@@ -69,7 +69,9 @@ export const PaymentGatewayListItem = ( {
 		<div
 			id={ gateway.id }
 			className={ `transitions-disabled woocommerce-list__item woocommerce-list__item-enter-done woocommerce-item__payment-gateway ${
-				isWcPay ? `woocommerce-item__woocommerce-payments` : ''
+				itemIsWooPayments
+					? `woocommerce-item__woocommerce-payments`
+					: ''
 			} ${ shouldHighlightIncentive ? `has-incentive` : '' }` }
 			{ ...props }
 		>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.scss
@@ -1,5 +1,7 @@
 .settings-payment-gateways__list {
 	border-top: 1px solid $gray-200;
+	// Without this, the window.innerWidth is not calculated correctly when elements are pushed outside the container.
+	overflow: hidden;
 
 	.woocommerce-list__item {
 		padding: 0 48px;

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -75,6 +75,16 @@ export const isWooPayments = ( id: string ) => {
 	return [ '_wc_pes_woopayments', 'woocommerce_payments' ].includes( id );
 };
 
+/**
+ * Checks whether a provider is WooPayments and that it is eligible for WooPay.
+ */
+export const isWooPayEligible = ( provider: PaymentProvider ) => {
+	return (
+		isWooPayments( provider.id ) &&
+		( provider.tags?.includes( 'woopay_eligible' ) || false )
+	);
+};
+
 export const getWooPaymentsTestDriveAccountLink = () => {
 	return getAdminLink(
 		'admin.php?wcpay-connect=1&_wpnonce=' +

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -12,7 +12,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { sanitize } from 'dompurify';
 import { __ } from '@wordpress/i18n';
-import { WooPaymentMethodsLogos } from '@woocommerce/onboarding';
+import { WooPaymentsMethodsLogos } from '@woocommerce/onboarding';
 
 /**
  * Internal dependencies
@@ -138,7 +138,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 								{ gatewayId ===
 									'pre_install_woocommerce_payments_promotion' && (
 									<div className="pre-install-payment-gateway__subtitle">
-										<WooPaymentMethodsLogos
+										<WooPaymentsMethodsLogos
 											maxElements={ 5 }
 											isWooPayEligible={
 												isWooPayEligible

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentExtensionSuggestions.php
@@ -122,7 +122,11 @@ class PaymentExtensionSuggestions {
 			self::KLARNA,
 		),
 		'US' => array(
-			self::WOOPAYMENTS,
+			self::WOOPAYMENTS  => array(
+				'_append' => array(
+					'tags' => array( 'woopay_eligible' ), // Add a special tag that will be used to determine if the merchant is eligible for WooPay.
+				),
+			),
 			self::PAYPAL_FULL_STACK,
 			self::STRIPE,
 			self::AIRWALLEX,

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentExtensionSuggestions.php
@@ -122,7 +122,7 @@ class PaymentExtensionSuggestions {
 			self::KLARNA,
 		),
 		'US' => array(
-			self::WOOPAYMENTS  => array(
+			self::WOOPAYMENTS => array(
 				'_append' => array(
 					'tags' => array( 'woopay_eligible' ), // Add a special tag that will be used to determine if the merchant is eligible for WooPay.
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We refactored, fixed, and improved the `WooPaymentsMethodsLogos` component:

- The total number of PMs adapts to WooPay eligibility.
- The number of PMs shown on mobile and tablets is adjustable.

On the new Payments settings page:
- The number of PMs shown on mobile and tablet is reduced because of the limited space.
- WooPay eligibility is determined by the selected business country.

Closes #53920 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja site with WooCommerce on this PR's live branch and the WooCommerce Beta Tester plugin (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=update/nox-fix-woopayments-pms-logos-list))
2. Go to WP admin > Tools > WCA Test Helper > Features and make sure the `reactify-classic-payments-settings` is NOT enabled.
3. Click on the "WooCommerce" main menu item, go through the WC profiler, skip it by clicking on "Skip guided setup", and set the store's business location to US.
4. Click on the "Payments" main menu item (with a red dot notice) and you should see the Incentives page with the WooPayments PMs logos:
![Screenshot 2024-12-20 at 14 18 41](https://github.com/user-attachments/assets/e436c825-84b0-4985-a0c2-0f37b5ad702c)
5. Reduce your window size to the minimum, and the number of shown logos should change to 7 (with a "+13" as the end):
![Screenshot 2024-12-20 at 14 20 18](https://github.com/user-attachments/assets/56d32303-27ce-471f-a745-aff818ff5a29)
6. Dismiss the incentive by clicking on the "No thanks" link and then "Just dismiss WooPayments" in the modal.
7. Click on the "Payments" main menu item and you should see the Payments task page with the WooPayments PMs logos:
![Screenshot 2024-12-20 at 14 23 12](https://github.com/user-attachments/assets/3c9446ac-a6b2-4d8f-8ede-4e71d9d0f728)
8. Reduce your window size to the minimum, and the number of shown logos should change to 7 (with a "+13" as the end):
![Screenshot 2024-12-20 at 14 23 35](https://github.com/user-attachments/assets/c8a6646d-2638-49fe-ad2b-8d77225113db)
9. Go to WP admin > Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature flag.
10. Click on "Payments" main menu item and you should be taken to the new Payments settings page with WooPayments as a suggestion including the PMs logos (dismiss the banner incentive at the top):
![Screenshot 2024-12-20 at 14 27 19](https://github.com/user-attachments/assets/de5efb57-7b09-468a-b2db-348c64a58656)
11. Reduce your window size to a tablet-like dimension, and the number of shown logos should change to 7 (with a "+13" as the end):
![Screenshot 2024-12-20 at 14 28 47](https://github.com/user-attachments/assets/504a0f63-b31b-4524-889d-f3b62f535c73)
12. Reduce your windows size further and the number of shown logos should change to 5 (with a "+15" as the end):
![Screenshot 2024-12-20 at 14 28 11](https://github.com/user-attachments/assets/57857eec-14d2-444a-b8c2-87746185e570)
13. Change the providers business location to "Germany" and the WooPayments PMs logos list should display 10 logos with a "+9" at the end and WooPay should not be present:
![Screenshot 2024-12-20 at 14 30 51](https://github.com/user-attachments/assets/93a98cd5-672d-4367-8d26-53897ed269b9)
14. Change the providers business location back to "United States" and WooPay should be part of the PMs and the list should have a "+10" at the end.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
