### PR TITLE
[Experimental] Avoid duplicate store registration of template-state store

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -8,6 +8,7 @@ import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 import { registerProductBlockType } from '@woocommerce/atomic-utils';
 import type { BlockConfiguration } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ import AddToCartOptionsEdit from './edit';
 import save from './save';
 import './style.scss';
 import type { Attributes } from './types';
+import { STORE_NAME } from '../../shared/store/constants';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -31,7 +33,9 @@ export const shouldBlockifiedAddToCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
 if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
-	registerStore();
+	if ( ! select( STORE_NAME ) ) {
+		registerStore();
+	}
 
 	// Register a plugin that adds a product type selector to the template sidebar.
 	const PLUGIN_NAME = 'document-settings-template-selector-pane';

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -8,7 +8,6 @@ import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 import { registerProductBlockType } from '@woocommerce/atomic-utils';
 import type { BlockConfiguration } from '@wordpress/blocks';
-import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,7 +19,6 @@ import AddToCartOptionsEdit from './edit';
 import save from './save';
 import './style.scss';
 import type { Attributes } from './types';
-import { STORE_NAME } from '../../shared/store/constants';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -33,9 +31,7 @@ export const shouldBlockifiedAddToCartWithOptionsBeRegistered =
 	isExperimentalBlocksEnabled() && isBlockifiedAddToCart;
 
 if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
-	if ( ! select( STORE_NAME ) ) {
-		registerStore();
-	}
+	registerStore();
 
 	// Register a plugin that adds a product type selector to the template sidebar.
 	const PLUGIN_NAME = 'document-settings-template-selector-pane';

--- a/plugins/woocommerce-blocks/assets/js/shared/store/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/shared/store/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -137,5 +137,7 @@ export const store = createReduxStore( STORE_NAME, {
 } );
 
 export default function registerStore() {
-	register( store );
+	if ( ! select( STORE_NAME ) ) {
+		register( store );
+	}
 }

--- a/plugins/woocommerce/changelog/update-only-register-template-state-store-once
+++ b/plugins/woocommerce/changelog/update-only-register-template-state-store-once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Register template-state store only once


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the editor console we are getting some errors related to the `woocommerce/template-state` store saying we are attempting to register it multiple times. This change ensures we check if its not already been registered before doing so to prevent duplicate attempts.

![image](https://github.com/user-attachments/assets/5c983077-9b2f-4a39-a38c-c9252f10fecb)

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Since this is an experimental block it's not necessary to test it during release testing**

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the `WooCommerce Beta Tester` plugin
2. Go to `WooCommerce Admin Test Helper` -> `Features` and enable `add-to-cart-with-options-stepper-layout` and `blockified-add-to-cart`.
3. Smoke test the `Add to Cart with Options (Experimental)` block.
4. Create a new product.
5. Go to Pages > Add New Page.
6. Add a `Single product` block and select the product you just created.
7. Remove the current _Add to Cart with Options_ block.
8. Everything should work well
9. Now go to the Sincle Product template and add an `Add to Cart with Options (Experimental)` block.
10. Verify that after adding the block the `Type switcher` selector is now visible in the Inspector > Template.
11. Confirm the selected product type is consistent.
12. Confirm you do not see the console errors shown in the above screenshot when you're in the Gutenberg editor on the Single Product template, or a post/page.
13. Confirm all E2E tests pass.

https://github.com/user-attachments/assets/0c56abdb-fc03-416c-b893-b4cca89049ca
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
