### PR TITLE
dev: added env vars to allow disabling and or hiding typescript warnings

### DIFF
--- a/plugins/woocommerce/changelog/dev-typescript-env-var-disable
+++ b/plugins/woocommerce/changelog/dev-typescript-env-var-disable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Added env vars to allow for disabling typescipt checking and hiding warnings.

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -302,6 +302,16 @@
 		},
 		"watch:build:project:bundle": {
 			"command": "webpack --watch",
+			"env": {
+				"DISABLE_TYPESCRIPT_CHECKING": {
+					"external": true,
+					"default": "true"
+				},
+				"HIDE_TYPESCRIPT_WARNINGS": {
+					"external": true,
+					"default": "false"
+				}
+			},
 			"service": true
 		},
 		"dependencyOutputs": {

--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -89,6 +89,10 @@ require( 'fs-extra' ).ensureSymlinkSync(
 
 const webpackConfig = {
 	mode: NODE_ENV,
+	ignoreWarnings:
+		process.env.HIDE_TYPESCRIPT_WARNINGS === 'true'
+			? [ { message: /TS\d{4,6}:\ / } ]
+			: [],
 	entry: getEntryPoints(),
 	output: {
 		filename: ( data ) => {
@@ -179,7 +183,9 @@ const webpackConfig = {
 	plugins: [
 		...styleConfig.plugins,
 		// Runs TypeScript type checker on a separate process.
-		! process.env.STORYBOOK && new ForkTsCheckerWebpackPlugin(),
+		! process.env.STORYBOOK &&
+			! ( process.env.DISABLE_TYPESCRIPT_CHECKING === 'true' ) &&
+			new ForkTsCheckerWebpackPlugin(),
 		! process.env.STORYBOOK &&
 			new TypeScriptWarnOnlyWebpackPlugin( [
 				// these are the errors that have been converted into warnings during the react-18 upgrade


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After merging https://github.com/woocommerce/woocommerce/pull/53531 the long list of typescript warnings made it impossible to use `pnpm watch:build` because it takes over a few minutes to finish printing the warnings each time you save.

Adding env vars to allow
- disabling typescript checking for webpack (default: true - typescript disabled)
- hiding typescript warnings for webpack (default: false - not hidden)

This default combination means that anyone who's not actively working on fixing the typescript errors is not impeded by the warnings.

There exists the combination of enabling TS checking but also hiding the warnings, this is to facilitate working on fixing the errors. 

When the specific error code in `webpack.config.js` is commented out, it is converted to an error. This error however becomes hard to find in the backscroll of warnings, so it's been made possible to hide the warnings and focus only on the focused errors.

There's however an issue I couldn't resolve - it doesn't seem like ignoreWarnings works when ForkTsCheckerWebpackPlugin is running in async mode. It runs in async mode when `webpack --watch` is used. So, the workaround is to only use `npx webpack` to print the errors.

So for example, if I'd like to work on 'TS2578' // Unused '@ts-expect-error' directive.

1. I'd go to [webpack.config.js](https://github.com/woocommerce/woocommerce/blob/1de7ef6be3e826cfc995594ab0bab4ef9777efc3/plugins/woocommerce/client/admin/webpack.config.js#L195)
1. Uncomment the line with TS2578
1. go to `./plugins/woocommerce/client/admin` and run `DISABLE_TYPESCRIPT_CHECKING=true HIDE_TYPESCRIPT_WARNINGS=true npx webpack`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build should be unchanged and still work
3. `pnpm watch:build` in ./plugins/woocommerce/client/admin should not flood with typescript warnings
4. Above steps to work on specific TS errors should work

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
