### PR TITLE
Fix failing `EmailPreviewTest::test_dummy_product_filter` test

### DIFF
--- a/plugins/woocommerce/changelog/fix-eamil-preview-test
+++ b/plugins/woocommerce/changelog/fix-eamil-preview-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix EmailPreviewTest::test_dummy_product_filter to validate dummy product properties directly

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -141,13 +141,9 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 			return $product;
 		};
 		add_filter( 'woocommerce_email_preview_dummy_product', $product_filter, 10, 1 );
-
-		$content = $this->sut->render();
-		$this->assertStringContainsString( 'Filtered Product', $content );
-		$this->assertStringContainsString( '99', $content );
-		$this->assertStringNotContainsString( 'Dummy Product', $content );
-		$this->assertStringNotContainsString( '25', $content );
-
+		$product = $this->sut->get_dummy_product_when_not_set( null );
+		$this->assertEquals( 'Filtered Product', $product->get_name() );
+		$this->assertEquals( '99', $product->get_price() );
 		remove_filter( 'woocommerce_email_preview_dummy_product', $product_filter, 10 );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


The `EmailPreviewTest::test_dummy_product_filter` is failing (https://github.com/woocommerce/woocommerce/actions/runs/12567268695/job/35033627778?pr=54103
) because it expects the rendered email to NOT contain `25` but it does because it's 2025 now (Order date contains 2025).

This PR fixes the test by updating assertions to check product name and price instead of rendering content. It should be more stable.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Review the changes and CI should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
