### PR TITLE
Fix Stock Indicator not loading when "experimental-blocks" is disabled

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
@@ -20,7 +20,6 @@ import { useSelect } from '@wordpress/data';
 import './style.scss';
 import type { BlockAttributes } from './types';
 import { store as woocommerceTemplateStateStore } from '../../../../shared/store';
-import type { ProductTypeProps } from '../../../../utils/get-product-type-options';
 
 type Props = BlockAttributes & HTMLAttributes< HTMLDivElement >;
 
@@ -60,9 +59,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	const { text: availabilityText, class: availabilityClass } =
 		product.stock_availability;
 
-	const { selectedProductType } = useSelect< {
-		selectedProductType: ProductTypeProps;
-	} >( ( select ) => {
+	const { selectedProductType } = useSelect( ( select ) => {
 		const { getCurrentProductType } = select(
 			woocommerceTemplateStateStore
 		);

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/hooks/use-product-type-selector/index.ts
@@ -10,7 +10,7 @@ import type { ProductTypeProps } from '../../types';
 
 type ProductTypeSelector = {
 	productTypes: ProductTypeProps[];
-	current: ProductTypeProps;
+	current: ProductTypeProps | undefined;
 	set: ( productType: string ) => void;
 	registeredListeners: string[];
 	registerListener: ( listener: string ) => void;
@@ -29,29 +29,25 @@ export default function useProductTypeSelector(): ProductTypeSelector {
 	 * Get the registered listeners, available product types and the current product type
 	 * from the store.
 	 */
-	const { productTypes, current, registeredListeners } = useSelect< {
-		productTypes: ProductTypeProps[];
-		current: ProductTypeProps;
-		registeredListeners: string[];
-	} >( ( select ) => {
-		const {
-			getProductTypes,
-			getCurrentProductType,
-			getRegisteredListeners,
-		} = select( woocommerceTemplateStateStore );
+	const { productTypes, current, registeredListeners } = useSelect(
+		( select ) => {
+			const {
+				getProductTypes,
+				getCurrentProductType,
+				getRegisteredListeners,
+			} = select( woocommerceTemplateStateStore );
 
-		return {
-			productTypes: getProductTypes(),
-			current: getCurrentProductType(),
-			registeredListeners: getRegisteredListeners(),
-		};
-	}, [] );
-
-	const { registerListener, unregisterListener } = useDispatch(
-		woocommerceTemplateStateStore
+			return {
+				productTypes: getProductTypes(),
+				current: getCurrentProductType(),
+				registeredListeners: getRegisteredListeners(),
+			};
+		},
+		[]
 	);
 
-	const { switchProductType } = useDispatch( woocommerceTemplateStateStore );
+	const { switchProductType, registerListener, unregisterListener } =
+		useDispatch( woocommerceTemplateStateStore );
 
 	return {
 		productTypes,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -12,7 +12,6 @@ import type { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import registerStore from '../../shared/store';
 import ProductTypeSelectorPlugin from './plugins';
 import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
@@ -31,8 +30,6 @@ export const shouldBlockifiedAddToCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
 if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
-	registerStore();
-
 	// Register a plugin that adds a product type selector to the template sidebar.
 	const PLUGIN_NAME = 'document-settings-template-selector-pane';
 	if ( ! getPlugin( PLUGIN_NAME ) ) {

--- a/plugins/woocommerce-blocks/assets/js/shared/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/shared/store/index.ts
@@ -136,8 +136,6 @@ export const store = createReduxStore( STORE_NAME, {
 	selectors,
 } );
 
-export default function registerStore() {
-	if ( ! select( STORE_NAME ) ) {
-		register( store );
-	}
+if ( ! select( STORE_NAME ) ) {
+	register( store );
 }

--- a/plugins/woocommerce/changelog/fix-54068-stock-indicator-error
+++ b/plugins/woocommerce/changelog/fix-54068-stock-indicator-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Stock Indicator not loading when "experimental-blocks" is disabled
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/54068.

This PR makes it so the product type store is always registered. Until now, we were only registering it when the `experimental-blocks` feature flag was enabled, but the store is also used by the _Stock Indicator_ block, which is not an experimental one.

This PR also adds some minor TypeScript fixes (it might be easier to review the two commits separately).

### How to test the changes in this Pull Request:

2. Go to Pages > Add New Page
3. Add a `Single Product` block and select the product you just created.
4. Add a `Stock indicator` block.
5. Go to Tools > WCA Test Helper > Features
6. Disable the feature: `experimental-blocks`
6. Go back to the page you created and edit it.
7. Verify the `Stock indicator` block is still visible without errors.