### PR TITLE
FlexSlider fade animation small code refactor

### DIFF
--- a/plugins/woocommerce/changelog/54091-flexslider-fade-refactor
+++ b/plugins/woocommerce/changelog/54091-flexslider-fade-refactor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+FlexSlider fade animation small code refactor

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -887,17 +887,17 @@
         }
         if (type === "init") {
           if (!touch) {
-            // Every "opacity" change before outerWidth() does NOT get animated; every "opacity" change after outerWidth() becomes a fadeIn
+            // Every "opacity" change before outerWidth() does NOT get animated; every "opacity" change after outerWidth() becomes a fadeIn animation
             if (slider.vars.fadeFirstSlide == false) {
-              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).css({"zIndex": 2}).css({"opacity": 1});
+              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).css({ "opacity": 1, "zIndex": 2 });
               slider.slides.outerWidth();
             } else {
               slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).outerWidth();
-              slider.slides.eq(slider.currentSlide).css({"zIndex": 2}).css({"opacity": 1});
+              slider.slides.eq(slider.currentSlide).css({ "opacity": 1, "zIndex": 2 });
             }
             slider.slides.css({ "transition": "opacity " + slider.vars.animationSpeed / 1000 + "s " + easing });
           } else {
-            slider.slides.css({ "opacity": 0, "display": "block", "transition": "opacity " + slider.vars.animationSpeed / 1000 + "s ease", "zIndex": 1 }).eq(slider.currentSlide).css({ "opacity": 1, "zIndex": 2});
+            slider.slides.css({ "opacity": 0, "display": "block", "transition": "opacity " + slider.vars.animationSpeed / 1000 + "s ease", "zIndex": 1 }).eq(slider.currentSlide).css({ "opacity": 1, "zIndex": 2 });
           }
         }
         // SMOOTH HEIGHT:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A small code refactor to make the FlexSlider `.css()` calls consistent with each other - no change to functionality.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates #36689.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this custom code to your theme's `functions.php` in order to enable fade animations:
```
function carousel_options( $options ) {
	return array_merge(
		$options,
		array(
			'animation' => 'fade',
			'animationSpeed' => 2600,
			'fadeFirstSlide' => false,
		)
	);
}
add_filter( 'woocommerce_single_product_carousel_options', 'carousel_options' );
```
2. Visit a Single Product Page on a non-touch-enabled device (a PC or a laptop).
3. Confirm that the first gallery image does NOT do a fadeIn animation on page load.
4. Confirm that switching between gallery images happens with a fade animation that lasts 2.6 seconds.
5. Enable `fadeFirstSlide` in the custom code in your theme's `functions.php`:
```
function carousel_options( $options ) {
	return array_merge(
		$options,
		array(
			'animation' => 'fade',
			'animationSpeed' => 2600,
			'fadeFirstSlide' => true,
		)
	);
}
add_filter( 'woocommerce_single_product_carousel_options', 'carousel_options' );
```
6. Visit a Single Product Page on a non-touch-enabled device (a PC or a laptop).
7. Confirm that the first gallery image DOES a fadeIn animation on page load.
8. Confirm that switching between gallery images happens with a fade animation that lasts 2.6 seconds.

<!-- End testing instructions -->