### PR TITLE
Fix lint warning in the Stock Indicator

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
@@ -112,10 +112,12 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	);
 };
 
-export default ( props: Props ) => {
+const StockIndicatorBlock: React.FC< Props > = ( props ) => {
 	const { product } = useProductDataContext();
 	if ( product.id === 0 ) {
 		return <Block { ...props } />;
 	}
 	return withProductDataContext( Block )( props );
 };
+
+export default StockIndicatorBlock;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/edit.tsx
@@ -56,12 +56,14 @@ const Edit = ( {
 	);
 };
 
-export default (
-	props: BlockEditProps< BlockAttributes > & { context: Context }
-) => {
+const StockIndicatorEdit: React.FC<
+	BlockEditProps< BlockAttributes > & { context: Context }
+> = ( props ) => {
 	const { product } = useProductDataContext();
 	if ( product.id === 0 ) {
 		return <Edit { ...props } />;
 	}
 	return withProductSelector( { icon, label, description } )( Edit )( props );
 };
+
+export default StockIndicatorEdit;

--- a/plugins/woocommerce/changelog/fix-54007_lint_warning_in_stock_indicator
+++ b/plugins/woocommerce/changelog/fix-54007_lint_warning_in_stock_indicator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Comment: Fix lint warning in the Stock Indicator #54008


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a lint warning in the `Stock Indicator` [edit.tsx file](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/edit.tsx#L59-L67) and [block.tsx](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx#L115-L121).

The message says:

```
The inferred type of 'default' cannot be named without a reference to '.pnpm/@types+react@17.0.71/node_modules/@types/react'. This is likely not portable. A type annotation is necessary.
```

Closes #54007.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify that the lint warning is not visible anymore in `plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx` and `plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/edit.tsx`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
