### PR TITLE
Use decodeEntities() to render product name in Reviews blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/read-more/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/read-more/index.tsx
@@ -12,33 +12,33 @@ import { clampLines } from './utils';
 
 export interface ReadMoreProps {
 	/**
-	 * The entire content to clamp
+	 * The entire content to clamp.
 	 */
 	children: ReactNode;
 	/**
-	 * Class names for the wrapped component
+	 * Class names for the wrapped component.
 	 */
 	className: string;
 	/**
-	 * What symbol to show after the allowed lines are reached
+	 * What symbol to show after the allowed lines are reached.
 	 *
 	 * @default '&hellip';
 	 */
 	ellipsis: string;
 	/**
-	 * The string to show to collapse the entire text into its clamped form
+	 * The string to show to collapse the entire text into its clamped form.
 	 *
 	 * @default 'Read less'
 	 */
 	lessText: string;
 	/**
-	 * How many lines to show before the text is clamped
+	 * How many lines to show before the text is clamped.
 	 *
 	 * @default 3
 	 */
 	maxLines: number;
 	/**
-	 * The string to show to expande the entire text
+	 * The string to show to expand the entire text.
 	 *
 	 * @default 'Read more'
 	 */

--- a/plugins/woocommerce-blocks/assets/js/base/components/reviews/review-list-item/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/reviews/review-list-item/index.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import ReadMore from '@woocommerce/base-components/read-more';
 import { ReviewBlockAttributes } from '@woocommerce/blocks/reviews/attributes';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -76,15 +77,9 @@ function getReviewContent( review: Review ): JSX.Element {
 function getReviewProductName( review: Review ): JSX.Element {
 	return (
 		<div className="wc-block-review-list-item__product wc-block-components-review-list-item__product">
-			<a
-				href={ review.product_permalink }
-				dangerouslySetInnerHTML={ {
-					// `product_name` might have html entities for things like
-					// emdash. So to display properly we need to allow the
-					// browser to render.
-					__html: review.product_name,
-				} }
-			/>
+			<a href={ review.product_permalink }>
+				{ decodeEntities( review.product_name ) }
+			</a>
 		</div>
 	);
 }

--- a/plugins/woocommerce/changelog/fix-review-product-name-decode-entities
+++ b/plugins/woocommerce/changelog/fix-review-product-name-decode-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Use decodeEntities() to render Review product name in Reviews blocks


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We can simplify the code and use `decodeEntities()` to render the product name in the _All Reviews_, _Reviews by Category_ and _Reviews by Product_ blocks.

### How to test the changes in this Pull Request:

Testing this PR means making sure there are no regressions.

1. Create a product with a hyphen between two spaces in the name (ie: `Beanie - Limited edition`).
2. Go to the product page in the frontend and leave a review for that product.
3. Create a new post or page and add the _All Reviews_, _Reviews by Category_ and _Reviews by Product_ blocks so they display the review you just created.
4. Verify the hyphen in the product name is displayed correctly.