### PR TITLE
Fix some wcadmin tracks missing request timestamp

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracks-missing-timestamp
+++ b/plugins/woocommerce/changelog/fix-tracks-missing-timestamp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tracks: Fix missing requesttimestamp in tracks

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php
@@ -108,8 +108,8 @@ class WC_Tracks_Client {
 	 * @return bool Always returns true.
 	 */
 	public static function record_pixel( $pixel ) {
-		// Add the Request Timestamp and URL terminator just before the HTTP request.
-		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
+		// Add the Request Timestamp and no cache parameter just before the HTTP request.
+		$pixel = self::add_request_timestamp_and_nocache( $pixel );
 
 		wp_safe_remote_get(
 			$pixel,
@@ -133,6 +133,19 @@ class WC_Tracks_Client {
 		$ts = NumberUtil::round( microtime( true ) * 1000 );
 
 		return number_format( $ts, 0, '', '' );
+	}
+
+	/**
+	 * Add request timestamp and no cache parameter to pixel.
+	 * Use this the latest possible before the HTTP request.
+	 *
+	 * @param string $pixel Pixel URL.
+	 * @return string Pixel URL with request timestamp and URL terminator.
+	 */
+	public static function add_request_timestamp_and_nocache( $pixel ) {
+		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
+
+		return $pixel;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-footer-pixel.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-footer-pixel.php
@@ -90,6 +90,9 @@ class WC_Tracks_Footer_Pixel {
 				continue;
 			}
 
+			// Add the Request Timestamp the latest possible before the HTTP request.
+			$pixel .= '&_rt=' . WC_Tracks_Client::build_timestamp();
+
 			echo '<img style="position: fixed;" src="', esc_url( $pixel ), '" />';
 		}
 

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-footer-pixel.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-footer-pixel.php
@@ -90,8 +90,8 @@ class WC_Tracks_Footer_Pixel {
 				continue;
 			}
 
-			// Add the Request Timestamp the latest possible before the HTTP request.
-			$pixel .= '&_rt=' . WC_Tracks_Client::build_timestamp();
+			// Add the Request Timestamp and no cache parameter just before the HTTP request.
+			$pixel = WC_Tracks_Client::add_request_timestamp_and_nocache( $pixel );
 
 			echo '<img style="position: fixed;" src="', esc_url( $pixel ), '" />';
 		}

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
@@ -418,6 +418,22 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	}
 
 	/**
+	 * Test that render_tracking_pixels includes required timestamp parameters.
+	 *
+	 * @param string $event_name Event name.
+	 */
+	public function assertTracksEventHasRequestTimestampAndNoCache( $event_name ) {
+		ob_start();
+		WC_Tracks_Footer_Pixel::instance()->render_tracking_pixels();
+		$output = ob_get_clean();
+
+		// Verify request timestamp and no cache parameters are present.
+		$this->assertStringContainsString( $event_name, $output, 'Event name should be present in the output' );
+		$this->assertStringContainsString( '_rt=', $output, 'Pixel URL should contain request timestamp parameter' );
+		$this->assertStringContainsString( '_=', $output, 'Pixel URL should contain nocache parameter' );
+	}
+
+	/**
 	 * Assert that the difference between two floats is smaller than a given delta.
 	 *
 	 * @param float      $expected The expected value.

--- a/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
@@ -71,6 +71,7 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_order_status_changed', $order->get_id(), OrderStatus::PENDING, 'finished' );
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_edit_status_change' );
+		$this->assertTracksEventHasRequestTimestampAndNoCache( 'wcadmin_orders_edit_status_change' );
 	}
 
 	/**
@@ -90,6 +91,7 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 		do_action( $hpos_enabled ? 'load-woocommerce_page_wc-orders' : 'load-edit.php' );
 
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_view' );
+		$this->assertTracksEventHasRequestTimestampAndNoCache( 'wcadmin_orders_view' );
 	}
 
 	/**
@@ -109,6 +111,7 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 		do_action( 'load-edit.php' );
 
 		$this->assertRecordedTracksEvent( 'wcadmin_orders_view_search' );
+		$this->assertTracksEventHasRequestTimestampAndNoCache( 'wcadmin_orders_view_search' );
 	}
 
 	/**
@@ -155,5 +158,4 @@ class WC_Orders_Tracking_Test extends \WC_Unit_Test_Case {
 	public function allow_edit_shop_orders( $caps, $cap, $user_id ) {
 		return ( 0 === $user_id && 'edit_shop_orders' === $cap ) ? array() : $caps;
 	}
-
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix some wcadmin tracks missing required request timestamp (`_rt`).

Context: p7Ldg5-8ur-p2

**Problem:**

Request timestamp was unset from `event` in here:

https://github.com/woocommerce/woocommerce/blob/3f6b19126e26235ba6df5688632e96f8be6a08f5/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php#L123

in order to add them the latest before the request possible so they better reflect the reality.

They are set again in here:

https://github.com/woocommerce/woocommerce/blob/3f6b19126e26235ba6df5688632e96f8be6a08f5/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php#L112

for one type of event recording but it wasn't set for another one involving rendering actual pixel in footer.

This PR adds the `_rt` property to pixel's URL. Also, I added test function verifying there are necessary parameters in the pixel URL and added it to some exemplary events.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the tracking is enabled (WooCommerce > Settings > Advanced > ☑️  Enable WooCommerce Analytics )
2. Open broswer's console and go to network tab. Filter `gif`
3. Go to WooCommerce > Orders
4. Find gif request and go to payload
5. Expected: There's `_rt` property in the payload

Before | After
-- | --
![Screen Shot 2024-12-30 at 17 42 22 PM](https://github.com/user-attachments/assets/f689b20a-2dfd-466a-81bb-88fbb0d9428d) | ![Screen Shot 2024-12-30 at 17 40 41 PM](https://github.com/user-attachments/assets/5f381ec5-c0f0-45c7-aee0-ef21d71bc93d)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>