### PR TITLE
Fix logic for skipping found rows query in OrdersTableQuery.

### DIFF
--- a/plugins/woocommerce/changelog/fix-53065-skip-count-for-no-found-rows
+++ b/plugins/woocommerce/changelog/fix-53065-skip-count-for-no-found-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix logic for skipping found rows query in OrdersTableQuery

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1351,7 +1351,7 @@ class OrdersTableQuery {
 		$this->orders = array_map( 'absint', $wpdb->get_col( $this->sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		// Set max_num_pages and found_orders if necessary.
-		if ( ( $this->arg_isset( 'no_found_rows' ) && ! $this->args['no_found_rows'] ) || empty( $this->orders ) ) {
+		if ( ( $this->arg_isset( 'no_found_rows' ) && $this->args['no_found_rows'] ) || empty( $this->orders ) ) {
 			return;
 		}
 


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #53065.

The check to skip the found rows query was checking against `! $this->args['no_found_rows']`, however, we want to skip when `no_found_rows` is truthy.  This removes the negation.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. The simplest way to test is with a test site running WooCommerce Subscriptions setup with the ability to monitor DB queries.
2. Visit the admin order listing page. 
3. Check the queries run for the page.  Check that queries run to get related subscriptions for orders do not include a separate count query after.

Alternatively, through a script or active shell with query monitoring available:
1. Call `wc_get_orders()`
2. Verify that no additional count query is run when retrieving the results.

<!-- End testing instructions -->