### PR TITLE
Remove e2e test scenario in loading-screen test for subsequent run and not loading screen

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-loading-screen-third-scenario
+++ b/plugins/woocommerce/changelog/e2e-remove-loading-screen-third-scenario
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove the third test scenario in e2e loading screen test

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/loading-screen/loading-screen.spec.js
@@ -117,38 +117,5 @@ test.describe(
 					)
 			).toBeVisible();
 		} );
-
-		test( 'should hide loading screen and steps on subsequent runs', async ( {
-			pageObject,
-			baseURL,
-			page,
-		} ) => {
-			await pageObject.setupSite( baseURL );
-			await pageObject.waitForLoadingScreenFinish();
-
-			const assembler = await pageObject.getAssembler();
-			await assembler
-				.getByRole( 'button', { name: 'Finish customizing' } )
-				.click();
-			await assembler.getByText( 'Your store looks great!' ).waitFor();
-			// Abort any additional unnecessary requests
-			await page.evaluate( () => window.stop() );
-			await pageObject.setupSite( baseURL );
-
-			const requestToSetupStore = createRequestsToSetupStoreDictionary();
-
-			setupRequestInterceptor( page, requestToSetupStore );
-
-			for ( const step of steps ) {
-				await expect( page.getByText( step ) ).toBeHidden();
-				await expect( page.getByAltText( step ) ).toBeHidden();
-			}
-
-			expect( Object.values( requestToSetupStore ) ).toEqual( [
-				false,
-				false,
-				false,
-			] );
-		} );
 	}
 );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #50427

Previously skipped as per #53663 and afterward accidentally overridden with old trunk #53754 

Now, removing completely this e2e test scenario, here are some Slack discussions about it:
p1734611524402449-slack-C01BWDDTGKX / p1732875096063979-slack-C01BWDDTGKX / p1734005818948669-slack-C02FL3X7KR6

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

CI green 🟢 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
