### PR TITLE
[Settings] Load external scripts

### DIFF
--- a/packages/js/settings-editor/changelog/54112-update-settings-external-scripts
+++ b/packages/js/settings-editor/changelog/54112-update-settings-external-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Load and run external scripts in WooCommerce Settings
+

--- a/packages/js/settings-editor/changelog/54112-update-settings-external-scripts
+++ b/packages/js/settings-editor/changelog/54112-update-settings-external-scripts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Load and run external scripts in WooCommerce Settings
-

--- a/plugins/woocommerce/changelog/54112-update-settings-external-scripts
+++ b/plugins/woocommerce/changelog/54112-update-settings-external-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Load and run external scripts in WooCommerce Settings
+

--- a/plugins/woocommerce/client/admin/client/settings/index.js
+++ b/plugins/woocommerce/client/admin/client/settings/index.js
@@ -23,6 +23,10 @@ const appendSettingsScripts = ( scripts ) => {
 	return scripts.map( ( script ) => {
 		const scriptElement = document.createElement( 'script' );
 		scriptElement.src = script;
+		scriptElement.onerror = () => {
+			// eslint-disable-next-line no-console
+			console.error( `Failed to load script: ${ script }` );
+		};
 		document.body.appendChild( scriptElement );
 		return scriptElement;
 	} );
@@ -44,12 +48,14 @@ const Settings = () => {
 	const { activePage, activeSection } = useActiveRoute();
 
 	useLayoutEffect( () => {
-		const settingsScripts = [
-			...( SETTINGS_SCRIPTS._default || [] ),
-			...( SETTINGS_SCRIPTS[ activePage ] || [] ),
-		];
+		const scripts = Array.from(
+			new Set( [
+				...( SETTINGS_SCRIPTS._default || [] ),
+				...( SETTINGS_SCRIPTS[ activePage ] || [] ),
+			] )
+		);
 
-		const scriptsElements = appendSettingsScripts( settingsScripts );
+		const scriptsElements = appendSettingsScripts( scripts );
 
 		return () => {
 			removeSettingsScripts( scriptsElements );

--- a/plugins/woocommerce/client/admin/client/settings/index.js
+++ b/plugins/woocommerce/client/admin/client/settings/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createRoot, useEffect } from '@wordpress/element';
+import { createRoot, useEffect, useLayoutEffect } from '@wordpress/element';
 import {
 	SettingsEditor,
 	useActiveRoute,
@@ -19,12 +19,42 @@ import './settings.scss';
 
 const node = document.getElementById( 'wc-settings-page' );
 
+const appendSettingsScripts = ( scripts ) => {
+	return scripts.map( ( script ) => {
+		const scriptElement = document.createElement( 'script' );
+		scriptElement.src = script;
+		document.body.appendChild( scriptElement );
+		return scriptElement;
+	} );
+};
+
+const removeSettingsScripts = ( scripts ) => {
+	scripts.forEach( ( script ) => {
+		document.body.removeChild( script );
+	} );
+};
+
+const SETTINGS_SCRIPTS = window.wcSettings?.admin?.settingsScripts || [];
+
 registerTaxSettingsConflictErrorFill();
 registerPaymentsSettingsBannerFill();
 registerSiteVisibilitySlotFill();
 
 const Settings = () => {
 	const { activePage, activeSection } = useActiveRoute();
+
+	useLayoutEffect( () => {
+		const settingsScripts = [
+			...( SETTINGS_SCRIPTS._default || [] ),
+			...( SETTINGS_SCRIPTS[ activePage ] || [] ),
+		];
+
+		const scriptsElements = appendSettingsScripts( settingsScripts );
+
+		return () => {
+			removeSettingsScripts( scriptsElements );
+		};
+	}, [ activePage, activeSection ] );
 
 	// Render the settings slots every time the page or section changes.
 	useEffect( () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53860

This PR ensures that external scripts registered in the Settings are loaded and executed dynamically based on tab or section changes.

This implementation is similar to POC in https://github.com/woocommerce/woocommerce/pull/48340/files#diff-2eda4b4f15229298aab5b05def76b8abadde4d0d2931fd9929de97ac5e2b53f3 with some improvements.

This PR does't solve the issues below but it should be a good start. I think we can test with plugins to better understand the issues.

Some known issues:

1. All scripts are loaded on the settings page, even if not needed for the current tab, due to the inability to determine their necessity.
2. The default scripts are loaded again whenever the route changes even if they don't need to be loaded again because we don't have a good way to determine if the script only needs to be loaded once or not.
3. Scripts might not work when revisiting the same tab because global variables/listeners/dom elements are not reset properly.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add/Enable Gutenberg version `19.8.0` or earlier.
2. Turn on the `settings` feature flag
3. Upload [settings-tester.zip](https://github.com/user-attachments/files/18296277/settings-tester.zip)
 and activate the Tester
4. Go to WooCommerce Settings page and navigate to `Legacy Settings > Slotfill`
5. It should display `This is a fill created by Settings Tester` in the slotfill.

![Screenshot 2025-01-02 at 17 14 45](https://github.com/user-attachments/assets/82f67a47-699f-4b96-a470-4bcef36ae8ce)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Load and run external scripts in WooCommerce Settings



</details>
