### PR TITLE
Fix undefined array key issue in class-wc-tracks.php for role handling

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-tracks-undefined-array-key
+++ b/plugins/woocommerce/changelog/fix-wc-tracks-undefined-array-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix role retrieval for users with non-sequential roles

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -75,7 +75,7 @@ class WC_Tracks {
 	 */
 	public static function get_role_details( $user ) {
 		return array(
-			'role'                   => ! empty( $user->roles ) ? $user->roles[0] : '',
+			'role'                   => ! empty( $user->roles ) ? reset( $user->roles ) : '',
 			'can_install_plugins'    => $user->has_cap( 'install_plugins' ),
 			'can_activate_plugins'   => $user->has_cap( 'activate_plugins' ),
 			'can_manage_woocommerce' => $user->has_cap( 'manage_woocommerce' ),

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -108,6 +108,25 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test role properties for non-sequential roles.
+	 */
+	public function test_role_properties_for_non_sequential_roles() {
+		$user = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $user );
+		$current_user = wp_get_current_user();
+		$current_user->add_role( 'administrator' );
+		// Mock the roles to be an associative array to simulate the scenario where the roles are not sequential.
+		$current_user->roles = array(
+			2 => 'administrator',
+		);
+		$properties          = \WC_Tracks::get_role_details( $current_user );
+		$this->assertEquals( 'administrator', $properties['role'] );
+		$this->assertEquals( true, $properties['can_install_plugins'] );
+		$this->assertEquals( true, $properties['can_activate_plugins'] );
+		$this->assertEquals( true, $properties['can_manage_woocommerce'] );
+	}
+
+	/**
 	 * Test the event validation and sanitization with a valid event.
 	 */
 	public function test_event_validation_and_sanitization_valid_event() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53848

This PR addresses an issue where an undefined array key error occurs in class-wc-tracks.php when handling user roles. The error arises due to the assumption that roles are a zero-indexed array, but in some cases, they may be an associative array. This update makes the role handling code more robust to avoid such errors.

I wasn't able to reproduce the issue but I added a test case to cover the scenario where the roles are not sequential to confirm the fix.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a site with this branch
2. Install `Code Snippets` plugin
3. Add the following code snippet:

```php
add_action( 'init', function() {
    if ( class_exists( 'WC_Tracks' ) && method_exists( 'WC_Tracks', 'get_role_details' ) ) {
        $user = wp_get_current_user();
        $user->roles = array(
            2 => 'administrator',
        );
        $role_details = WC_Tracks::get_role_details( $user );
		error_log( "role_details: " . print_r( $role_details, true ));
    }
});
```

4. Go to `wp-admin/themes.php` and confirm no error is thrown.
5. Check the `debug.log` file and confirm role details are correctly retrieved.

```bash
role_details: Array
(
    [role] => administrator
    [can_install_plugins] => 1
    [can_activate_plugins] => 1
    [can_manage_woocommerce] => 1
)
```


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
