### PR TITLE
Fix stock indicator visibility for Variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-53720_stock_indicator_visibility_for_variable_product
+++ b/plugins/woocommerce/changelog/fix-53720_stock_indicator_visibility_for_variable_product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix stock indicator visibility for Variable products #54156

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Blocks\Utils\ProductAvailabilityUtils;
 use Automattic\WooCommerce\Enums\ProductType;
 
 /**
@@ -45,7 +46,7 @@ class ProductStockIndicator extends AbstractBlock {
 	 * @return array
 	 */
 	protected function get_product_types_without_stock_indicator() {
-		return array( ProductType::EXTERNAL, ProductType::GROUPED, ProductType::VARIABLE );
+		return array( ProductType::EXTERNAL, ProductType::GROUPED );
 	}
 
 	/**
@@ -82,15 +83,13 @@ class ProductStockIndicator extends AbstractBlock {
 			return '';
 		}
 
-		$availability = $product->get_availability();
+		$availability = ProductAvailabilityUtils::get_product_availability( $product );
 
 		if ( empty( $availability['availability'] ) ) {
 			return '';
 		}
 
-		$low_stock_amount   = $product->get_low_stock_amount();
 		$total_stock        = $product->get_stock_quantity();
-		$is_low_stock       = $low_stock_amount && $total_stock <= $low_stock_amount;
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		$classnames  = isset( $classes_and_styles['classes'] ) ? ' ' . $classes_and_styles['classes'] . ' ' : '';

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+use Automattic\WooCommerce\Blocks\Templates\ProductStockIndicator;
+use Automattic\WooCommerce\Enums\ProductType;
+/**
+ * Utility functions for product availability.
+ */
+class ProductAvailabilityUtils {
+
+	/**
+	 * Get product availability information.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return string[] The product availability class and text.
+	 */
+	public static function get_product_availability( $product ) {
+		$product_availability = array(
+			'availability' => '',
+			'class'        => '',
+		);
+
+		if ( ! $product ) {
+			return $product_availability;
+		}
+
+		// If the product is a variable product, check if it has any available variations.
+		// We will show a custom availability message if it does.
+		if ( $product->get_type() === ProductType::VARIABLE ) {
+			$available_variations = $product->get_available_variations();
+			if ( empty( $available_variations ) && false !== $available_variations ) {
+				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
+				$product_availability['class']        = 'out-of-stock';
+			}
+		} else {
+			$product_availability = $product->get_availability();
+		}
+
+		/**
+		 * Filters the product availability information.
+		 *
+		 * @since 9.7.0
+		 * @param array $product_availability The product availability information.
+		 */
+		return apply_filters( 'woocommerce_product_availability', $product_availability );
+	}
+}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -5,6 +5,7 @@ use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
+use Automattic\WooCommerce\Blocks\Utils\ProductAvailabilityUtils;
 
 /**
  * ProductSchema class.
@@ -472,7 +473,7 @@ class ProductSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $product ) {
-		$availability = $product->get_availability();
+		$availability = ProductAvailabilityUtils::get_product_availability( $product );
 		return [
 			'id'                  => $product->get_id(),
 			'name'                => $this->prepare_html_response( $product->get_title() ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an error with the `Stock Indicator` message for variable products (in the `Single Product` block) when they don't have variations with a price. In such case, the stock indicator message will read:
`This product is currently out of stock and unavailable.`

| Before | After |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/b096f561-f3b8-46d6-8467-2e538d8bedad) | ![Image](https://github.com/user-attachments/assets/34815365-eac9-4733-9b5c-8bd1c6032dd4) |
| ![Image](https://github.com/user-attachments/assets/3cd1d0fa-9c6f-4e7a-9978-d0df58f750ca) | ![Image](https://github.com/user-attachments/assets/28b5e6e8-1504-4412-81a4-46543f1ec0bd) | 

Additionally, the `Stock Indicator` block should not be visible for variable products in any other circumstances. This PR also fixes that error.

Closes #53720.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new variable product; create a few variations, but don't add a price to them.
2.  Go to Pages > Add New Page.
3. Add a `Single Product` block and select the product you just created (not the variations, but the parent).
4. Add a `Stock indicator` inside the `Single Product` block.
5. The stock indicator should say:
```
This product is currently out of stock and unavailable.
```
6. Save the page and view it.
7. Verify the text looks correct in the front end as well.
8. Add a price for every variation and go back to the page you created.
9. No stock indicator message should be shown for variable products.

![Screenshot 2025-01-03 at 1 17 52 PM](https://github.com/user-attachments/assets/8775fa66-b4a6-44f1-99d6-41c7a110a6da)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
