### PR TITLE
Product Gallery: fix pager position

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/utils.tsx
@@ -72,7 +72,10 @@ const setGroupBlockLayoutByThumbnailsPosition = (
 ): void => {
 	const block = select( 'core/block-editor' ).getBlock( clientId );
 	block?.innerBlocks.forEach( ( innerBlock ) => {
-		if ( innerBlock.name === 'core/group' ) {
+		if (
+			innerBlock.name === 'core/group' &&
+			innerBlock.attributes.metadata.name === 'Gallery Area'
+		) {
 			updateBlockAttributes(
 				{
 					layout: getGroupLayoutAttributes( thumbnailsPosition ),

--- a/plugins/woocommerce/changelog/fix-product-galler-pager-position
+++ b/plugins/woocommerce/changelog/fix-product-galler-pager-position
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: The issue this PR fixes was introduced in the same version and wasn't exposed to users hence no need to mention it.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After https://github.com/woocommerce/woocommerce/pull/53847 was merged I noticed the pager could lose its position when changing thumbnails position. The bug was there but it was guarded by locked blocks. Basically all `core/group` blocks used in Product Gallery were tried to be updated unnecessarily. Only a specific one should.

This PR patches it but also shows there's lot of logic that could be simplified in the Product Gallery block.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Editor > Single Product template.
2. Replace the Product Image Gallery block with the Product Gallery (beta) block.
4. Change the Thumbnails position to all options
5. **Expected:** Make sure Pager stays centred and below large image

Scenario | Before | After
-- | -- | --
Below | <img width="722" alt="image" src="https://github.com/user-attachments/assets/39985b4b-19c4-4f09-b43a-f35604e9ebe5" /> |<img width="723" alt="image" src="https://github.com/user-attachments/assets/378c49f7-09bb-4e46-b1c6-8ea81dd56a77" />
On the right | <img width="735" alt="image" src="https://github.com/user-attachments/assets/9c012ce9-6165-4b13-a668-4c5b2c3a1c10" /> | <img width="725" alt="image" src="https://github.com/user-attachments/assets/2d9a6af3-da11-4e3c-80ee-580a322d8b15" />
On the left again |  <img width="727" alt="image" src="https://github.com/user-attachments/assets/2d7c35b1-e2b0-48ee-8e50-9b6287dbe84d" /> | <img width="731" alt="image" src="https://github.com/user-attachments/assets/7311a2a2-1111-4eb0-b050-a3417d730b57" />


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
