### PR TITLE
Add To Cart With Options: enable stepper layout

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -213,12 +213,6 @@ test.describe( `${ blockData.name } Block`, () => {
 	} );
 
 	test.describe( 'Stepper Layout', () => {
-		test.beforeEach( async ( { requestUtils } ) => {
-			await requestUtils.setFeatureFlag(
-				'add-to-cart-with-options-stepper-layout',
-				true
-			);
-		} );
 		test( 'has the stepper option visible', async ( {
 			admin,
 			editor,

--- a/plugins/woocommerce/changelog/54116-add-add-to-cart-stepper-layout
+++ b/plugins/woocommerce/changelog/54116-add-add-to-cart-stepper-layout
@@ -1,0 +1,4 @@
+Significance: major
+Type: add
+
+Add To Cart With Options: enable stepper layout.

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -41,7 +41,7 @@
 		"blueprint": false,
 		"reactify-classic-payments-settings": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": false,
+		"add-to-cart-with-options-stepper-layout": true,
 		"blockified-add-to-cart": false
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR enables the Stepper Layout mode, previously under a feature flag in WooCommerce 9.5 and 9.6.

For more details, you can check https://github.com/woocommerce/woocommerce/discussions/53039

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable a block theme.
2. Edit the Single Product Template.
3. Ensure that you have the Add To Cart with Options block added.
4. Click on it.
5. Open the block settings.
6. Ensure that you have the Quantity Selector option.
7. Ensure that the default one is Input.
8. Switch the option to Stepper.
9. Save it.
10. Visit a product page. For instance, `/product/beanie-with-logo/`.
11. Ensure that the stepper button works correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add To Cart With Options: enable stepper layout.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
