### PR TITLE
Fix TS warnings after React upgrade in client/settings-email/

### DIFF
--- a/plugins/woocommerce/changelog/54228-53939-client-settings-email-typescript-errors
+++ b/plugins/woocommerce/changelog/54228-53939-client-settings-email-typescript-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix TS warnings in plugins/woocommerce/client/admin/client/settings-email

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { createSlotFill, SelectControl, Spinner } from '@wordpress/components';
+import { createSlotFill, Spinner } from '@wordpress/components';
+import { SelectControlSingleSelectionProps } from '@wordpress/components/build-types/select-control/types';
 import { registerPlugin } from '@wordpress/plugins';
 import { useEffect, useState } from '@wordpress/element';
 import { debounce } from 'lodash';
@@ -22,10 +23,12 @@ import { EmailPreviewType } from './settings-email-preview-type';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
-export type EmailType = SelectControl.Option;
+export type EmailTypes = NonNullable<
+	SelectControlSingleSelectionProps[ 'options' ]
+>;
 
 type EmailPreviewFillProps = {
-	emailTypes: EmailType[];
+	emailTypes: EmailTypes;
 	previewUrl: string;
 	settingsIds: string[];
 };
@@ -117,7 +120,7 @@ export const registerSettingsEmailPreviewFill = () => {
 		return null;
 	}
 	const emailTypesData = slotElement.getAttribute( 'data-email-types' );
-	let emailTypes: EmailType[] = [];
+	let emailTypes: EmailTypes = [];
 	try {
 		emailTypes = JSON.parse( emailTypesData || '' );
 	} catch ( e ) {}

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-type.tsx
@@ -7,10 +7,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { EmailType } from './settings-email-preview-slotfill';
+import { EmailTypes } from './settings-email-preview-slotfill';
 
 type EmailPreviewTypeProps = {
-	emailTypes: EmailType[];
+	emailTypes: EmailTypes;
 	emailType: string;
 	setEmailType: ( emailType: string ) => void;
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #54225.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch
2. Go to admin-library folder `cd plugins/woocommerce/client/admin`
3. Run new ts check `pnpm ts:check`
4. Confirm that there are no warnings related to `/settings-email/` directory
5. Go back to woocommerce plugin dir `cd ../..`
6. Build admin folder and confirm it works fine `pnpm --filter='@woocommerce/plugin-woocommerce' build:admin`
7. Do smoke tests in **WooCommerce > Settings > Emails** regarding email preview
8. Please test around this issue

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix TS warnings in plugins/woocommerce/client/admin/client/settings-email

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
