### PR TITLE
Fix registerProductBlockType() types

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -66,7 +66,7 @@ export class BlockRegistrationManager {
 		string,
 		ProductBlockSettings & {
 			blockName: string;
-			settings: Record< string, unknown >;
+			settings: Partial< BlockConfiguration< BlockAttributes > >;
 		}
 	> = new Map();
 	/** Current template ID being edited */
@@ -149,9 +149,7 @@ export class BlockRegistrationManager {
 				subscribe( () => {
 					const previousTemplateId = this.currentTemplateId;
 					this.currentTemplateId = this.parseTemplateId(
-						editSiteStore.getEditedPostId<
-							string | number | undefined
-						>()
+						editSiteStore.getEditedPostId()
 					);
 
 					if ( previousTemplateId !== this.currentTemplateId ) {
@@ -319,7 +317,7 @@ export class BlockRegistrationManager {
 		config: ProductBlockConfig< T >
 	): void {
 		const key = config.variationName || config.blockName;
-		this.blocks.set( key, config );
+		this.blocks.set( key, config as ProductBlockConfig< BlockAttributes > );
 		this.registerBlock( config );
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -31,6 +31,7 @@ type ProductBlockSettings = {
  * Internal block config type used by the BlockRegistrationManager
  *
  * @typedef {Object} ProductBlockConfig
+ * @template T Extends BlockAttributes to define the block's attribute types
  * @property {string}                      blockName            - The name of the block
  * @property {Partial<BlockConfiguration>} settings             - Block settings configuration
  * @property {ProductBlockSettings}        productBlockSettings - Product block settings
@@ -44,6 +45,7 @@ type ProductBlockConfig< T extends BlockAttributes > = ProductBlockSettings & {
  * Configuration object for registering a product block type.
  *
  * @typedef {Object} ProductBlockRegistrationConfig
+ * @template T Extends BlockAttributes to define the block's attribute types
  * @property {Partial<BlockConfiguration>} settings                - Block settings configuration
  * @property {boolean}                     [isVariationBlock]      - Whether this block is a variation
  * @property {string}                      [variationName]         - The name of the variation if applicable
@@ -222,7 +224,8 @@ export class BlockRegistrationManager {
 	 * Unregisters a block or block variation.
 	 * Handles both regular blocks and variations with error handling.
 	 *
-	 * @param {ProductBlockConfig} config - Configuration of the block to unregister
+	 * @template T The type of block attributes
+	 * @param {ProductBlockConfig<T>} config - Configuration of the block to unregister
 	 */
 	private unregisterBlock< T extends BlockAttributes >(
 		config: ProductBlockConfig< T >
@@ -251,7 +254,8 @@ export class BlockRegistrationManager {
 	 * Handles different registration requirements for various contexts.
 	 * Includes checks to prevent recursive registration.
 	 *
-	 * @param {ProductBlockConfig} config - Configuration of the block to register
+	 * @template T The type of block attributes
+	 * @param {ProductBlockConfig<T>} config - Configuration of the block to unregister
 	 */
 	private registerBlock< T extends BlockAttributes >(
 		config: ProductBlockConfig< T >
@@ -311,7 +315,8 @@ export class BlockRegistrationManager {
 	 * Registers a new block configuration with the manager.
 	 * Main entry point for adding new blocks to be managed.
 	 *
-	 * @param {ProductBlockConfig} config - Configuration for the block to register
+	 * @template T The type of block attributes
+	 * @param {ProductBlockConfig<T>} config - Configuration of the block to unregister
 	 */
 	public registerBlockConfig< T extends BlockAttributes >(
 		config: ProductBlockConfig< T >
@@ -343,6 +348,11 @@ export class BlockRegistrationManager {
  * with no ancestor constraints. The `isAvailableOnPostEditor` flag can be used to make
  * the block available in regular post editing contexts as well where ancestor constraints are enforced.
  *
+ * @template T Extends BlockAttributes to define the block's attribute types
+ * @param {string | Partial<BlockConfiguration<T>>}               blockNameOrMetadata - Either a string block name or block metadata object
+ * @param {ProductBlockRegistrationConfig<BlockConfiguration<T>>} [settings]          - Optional settings for block registration
+ * @return {void}
+ *
  * @example
  * ```typescript
  * registerProductBlockType({
@@ -355,8 +365,6 @@ export class BlockRegistrationManager {
  *     isAvailableOnPostEditor: true
  * });
  * ```
- *
- * @return {void}
  */
 export const registerProductBlockType = < T extends BlockAttributes >(
 	blockNameOrMetadata: string | Partial< BlockConfiguration< T > >,

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -255,7 +255,7 @@ export class BlockRegistrationManager {
 	 * Includes checks to prevent recursive registration.
 	 *
 	 * @template T The type of block attributes
-	 * @param {ProductBlockConfig<T>} config - Configuration of the block to unregister
+	 * @param {ProductBlockConfig<T>} config - Configuration of the block to register
 	 */
 	private registerBlock< T extends BlockAttributes >(
 		config: ProductBlockConfig< T >
@@ -316,7 +316,7 @@ export class BlockRegistrationManager {
 	 * Main entry point for adding new blocks to be managed.
 	 *
 	 * @template T The type of block attributes
-	 * @param {ProductBlockConfig<T>} config - Configuration of the block to unregister
+	 * @param {ProductBlockConfig<T>} config - Configuration of the block to register
 	 */
 	public registerBlockConfig< T extends BlockAttributes >(
 		config: ProductBlockConfig< T >

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, button } from '@wordpress/icons';
+import { button } from '@wordpress/icons';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
@@ -42,7 +42,9 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	registerProductBlockType< Attributes >(
 		{
 			...( metadata as BlockConfiguration< Attributes > ),
-			icon: <Icon icon={ button } />,
+			icon: {
+				src: button,
+			},
 			edit: AddToCartOptionsEdit,
 			save,
 			ancestor: [ 'woocommerce/single-product' ],

--- a/plugins/woocommerce/changelog/fix-registerProductBlockType-types
+++ b/plugins/woocommerce/changelog/fix-registerProductBlockType-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix registerProductBlockType() types
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds some TypeScript fixes on top of the changes made in https://github.com/woocommerce/woocommerce/pull/54087/.

### How to test the changes in this Pull Request:

This PR only includes changes to types, so there are no user-facing changes.

1. Open `plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts` and `plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx`.
2. Verify there are no TypeScript errors introduced by this PR.