### PR TITLE
Update e2e test util for filling page title to close expanded block inserter if present

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-editor-util-fill-page-title
+++ b/plugins/woocommerce/changelog/e2e-fix-editor-util-fill-page-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix the fillPageTitle in editor util to fulfill the latest update in Gutenberg 19.9-nightly

--- a/plugins/woocommerce/tests/e2e-pw/utils/editor.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/editor.js
@@ -53,6 +53,19 @@ const goToPostEditor = async ( { page } ) => {
 };
 
 const fillPageTitle = async ( page, title ) => {
+	// Gutenberg 19.9-nightly: Block Inserter expanded by default and showing patterns tab.
+	// TODO (Gutenberg 19.9.1+): Remove conditional and make this explicit.
+	if (
+		await page
+			.getByRole( 'button', {
+				name: /Toggle block inserter|Block Inserter/,
+				expanded: true,
+			} )
+			.isVisible()
+	) {
+		await page.getByLabel( 'Close Block Inserter' ).click();
+	}
+
 	// TODO (Gutenberg 19.9): Keep only the "Block: Title" label locator.
 	// Current stable version of Gutenberg (19.7) uses the "Add title" label locator.
 	// Upcoming Gutenberg 19.9 uses the "Block: Title" one. We should use it instead when GB 19.9 comes out.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54030

I will add a closing action for the blocks sidebar before attempting to fill the page title to avoid:

- race conditional issues
- blockage inserting blocks

I tested this locally against Gutenberg stable and nightly + without installed Gutenberg.

Also ran [daily tests against this branch](https://github.com/woocommerce/woocommerce/actions/runs/12494527280) to ensure passing state.

Commented the purpose of the addition and TODO for the future when Gutenberg meets 19.9.1+ versioning.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

```
pnpm test:e2e create-cart-block.spec.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
