### PR TITLE
[Experimental]: Improve variation selector frontend

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/index.tsx
@@ -10,6 +10,7 @@ import { Icon, button } from '@wordpress/icons';
 import metadata from './block.json';
 import AddToCartWithOptionsVariationSelectorEdit from './edit';
 import { shouldRegisterBlock } from '..';
+import './style.scss';
 import './editor.scss';
 
 if ( shouldRegisterBlock ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/style.scss
@@ -1,0 +1,5 @@
+.wp-block-woocommerce-add-to-cart-with-options {
+	.variations_form.cart {
+		margin-bottom: 0 !important;
+	}
+}

--- a/plugins/woocommerce/changelog/dev-53012_create_variation_selector_backend
+++ b/plugins/woocommerce/changelog/dev-53012_create_variation_selector_backend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Comment: Improve variation selector frontend #53947

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -58,7 +58,7 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 		);
 
 		$html .= '<option value="">' . esc_html__( 'Choose an option', 'woocommerce' ) . '</option>';
-		$html .= $this->get_options_html( $product, $attribute_name, $options, $selected );
+		$html .= $this->get_variation_options_html( $product, $attribute_name, $options, $selected, taxonomy_exists( $attribute_name ) );
 		$html .= '</select>';
 
 		return $html;
@@ -82,29 +82,14 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 	 * @param string     $attribute_name Name of the attribute.
 	 * @param array      $options Available options.
 	 * @param string     $selected Selected value.
-	 * @return string Options HTML
-	 */
-	private function get_options_html( $product, $attribute_name, $options, $selected ): string {
-		if ( empty( $options ) ) {
-			return '';
-		}
-
-		return taxonomy_exists( $attribute_name )
-			? $this->get_variation_options_html( $product, $attribute_name, $options, $selected, true )
-			: $this->get_variation_options_html( $product, $attribute_name, $options, $selected, false );
-	}
-
-	/**
-	 * Get HTML for variation options.
-	 *
-	 * @param WC_Product $product The product object.
-	 * @param string     $attribute_name Name of the attribute.
-	 * @param array      $options Available options.
-	 * @param string     $selected Selected value.
 	 * @param bool       $is_taxonomy Whether this is a taxonomy-based attribute.
 	 * @return string Options HTML
 	 */
 	private function get_variation_options_html( $product, $attribute_name, $options, $selected, $is_taxonomy ): string {
+		if ( empty( $options ) ) {
+			return '';
+		}
+
 		$html  = '';
 		$items = $is_taxonomy
 			? wc_get_product_terms( $product->get_id(), $attribute_name, array( 'fields' => 'all' ) )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -147,12 +147,12 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 			return '';
 		}
 
-		wp_enqueue_script( 'wc-add-to-cart-variation' );
-
 		$variations = $this->get_variations_data( $product );
 		if ( empty( $variations ) ) {
 			return '';
 		}
+
+		wp_enqueue_script( 'wc-add-to-cart-variation' );
 
 		return $this->get_form_html( $product, $variations, $variation_attributes );
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -28,7 +28,7 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 		$label_text = wc_attribute_label( $attribute_name );
 
 		$html = sprintf(
-			'<label class="wc-block-components-product-add-to-cart-attribute-label" for="%s">%s</label>',
+			'<label class="wc-block-product-add-to-cart-attribute-label" for="%s">%s</label>',
 			$label_id,
 			esc_html( $label_text )
 		);
@@ -49,7 +49,7 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 
 		$html = sprintf(
 			'<select id="%1$s"
-				class="wc-block-components-product-add-to-cart-attribute-select"
+				class="wc-block-product-add-to-cart-attribute-select"
 				name="%1$s"
 				data-attribute_name="attribute_%2$s">',
 			$select_id,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -51,8 +51,7 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 			'<select id="%1$s"
 				class="wc-block-components-product-add-to-cart-attribute-select"
 				name="%1$s"
-				data-attribute_name="attribute_%2$s"
-				data-wc-on--change="actions.updateVariation">',
+				data-attribute_name="attribute_%2$s">',
 			$select_id,
 			esc_attr( sanitize_title( $attribute_name ) )
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -105,7 +105,7 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 	 * @return string Options HTML
 	 */
 	private function get_variation_options_html( $product, $attribute_name, $options, $selected, $is_taxonomy ): string {
-		$html = '';
+		$html  = '';
 		$items = $is_taxonomy
 			? wc_get_product_terms( $product->get_id(), $attribute_name, array( 'fields' => 'all' ) )
 			: $options;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -188,13 +188,11 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 		$variations_json = wp_json_encode( $variations );
 		$variations_attr = function_exists( 'wc_esc_json' ) ? wc_esc_json( $variations_json ) : _wp_specialchars( $variations_json, ENT_QUOTES, 'UTF-8', true );
 
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wc-block-add-to-cart-form' ) );
-
 		$form  = $this->get_form_opening( $product, $variations_attr );
 		$form .= $this->get_variations_table( $product, $variation_attributes );
 		$form .= '</form>';
 
-		return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $form );
+		return $form;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially addresses [53012](https://github.com/woocommerce/woocommerce/issues/53012).

This PR adds the code to show the variation selector on the page frontend. The change is part of [a bigger PR](https://github.com/woocommerce/woocommerce/pull/53855) split to make reviewing easier.

![Screenshot 2024-12-23 at 10 44 30 AM](https://github.com/user-attachments/assets/c5eee9fd-ba2e-4f21-be01-25cfc4ae0f14)

The selector is not tied yet with the `Add to cart` button, so only test the variation selection and `clear` button.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Having `WooCommerce Beta Tester` installed and activater
1. Go to Tools > WCA Test Helper > Features
2. Enable the features: `blockified-add-to-cart` and `experimental-blocks`
3. Create a variable product with variations.
4. Go to Pages > Add New Page
5. Add a `Single Product` block and select the product you created in step 3.
6. Add an `Add to Cart with Option (Experimental)` block.
7. Verify that the selectors with the attributes are visible.
8. Save the page and view it.
9. There should be one selector per attribute you choose for your variations.
10. Pick one, and a `Clear` button should appear.
11. Press it to clear the selectors.

https://github.com/user-attachments/assets/b8369d1a-7d54-415a-aa3f-8b61a3288627

12. Go to the variable product you created in step 3. Go to Product data > Variations and select a default variation in `Default Form Values`.
13. Verify that the variation you pick to be shown by default is shown correctly.

![Screenshot 2024-12-23 at 11 27 41 AM](https://github.com/user-attachments/assets/0d3b5e86-fcc8-4917-9441-785d1002d675)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
