### PR TITLE
Add selector for variable products in template

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -72,13 +72,19 @@ const AddToCartWithOptionsVariationSelectorEdit = (
 	};
 
 	const renderDefaultVariationSelector = () => {
-		return (
-			<div className="wc-block-variation-selector__wrapper">
+		return [
+			__( 'Color', 'woocommerce' ),
+			__( 'Size', 'woocommerce' ),
+		].map( ( attribute ) => (
+			<div
+				className="wc-block-variation-selector__wrapper"
+				key={ attribute }
+			>
 				<Heading
 					className="wc-block-variation-selector__label"
 					level="3"
 				>
-					{ __( 'Example Attribute', 'woocommerce' ) }
+					{ attribute }
 				</Heading>
 				<SelectControl
 					value=""
@@ -95,7 +101,7 @@ const AddToCartWithOptionsVariationSelectorEdit = (
 					className="wc-block-variation-selector__select"
 				/>
 			</div>
-		);
+		) );
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -12,6 +12,11 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import useProductTypeSelector from '../hooks/use-product-type-selector';
+
 interface Attributes {
 	className?: string;
 }
@@ -21,14 +26,17 @@ const AddToCartWithOptionsVariationSelectorEdit = (
 ) => {
 	const { className } = props.attributes;
 	const { product } = useProductDataContext();
+	const { current: currentProductType } = useProductTypeSelector();
 
 	const blockProps = useBlockProps( {
 		className,
 	} );
 
-	if ( product.type !== 'variable' ) {
+	if ( currentProductType?.slug !== 'variable' ) {
 		return null;
 	}
+
+	const isInTemplate = product.id === 0;
 
 	const renderAttributeSelectors = () => {
 		return Object.entries( product.attributes ).map(
@@ -63,11 +71,40 @@ const AddToCartWithOptionsVariationSelectorEdit = (
 		);
 	};
 
+	const renderDefaultVariationSelector = () => {
+		return (
+			<div className="wc-block-variation-selector__wrapper">
+				<Heading
+					className="wc-block-variation-selector__label"
+					level="3"
+				>
+					{ __( 'My Attribute', 'woocommerce' ) }
+				</Heading>
+				<SelectControl
+					value=""
+					options={ [
+						{
+							label: __( 'Choose an option', 'woocommerce' ),
+							value: '',
+							disabled: true,
+						},
+					] }
+					disabled
+					// eslint-disable-next-line @typescript-eslint/no-empty-function
+					onChange={ () => {} }
+					className="wc-block-variation-selector__select"
+				/>
+			</div>
+		);
+	};
+
 	return (
 		<>
 			<div { ...blockProps }>
 				<div className="wc-block-variation-selector">
-					{ renderAttributeSelectors() }
+					{ isInTemplate
+						? renderDefaultVariationSelector()
+						: renderAttributeSelectors() }
 				</div>
 			</div>
 		</>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -78,7 +78,7 @@ const AddToCartWithOptionsVariationSelectorEdit = (
 					className="wc-block-variation-selector__label"
 					level="3"
 				>
-					{ __( 'My Attribute', 'woocommerce' ) }
+					{ __( 'Example Attribute', 'woocommerce' ) }
 				</Heading>
 				<SelectControl
 					value=""

--- a/plugins/woocommerce/changelog/add-54135_selector_for_variable_product
+++ b/plugins/woocommerce/changelog/add-54135_selector_for_variable_product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Comment: Add selector for variable products in template


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a selector for variable products in the `Single Product` template.

The selector is visible under the `Add to Cart with Options (Experimental)` block when the `Variable product` type is selected in the inspector.

![Image](https://github.com/user-attachments/assets/eb1ad380-3cf6-4688-b995-4ab0c7286ab4)

Example attributes to show: `Color` and `Size`.

<img width="1022" alt="Screenshot 2025-01-06 at 9 02 15 AM" src="https://github.com/user-attachments/assets/066e95ad-085e-44e1-b69c-5e2b07e6da35" />

### Follow-up
As a follow-up, we should remove the `Variation Selector (Experimental)` element from the sidebar when another product type is picked in the inspector.
 
https://github.com/user-attachments/assets/eed3ad27-d098-4806-b313-b4ac6a2a8e9e

Closes #54135.

### Update

After some design feedback (see p1736126982177559/1735931767.019919-slack-C07C8QE83SM) we will use `Color` and `Size` instead of `My Attribute`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Enable the `experimental-blocks` and `blockified-add-to-cart` features flags
  * Go to WooCommerce Admin Test Helper -> Features and enable `blockified-add-to-cart`

<img width="450" alt="Screenshot 2024-12-05 at 8 18 00 AM" src="https://github.com/user-attachments/assets/d61d0bb3-6ecf-41c6-a35e-7d388acd7cb5">

3. Edit the `Single Product` template
4. Go to Inspector > Template > Product Type
5. Verify that the variation selector is visible after switching the product type to `Variable product`. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>