### PR TITLE
[dev] fix: gravatar using sha256 for the user id (9.5 release branch)

### DIFF
--- a/plugins/woocommerce/changelog/fix-gravatar-url-sha256
+++ b/plugins/woocommerce/changelog/fix-gravatar-url-sha256
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix test previously expecting a md5 hash but now produces a SHA-256 hash for the gravatar URL.

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/crud.php
@@ -276,9 +276,16 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_avatar_url() {
-		$customer = WC_Helper_Customer::create_customer();
-		$this->assertStringContainsString( 'gravatar.com/avatar', $customer->get_avatar_url() );
-		$this->assertStringContainsString( md5( 'test@woo.local' ), $customer->get_avatar_url() );
+		$customer            = WC_Helper_Customer::create_customer();
+		$customer_avatar_url = $customer->get_avatar_url();
+		$customer_email      = 'test@woo.local';
+
+		$this->assertStringContainsString( 'gravatar.com/avatar', $customer_avatar_url );
+
+		$this->assertTrue(
+			strpos( $customer_avatar_url, hash( 'sha256', $customer_email ) ) !== false || strpos( $customer_avatar_url, md5( $customer_email ) ) !== false,
+			"The retrieved avatar URL should be a SHA-256 or MD5 hash of the customer's email."
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Backports https://github.com/woocommerce/woocommerce/pull/53864 to the 9.5 release branch to allow CI checks to pass there.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Observe that the PHP tests pass on CI

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
