### PR TITLE
Experiment: Single Product Dynamic Image Loading

### DIFF
--- a/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
@@ -12,14 +12,12 @@ const galleryObserver = new ResizeObserver(entries => {
 		const srcset = img.dataset.srcset;
 		
 		if (!srcset) {
-			if (!srcset) {
-				// Fallback to original image if no srcset available
-				const originalSrc = img.getAttribute('data-original-image-src');
-				if (originalSrc && img.src !== originalSrc) {
-					img.src = originalSrc;
-				}
-				return;
+			// Fallback to original image if no srcset available
+			const originalSrc = img.getAttribute('data-original-image-src');
+			if (originalSrc && img.src !== originalSrc) {
+				img.src = originalSrc;
 			}
+			return;
 		}
 
 		try {

--- a/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
@@ -8,11 +8,6 @@ const galleryObserver = new ResizeObserver(entries => {
 			return;
 		}
 
-		// Remove sizes attribute if it exists
-		if (img.hasAttribute('sizes')) {
-			img.removeAttribute('sizes');
-		}
-
 		const containerWidth = entry.contentRect.width;
 		const srcset = img.dataset.srcset;
 		

--- a/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
@@ -1,0 +1,68 @@
+// Initialize ResizeObserver to watch gallery containers
+const galleryObserver = new ResizeObserver(entries => {
+	entries.forEach(entry => {
+		const container = entry.target;
+		const img = container.querySelector('img[data-product-image="responsive"]');
+		
+		if (!img) {
+			return;
+		}
+
+		// Remove sizes attribute if it exists
+		if (img.hasAttribute('sizes')) {
+			img.removeAttribute('sizes');
+		}
+
+		const containerWidth = entry.contentRect.width;
+		const srcset = img.dataset.srcset;
+		
+		if (!srcset) {
+			return;
+		}
+
+		// Parse srcset into array of objects
+		const sources = srcset.split(',').map(src => {
+			const [url, width] = src.trim().split(' ');
+			return {
+				url,
+				width: parseInt(width.replace('w', ''))
+			};
+		});
+
+		// Sort sources by width to ensure we get the next size up if exact match not found
+		sources.sort((a, b) => a.width - b.width);
+
+		// Find the most appropriate image size
+		// Use the smallest image larger than the container width
+		// Or fall back to the largest available image
+		const appropriateSource = sources.find(source => source.width >= containerWidth) || sources[sources.length - 1];
+
+		// Update the image source if it's different
+		if (img.src !== appropriateSource.url) {
+			img.src = appropriateSource.url;
+		}
+	});
+});
+
+// Find and observe all product gallery containers
+function initializeGalleryObserver() {
+	const galleryContainers = document.querySelectorAll('.woocommerce-product-gallery__image');
+	galleryContainers.forEach(container => galleryObserver.observe(container));
+}
+
+(function() {
+	// Run on DOM ready
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', initializeGalleryObserver);
+	} else {
+		initializeGalleryObserver();
+	}
+
+	// Handle dynamic gallery updates (e.g., variation changes)
+	document.addEventListener('wc_additional_variation_images_frontend_update_gallery', initializeGalleryObserver);
+
+	// Cleanup on page unload
+	window.addEventListener('unload', () => {
+		galleryObserver.disconnect();
+	});
+})();

--- a/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/image-resize-observer.js
@@ -28,7 +28,7 @@ const galleryObserver = new ResizeObserver(entries => {
 		sources.sort((a, b) => a.width - b.width);
 
 		// Find the most appropriate image size
-		// Use the smallest image larger than the container width
+		// Use the smallest image which is larger than the container width
 		// Or fall back to the largest available image
 		const appropriateSource = sources.find(source => source.width >= containerWidth) || sources[sources.length - 1];
 
@@ -46,17 +46,12 @@ function initializeGalleryObserver() {
 }
 
 (function() {
-	// Run on DOM ready
 	if (document.readyState === 'loading') {
 		document.addEventListener('DOMContentLoaded', initializeGalleryObserver);
 	} else {
 		initializeGalleryObserver();
 	}
 
-	// Handle dynamic gallery updates (e.g., variation changes)
-	document.addEventListener('wc_additional_variation_images_frontend_update_gallery', initializeGalleryObserver);
-
-	// Cleanup on page unload
 	window.addEventListener('unload', () => {
 		galleryObserver.disconnect();
 	});

--- a/plugins/woocommerce/includes/class-wc-product-image-handler.php
+++ b/plugins/woocommerce/includes/class-wc-product-image-handler.php
@@ -32,24 +32,34 @@ class WC_Product_Image_Handler {
 	}
 
 	/**
-	 * Output responsive image markup with container awareness
+	 * Get container style attributes
+	 *
+	 * @return string
+	 */
+	public static function get_container_style() {
+		return 'container-type: inline-size;';
+	}
+
+
+	/**
+	 * Output responsive image markup without container
 	 *
 	 * @param int   $attachment_id The image attachment ID.
 	 * @param array $args Additional arguments.
+	 * @return string HTML markup for responsive image
 	 */
-	public static function render_responsive_image( $attachment_id, $args = array() ) {
+	public static function render_responsive_image_tag( $attachment_id, $args = array() ) {
 		$defaults = array(
-			'context'         => 'gallery',
-			'class'           => '',
-			'container_class' => 'wc-product-gallery__container',
-			'lazy_load'       => true,
+			'context'   => 'gallery',
+			'class'     => '',
+			'lazy_load' => true,
 		);
 
 		$args       = wp_parse_args( $args, $defaults );
-		$image_data = self::get_responsive_image_data( $attachment_id, $args['context'] );
+		$image_data = self::get_responsive_image_data( $attachment_id );
 
 		if ( empty( $image_data ) ) {
-			return;
+			return '';
 		}
 
 		// Get the default image (smallest size).
@@ -61,17 +71,13 @@ class WC_Product_Image_Handler {
 			$srcset[] = sprintf( '%s %dw', $data['url'], $data['width'] );
 		}
 
-		$wrapper_attributes = array(
-			'class'              => $args['container_class'],
-			'data-product-image' => 'container',
-			'style'              => 'container-type: inline-size;',
-		);
-
 		$sizes_attribute_value = array_reduce(
-			array_reverse( $image_data ),
+			$image_data,
 			function ( $sizes, $data ) {
 				$width = $data['width'];
-				return $sizes ? "(min-container-width: {$width}px) {$width}px, {$sizes}" : "{$width}px";
+				return $sizes
+					? "{$sizes}, @container (min-width: {$width}px) {$width}px"
+					: "{$width}px";
 			},
 			''
 		);
@@ -89,14 +95,62 @@ class WC_Product_Image_Handler {
 			$image_attributes['loading'] = 'lazy';
 		}
 
-		// Build HTML output.
-		$html = sprintf(
-			'<div %s><img %s></div>',
-			self::build_attributes( $wrapper_attributes ),
-			self::build_attributes( $image_attributes )
-		);
+		return sprintf( '<img %s>', self::build_attributes( $image_attributes ) );
+	}
 
-		return $html;
+	/**
+	 * Register container query styles
+	 *
+	 * @return void
+	 */
+	public static function register_container_styles() {
+		// Only add on single product pages.
+		if ( ! is_product() ) {
+			return;
+		}
+
+		$styles = '
+            .woocommerce-product-gallery__image {
+                container-type: inline-size;
+                container-name: gallery-image;
+            }
+            
+            @container gallery-image (min-width: 300px) {
+                img {
+                    width: 300px;
+                }
+            }
+            
+            @container gallery-image (min-width: 600px) {
+                img {
+                    width: 600px;
+                }
+            }
+            
+            @container gallery-image (min-width: 900px) {
+                img {
+                    width: 900px;
+                }
+            }
+            
+            @container gallery-image (min-width: 1200px) {
+                img {
+                    width: 1200px;
+                }
+            }
+        ';
+
+		// Add fallback for browsers that don't support container queries.
+		$styles .= '
+            @supports not (container-type: inline-size) {
+                .woocommerce-product-gallery__image img {
+                    width: 100%;
+                    max-width: 1200px;
+                }
+            }
+        ';
+
+		wp_add_inline_style( 'woocommerce-single-product', $styles );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-image-handler.php
+++ b/plugins/woocommerce/includes/class-wc-product-image-handler.php
@@ -129,37 +129,4 @@ class WC_Product_Image_Handler {
 
 		return implode( ' ', $html );
 	}
-
-	/**
-	 * Render the JavaScript for container-aware image sizing
-	 */
-	private static function render_container_script() {
-		?>
-		<script>
-		(function() {
-			if (!('ResizeObserver' in window)) {
-				return;
-			}
-			
-			const observer = new ResizeObserver(entries => {
-				entries.forEach(entry => {
-					const container = entry.target;
-					const image = container.querySelector('[data-product-image="responsive"]');
-					
-					if (image) {
-						// Update sizes attribute based on container width
-						image.sizes = `${entry.contentRect.width}px`;
-					}
-				});
-			});
-			
-			// Observe all product image containers
-			document.querySelectorAll('[data-product-image="container"]').forEach(container => {
-				observer.observe(container);
-			});
-		})();
-		</script>
-		<?php
-	}
 }
-

--- a/plugins/woocommerce/includes/class-wc-product-image-handler.php
+++ b/plugins/woocommerce/includes/class-wc-product-image-handler.php
@@ -1,0 +1,165 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Class to handle responsive product images with container awareness
+ */
+class WC_Product_Image_Handler {
+	/**
+	 * Get product image sizes for responsive loading
+	 *
+	 * @param int $attachment_id The image attachment ID.
+	 * @return array Array of image sizes and their URLs.
+	 */
+	public static function get_responsive_image_data( $attachment_id ) {
+		// Define the sizes we want to support.
+		$sizes      = array( 300, 600, 900, 1200 );
+		$image_data = array();
+
+		foreach ( $sizes as $size ) {
+			$name  = 'woocommerce_' . $size;
+			$image = wp_get_attachment_image_src( $attachment_id, $name );
+			if ( $image ) {
+				$image_data[] = array(
+					'name'  => $name,
+					'url'   => $image[0],
+					'width' => $image[1],
+				);
+			}
+		}
+
+		return $image_data;
+	}
+
+	/**
+	 * Output responsive image markup with container awareness
+	 *
+	 * @param int   $attachment_id The image attachment ID.
+	 * @param array $args Additional arguments.
+	 */
+	public static function render_responsive_image( $attachment_id, $args = array() ) {
+		$defaults = array(
+			'context'         => 'gallery',
+			'class'           => '',
+			'container_class' => 'wc-product-gallery__container',
+			'lazy_load'       => true,
+		);
+
+		$args       = wp_parse_args( $args, $defaults );
+		$image_data = self::get_responsive_image_data( $attachment_id, $args['context'] );
+
+		if ( empty( $image_data ) ) {
+			return;
+		}
+
+		// Get the default image (smallest size).
+		$default_image = reset( $image_data );
+
+		// Build srcset.
+		$srcset = array();
+		foreach ( $image_data as $data ) {
+			$srcset[] = sprintf( '%s %dw', $data['url'], $data['width'] );
+		}
+
+		$wrapper_attributes = array(
+			'class'              => $args['container_class'],
+			'data-product-image' => 'container',
+			'style'              => 'container-type: inline-size;',
+		);
+
+		$sizes_attribute_value = array_reduce(
+			array_reverse( $image_data ),
+			function ( $sizes, $data ) {
+				$width = $data['width'];
+				return $sizes ? "(min-container-width: {$width}px) {$width}px, {$sizes}" : "{$width}px";
+			},
+			''
+		);
+
+		$image_attributes = array(
+			'src'                => $default_image['url'],
+			'class'              => trim( 'wp-post-image ' . $args['class'] ),
+			'alt'                => trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ),
+			'srcset'             => implode( ', ', $srcset ),
+			'sizes'              => $sizes_attribute_value,
+			'data-product-image' => 'responsive',
+		);
+
+		if ( $args['lazy_load'] ) {
+			$image_attributes['loading'] = 'lazy';
+		}
+
+		// Build HTML output.
+		$html = sprintf(
+			'<div %s><img %s></div>',
+			self::build_attributes( $wrapper_attributes ),
+			self::build_attributes( $image_attributes )
+		);
+
+		// Add JavaScript if not already rendered.
+		static $js_rendered = true;
+		if ( ! $js_rendered ) {
+			ob_start();
+			self::render_container_script();
+			$html       .= ob_get_clean();
+			$js_rendered = true;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Build HTML attributes string.
+	 *
+	 * @param array $attributes Array of HTML attributes.
+	 * @return string HTML attributes string.
+	 */
+	private static function build_attributes( $attributes ) {
+		$html = array();
+
+		foreach ( $attributes as $key => $value ) {
+			if ( is_bool( $value ) ) {
+				if ( $value ) {
+					$html[] = esc_attr( $key );
+				}
+			} else {
+				$html[] = sprintf( '%s="%s"', $key, $value );
+			}
+		}
+
+		return implode( ' ', $html );
+	}
+
+	/**
+	 * Render the JavaScript for container-aware image sizing
+	 */
+	private static function render_container_script() {
+		?>
+		<script>
+		(function() {
+			if (!('ResizeObserver' in window)) {
+				return;
+			}
+			
+			const observer = new ResizeObserver(entries => {
+				entries.forEach(entry => {
+					const container = entry.target;
+					const image = container.querySelector('[data-product-image="responsive"]');
+					
+					if (image) {
+						// Update sizes attribute based on container width
+						image.sizes = `${entry.contentRect.width}px`;
+					}
+				});
+			});
+			
+			// Observe all product image containers
+			document.querySelectorAll('[data-product-image="container"]').forEach(container => {
+				observer.observe(container);
+			});
+		})();
+		</script>
+		<?php
+	}
+}
+

--- a/plugins/woocommerce/includes/class-wc-product-image-handler.php
+++ b/plugins/woocommerce/includes/class-wc-product-image-handler.php
@@ -70,14 +70,16 @@ class WC_Product_Image_Handler {
 			''
 		);
 
+		// We use data-srcset and data-sizes for ResizeObserver, so that the browser doesn't hijack the image
+		// and we can use the correct image size for the container width.
 		$image_attributes = array(
-			'src'                 => wc_placeholder_img_src(),
-			'class'               => trim( 'wp-post-image ' . $args['class'] ),
-			'alt'                 => trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ),
-			'data-srcset'         => implode( ', ', $srcset ),
-			'data-sizes'          => $sizes_attribute_value, // Keep this for ResizeObserver.
-			'data-original-image' => $image_data[ count( $image_data ) - 1 ]['url'],
-			'data-product-image'  => 'responsive',
+			'src'                     => wc_placeholder_img_src(),
+			'class'                   => trim( 'wp-post-image ' . $args['class'] ),
+			'alt'                     => trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ),
+			'data-srcset'             => implode( ', ', $srcset ),
+			'data-sizes'              => $sizes_attribute_value,
+			'data-original-image-src' => $image_data[ count( $image_data ) - 1 ]['url'],
+			'data-product-image'      => 'container-responsive',
 		);
 
 		// Add loading="lazy" if enabled.

--- a/plugins/woocommerce/includes/class-wc-product-image-handler.php
+++ b/plugins/woocommerce/includes/class-wc-product-image-handler.php
@@ -16,6 +16,7 @@ class WC_Product_Image_Handler {
 		$sizes      = array( 300, 600, 900, 1200 );
 		$image_data = array();
 
+		// Get sized images first
 		foreach ( $sizes as $size ) {
 			$name  = 'woocommerce_' . $size;
 			$image = wp_get_attachment_image_src( $attachment_id, $name );
@@ -26,6 +27,16 @@ class WC_Product_Image_Handler {
 					'width' => $image[1],
 				);
 			}
+		}
+
+		// Get original image last
+		$original_image = wp_get_attachment_image_src( $attachment_id, 'full' );
+		if ( $original_image ) {
+			$image_data[] = array(
+				'name'  => 'full',
+				'url'   => $original_image[0],
+				'width' => $original_image[1],
+			);
 		}
 
 		return $image_data;
@@ -70,6 +81,15 @@ class WC_Product_Image_Handler {
 			''
 		);
 
+		// Find the full size image URL
+		$full_image_url = wc_placeholder_img_src();
+		foreach ( $image_data as $data ) {
+			if ( $data['name'] === 'full' ) {
+				$full_image_url = $data['url'];
+				break;
+			}
+		}
+
 		// We use data-srcset and data-sizes for ResizeObserver, so that the browser doesn't hijack the image
 		// and we can use the correct image size for the container width.
 		$image_attributes = array(
@@ -78,7 +98,7 @@ class WC_Product_Image_Handler {
 			'alt'                     => trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ),
 			'data-srcset'             => implode( ', ', $srcset ),
 			'data-sizes'              => $sizes_attribute_value,
-			'data-original-image-src' => $image_data[ count( $image_data ) - 1 ]['url'],
+			'data-original-image-src' => $full_image_url,
 			'data-product-image'      => 'container-responsive',
 		);
 

--- a/plugins/woocommerce/includes/class-wc-product-image-handler.php
+++ b/plugins/woocommerce/includes/class-wc-product-image-handler.php
@@ -96,15 +96,6 @@ class WC_Product_Image_Handler {
 			self::build_attributes( $image_attributes )
 		);
 
-		// Add JavaScript if not already rendered.
-		static $js_rendered = true;
-		if ( ! $js_rendered ) {
-			ob_start();
-			self::render_container_script();
-			$html       .= ob_get_clean();
-			$js_rendered = true;
-		}
-
 		return $html;
 	}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -926,6 +926,30 @@ final class WooCommerce {
 		$single            = wc_get_image_size( 'single' );
 		$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
 
+		// Add responsive image sizes for product images so we can render them with container awareness.
+		$responsive_sizes = array(
+			array(
+				'name'  => 'woocommerce_300',
+				'width' => 300,
+			),
+			array(
+				'name'  => 'woocommerce_600',
+				'width' => 600,
+			),
+			array(
+				'name'  => 'woocommerce_900',
+				'width' => 900,
+			),
+			array(
+				'name'  => 'woocommerce_1200',
+				'width' => 1200,
+			),
+		);
+
+		foreach ( $responsive_sizes as $size ) {
+			add_image_size( $size['name'], $size['width'] );
+		}
+
 		add_image_size( 'woocommerce_thumbnail', $thumbnail['width'], $thumbnail['height'], $thumbnail['crop'] );
 		add_image_size( 'woocommerce_single', $single['width'], $single['height'], $single['crop'] );
 		add_image_size( 'woocommerce_gallery_thumbnail', $gallery_thumbnail['width'], $gallery_thumbnail['height'], $gallery_thumbnail['crop'] );

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1721,13 +1721,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 		)
 	);
 
-	// Add container styles to wrapper div.
-	$wrapper_style = sprintf(
-		'style="%s"',
-		esc_attr( WC_Product_Image_Handler::get_container_style() )
-	);
-
-	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a ' . $wrapper_style . ' href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }
 
 if ( ! function_exists( 'woocommerce_get_alt_from_product_title_and_position' ) ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1680,11 +1680,9 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single' : $thumbnail_size );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
-	$thumbnail_srcset  = wp_get_attachment_image_srcset( $attachment_id, $thumbnail_size );
-	$thumbnail_sizes   = wp_get_attachment_image_sizes( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-	$alt_text          = ( empty( $alt_text ) && ( $product instanceof WC_Product ) ) ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
+	$alt_text          = empty( $alt_text ) && $product instanceof WC_Product ? woocommerce_get_alt_from_product_title_and_position( $product->get_title(), $main_image, $image_index ) : $alt_text;
 
 	/**
 	 * Filters the attributes for the image markup.
@@ -1714,14 +1712,22 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false, $image_
 		unset( $image_params['title'] );
 	}
 
-	$image = wp_get_attachment_image(
+	// Get the responsive image HTML.
+	$image = WC_Product_Image_Handler::render_responsive_image_tag(
 		$attachment_id,
-		$image_size,
-		false,
-		$image_params
+		array(
+			'class'     => $main_image ? 'wp-post-image' : '',
+			'lazy_load' => true,
+		)
 	);
 
-	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" data-thumb-srcset="' . esc_attr( $thumbnail_srcset ) . '"  data-thumb-sizes="' . esc_attr( $thumbnail_sizes ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	// Add container styles to wrapper div.
+	$wrapper_style = sprintf(
+		'style="%s"',
+		esc_attr( WC_Product_Image_Handler::get_container_style() )
+	);
+
+	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a ' . $wrapper_style . ' href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 }
 
 if ( ! function_exists( 'woocommerce_get_alt_from_product_title_and_position' ) ) {

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -158,7 +158,7 @@ add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_s
 /**
  * Product Gallery
  */
-add_action( 'woocommerce_before_single_product', 'WC_Product_Image_Handler::register_container_styles' );
+add_action( 'woocommerce_before_single_product', 'WC_Product_Image_Handler::enqueue_image_resize_observer', 10 );
 
 /**
  * Reviews

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -156,6 +156,11 @@ add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_m
 add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_sharing', 50 );
 
 /**
+ * Product Gallery
+ */
+add_action( 'woocommerce_before_single_product', 'WC_Product_Image_Handler::register_container_styles' );
+
+/**
  * Reviews
  *
  * @see woocommerce_review_display_gravatar()

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -42,13 +42,7 @@ $wrapper_classes   = apply_filters(
 	<div class="woocommerce-product-gallery__wrapper">
 		<?php
 		if ( $post_thumbnail_id ) {
-			$html = WC_Product_Image_Handler::render_responsive_image(
-				$post_thumbnail_id,
-				array(
-					'container_class' => 'wp-gallery-image-container',
-				)
-			);
-			// $html = wc_get_gallery_image_html( $post_thumbnail_id, true );
+			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$wrapper_classname = $product->is_type( ProductType::VARIABLE ) && ! empty( $product->get_available_variations( 'image' ) ) ?
 				'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder' :

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -42,7 +42,13 @@ $wrapper_classes   = apply_filters(
 	<div class="woocommerce-product-gallery__wrapper">
 		<?php
 		if ( $post_thumbnail_id ) {
-			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
+			$html = WC_Product_Image_Handler::render_responsive_image(
+				$post_thumbnail_id,
+				array(
+					'container_class' => 'wp-gallery-image-container',
+				)
+			);
+			// $html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$wrapper_classname = $product->is_type( ProductType::VARIABLE ) && ! empty( $product->get_available_variations( 'image' ) ) ?
 				'woocommerce-product-gallery__image woocommerce-product-gallery__image--placeholder' :


### PR DESCRIPTION
### Changes proposed in this Pull Request:

#### Important: This is experimental, don't focus too much on the code and structure but more so the solution overall.

Currently we load in the original image all the time (even on small devices). This is unncessary as we may not always need it, only if the user wants to use the zoom feature. Another problem is that due to the block paradigm its hard to know upfront what is the most appropriate image the load, for example is the image full-width, or in 1/3 of a column block?

This PR changes the way the classic gallery loads product images. I introduce the usage of the `ResizeObserver` to detect and react to changes of the images container width to load in the appropriate image based on the size available.

By deprecating our reliance on context related images generated by WooCommerce and focus on using the most appropriately sized one, we could start to phase out image references bound by context such as `woocommerce_thumbnail` and `woocommerce_gallery_thumbnail`.

### Changes
- Introduced new `WC_Product_Image_Handler` class to manage responsive product images
- Implemented ResizeObserver-based solution for dynamic image sizing
- Removed reliance on browser's native `sizes` attribute in favor of container-aware approach
- ~Added support for multiple predefined image sizes (300px, 600px, 900px, 1200px)~ (Refer to the TODO list)

### Technical Details
- Images are now loaded based on their container's actual dimensions rather than viewport width
- ResizeObserver monitors gallery container size changes and updates image sources accordingly
- Lazy loading support maintained for performance optimization
- Handles dynamic gallery updates (e.g., variation changes) through event listeners

### Benefits
- Improved performance by serving right-sized images
- Reduced bandwidth usage for both users and servers
- Better responsive behavior using container queries instead of viewport queries
- Maintains image quality by preserving aspect ratios

### TODO:
- [ ] Use WordPress default image sizes instead of adding additional image sizes
- [ ] Backwards compatibility
- [x] Fallbacks
- [ ] Maintain old extensibility (hooks/filters)
- [ ] Load full-size image on hover

Closes https://github.com/woocommerce/woocommerce/issues/54186

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Upload a product image larger than 1200px wide
2. Verify that WordPress generates the intermediate sizes (check wp-content/uploads)
3. View a product in different viewport sizes and check browser dev tools/network tab to confirm the appropriate image size is being loaded based on the container width

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
