### PR TITLE
Show button for activate Jetpack in WooCommerce Stats when Jetpack is deactivated but connected

### DIFF
--- a/plugins/woocommerce/changelog/fix-jetpack-connection-check-for-stats
+++ b/plugins/woocommerce/changelog/fix-jetpack-connection-check-for-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show button for activate Jetpack in WooCommerce Stats when Jetpack is deactivated but connected

--- a/plugins/woocommerce/client/admin/client/homescreen/stats-overview/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/stats-overview/index.js
@@ -48,8 +48,12 @@ export const StatsOverview = () => {
 		DEFAULT_HIDDEN_STATS
 	);
 
-	const jetPackIsConnected = useSelect( ( select ) => {
-		return select( PLUGINS_STORE_NAME ).isJetpackConnected();
+	const jetPackIsConnectedAndActivated = useSelect( ( select ) => {
+		const store = select( PLUGINS_STORE_NAME );
+		return (
+			store.isJetpackConnected() &&
+			store.getPluginInstallState( 'jetpack' ) === 'activated'
+		);
 	}, [] );
 
 	const homePageStats = userPrefs.homepage_stats || {};
@@ -134,7 +138,7 @@ export const StatsOverview = () => {
 			>
 				{ ( tab ) => (
 					<Fragment>
-						{ ! jetPackIsConnected &&
+						{ ! jetPackIsConnectedAndActivated &&
 							! userDismissedJetpackInstall && (
 								<InstallJetpackCTA />
 							) }


### PR DESCRIPTION
… deactivated but connected

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39384 

This PR fixes a bug when Jetpack is Connected  to WPCOM but deactivated. It doesn't show an option in WooCommerce - Home - Stats to just activate the plugin:

Not installed:

<img width="756" alt="Screenshot 2024-12-30 at 17 45 38" src="https://github.com/user-attachments/assets/6c10ae2e-9ff5-4541-b9d8-739c68d4b711" />

Not activated:

<img width="698" alt="Screenshot 2024-12-30 at 17 47 30" src="https://github.com/user-attachments/assets/099673ce-4f37-4a6c-9abd-3ff68e9ffdea" />

Not Connected (still shows the stats Views and Visitors, I don't now if that's expected.  but that's something in the JP Scope not covered in this PR)  

<img width="693" alt="Screenshot 2024-12-30 at 17 57 38" src="https://github.com/user-attachments/assets/fb777e4f-b4df-472f-b667-ade451778675" />

Connected and activated:

<img width="721" alt="Screenshot 2024-12-30 at 17 47 01" src="https://github.com/user-attachments/assets/7d0f6bee-ef1a-49f4-ae53-bc05a9768ba7" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce with this PR
2. Dont install either activate jetpack or connect to WPCOM
3. Go to WooCommerce - Home Store stats 
4. See the UI as "Not installed:" in the screenshots
5. Click on Get Jetpack and Approve & Connect 
6. Go to WooCommerce - Home Store stats 
7. See the UI as "Connected and activated:" in the screenshots 
8. Go to Plugins.
9. Deactivate Jetpack
10. Go to WooCommerce - Home Store stats 
11.  See the UI as "Not activated:" in the screenshots 
12. Activate Jetpack
13. Go to Jetpack - My jetpack
14. Scroll down until you see the Connection section
15. Click on Manage
16. Disconnect
17. Go to WooCommerce - Home Store stats 
18. See the UI as "Not connected:" in the screenshots 
19. Connect Jetpack
20. Go to WooCommerce - Home Store stats 
21. See the UI as "Connected and activated:" in the screenshots 

Videos with the testing steps:


https://github.com/user-attachments/assets/bbd5cc98-4491-487b-a7d5-cc3e5a1a2cba

https://github.com/user-attachments/assets/9dc8480f-9762-4072-ac12-34a422a4828f


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


