### PR TITLE
Fix - Skip variations without prices during bulk price adjustments to prevent 500 error

### DIFF
--- a/plugins/woocommerce/changelog/54202-54140-bulk-actions-to-update-prices-crash-if-any-variation-has-no-price
+++ b/plugins/woocommerce/changelog/54202-54140-bulk-actions-to-update-prices-crash-if-any-variation-has-no-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix - Skip variations without prices during bulk price adjustments to prevent 500 error

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2804,6 +2804,11 @@ class WC_AJAX {
 			$variation   = wc_get_product( $variation_id );
 			$field_value = $variation->{"get_$field"}( 'edit' );
 
+			// Skip variations without a price set
+			if ( '' === $field_value || null === $field_value ) {
+				continue;
+			}
+
 			if ( '%' === substr( $value, -1 ) ) {
 				$percent      = wc_format_decimal( substr( $value, 0, -1 ) );
 				$field_value += NumberUtil::round( ( $field_value / 100 ) * $percent, wc_get_price_decimals() ) * "{$operator}1";


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54140

This PR fixes an issue with bulk price adjustments for variations where the operation would fail silently with an infinite loading spinner if any variation was missing a price. The fix skips variations without prices set, allowing the bulk update to proceed for variations that do have prices.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a variable product with multiple variations
2. Leave some variations without prices set
3. Click on "Bulk actions" dropdown and select "Increase regular prices (fixed amount or percentage)"
4. Enter a value (e.g. "10" or "10%") and click OK
5. Verify that:
	- The operation completes successfully
	- Only variations with existing prices are updated
	- Variations without prices are skipped
	- No infinite loading spinner appears
6. Perform the same steps i.e. step 1-5 for following options:
	- "Decrease regular prices (fixed amount or percentage)"
	- "Increase sale prices (fixed amount or percentage)"
	- "Decrease sale prices (fixed amount or percentage)"

![Image](https://github.com/user-attachments/assets/4c8b756e-60bd-4aef-b3d1-df1e5175d234)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix - Skip variations without prices during bulk price adjustments to prevent 500 error
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>