### PR TITLE
Relax check in `wc_get_order_status_name()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-51690-redux
+++ b/plugins/woocommerce/changelog/fix-51690-redux
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This change slightly relaxes a check that was introduced in a prior change (and for which a changelog entry already exists).
+
+

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -164,7 +164,7 @@ function wc_get_is_pending_statuses() {
  */
 function wc_get_order_status_name( $status ) {
 	// "Special statuses": these are in common usage across WooCommerce, but are not normally returned by
-	// wc_get_order_statuses(). We add them only to avoid unnecessary doing-it-wrong errors.
+	// wc_get_order_statuses().
 	$special_statuses = array(
 		'wc-' . OrderStatus::AUTO_DRAFT => OrderStatus::AUTO_DRAFT,
 		'wc-' . OrderStatus::TRASH      => OrderStatus::TRASH,
@@ -175,7 +175,7 @@ function wc_get_order_status_name( $status ) {
 	$statuses   = array_merge( $special_statuses, wc_get_order_statuses() );
 	$unprefixed = OrderUtil::remove_status_prefix( (string) $status );
 
-	if ( ! is_string( $status ) || ! isset( $statuses[ 'wc-' . $unprefixed ] ) ) {
+	if ( ! is_string( $status ) ) {
 		wc_doing_it_wrong(
 			__FUNCTION__,
 			__( 'An invalid order status slug was supplied.', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #52797 (targeting 9.6) we introduced some defensive checks to prevent fatal errors which could result from calling `wc_get_order_status_name()` with an invalid parameters (such as a NULL value). In those cases, the function would trigger a doing-it-wrong notice.

It'll also do so when passed an order status that doesn't exist, which can have an effect on other plugins using order-derived types (such as Subscriptions) and using their own order statuses (which aren't included in the default order statuses as they aren't truly **order** statuses). See https://github.com/Automattic/woocommerce-payments/issues/10053

This PR reintroduces prior behavior where passing a non-existent status wouldn't trigger a doing-it-wrong notice. We keep the checks to ensure the parameter is a string to prevent any fatal errors.

Related: p1735820321777489-slack-C0E1AV8T0

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

(Slightly adapted from #52797)

   > Real-world testing can be done in the following ways:
   > 
   > 1. Install and activate Query Monitor, or ensure you have some other means of detecting errors and problems (including *doing it wrong* notices).
   > 2. Ensure you have some order data.
   > 3. Visit **WooCommerce ‣ Orders**. There should be no errors that map back to the `wc_get_order_status_name()` function (this function will be called    > multiple times when this screen is rendered, so this test is just to give us additional confidence that nothing has broken as a result of this change).
   > 
   > You can also do some console-based testing via `wp shell`. Examples:
   > 
   > ```sh
   > >>> wc_get_order_status_name( 'pending' )
   > => "Pending payment"
   > ```
   > 
   > ```sh
   > >>> wc_get_order_status_name( 'unknown' )
   > => "unknown"
   > ```
   > 
   > ```sh
   > >>> wc_get_order_status_name( 5 )
   > PHP Notice:  Function wc_get_order_status_name was called <strong>incorrectly</strong>. An invalid order status slug was supplied. 
   > => "5"
   > ```
   > 
   > ```sh
   > >>> wc_get_order_status_name( null )
   > PHP Notice:  Function wc_get_order_status_name was called <strong>incorrectly</strong>. An invalid order status slug was supplied.
   > => ""
   > ```
   > 
   > ```sh
   > >>> wc_get_order_status_name( [] )
   > PHP Warning:  Array to string conversion
   > PHP Notice:  Function wc_get_order_status_name was called <strong>incorrectly</strong>. An invalid order status slug was supplied. 
   > => "Array"
   > ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>