### PR TITLE
Fix product-image border for images without "alt"

### DIFF
--- a/plugins/woocommerce/changelog/fix-54171_product_image_border_alt
+++ b/plugins/woocommerce/changelog/fix-54171_product_image_border_alt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product-image border for images without "alt" #54247

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -166,13 +166,20 @@ class ProductImage extends AbstractBlock {
 		}
 
 		$image_id = $product->get_image_id();
+		$alt_text = '';
+		$title = '';
+		if ( $image_id ) {
+			$alt_text = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+			$title = get_the_title( $image_id );
+		}
 
 		return $product->get_image(
 			$image_size,
 			array(
+				'alt'         => empty( $alt_text ) ? $product->get_title() : $alt_text,
 				'data-testid' => 'product-image',
 				'style'       => $image_style,
-				'title'       => $image_id ? get_the_title( $image_id ) : '',
+				'title'       => $title,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -167,10 +167,10 @@ class ProductImage extends AbstractBlock {
 
 		$image_id = $product->get_image_id();
 		$alt_text = '';
-		$title = '';
+		$title    = '';
 		if ( $image_id ) {
 			$alt_text = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
-			$title = get_the_title( $image_id );
+			$title    = get_the_title( $image_id );
 		}
 
 		return $product->get_image(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the `Product Image` block to use the product name for the `alt` attribute when an `alt` text is not set for the image. These changes apply only to the front end.

### For context

Before merging https://github.com/woocommerce/woocommerce/pull/52593, the `alt` text was always overwritten with the product's name, and that was an error. However, because the `alt` attribute is not always set, the styles [declared here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/image/style.scss#L26-L28) were applied incorrectly.

The expected behavior for a product image is to use the `alt` text if provided or the product name if it's not.


| Before | After |
|--------|--------|
| ![Screenshot 2025-01-07 at 3 10 16 PM](https://github.com/user-attachments/assets/8c6e35ae-3fdd-4661-a503-3774adec73c5) | ![Screenshot 2025-01-07 at 3 10 08 PM](https://github.com/user-attachments/assets/bdcfe2f9-b664-4f27-ab2d-b36f44491ead) |

https://github.com/user-attachments/assets/0c990b47-41e5-4887-b0f5-2cdcf22a3253

Closes #54171.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product with an image that does not have an `alt` text.
2. Go to Pages > Add New Page
3. Add a `Single Product` block and select the product you just created.
4. Press `Save` and view the page.
5. Verify that the image `alt` text is the product's name.
6. Now use a `Product Collection` block.
7. `Save` and view the page.
8. Verify that the `alt` text for each product image matches the respective product's name.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
