### PR TITLE
[Experimental] Hide Add to Cart with Options (Experimental) block from widgets screen

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -346,8 +346,8 @@ export class BlockRegistrationManager {
  *
  * @return {void}
  */
-export const registerProductBlockType = (
-	blockNameOrMetadata: string | Partial< BlockConfiguration >,
+export const registerProductBlockType = < T extends BlockAttributes >(
+	blockNameOrMetadata: string | Partial< BlockConfiguration< T > >,
 	settings?: ProductBlockRegistrationConfig
 ): void => {
 	const blockName =

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -19,7 +19,7 @@ import ToolbarProductTypeGroup from './components/toolbar-type-product-selector-
 import { DowngradeNotice } from './components/downgrade-notice';
 import getInnerBlocksTemplate from './utils/get-inner-blocks-template';
 import useProductTypeSelector from './hooks/use-product-type-selector';
-import type { Attributes } from './';
+import type { Attributes } from './types';
 
 export type FeaturesKeys = 'isBlockifiedAddToCart';
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.tsx
@@ -19,11 +19,7 @@ import ToolbarProductTypeGroup from './components/toolbar-type-product-selector-
 import { DowngradeNotice } from './components/downgrade-notice';
 import getInnerBlocksTemplate from './utils/get-inner-blocks-template';
 import useProductTypeSelector from './hooks/use-product-type-selector';
-
-export interface Attributes {
-	className?: string;
-	isDescendentOfSingleProductBlock: boolean;
-}
+import type { Attributes } from './';
 
 export type FeaturesKeys = 'isBlockifiedAddToCart';
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -18,6 +18,7 @@ import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import save from './save';
 import './style.scss';
+import type { Attributes } from './types';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -25,11 +26,6 @@ const isBlockifiedAddToCart = getSettingWithCoercion(
 	false,
 	isBoolean
 );
-
-export interface Attributes {
-	className?: string;
-	isDescendentOfSingleProductBlock: boolean;
-}
 
 export const shouldBlockifiedAddToCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
 import { Icon, button } from '@wordpress/icons';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
+import { registerProductBlockType } from '@woocommerce/atomic-utils';
+import type { BlockConfiguration } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -25,6 +26,11 @@ const isBlockifiedAddToCart = getSettingWithCoercion(
 	isBoolean
 );
 
+export interface Attributes {
+	className?: string;
+	isDescendentOfSingleProductBlock: boolean;
+}
+
 export const shouldBlockifiedAddToCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
@@ -40,9 +46,16 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	}
 
 	// Register the block
-	registerBlockType( metadata, {
-		icon: <Icon icon={ button } />,
-		edit: AddToCartOptionsEdit,
-		save,
-	} );
+	registerProductBlockType< Attributes >(
+		{
+			...( metadata as BlockConfiguration< Attributes > ),
+			icon: <Icon icon={ button } />,
+			edit: AddToCartOptionsEdit,
+			save,
+			ancestor: [ 'woocommerce/single-product' ],
+		},
+		{
+			isAvailableOnPostEditor: true,
+		}
+	);
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -4,3 +4,8 @@ export type ProductTypeProps = {
 };
 
 export type QuantitySelectorStyleProps = 'input' | 'stepper';
+
+export interface Attributes {
+	className?: string;
+	isDescendentOfSingleProductBlock: boolean;
+}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -20,12 +20,7 @@ import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/prod
 import { QuantitySelectorStyle, AddToCartFormSettings } from './settings';
 import { shouldBlockifiedAddToCartWithOptionsBeRegistered } from '../../add-to-cart-with-options';
 import { UpgradeNotice } from './components/upgrade-notice';
-
-export interface Attributes {
-	className?: string;
-	isDescendentOfSingleProductBlock: boolean;
-	quantitySelectorStyle: QuantitySelectorStyle;
-}
+import type { Attributes } from './';
 
 export type FeaturesKeys =
 	| 'isStepperLayoutFeatureEnabled'

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
@@ -3,18 +3,26 @@
  */
 import { registerProductBlockType } from '@woocommerce/atomic-utils';
 import { Icon, button } from '@wordpress/icons';
+import type { BlockConfiguration } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
+import { QuantitySelectorStyle } from './settings';
 import AddToCartFormEdit from './edit';
 import './style.scss';
 import './editor.scss';
 import '../../../base/components/quantity-selector/style.scss';
 
+export interface Attributes {
+	className?: string;
+	isDescendentOfSingleProductBlock: boolean;
+	quantitySelectorStyle: QuantitySelectorStyle;
+}
+
 const blockConfig = {
-	...metadata,
+	...( metadata as BlockConfiguration< Attributes > ),
 	edit: AddToCartFormEdit,
 	icon: {
 		src: (

--- a/plugins/woocommerce/changelog/fix-hide-add-to-cart-with-options-from-widgets-screen
+++ b/plugins/woocommerce/changelog/fix-hide-add-to-cart-with-options-from-widgets-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide Add to Cart with Options block from widgets screen


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the function used to register the _Add to Cart with Options_ block from `registerBlockType()` to `registerProductBlockType()`, which takes care of not displaying the _Add to Cart with Options_ block in unwanted contexts like the widgets screen.

I also took the opportunity to fix a TypeScript error affecting the old _Add to Cart Form_ block.

### How to test the changes in this Pull Request:

1. Install and activate the `WooCommerce Beta Tester` plugin
2. Go to `WooCommerce Admin Test Helper` -> `Features` and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Create a post or page and verify you can't add the _Add to Cart with Options (Experimental)_ block directly into the post/page.
4. Now, add the Single Product block and select a product.
5. Verify you can add the _Add to Cart with Options (Experimental)_ block inside the Single Product block.
6. Go to Appearance > Editor > Templates > Single Product.
7. Verify you can add the _Add to Cart with Options (Experimental)_ block anywhere in the template.
8. Switch to a classic theme and go to Appearance > Widgets.
9. Verify you can't add the _Add to Cart with Options (Experimental)_ block in the widget areas.