### PR TITLE
Add order by option to Product Collection block when in default query mode

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -176,9 +176,7 @@ const ProductCollectionInspectorControls = (
 				{ showCustomOrderControl && (
 					<CustomQueryOrderByControl { ...queryControlProps } />
 				) }
-				{ showDefaultOrderControl && (
-					<CustomQueryOrderByControl { ...queryControlProps } />
-				) }
+				{ showDefaultOrderControl && <DefaultQueryOrderByControl /> }
 				{ showOffsetControl && (
 					<OffsetControl { ...queryControlProps } />
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -39,7 +39,8 @@ import {
 	InheritQueryControl,
 	FilterableControl,
 } from './use-page-context-control';
-import OrderByControl from './order-by-control';
+import DefaultQueryOrderByControl from './order-by-control/default-query-order-by-control';
+import CustomQueryOrderByControl from './order-by-control/custom-query-order-by-control';
 import OnSaleControl from './on-sale-control';
 import StockStatusControl from './stock-status-control';
 import KeywordControl from './keyword-control';
@@ -91,7 +92,7 @@ const ProductCollectionInspectorControls = (
 		isArchiveTemplate && shouldShowFilter( CoreFilterNames.INHERIT );
 	const showFilterableControl =
 		! isArchiveTemplate && shouldShowFilter( CoreFilterNames.FILTERABLE );
-	const showOrderControl =
+	const showCustomOrderControl =
 		showQueryControls && shouldShowFilter( CoreFilterNames.ORDER );
 	const showOffsetControl =
 		showQueryControls && shouldShowFilter( CoreFilterNames.OFFSET );
@@ -171,8 +172,10 @@ const ProductCollectionInspectorControls = (
 					<ProductsPerPageControl { ...queryControlProps } />
 				) }
 				<ColumnsControl { ...displayControlProps } />
-				{ showOrderControl && (
-					<OrderByControl { ...queryControlProps } />
+				{ showCustomOrderControl ? (
+					<CustomQueryOrderByControl { ...queryControlProps } />
+				) : (
+					<DefaultQueryOrderByControl />
 				) }
 				{ showOffsetControl && (
 					<OffsetControl { ...queryControlProps } />

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -164,6 +164,14 @@ const ProductCollectionInspectorControls = (
 				{ showInheritQueryControl && (
 					<InheritQueryControl { ...queryControlProps } />
 				) }
+				{ showCustomOrderControl && (
+					<CustomQueryOrderByControl { ...queryControlProps } />
+				) }
+				{ showDefaultOrderControl && (
+					<DefaultQueryOrderByControl
+						trackInteraction={ trackInteraction }
+					/>
+				) }
 				{ showFilterableControl && (
 					<FilterableControl { ...queryControlProps } />
 				) }
@@ -173,14 +181,6 @@ const ProductCollectionInspectorControls = (
 					<ProductsPerPageControl { ...queryControlProps } />
 				) }
 				<ColumnsControl { ...displayControlProps } />
-				{ showCustomOrderControl && (
-					<CustomQueryOrderByControl { ...queryControlProps } />
-				) }
-				{ showDefaultOrderControl && (
-					<DefaultQueryOrderByControl
-						trackInteraction={ trackInteraction }
-					/>
-				) }
 				{ showOffsetControl && (
 					<OffsetControl { ...queryControlProps } />
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -87,21 +87,21 @@ const ProductCollectionInspectorControls = (
 		tracksLocation === 'product-catalog' ||
 		tracksLocation === 'product-archive';
 
-	const showQueryControls = inherit === false;
+	const showCustomQueryControls = inherit === false;
 	const showInheritQueryControl =
 		isArchiveTemplate && shouldShowFilter( CoreFilterNames.INHERIT );
 	const showFilterableControl =
 		! isArchiveTemplate && shouldShowFilter( CoreFilterNames.FILTERABLE );
 	const showCustomOrderControl =
-		showQueryControls && shouldShowFilter( CoreFilterNames.ORDER );
-	const showDefaultOrderControl = inherit === true;
+		showCustomQueryControls && shouldShowFilter( CoreFilterNames.ORDER );
+	const showDefaultOrderControl = ! showCustomQueryControls;
 	const showOffsetControl =
-		showQueryControls && shouldShowFilter( CoreFilterNames.OFFSET );
+		showCustomQueryControls && shouldShowFilter( CoreFilterNames.OFFSET );
 	const showMaxPagesToShowControl =
-		showQueryControls &&
+		showCustomQueryControls &&
 		shouldShowFilter( CoreFilterNames.MAX_PAGES_TO_SHOW );
 	const showProductsPerPageControl =
-		showQueryControls &&
+		showCustomQueryControls &&
 		shouldShowFilter( CoreFilterNames.PRODUCTS_PER_PAGE );
 	const showOnSaleControl = shouldShowFilter( CoreFilterNames.ON_SALE );
 	const showStockStatusControl = shouldShowFilter(
@@ -185,7 +185,7 @@ const ProductCollectionInspectorControls = (
 				) }
 			</ToolsPanel>
 
-			{ showQueryControls ? (
+			{ showCustomQueryControls ? (
 				<ToolsPanel
 					label={ __( 'Filters', 'woocommerce' ) }
 					resetAll={ ( resetAllFilters: ( () => void )[] ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -176,7 +176,11 @@ const ProductCollectionInspectorControls = (
 				{ showCustomOrderControl && (
 					<CustomQueryOrderByControl { ...queryControlProps } />
 				) }
-				{ showDefaultOrderControl && <DefaultQueryOrderByControl /> }
+				{ showDefaultOrderControl && (
+					<DefaultQueryOrderByControl
+						trackInteraction={ trackInteraction }
+					/>
+				) }
 				{ showOffsetControl && (
 					<OffsetControl { ...queryControlProps } />
 				) }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -94,7 +94,7 @@ const ProductCollectionInspectorControls = (
 		! isArchiveTemplate && shouldShowFilter( CoreFilterNames.FILTERABLE );
 	const showCustomOrderControl =
 		showQueryControls && shouldShowFilter( CoreFilterNames.ORDER );
-	const showDefaultOrderControl = ! showQueryControls;
+	const showDefaultOrderControl = inherit === true;
 	const showOffsetControl =
 		showQueryControls && shouldShowFilter( CoreFilterNames.OFFSET );
 	const showMaxPagesToShowControl =

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -94,6 +94,7 @@ const ProductCollectionInspectorControls = (
 		! isArchiveTemplate && shouldShowFilter( CoreFilterNames.FILTERABLE );
 	const showCustomOrderControl =
 		showQueryControls && shouldShowFilter( CoreFilterNames.ORDER );
+	const showDefaultOrderControl = ! showQueryControls;
 	const showOffsetControl =
 		showQueryControls && shouldShowFilter( CoreFilterNames.OFFSET );
 	const showMaxPagesToShowControl =
@@ -172,10 +173,11 @@ const ProductCollectionInspectorControls = (
 					<ProductsPerPageControl { ...queryControlProps } />
 				) }
 				<ColumnsControl { ...displayControlProps } />
-				{ showCustomOrderControl ? (
+				{ showCustomOrderControl && (
 					<CustomQueryOrderByControl { ...queryControlProps } />
-				) : (
-					<DefaultQueryOrderByControl />
+				) }
+				{ showDefaultOrderControl && (
+					<CustomQueryOrderByControl { ...queryControlProps } />
 				) }
 				{ showOffsetControl && (
 					<OffsetControl { ...queryControlProps } />

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/custom-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/custom-query-order-by-control.tsx
@@ -2,12 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	SelectControl,
-	// @ts-expect-error Using experimental features
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,8 +11,9 @@ import {
 	TProductCollectionOrderBy,
 	QueryControlProps,
 	CoreFilterNames,
-} from '../../types';
-import { DEFAULT_QUERY } from '../../constants';
+} from '../../../types';
+import { DEFAULT_QUERY } from '../../../constants';
+import OrderByControl from './order-by-control';
 
 const orderOptions = [
 	{
@@ -73,7 +68,7 @@ const orderOptions = [
 	},
 ];
 
-const OrderByControl = ( props: QueryControlProps ) => {
+const CustomQueryOrderByControl = ( props: QueryControlProps ) => {
 	const { query, trackInteraction, setQueryAttribute } = props;
 	const { order, orderBy } = query;
 
@@ -90,33 +85,24 @@ const OrderByControl = ( props: QueryControlProps ) => {
 	}
 
 	return (
-		<ToolsPanelItem
-			label={ __( 'Order by', 'woocommerce' ) }
+		<OrderByControl
+			selectedValue={ orderValue }
 			hasValue={ () =>
 				order !== DEFAULT_QUERY.order ||
 				orderBy !== DEFAULT_QUERY.orderBy
 			}
-			isShownByDefault
+			orderOptions={ orderOptions }
+			onChange={ ( value: string ) => {
+				const [ newOrderBy, newOrder ] = value.split( '/' );
+				setQueryAttribute( {
+					orderBy: newOrderBy as TProductCollectionOrderBy,
+					order: ( newOrder as TProductCollectionOrder ) || undefined,
+				} );
+				trackInteraction( CoreFilterNames.ORDER );
+			} }
 			onDeselect={ deselectCallback }
-			resetAllFilter={ deselectCallback }
-		>
-			<SelectControl
-				value={ orderValue }
-				options={ orderOptions }
-				label={ __( 'Order by', 'woocommerce' ) }
-				onChange={ ( value ) => {
-					const [ newOrderBy, newOrder ] = value.split( '/' );
-					setQueryAttribute( {
-						orderBy: newOrderBy as TProductCollectionOrderBy,
-						order:
-							( newOrder as TProductCollectionOrder ) ||
-							undefined,
-					} );
-					trackInteraction( CoreFilterNames.ORDER );
-				} }
-			/>
-		</ToolsPanelItem>
+		/>
 	);
 };
 
-export default OrderByControl;
+export default CustomQueryOrderByControl;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/custom-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/custom-query-order-by-control.tsx
@@ -101,6 +101,10 @@ const CustomQueryOrderByControl = ( props: QueryControlProps ) => {
 				trackInteraction( CoreFilterNames.ORDER );
 			} }
 			onDeselect={ deselectCallback }
+			help={ __(
+				'Set the products order in this collection.',
+				'woocommerce'
+			) }
 		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -63,7 +63,7 @@ const DefaultQueryOrderByControl = () => {
 			orderOptions={ orderOptions }
 			onChange={ onChange }
 			help={ __(
-				'This setting is sincyed across all Product Collection blocks using the default query type.',
+				'This setting is synced across all Product Collection blocks using the default query type.',
 				'woocommerce'
 			) }
 		/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -55,11 +55,16 @@ const DefaultQueryOrderByControl = () => {
 			[ `woocommerce_default_catalog_orderby` ]: newValue,
 		} );
 	};
+
 	return (
 		<OrderByControl
 			selectedValue={ value }
 			orderOptions={ orderOptions }
 			onChange={ onChange }
+			help={ __(
+				'This setting is sincyed across all Product Collection blocks using the default query type.',
+				'woocommerce'
+			) }
 		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { dispatch, select } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import OrderByControl from './order-by-control';
+
+const orderOptions = [
+	{
+		label: __( 'Newest to oldest', 'woocommerce' ),
+		value: 'date',
+	},
+	{
+		label: __( 'Price, high to low', 'woocommerce' ),
+		value: 'price-desc',
+	},
+	{
+		label: __( 'Price, low to high', 'woocommerce' ),
+		value: 'price',
+	},
+	{
+		label: __( 'Sales, high to low', 'woocommerce' ),
+		value: 'popularity',
+	},
+	{
+		label: __( 'Rating, high to low', 'woocommerce' ),
+		value: 'rating',
+	},
+	{
+		// In WooCommerce, "Manual (menu order)" refers to a custom ordering set by the store owner.
+		// Products can be manually arranged in the desired order in the WooCommerce admin panel.
+		value: 'menu_order',
+		label: __( 'Manual (menu order)', 'woocommerce' ),
+	},
+];
+
+const DefaultQueryOrderByControl = () => {
+	const settings = select(
+		coreStore as unknown as string
+	).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
+
+	const [ value, setValue ] = useState(
+		settings.woocommerce_default_catalog_orderby || 'menu_order'
+	);
+
+	const onChange = ( newValue: string ) => {
+		setValue( newValue );
+		dispatch( coreStore ).editEntityRecord( 'root', 'site', undefined, {
+			[ `woocommerce_default_catalog_orderby` ]: newValue,
+		} );
+	};
+	return (
+		<OrderByControl
+			selectedValue={ value }
+			orderOptions={ orderOptions }
+			onChange={ onChange }
+		/>
+	);
+};
+
+export default DefaultQueryOrderByControl;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -5,6 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, select } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import {
+	CoreFilterNames,
+	TrackInteraction,
+} from '@woocommerce/blocks/product-collection/types';
 
 /**
  * Internal dependencies
@@ -40,7 +44,11 @@ const orderOptions = [
 	},
 ];
 
-const DefaultQueryOrderByControl = () => {
+const DefaultQueryOrderByControl = ( {
+	trackInteraction,
+}: {
+	trackInteraction: TrackInteraction;
+} ) => {
 	const settings = select( 'core' ).getEditedEntityRecord(
 		'root',
 		'site'
@@ -55,6 +63,7 @@ const DefaultQueryOrderByControl = () => {
 		dispatch( coreStore ).editEntityRecord( 'root', 'site', undefined, {
 			[ `woocommerce_default_catalog_orderby` ]: newValue,
 		} );
+		trackInteraction( CoreFilterNames.DEFAULT_ORDER );
 	};
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -41,9 +41,10 @@ const orderOptions = [
 ];
 
 const DefaultQueryOrderByControl = () => {
-	const settings = select(
-		coreStore as unknown as string
-	).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
+	const settings = select( 'core' ).getEditedEntityRecord(
+		'root',
+		'site'
+	) as Record< string, string >;
 
 	const [ value, setValue ] = useState(
 		settings.woocommerce_default_catalog_orderby || 'menu_order'

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -68,6 +68,7 @@ const DefaultQueryOrderByControl = ( {
 
 	return (
 		<OrderByControl
+			label={ __( 'Default sort by', 'woocommerce' ) }
 			selectedValue={ value }
 			orderOptions={ orderOptions }
 			onChange={ onChange }

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/default-query-order-by-control.tsx
@@ -72,7 +72,7 @@ const DefaultQueryOrderByControl = ( {
 			orderOptions={ orderOptions }
 			onChange={ onChange }
 			help={ __(
-				'This setting is synced across all Product Collection blocks using the default query type.',
+				'All Product Collection blocks using the Default Query will sync to this sort order.',
 				'woocommerce'
 			) }
 		/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/order-by-control.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	SelectControl,
+	// @ts-expect-error Using experimental features
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+
+const OrderByControl = ( {
+	hasValue = () => true,
+	orderOptions,
+	onChange,
+	onDeselect = () => void 0,
+	selectedValue,
+}: {
+	hasValue?: () => boolean;
+	orderOptions: { value: string; label: string }[];
+	onChange: ( value: string ) => void;
+	onDeselect?: () => void;
+	selectedValue: string;
+} ) => {
+	return (
+		<ToolsPanelItem
+			label={ __( 'Order by', 'woocommerce' ) }
+			hasValue={ hasValue }
+			isShownByDefault
+			onDeselect={ onDeselect }
+			resetAllFilter={ onDeselect }
+		>
+			<SelectControl
+				value={ selectedValue }
+				options={ orderOptions }
+				label={ __( 'Order by', 'woocommerce' ) }
+				onChange={ onChange }
+			/>
+		</ToolsPanelItem>
+	);
+};
+
+export default OrderByControl;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/order-by-control.tsx
@@ -15,12 +15,14 @@ const OrderByControl = ( {
 	onChange,
 	onDeselect = () => void 0,
 	selectedValue,
+	help,
 }: {
 	hasValue?: () => boolean;
 	orderOptions: { value: string; label: string }[];
 	onChange: ( value: string ) => void;
 	onDeselect?: () => void;
 	selectedValue: string;
+	help?: string;
 } ) => {
 	return (
 		<ToolsPanelItem
@@ -35,6 +37,7 @@ const OrderByControl = ( {
 				options={ orderOptions }
 				label={ __( 'Order by', 'woocommerce' ) }
 				onChange={ onChange }
+				help={ help }
 			/>
 		</ToolsPanelItem>
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/order-by-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/order-by-control/order-by-control.tsx
@@ -15,6 +15,7 @@ const OrderByControl = ( {
 	onChange,
 	onDeselect = () => void 0,
 	selectedValue,
+	label,
 	help,
 }: {
 	hasValue?: () => boolean;
@@ -22,11 +23,12 @@ const OrderByControl = ( {
 	onChange: ( value: string ) => void;
 	onDeselect?: () => void;
 	selectedValue: string;
+	label?: string;
 	help?: string;
 } ) => {
 	return (
 		<ToolsPanelItem
-			label={ __( 'Order by', 'woocommerce' ) }
+			label={ label || __( 'Order by', 'woocommerce' ) }
 			hasValue={ hasValue }
 			isShownByDefault
 			onDeselect={ onDeselect }
@@ -35,7 +37,7 @@ const OrderByControl = ( {
 			<SelectControl
 				value={ selectedValue }
 				options={ orderOptions }
-				label={ __( 'Order by', 'woocommerce' ) }
+				label={ label || __( 'Order by', 'woocommerce' ) }
 				onChange={ onChange }
 				help={ help }
 			/>

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/types.ts
@@ -198,6 +198,7 @@ export enum CoreFilterNames {
 	KEYWORD = 'keyword',
 	ON_SALE = 'on-sale',
 	ORDER = 'order',
+	DEFAULT_ORDER = 'default-order',
 	STOCK_STATUS = 'stock-status',
 	TAXONOMY = 'taxonomy',
 	PRICE_RANGE = 'price-range',

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
@@ -5,7 +5,7 @@
  */
 import clsx from 'clsx';
 import { memo, useMemo, useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockContextProvider,
@@ -130,6 +130,50 @@ const ProductContent = withProduct(
 		);
 	}
 );
+
+const getOrderPropertiesForDefaultQuery = () => {
+	const settings = select(
+		coreStore as unknown as string
+	).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
+
+	switch ( settings.woocommerce_default_catalog_orderby ) {
+		case 'title':
+			return {
+				orderby: 'title',
+				order: 'asc',
+			};
+		case 'price':
+			return {
+				orderby: 'price',
+				order: 'asc',
+			};
+		case 'price-desc':
+			return {
+				orderby: 'price',
+				order: 'desc',
+			};
+		case 'popularity':
+			return {
+				orderby: 'popularity',
+				order: 'desc',
+			};
+		case 'rating':
+			return {
+				orderby: 'rating',
+				order: 'desc',
+			};
+		case 'date':
+			return {
+				orderby: 'date',
+				order: 'desc',
+			};
+	}
+
+	return {
+		orderby: 'menu_order',
+		order: 'asc',
+	};
+};
 
 const ProductTemplateEdit = (
 	props: BlockEditProps< {
@@ -261,6 +305,10 @@ const ProductTemplateEdit = (
 					}
 				}
 				query.per_page = loopShopPerPage;
+
+				const orderProperties = getOrderPropertiesForDefaultQuery();
+				query.orderby = orderProperties.orderby;
+				query.order = orderProperties.order;
 			}
 			return {
 				products: getEntityRecords( 'postType', postType, {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
@@ -132,9 +132,10 @@ const ProductContent = withProduct(
 );
 
 const getOrderPropertiesForDefaultQuery = () => {
-	const settings = select(
-		coreStore as unknown as string
-	).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
+	const settings = select( 'core' ).getEditedEntityRecord(
+		'root',
+		'site'
+	) as Record< string, string >;
 
 	switch ( settings.woocommerce_default_catalog_orderby ) {
 		case 'title':

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-template/edit.tsx
@@ -5,7 +5,7 @@
  */
 import clsx from 'clsx';
 import { memo, useMemo, useState } from '@wordpress/element';
-import { select, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockContextProvider,
@@ -131,13 +131,8 @@ const ProductContent = withProduct(
 	}
 );
 
-const getOrderPropertiesForDefaultQuery = () => {
-	const settings = select( 'core' ).getEditedEntityRecord(
-		'root',
-		'site'
-	) as Record< string, string >;
-
-	switch ( settings.woocommerce_default_catalog_orderby ) {
+const getOrderPropertiesForDefaultQuery = ( defaultSetting: string ) => {
+	switch ( defaultSetting ) {
 		case 'title':
 			return {
 				orderby: 'title',
@@ -237,7 +232,8 @@ const ProductTemplateEdit = (
 
 	const { products, blocks } = useSelect(
 		( select ) => {
-			const { getEntityRecords, getTaxonomies } = select( coreStore );
+			const { getEntityRecords, getEditedEntityRecord, getTaxonomies } =
+				select( coreStore );
 			const { getBlocks } = select( blockEditorStore );
 			const taxonomies = getTaxonomies( {
 				type: postType,
@@ -307,7 +303,15 @@ const ProductTemplateEdit = (
 				}
 				query.per_page = loopShopPerPage;
 
-				const orderProperties = getOrderPropertiesForDefaultQuery();
+				const settings = getEditedEntityRecord(
+					'root',
+					'site',
+					undefined
+				) as unknown as Record< string, string >;
+
+				const orderProperties = getOrderPropertiesForDefaultQuery(
+					settings.woocommerce_default_catalog_orderby
+				);
 				query.orderby = orderProperties.orderby;
 				query.order = orderProperties.order;
 			}

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Request } from '@playwright/test';
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -816,18 +816,9 @@ test.describe( 'Product Collection', () => {
 			editor,
 			frontendUtils,
 		} ) => {
-			// Go to Customizer.
-			await page.goto( '/wp-admin/customize.php' );
-			await page.getByRole( 'button', { name: 'WooCommerce' } ).click();
-			await page
-				.getByRole( 'button', { name: 'Product Catalog' } )
-				.click();
-			await page
-				.getByLabel( 'Default product sorting' )
-				.selectOption( 'price' );
-			await page
-				.getByRole( 'button', { name: 'Publish', exact: true } )
-				.click();
+			await wpCLI(
+				'option update woocommerce_default_catalog_orderby price'
+			);
 
 			await admin.visitSiteEditor( {
 				postId: `woocommerce/woocommerce//archive-product`,
@@ -837,12 +828,12 @@ test.describe( 'Product Collection', () => {
 
 			await pageObject.focusProductCollection();
 
-			// Verify the default order matches the option set in the Customizer..
-			await expect( page.getByLabel( 'Order by' ) ).toHaveValue(
-				'price'
-			);
+			const orderBySelect = await pageObject.getOrderByElement();
 
-			await page.getByLabel( 'Order by' ).selectOption( 'price-desc' );
+			// Verify the default order matches the option in the database.
+			await expect( orderBySelect ).toHaveValue( 'price' );
+
+			await orderBySelect.selectOption( 'price-desc' );
 
 			await editor.saveSiteEditorEntities();
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -842,6 +842,10 @@ test.describe( 'Product Collection', () => {
 				.locator( SELECTORS.productTitle )
 				.first();
 			await expect( frontendProductTitle ).toContainText( 'Sunglasses' );
+
+			await wpCLI(
+				'option update woocommerce_default_catalog_orderby menu_order'
+			);
 		} );
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -810,40 +810,38 @@ test.describe( 'Product Collection', () => {
 
 	test.describe( 'default query can be modified', () => {
 		test( 'default query can be modified', async ( {
-			admin,
 			page,
 			pageObject,
 			editor,
-			frontendUtils,
 		} ) => {
 			await wpCLI(
 				'option update woocommerce_default_catalog_orderby price'
 			);
 
-			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//archive-product`,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+			await pageObject.goToEditorTemplate();
 
 			await pageObject.focusProductCollection();
 
-			const orderBySelect = await pageObject.getOrderByElement();
-
 			// Verify the default order matches the option in the database.
+			const orderBySelect = await pageObject.getOrderByElement();
+			const editorProductTitle = editor.canvas
+				.locator( SELECTORS.productTitle )
+				.first();
+
 			await expect( orderBySelect ).toHaveValue( 'price' );
+			await expect( editorProductTitle ).toHaveText( 'Single' );
 
 			await orderBySelect.selectOption( 'price-desc' );
 
+			await expect( editorProductTitle ).toHaveText( 'Sunglasses' );
+
 			await editor.saveSiteEditorEntities();
+			await pageObject.goToProductCatalogFrontend();
 
-			// Go to shop.
-			await frontendUtils.goToShop();
-
-			// Verify the first <h3> element has the text "Sunglasses".
-			await expect( page.locator( 'h3' ).first() ).toContainText(
-				'Sunglasses'
-			);
+			const frontendProductTitle = page
+				.locator( SELECTORS.productTitle )
+				.first();
+			await expect( frontendProductTitle ).toContainText( 'Sunglasses' );
 		} );
 	} );
 

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -807,6 +807,55 @@ test.describe( 'Product Collection', () => {
 			} );
 		}
 	);
+
+	test.describe( 'default query can be modified', () => {
+		test( 'default query can be modified', async ( {
+			admin,
+			page,
+			pageObject,
+			editor,
+			frontendUtils,
+		} ) => {
+			// Go to Customizer.
+			await page.goto( '/wp-admin/customize.php' );
+			await page.getByRole( 'button', { name: 'WooCommerce' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Product Catalog' } )
+				.click();
+			await page
+				.getByLabel( 'Default product sorting' )
+				.selectOption( 'price' );
+			await page
+				.getByRole( 'button', { name: 'Publish', exact: true } )
+				.click();
+
+			await admin.visitSiteEditor( {
+				postId: `woocommerce/woocommerce//archive-product`,
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+
+			await pageObject.focusProductCollection();
+
+			// Verify the default order matches the option set in the Customizer..
+			await expect( page.getByLabel( 'Order by' ) ).toHaveValue(
+				'price'
+			);
+
+			await page.getByLabel( 'Order by' ).selectOption( 'price-desc' );
+
+			await editor.saveSiteEditorEntities();
+
+			// Go to shop.
+			await frontendUtils.goToShop();
+
+			// Verify the first <h3> element has the text "Sunglasses".
+			await expect( page.locator( 'h3' ).first() ).toContainText(
+				'Sunglasses'
+			);
+		} );
+	} );
+
 	test.describe( 'Editor: In taxonomies templates', () => {
 		test( 'Products by specific category template displays products from this category', async ( {
 			admin,

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -858,6 +858,10 @@ test.describe( 'Product Collection', () => {
 			page,
 			editor,
 		} ) => {
+			await wpCLI(
+				'option update woocommerce_default_catalog_orderby price'
+			);
+
 			const expectedProducts = [
 				'Hoodie',
 				'Hoodie with Logo',
@@ -884,12 +888,20 @@ test.describe( 'Product Collection', () => {
 			const products = editor.canvas.getByLabel( 'Block: Title' );
 
 			await expect( products ).toHaveText( expectedProducts );
+
+			await wpCLI(
+				'option update woocommerce_default_catalog_orderby menu_order'
+			);
 		} );
 		test( 'Products by specific tag template displays products from this tag', async ( {
 			admin,
 			page,
 			editor,
 		} ) => {
+			await wpCLI(
+				'option update woocommerce_default_catalog_orderby price'
+			);
+
 			const expectedProducts = [ 'Beanie', 'Hoodie' ];
 
 			await admin.visitSiteEditor( { path: '/wp_template' } );
@@ -912,6 +924,10 @@ test.describe( 'Product Collection', () => {
 			const products = editor.canvas.getByLabel( 'Block: Title' );
 
 			await expect( products ).toHaveText( expectedProducts );
+
+			await wpCLI(
+				'option update woocommerce_default_catalog_orderby menu_order'
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -823,7 +823,10 @@ test.describe( 'Product Collection', () => {
 			await pageObject.focusProductCollection();
 
 			// Verify the default order matches the option in the database.
-			const orderBySelect = await pageObject.getOrderByElement();
+			const sidebarSettings = pageObject.locateSidebarSettings();
+			const orderBySelect = sidebarSettings.getByRole( 'combobox', {
+				name: 'Default sort by',
+			} );
 			const editorProductTitle = editor.canvas
 				.locator( SELECTORS.productTitle )
 				.first();

--- a/plugins/woocommerce/changelog/add-product-collection-global-query-order-by
+++ b/plugins/woocommerce/changelog/add-product-collection-global-query-order-by
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add order by options to Product Collection block when in default query mode

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
@@ -248,12 +248,6 @@ class Controller extends AbstractBlock {
 	 * the default query.
 	 */
 	public function register_settings() {
-		// $option_value = get_option( 'woocommerce_default_catalog_orderby' );
-
-		// if ( ! $option_value ) {
-		// $option_value = 'menu_order';
-		// }
-
 		register_setting(
 			'options',
 			'woocommerce_default_catalog_orderby',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
@@ -67,6 +67,9 @@ class Controller extends AbstractBlock {
 			2
 		);
 
+		// Register the backend settings so they can be used in the editor.
+		add_action( 'rest_api_init', array( $this, 'register_settings' ) );
+
 		// Update the query for Editor.
 		add_filter( 'rest_product_query', array( $this, 'update_rest_query_in_editor' ), 10, 2 );
 
@@ -238,6 +241,36 @@ class Controller extends AbstractBlock {
 		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ) );
+	}
+
+	/**
+	 * Exposes settings used by the Product Collection block when manipulating
+	 * the default query.
+	 */
+	public function register_settings() {
+		// $option_value = get_option( 'woocommerce_default_catalog_orderby' );
+
+		// if ( ! $option_value ) {
+		// $option_value = 'menu_order';
+		// }
+
+		register_setting(
+			'options',
+			'woocommerce_default_catalog_orderby',
+			array(
+				'type'         => 'object',
+				'description'  => __( 'How should products be sorted in the catalog by default?', 'woocommerce' ),
+				'label'        => __( 'Default product sorting', 'woocommerce' ),
+				'show_in_rest' => array(
+					'name'   => 'woocommerce_default_catalog_orderby',
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( 'menu_order', 'popularity', 'rating', 'date', 'price', 'price-desc' ),
+					),
+				),
+				'default'      => 'menu_order',
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Controller.php
@@ -294,13 +294,14 @@ class Controller extends AbstractBlock {
 			$collection_args = call_user_func( $handlers['editor_args'], $collection_args, $query, $request );
 		}
 
+		$orderby = $request->get_param( 'orderby' );
+
 		// When requested, short-circuit the query and return the preview query args.
 		$preview_state = $request->get_param( 'previewState' );
 		if ( isset( $preview_state['isPreview'] ) && 'true' === $preview_state['isPreview'] ) {
-			return $this->query_builder->get_preview_query_args( $collection_args, $query, $request );
+			return $this->query_builder->get_preview_query_args( $collection_args, array_merge( $query, array( 'orderby' => $orderby ) ), $request );
 		}
 
-		$orderby             = $request->get_param( 'orderby' );
 		$on_sale             = $request->get_param( 'woocommerceOnSale' ) === 'true';
 		$stock_status        = $request->get_param( 'woocommerceStockStatus' );
 		$product_attributes  = $request->get_param( 'woocommerceAttributes' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/QueryBuilder.php
@@ -312,8 +312,9 @@ class QueryBuilder {
 		if ( isset( $handlers['preview_query'] ) ) {
 			$collection_query = call_user_func( $handlers['preview_query'], $collection_args, $args, $request );
 		}
+		$orderby_query = $args['orderby'] ? $this->get_custom_orderby_query( $args['orderby'] ) : array();
 
-		$args = $this->merge_queries( $args, $collection_query );
+		$args = $this->merge_queries( $args, $orderby_query, $collection_query );
 		return $args;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/discussions/52840.

This PR tries a new approach to handle global settings directly from the _Product Collection_ block, until now those settings were only accessible from the _Customizer_.

[Enregistrament de pantalla del 2025-01-09 18-30-34.webm](https://github.com/user-attachments/assets/f7f563ba-906b-4447-beb9-8d1e99425a78)

Specifically, this PR adds the _Default sorting_ option for queries to the _Product Collection_ block UI. In the future, we could expand it to also include _Products per page_ and _Columns_ options (https://github.com/woocommerce/woocommerce/issues/54240).

This approach is inspired by a similar implementation in the _Checkout_ block, which migrated from attributes to global settings (see https://github.com/woocommerce/woocommerce/pull/52784).

### How to test the changes in this Pull Request:

1. Go to the Customizer (`/wp-admin/customize.php`, note: if you are using a block theme, it's expected this option won't be visible in the UI) > WooCommerce > Product Catalog > Default product sorting and one of the options (ie: _Sort by most recent_). Click on _Publish_ to save.
3. Go to the _Shop_ page (`/shop`) in the frontend and verify blocks are sorted accordingly.
4. With a block theme, go to Appearance > Editor > Templates > Product Catalog (`/wp-admin/site-editor.php?postId=woocommerce%2Fwoocommerce%2F%2Farchive-product&postType=wp_template&canvas=edit`) and select the _Product Catalog_ block.
5. Verify _Query type_ is set to _Default_ and _Order by_ to _Newest to oldest_.
6. Change the _Order by_ value to something different (ie: _Price, low to high_).
7. Click on _Save_ and verify you can save the _Default product sorting_ separately from the template.
8. Continue saving and go to the _Shop_ frontend again.
9. Verify products are now sorted by price (descending).
