### PR TITLE
registerProductBlockType: Fix TS errors

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -28,12 +28,13 @@ type ProductBlockSettings = {
 };
 
 /**
- * Internal block config type used by the BlockRegistrationManager
+ * Internal block config type used by the BlockRegistrationManager.
+ * This type combines product block settings with core block configuration.
  *
  * @typedef {Object} ProductBlockConfig
- * @property {string}                      blockName            - The name of the block
- * @property {Partial<BlockConfiguration>} settings             - Block settings configuration
- * @property {ProductBlockSettings}        productBlockSettings - Product block settings
+ * @template T - Block attributes type that extends BlockAttributes
+ * @property {string}                      blockName - The name of the block to be registered
+ * @property {Partial<BlockConfiguration>} settings  - Core block settings configuration including attributes, edit/save functions, etc.
  */
 type ProductBlockConfig< T extends BlockAttributes = BlockAttributes > =
 	ProductBlockSettings & {
@@ -42,13 +43,15 @@ type ProductBlockConfig< T extends BlockAttributes = BlockAttributes > =
 	};
 
 /**
- * Configuration object for registering a product block type.
+ * Configuration type for registering a product block type. This combines the core block configuration
+ * with additional WooCommerce-specific product block settings.
  *
  * @typedef {Object} ProductBlockRegistrationConfig
- * @property {Partial<BlockConfiguration>} settings                - Block settings configuration
- * @property {boolean}                     [isVariationBlock]      - Whether this block is a variation
- * @property {string}                      [variationName]         - The name of the variation if applicable
- * @property {boolean}                     isAvailableOnPostEditor - Whether the block should be available in post editor
+ * @template T - Block attributes type that extends BlockAttributes
+ * @property {Partial<BlockConfiguration<T>>} settings                  - Core block settings including attributes, edit/save functions, etc.
+ * @property {boolean}                        [isVariationBlock]        - Optional flag indicating if this block should be registered as a variation of another block
+ * @property {string}                         [variationName]           - Optional name for the block variation if isVariationBlock is true
+ * @property {boolean}                        [isAvailableOnPostEditor] - Optional flag to make block available in post editor context (defaults to false)
  */
 type ProductBlockRegistrationConfig<
 	T extends BlockAttributes = BlockAttributes

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -344,8 +344,8 @@ export class BlockRegistrationManager {
  *
  * @return {void}
  */
-export const registerProductBlockType = < T extends BlockAttributes >(
-	blockNameOrMetadata: string | Partial< BlockConfiguration< T > >,
+export const registerProductBlockType = (
+	blockNameOrMetadata: string | Partial< BlockConfiguration >,
 	settings?: ProductBlockRegistrationConfig
 ): void => {
 	const blockName =

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -49,9 +49,9 @@ type ProductBlockConfig< T extends BlockAttributes = BlockAttributes > =
  * @typedef {Object} ProductBlockRegistrationConfig
  * @template T - Block attributes type that extends BlockAttributes
  * @property {Partial<BlockConfiguration<T>>} settings                  - Core block settings including attributes, edit/save functions, etc.
- * @property {boolean}                        [isVariationBlock]        - Optional flag indicating if this block should be registered as a variation of another block
- * @property {string}                         [variationName]           - Optional name for the block variation if isVariationBlock is true
- * @property {boolean}                        [isAvailableOnPostEditor] - Optional flag to make block available in post editor context (defaults to false)
+ * @property {boolean}                        [isVariationBlock]        - Whether this block is a variation
+ * @property {string}                         [variationName]           - The name of the variation if applicable
+ * @property {boolean}                        [isAvailableOnPostEditor] - Whether the block should be available in post editor
  */
 type ProductBlockRegistrationConfig<
 	T extends BlockAttributes = BlockAttributes

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -35,10 +35,11 @@ type ProductBlockSettings = {
  * @property {Partial<BlockConfiguration>} settings             - Block settings configuration
  * @property {ProductBlockSettings}        productBlockSettings - Product block settings
  */
-type ProductBlockConfig = ProductBlockSettings & {
-	blockName: string;
-	settings: Partial< BlockConfiguration >;
-};
+type ProductBlockConfig< T extends BlockAttributes = BlockAttributes > =
+	ProductBlockSettings & {
+		blockName: string;
+		settings: Partial< BlockConfiguration< T > >;
+	};
 
 /**
  * Configuration object for registering a product block type.
@@ -49,8 +50,9 @@ type ProductBlockConfig = ProductBlockSettings & {
  * @property {string}                      [variationName]         - The name of the variation if applicable
  * @property {boolean}                     isAvailableOnPostEditor - Whether the block should be available in post editor
  */
-type ProductBlockRegistrationConfig = Partial< BlockConfiguration > &
-	ProductBlockSettings;
+type ProductBlockRegistrationConfig<
+	T extends BlockAttributes = BlockAttributes
+> = Partial< BlockConfiguration< T > > & ProductBlockSettings;
 
 /**
  * Manages block registration and unregistration for WooCommerce product blocks in different contexts.
@@ -344,9 +346,11 @@ export class BlockRegistrationManager {
  *
  * @return {void}
  */
-export const registerProductBlockType = < T extends BlockAttributes >(
+export const registerProductBlockType = <
+	T extends BlockAttributes = BlockAttributes
+>(
 	blockNameOrMetadata: string | Partial< BlockConfiguration< T > >,
-	settings?: ProductBlockRegistrationConfig
+	settings?: ProductBlockRegistrationConfig< T >
 ): void => {
 	const blockName =
 		typeof blockNameOrMetadata === 'string'
@@ -381,9 +385,9 @@ export const registerProductBlockType = < T extends BlockAttributes >(
 
 	const internalConfig: ProductBlockConfig = {
 		blockName,
-		settings: {
-			...( settingsWithoutCustomProperties as Partial< BlockConfiguration > ),
-		},
+		settings: settingsWithoutCustomProperties as unknown as Partial<
+			BlockConfiguration< BlockAttributes >
+		>,
 		isVariationBlock: isVariationBlock ?? false,
 		variationName: variationName ?? undefined,
 		isAvailableOnPostEditor: isAvailableOnPostEditor ?? false,

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -141,9 +141,7 @@ export class BlockRegistrationManager {
 				subscribe( () => {
 					const previousTemplateId = this.currentTemplateId;
 					this.currentTemplateId = this.parseTemplateId(
-						editSiteStore.getEditedPostId<
-							string | number | undefined
-						>()
+						editSiteStore.getEditedPostId()
 					);
 
 					if ( previousTemplateId !== this.currentTemplateId ) {

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -141,9 +141,7 @@ export class BlockRegistrationManager {
 				subscribe( () => {
 					const previousTemplateId = this.currentTemplateId;
 					this.currentTemplateId = this.parseTemplateId(
-						editSiteStore.getEditedPostId<
-							string | number | undefined
-						>()
+						editSiteStore.getEditedPostId()
 					);
 
 					if ( previousTemplateId !== this.currentTemplateId ) {
@@ -383,7 +381,9 @@ export const registerProductBlockType = < T extends BlockAttributes >(
 
 	const internalConfig: ProductBlockConfig = {
 		blockName,
-		settings: { ...settingsWithoutCustomProperties },
+		settings: {
+			...( settingsWithoutCustomProperties as Partial< BlockConfiguration > ),
+		},
 		isVariationBlock: isVariationBlock ?? false,
 		variationName: variationName ?? undefined,
 		isAvailableOnPostEditor: isAvailableOnPostEditor ?? false,

--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -22,9 +22,9 @@ import { isNumber, isEmpty } from '@woocommerce/types';
  * @property {boolean} [isAvailableOnPostEditor] - Whether the block should be available in post editor
  */
 type ProductBlockSettings = {
-	isVariationBlock?: boolean;
+	isVariationBlock?: boolean | undefined;
 	variationName?: string | undefined;
-	isAvailableOnPostEditor?: boolean;
+	isAvailableOnPostEditor?: boolean | undefined;
 };
 
 /**
@@ -386,17 +386,18 @@ export const registerProductBlockType = <
 		...( settings || {} ),
 	};
 
-	const internalConfig: ProductBlockConfig = {
+	const internalConfig: ProductBlockConfig< T > = {
 		blockName,
-		settings: settingsWithoutCustomProperties as unknown as Partial<
-			BlockConfiguration< BlockAttributes >
-		>,
+		settings: settingsWithoutCustomProperties,
 		isVariationBlock: isVariationBlock ?? false,
 		variationName: variationName ?? undefined,
 		isAvailableOnPostEditor: isAvailableOnPostEditor ?? false,
 	};
 
 	BlockRegistrationManager.getInstance().registerBlockConfig(
-		internalConfig
+		// We cast to BlockAttributes since we never use custom attributes in this function.
+		// This bypasses TypeScript errors from the BlockRegistrationManager storing blocks
+		// in a Map with a non-generic ProductBlockConfig type.
+		internalConfig as ProductBlockConfig< BlockAttributes >
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -42,7 +42,7 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	}
 
 	// Register the block
-	registerProductBlockType< Attributes >(
+	registerProductBlockType(
 		{
 			...( metadata as BlockConfiguration< Attributes > ),
 			icon: <Icon icon={ button } />,

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -18,7 +18,6 @@ import metadata from './block.json';
 import AddToCartOptionsEdit from './edit';
 import save from './save';
 import './style.scss';
-import type { Attributes } from './types';
 
 // Pick the value of the "blockify add to cart flag"
 const isBlockifiedAddToCart = getSettingWithCoercion(
@@ -44,12 +43,12 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	// Register the block
 	registerProductBlockType(
 		{
-			...( metadata as BlockConfiguration< Attributes > ),
+			...metadata,
 			icon: <Icon icon={ button } />,
 			edit: AddToCartOptionsEdit,
 			save,
 			ancestor: [ 'woocommerce/single-product' ],
-		},
+		} as unknown as BlockConfiguration,
 		{
 			isAvailableOnPostEditor: true,
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -50,7 +50,7 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 			edit: AddToCartOptionsEdit,
 			save,
 			ancestor: [ 'woocommerce/single-product' ],
-		} as unknown as BlockConfiguration,
+		} as unknown as Partial< BlockConfiguration >,
 		{
 			isAvailableOnPostEditor: true,
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, button } from '@wordpress/icons';
+import { button } from '@wordpress/icons';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import { getSettingWithCoercion } from '@woocommerce/settings';
@@ -44,7 +44,9 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 	registerProductBlockType(
 		{
 			...metadata,
-			icon: <Icon icon={ button } />,
+			icon: {
+				src: button,
+			},
 			edit: AddToCartOptionsEdit,
 			save,
 			ancestor: [ 'woocommerce/single-product' ],

--- a/plugins/woocommerce/changelog/fix-register-product-block-type-types
+++ b/plugins/woocommerce/changelog/fix-register-product-block-type-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fixed registerProductBlockType types


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes TypeScript types and errors for `registerProductBlockType`

* Removes ability to pass custom Attribute types. Motivation for this was to more closely align with Gutenbergs native `registerBlockType` API.
* Use `as unknown as Partial< BlockConfiguration >` for type casting the block settings, a pattern already established in the codebase and although not ideal I think fixing this aspect in general falls outside the scope of this PR which is to fix the errors in `registerProductBlockType`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open `plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts` and `plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx`.
2. Ensure there are no TS errors


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
