### PR TITLE
Remove dangerouslySetInnerHTML usage in classic shortcode block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
@@ -225,11 +225,7 @@ const Edit = ( { clientId, attributes }: BlockEditProps< Attributes > ) => {
 						</span>
 						<span>{ placeholderTitle }</span>
 					</div>
-					<p
-						dangerouslySetInnerHTML={ {
-							__html: placeholderDescription,
-						} }
-					/>
+					<p>{ placeholderDescription }</p>
 					<p>{ learnMoreContent }</p>
 					{ canConvert && blockifyConfig && (
 						<ConvertTemplate

--- a/plugins/woocommerce/changelog/fix-remove-html-usage-in-classic-shortcode
+++ b/plugins/woocommerce/changelog/fix-remove-html-usage-in-classic-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove dangerouslySetInnerHTML usage in classic-shortcode block where its not needed.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes usage of `dangerouslySetInnerHTML`. Its not needed as we're rendering strings. This is used for the classic cart and checkout placeholder content:

![Screenshot 2025-01-06 at 12 47 21](https://github.com/user-attachments/assets/efbf99f5-be62-4cc3-aa48-f7c9d52176b4)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. "transform" a cart block or cart shortcode into a "classic shortcode" block in the editor. [See screenshot here for transforms.](https://github.com/woocommerce/woocommerce/pull/54193#pullrequestreview-2533618582)
2. Confirm the placeholder text is correctly rendered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
