### PR TITLE
Fix "Go to the Editor" CYS button

### DIFF
--- a/plugins/woocommerce/changelog/fix-53866
+++ b/plugins/woocommerce/changelog/fix-53866
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Fix redirection in "Go to the store" link

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/intro-banners.tsx
@@ -13,7 +13,7 @@ import { Link } from '@woocommerce/components';
  */
 import { Intro } from '.';
 import { IntroSiteIframe } from './intro-site-iframe';
-import { getAdminSetting } from '~/utils/admin-settings';
+import { ADMIN_URL, getAdminSetting } from '~/utils/admin-settings';
 import { navigateOrParent } from '../utils';
 import { trackEvent } from '../tracking';
 
@@ -369,7 +369,7 @@ export const NonDefaultBlockThemeBanner = () => {
 				trackEvent( 'customize_your_store_intro_customize_click', {
 					theme_type: 'block',
 				} );
-				navigateOrParent( window, 'site-editor.php' );
+				navigateOrParent( window, `${ ADMIN_URL }site-editor.php` );
 			} }
 			bannerButtonText={ __( 'Go to the Editor', 'woocommerce' ) }
 			showAIDisclaimer={ false }

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -132,7 +132,10 @@ test.describe(
 			} );
 			await expect( button ).toBeVisible();
 			await button.click();
-			expect( page.url() ).toContain( 'wp-admin/site-editor.php' );
+			// Expecting heading from editor to be visible.
+			await expect(
+				page.getByRole( 'heading', { name: 'Design' } )
+			).toBeVisible();
 		} );
 		test( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -115,7 +115,7 @@ test.describe(
 			).toBeVisible();
 		} );
 
-		test( 'it shows the "non default block theme" banner when the theme is a block theme different than TT4', async ( {
+		test( 'it shows the "non default block theme" banner when the theme is a block theme different than TT4 and redirects to the editor', async ( {
 			page,
 			baseURL,
 		} ) => {
@@ -126,11 +126,14 @@ test.describe(
 			await expect( page.locator( 'h1' ) ).toHaveText(
 				'Customize your theme'
 			);
-			await expect(
-				page.getByRole( 'button', { name: 'Go to the Editor' } )
-			).toBeVisible();
-		} );
 
+			const button = page.getByRole( 'button', {
+				name: 'Go to the Editor',
+			} );
+			await expect( button ).toBeVisible();
+			await button.click();
+			expect( page.url() ).toContain( 'wp-admin/site-editor.php' );
+		} );
 		test( 'clicking on "Go to the Customizer" with a classic theme should go to the customizer', async ( {
 			page,
 			baseURL,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/53418 the logic to determine the final route was changed and that impacted the link to other areas of admin than  `page=wc-admin`. In the current shape, the `navigateOrParent( window, 'site-editor.php' );` resulted in incorrect wc-admin route which threw warnings and prevented the correct redirection.

In order to preserve that logic, we need to provide full url for redirection.

Closes https://github.com/woocommerce/woocommerce/issues/53866

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go through CYS flow if you haven't already (WooCommerce > Customize Your Store > Start customising)
2. Change the theme to block theme but different one than you originally passed CYS with (for example switch from TT4 > TT5)
3. Go to WooCommerce > Customize Your Store
4. Click "Go to the Editor"
5. **Expected:** You're successfully redirected to the editor

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
