### PR TITLE
[e2e tests] Fix flakiness in live email preview test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-53708-flaky-email-preview
+++ b/plugins/woocommerce/changelog/e2e-53708-flaky-email-preview
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixing flaky e2e test for live email preview
+
+

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-header.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 	const [ fromName, setFromName ] = useState( '' );
 	const [ fromAddress, setFromAddress ] = useState( '' );
 	const [ subject, setSubject ] = useState( '' );
-	let subjectEl: Element | null = null;
+	const subjectEl = useRef< Element | null >( null );
 
 	const fetchSubject = useCallback( async () => {
 		try {
@@ -32,13 +32,15 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 				path: `wc-admin-email/settings/email/preview-subject?type=${ emailType }`,
 			} );
 			setSubject( response.subject );
-			if ( subjectEl ) {
-				subjectEl.dispatchEvent( new Event( 'subject-updated' ) );
+			if ( subjectEl.current ) {
+				subjectEl.current.dispatchEvent(
+					new Event( 'subject-updated' )
+				);
 			}
 		} catch ( e ) {
 			setSubject( '' );
 		}
-	}, [ emailType ] );
+	}, [ emailType, subjectEl ] );
 
 	useEffect( () => {
 		const fromNameEl = document.getElementById(
@@ -82,24 +84,27 @@ export const EmailPreviewHeader: React.FC< EmailPreviewHeaderProps > = ( {
 
 	useEffect( () => {
 		fetchSubject();
-	}, [ emailType, fetchSubject ] );
+	}, [ fetchSubject ] );
 
 	useEffect( () => {
-		subjectEl = document.querySelector(
+		subjectEl.current = document.querySelector(
 			'[id^="woocommerce_"][id$="_subject"]'
 		);
 
-		if ( ! subjectEl ) {
+		if ( ! subjectEl.current ) {
 			return;
 		}
 
-		subjectEl.addEventListener( 'transient-saved', fetchSubject );
+		subjectEl.current.addEventListener( 'transient-saved', fetchSubject );
 
 		return () => {
-			if ( ! subjectEl ) {
+			if ( ! subjectEl.current ) {
 				return;
 			}
-			subjectEl.removeEventListener( 'transient-saved', fetchSubject );
+			subjectEl.current.removeEventListener(
+				'transient-saved',
+				fetchSubject
+			);
 		};
 	}, [ fetchSubject ] );
 

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -61,7 +61,7 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 		return () => {
 			window.removeEventListener( 'resize', handleResize );
 		};
-	}, [] );
+	}, [ isSingleEmail ] );
 
 	return (
 		<Fill>

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -137,51 +137,38 @@ test.describe( 'WooCommerce Email Settings', () => {
 			return content.includes( code );
 		};
 
-		// Define colors and corresponding fields
-		const emailFields = [
-			{ id: 'woocommerce_email_background_color', value: '#012345' },
-			{ id: 'woocommerce_email_base_color', value: '#6789ab' },
-			{ id: 'woocommerce_email_body_background_color', value: '#cdef01' },
-			{ id: 'woocommerce_email_footer_text_color', value: '#234567' },
-			// This color is ligtened in styles and not used with this specific value so can't be tested
-			// { id: 'woocommerce_email_text_color', value: '#89abcd' },
-			{ id: 'woocommerce_email_footer_text', value: 'New footer value' },
-		];
+		const baseColorId = 'woocommerce_email_base_color';
+		const baseColorValue = '#012345';
 
-		let iframeSrc = await iframeElement.getAttribute( 'src' );
+		const iframeSrc = await iframeElement.getAttribute( 'src' );
 
-		for ( const { id, value } of emailFields ) {
-			await page.fill( `#${ id }`, value );
-			await page.evaluate( ( inputId ) => {
-				const input = document.getElementById( inputId );
-				input.blur();
-			}, id );
+		await page.fill( `#${ baseColorId }`, baseColorValue );
+		await page.evaluate( ( inputId ) => {
+			const input = document.getElementById( inputId );
+			input.blur();
+		}, baseColorId );
 
-			// I've tried many ways to wait for the iframe to reload, but none of them
-			// worked consistently because of debounce, so I'm using a simple retry loop
-			let retries = 0;
-			let newIframeSrc = null;
-			while ( retries < 10 ) {
-				newIframeSrc = await iframeElement.getAttribute( 'src' );
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				if ( newIframeSrc !== iframeSrc ) {
-					break;
-				}
-				await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
-				retries++;
+		// I've tried many ways to wait for the iframe to reload, but none of them
+		// worked consistently because of debounce, so I'm using a simple retry loop
+		let retries = 0;
+		let newIframeSrc = null;
+		while ( retries < 10 ) {
+			newIframeSrc = await iframeElement.getAttribute( 'src' );
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			if ( newIframeSrc !== iframeSrc ) {
+				break;
 			}
-			await expect( newIframeSrc ).not.toEqual( iframeSrc );
-			iframeSrc = newIframeSrc;
-
-			// Check that the iframe contains the new value
-			await expect( await iframeContainsHtml( value ) ).toBeTruthy();
+			await new Promise( ( resolve ) => setTimeout( resolve, 200 ) );
+			retries++;
 		}
+		await expect( newIframeSrc ).not.toEqual( iframeSrc );
+
+		// Check that the iframe contains the new value
+		await expect( await iframeContainsHtml( baseColorValue ) ).toBeTruthy();
 
 		// Check that the iframe does not contain any of the new values after page reload
 		await page.reload();
-		for ( const { value } of emailFields ) {
-			await expect( await iframeContainsHtml( value ) ).toBeFalsy();
-		}
+		await expect( await iframeContainsHtml( baseColorValue ) ).toBeFalsy();
 	} );
 
 	test( 'Send email preview', async ( { page, baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -283,6 +283,21 @@ test.describe( 'WooCommerce Email Settings', () => {
 				} );
 			}, subjectId );
 			await expect( await getSubject() ).toContain( 'New subject' );
+
+			// Reset the subject to default value
+			await page.fill( `#${ subjectId }`, '' );
+			await page.evaluate( async ( inputId ) => {
+				const input = document.getElementById( inputId );
+				input.blur();
+
+				return await new Promise( ( resolve ) => {
+					input.addEventListener(
+						'transient-saved',
+						() => resolve(),
+						{ once: true }
+					);
+				} );
+			}, subjectId );
 		}
 	);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Fix the flaky ` Live preview when changing email settings` e2e test, which relied on retry loops. Rewrote to use events that should be more stable. 
- Removed testing all email style settings and only test a single one. Reduced test duration from 5s to 2.1s.
- Fixed some React warnings I've noticed in the related codebase. 

Closes #53708.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```
pnpm test:e2e settings-email.spec.js --repeat-each=100
```

To save some time, you can use `.only()` [here](https://github.com/woocommerce/woocommerce/pull/53930/files#diff-d66b12c05c5ee4a6131b29cfe82afa1af477a1a930fbd36f62e8c2721194eb0dL123).

<!-- End testing instructions -->