### PR TITLE
Fix: Multiple block compatibility layer for search results are executed

### DIFF
--- a/plugins/woocommerce/changelog/54060-fix-53990-multiple-block-compatibility-layer-for-search-results-are-executed
+++ b/plugins/woocommerce/changelog/54060-fix-53990-multiple-block-compatibility-layer-for-search-results-are-executed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Multiple block compatibility layer for search results are executed

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -49,7 +49,7 @@ class ProductCatalogTemplate extends AbstractTemplate {
 	 * Renders the default block template from Woo Blocks if no theme templates exist.
 	 */
 	public function render_block_template() {
-		if ( ! is_embed() && ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) ) {
+		if ( ! is_embed() && ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) && ! is_search() ) {
 			$compatibility_layer = new ArchiveProductTemplatesCompatibility();
 			$compatibility_layer->init();
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53990

When using a block-based theme, both ProductSearchResultsTemplate and ProductCatalogTemplate were injecting template hooks into search results, causing duplicate hook content. This adds a check to ensure ProductCatalogTemplate's compatibility layer is not initialized during search requests.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Make sure to use a block-theme
2. Add following snippet to see the duplicate injection:

```php
add_action( 'woocommerce_after_shop_loop_item', function() {
	echo "test hook injection";
} );
```

3. Visit a product search results page (e.g., `?s=shirt&post_type=product`)
4. Verify that the hook content ("test hook injection") appears only once per product

![image](https://github.com/user-attachments/assets/2a3c3c99-3c52-4ee0-830b-1b3a13a13e60)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Multiple block compatibility layer for search results are executed

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>