### PR TITLE
Translation changes to improve compatibility with WP 6.7 upwards.

### DIFF
--- a/plugins/woocommerce/changelog/fix-52646-translation-loading
+++ b/plugins/woocommerce/changelog/fix-52646-translation-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Adjust translation handling; improve support for custom translations under WP 6.7 upwards.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -871,16 +871,21 @@ final class WooCommerce {
 	 *      - WP_LANG_DIR/plugins/woocommerce-LOCALE.mo
 	 */
 	public function load_plugin_textdomain() {
-		$locale = determine_locale();
-
 		/**
 		 * Filter to adjust the WooCommerce locale to use for translations.
 		 */
-		$locale = apply_filters( 'plugin_locale', $locale, 'woocommerce' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		$locale                  = apply_filters( 'plugin_locale', determine_locale(), 'woocommerce' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		$custom_translation_path = WP_LANG_DIR . '/woocommerce/woocommerce-' . $locale . '.mo';
+		$plugin_translation_path = WP_LANG_DIR . '/plugins/woocommerce-' . $locale . '.mo';
 
-		unload_textdomain( 'woocommerce', true );
-		load_textdomain( 'woocommerce', WP_LANG_DIR . '/woocommerce/woocommerce-' . $locale . '.mo' );
-		load_plugin_textdomain( 'woocommerce', false, plugin_basename( dirname( WC_PLUGIN_FILE ) ) . '/i18n/languages' );
+		// If a custom translation exists (by default it will not, as it is not a standard WordPress convention)
+		// we unload the existing translation, then essentially layer the custom translation on top of the canonical
+		// translation. Otherwise, we simply step back and let WP manage things.
+		if ( is_readable( $custom_translation_path ) ) {
+			unload_textdomain( 'woocommerce' );
+			load_textdomain( 'woocommerce', $custom_translation_path );
+			load_textdomain( 'woocommerce', $plugin_translation_path );
+		}
 	}
 
 	/**


### PR DESCRIPTION
This change attempts to remedy a problem with text domain handling under WP 6.7, while retaining compatibility with text domain handling under WP 6.6 (remembering that, at present, we [don't support versions older than 6.6](https://github.com/woocommerce/woocommerce/blob/9.5.1/plugins/woocommerce/woocommerce.php#L11)).

Updates #52646 → *does not close it, as the original basis of the issue is a problem with translation-related 'doing it wrong' notices, which this PR does not address directly.*

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Let's establish some baselines around translation handling as it worked prior to WP 6.7. 

1. Setup WordPress 6.6 (the version is important to let us see translations in effect before the recent changes).
2. Install and activate [WooCommerce 9.4.3](https://downloads.wordpress.org/plugin/woocommerce.9.4.3.zip) (the version is important because the way we do [text domain unloading](https://github.com/woocommerce/woocommerce/blob/9.3.4/plugins/woocommerce/includes/class-woocommerce.php#L876) changed slightly after this version).
3. I propose enabling the French `fr_FR` translation, which is very complete. If you prefer to use something else that's fine, but you may need to adapt some of the following steps accordingly. I also ask that, initially, you ensure your user profile is using the default site language (in this case, that's French).
4. At this point, confirm that all (or most) strings are translated to French.
5. Now let's install a custom translation:

[woocommerce-fr_FR.zip](https://github.com/user-attachments/files/18216082/woocommerce-fr_FR.zip)

6. The above asset is a zip (GitHub doesn't allow `*.mo` files to be uploaded directly) ... unzip it, though, and you can extract the `*.mo` file, which you should copy to:

```
wp-content/languages/woocommerce/woocommerce-fr_FR.mo
```

7. What you need to know about this custom translation is that it translates only one string. Products is normally translated to *Produits,* but this file changes it to *Les Produits*  (this probably isn't good French, but the point is to be able to see that the custom translation is taking effect).
8. With this in position, if you refresh the admin environment you should see the **Produits** admin menu entry is now **Les Produits**. In addition, the remainder of the UI should still be translated, as per the canonical French translation.

Please now update to WP 6.7.1 and switch to this branch.

1. You should be able to verify that:
    1. Translations still work.
    2. *Custom* translations (like our `*.mo` file containing *Les Produits)* still work as before.
2. Let's now simulate one of the premature translation doing-it-wrong notices described in the original issue, by introducing some custom code like the following (which could temporarily live in `wp-content/mu-plugins/test-52646.php` or similar):

```php
<?php

// "Spike" the translation loading process.
add_action( 'plugins_loaded', function () {
    __( 'Early translation trigger', 'woocommerce' );
} );
```

3. With this in place (and activated, if necessary), refresh the admin UI. By monitoring your error logs, or by using a tool like [Query Monitor](https://wordpress.org/plugins/query-monitor/), you should see that a *doing-it-wrong* notice concerning the `woocommerce` text domain has been emitted. However, despite the notice, both the translation and custom translation should still function as before/should still take effect (you can compare this to how things behave with WooCommerce 9.5.1 to see the problematic handling some users are currently facing).

Last but not least, let's confirm that other facets of translation handling are not impacted. In particular, let's take a look at emails. Still using WP 6.7.1 and this branch, run through the following steps.

1. You will need some method of monitoring emails, like [Email Log](https://wordpress.org/plugins/email-log/).
2. With that in place, edit an order and **send order details to customer** *('Envoyer les détails de la commande au client')*.
3. The dispatched email should be in French (actually, this is a spot where gaps in the translation may show up ... so all we really want to know is that at least some of the email is being translated).
4. Now edit your user profile, change your preferred language to English (or to something other than French).
5. Repeat the test and trigger a fresh email. The email content (or a portion of it) should still be in French.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
