### PR TITLE
[Block Checkout] Hide shipping toggle when only local pickup methods exist

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -248,7 +248,7 @@
 	}
 }
 .wc-block-components-radio-control-accordion-content {
-	padding: 0 em($gap-small) em($gap);
+	padding: 0 em($gap) em($gap);
 
 	&:empty,
 	&:has(> *:only-child:empty) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -248,7 +248,7 @@
 	}
 }
 .wc-block-components-radio-control-accordion-content {
-	padding: $gap-smaller $gap;
+	padding: 0 em($gap-small) em($gap);
 
 	&:empty,
 	&:has(> *:only-child:empty) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -25,7 +25,6 @@ import {
 } from '@woocommerce/base-utils';
 import { ExperimentalOrderLocalPickupPackages } from '@woocommerce/blocks-checkout';
 import { LocalPickupSelect } from '@woocommerce/base-components/cart-checkout/local-pickup-select';
-import ReadMore from '@woocommerce/base-components/read-more';
 
 /**
  * Internal dependencies
@@ -129,10 +128,7 @@ const renderPickupLocation = (
 				{ decodeEntities( address ) }
 			</>
 		) : undefined,
-
-		secondaryDescription: (
-			<ReadMore maxLines={ 2 }>{ decodeEntities( details ) }</ReadMore>
-		),
+		secondaryDescription: details ? decodeEntities( details ) : undefined,
 	};
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -25,6 +25,7 @@ import {
 } from '@woocommerce/base-utils';
 import { ExperimentalOrderLocalPickupPackages } from '@woocommerce/blocks-checkout';
 import { LocalPickupSelect } from '@woocommerce/base-components/cart-checkout/local-pickup-select';
+import ReadMore from '@woocommerce/base-components/read-more';
 
 /**
  * Internal dependencies
@@ -128,7 +129,9 @@ const renderPickupLocation = (
 				{ decodeEntities( address ) }
 			</>
 		) : undefined,
-		secondaryDescription: details ? decodeEntities( details ) : undefined,
+		secondaryDescription: details ? (
+			<ReadMore maxLines={ 2 }>{ decodeEntities( details ) }</ReadMore>
+		) : undefined,
 	};
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -3,7 +3,7 @@
 	.wc-block-components-local-pickup-rates-control {
 		.wc-block-components-radio-control__option {
 			margin: 0;
-			padding: em($gap-small) em($gap-small) em($gap-small) em($gap-huge);
+			padding: em($gap) em($gap-small) em($gap) em($gap-huge);
 		}
 		.wc-block-components-shipping-rates-control__no-results-notice {
 			margin: em($gap-small) 0;
@@ -12,7 +12,6 @@
 		.wc-block-components-radio-control__input {
 			top: auto;
 			transform: none;
-			margin-top: 1px;
 		}
 		.wc-block-components-radio-control__option-layout {
 			display: block;
@@ -31,42 +30,26 @@
 				font-style: inherit;
 			}
 		}
-
-		.wc-block-components-radio-control__option-checked {
-			.wc-block-components-radio-control__description-group {
-				.read-more-content {
-					margin-left: em($gap-small * 0.25);
-					position: initial;
-					visibility: visible;
-					z-index: initial;
-					hyphens: auto;
-					word-break: normal;
-				}
-			}
-		}
-
 		.wc-block-components-radio-control__description-group {
 			display: block;
 			width: calc(100% + em($gap-huge / 0.875));
 			box-sizing: border-box;
 			border-radius: $universal-border-radius;
-			padding: 1px em($gap-small);
+			padding: 0 em($gap-small);
 			margin-left: -(em($gap-huge));
-			margin-top: em($gap-smaller);
+			margin-top: em($gap);
 			@include font-size(regular);
-
-			.read-more-content {
-				position: absolute;
-				visibility: hidden;
-				z-index: -1;
-			}
 		}
 		.wc-block-components-radio-control__description,
 		.wc-block-components-radio-control__secondary-description {
 			width: 100%;
 			text-align: left;
-			margin: em($gap-small) 0;
+			margin: 0;
 			display: block;
+			@include font-size(regular);
+		}
+		.wc-block-components-radio-control__description + .wc-block-components-radio-control__secondary-description {
+			margin-top: em($gap-small);
 		}
 		.wc-block-components-radio-control__description {
 			color: $gray-700;
@@ -79,6 +62,18 @@
 				vertical-align: middle;
 				margin-top: -4px;
 				fill: currentColor;
+			}
+		}
+		.wc-block-components-radio-control__description-group {
+			.wc-block-components-radio-control__secondary-description {
+				display: none;
+			}
+		}
+		.wc-block-components-radio-control__option-checked {
+			.wc-block-components-radio-control__description-group {
+				.wc-block-components-radio-control__secondary-description {
+					display: block;
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -35,7 +35,7 @@
 			width: calc(100% + em($gap-huge / 0.875));
 			box-sizing: border-box;
 			border-radius: $universal-border-radius;
-			padding: 0 em($gap-small);
+			padding: 0 em($gap);
 			margin-left: -(em($gap-huge));
 			margin-top: em($gap);
 			@include font-size(regular);

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -7,7 +7,10 @@ import { FormStep } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useShippingData } from '@woocommerce/base-context/hooks';
-import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
+import {
+	LOCAL_PICKUP_ENABLED,
+	SHIPPING_METHODS_EXIST,
+} from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
@@ -53,12 +56,15 @@ const FrontendBlock = ( {
 		isCollectable,
 	} = useShippingData();
 
+	// Note that display logic is also found in plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/register-components.ts
+	// where the block is not registered if the conditions are not met.
 	if (
 		! needsShipping ||
 		! hasCalculatedShipping ||
 		! shippingRates ||
 		! isCollectable ||
-		! LOCAL_PICKUP_ENABLED
+		! LOCAL_PICKUP_ENABLED ||
+		! SHIPPING_METHODS_EXIST
 	) {
 		return null;
 	}

--- a/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce-blocks/assets/js/settings/blocks/constants.ts
@@ -41,8 +41,14 @@ export const CART_URL = STORE_PAGES.cart?.permalink;
 export const LOGIN_URL = STORE_PAGES.myaccount?.permalink
 	? STORE_PAGES.myaccount.permalink
 	: getSetting( 'wpLoginUrl', '/wp-login.php' );
+
 export const LOCAL_PICKUP_ENABLED = getSetting< boolean >(
 	'localPickupEnabled',
+	false
+);
+
+export const SHIPPING_METHODS_EXIST = getSetting< boolean >(
+	'shippingMethodsExist',
 	false
 );
 

--- a/plugins/woocommerce/changelog/fix-48509-shipping-and-local-pickup-display
+++ b/plugins/woocommerce/changelog/fix-48509-shipping-and-local-pickup-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Hides the delivery/pickup toggle when only local pickup is enabled in block checkout.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -651,6 +651,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		$this->fees_api->remove_all_fees();
+		WC()->shipping()->reset_shipping();
 
 		do_action( 'woocommerce_cart_emptied', $clear_persistent_cart );
 	}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -632,6 +632,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	/**
 	 * Empties the cart and optionally the persistent cart too.
 	 *
+	 * @since 9.7.0 Also clears shipping methods and packages since the items they are linked to are cleared.
+	 *
 	 * @param bool $clear_persistent_cart Should the persistent cart be cleared too. Defaults to true.
 	 */
 	public function empty_cart( $clear_persistent_cart = true ) {

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1787,43 +1787,58 @@ function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $obj
 function wc_get_shipping_method_count( $include_legacy = false, $enabled_only = false ) {
 	global $wpdb;
 
-	$transient_name    = $include_legacy ? 'wc_shipping_method_count_legacy' : 'wc_shipping_method_count';
+	$transient_name    = 'wc_shipping_method_count';
 	$transient_version = WC_Cache_Helper::get_transient_version( 'shipping' );
 	$transient_value   = get_transient( $transient_name );
-
-	if ( isset( $transient_value['value'], $transient_value['version'] ) && $transient_value['version'] === $transient_version ) {
-		return absint( $transient_value['value'] );
-	}
-
-	// Count activated methods that don't support shipping zones if $include_legacy is true.
-	$methods      = WC()->shipping()->get_shipping_methods();
-	$method_ids   = array();
-	$method_count = 0;
-
-	foreach ( $methods as $method ) {
-		$method_ids[] = $method->id;
-
-		if ( $include_legacy && isset( $method->enabled ) && 'yes' === $method->enabled && ! $method->supports( 'shipping-zones' ) ) {
-			++$method_count;
-		}
-	}
-
-	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-	if ( $enabled_only ) {
-		$method_count = $method_count + absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=1 AND method_id IN ('" . implode( "','", array_map( 'esc_sql', $method_ids ) ) . "')" ) );
-	} else {
-		$method_count = $method_count + absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE method_id IN ('" . implode( "','", array_map( 'esc_sql', $method_ids ) ) . "')" ) );
-	}
-	// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-
-	$transient_value = array(
-		'version' => $transient_version,
-		'value'   => $method_count,
+	$counts            = array(
+		'legacy'   => 0,
+		'enabled'  => 0,
+		'disabled' => 0,
 	);
 
-	set_transient( $transient_name, $transient_value, DAY_IN_SECONDS * 30 );
+	if ( ! isset( $transient_value['legacy'], $transient_value['enabled'], $transient_value['disabled'], $transient_value['version'] ) || $transient_value['version'] !== $transient_version ) {
+		// Count activated methods that don't support shipping zones if $include_legacy is true.
+		$methods    = WC()->shipping()->get_shipping_methods();
+		$method_ids = array();
 
-	return $method_count;
+		foreach ( $methods as $method ) {
+			$method_ids[] = $method->id;
+
+			if ( isset( $method->enabled ) && 'yes' === $method->enabled && ! $method->supports( 'shipping-zones' ) ) {
+				++$counts['legacy'];
+			}
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$counts['enabled']  = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=1 AND method_id IN ('" . implode( "','", array_map( 'esc_sql', $method_ids ) ) . "')" ) );
+		$counts['disabled'] = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=0 AND method_id IN ('" . implode( "','", array_map( 'esc_sql', $method_ids ) ) . "')" ) );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		$transient_value = array(
+			'version'  => $transient_version,
+			'legacy'   => $counts['legacy'],
+			'enabled'  => $counts['enabled'],
+			'disabled' => $counts['disabled'],
+		);
+
+		set_transient( $transient_name, $transient_value, DAY_IN_SECONDS * 30 );
+	} else {
+		$counts = $transient_value;
+	}
+
+	$return = 0;
+
+	if ( $enabled_only ) {
+		$return = $counts['enabled'];
+	} else {
+		$return = $counts['enabled'] + $counts['disabled'];
+	}
+
+	if ( $include_legacy ) {
+		$return += $counts['legacy'];
+	}
+
+	return $return;
 }
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -431,16 +431,17 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme() );
 
 		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings();
-		$local_pickup_method_ids  = LocalPickupUtils::get_local_pickup_method_ids();
-		$local_pickup_enabled     = $pickup_location_settings['enabled'];
-		$shipping_methods_count   = wc_get_shipping_method_count( true, true );
 
-		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled );
+		$this->asset_data_registry->add( 'localPickupEnabled', $pickup_location_settings['enabled'] );
 		$this->asset_data_registry->add( 'localPickupText', $pickup_location_settings['title'] );
-		$this->asset_data_registry->add( 'collectableMethodIds', $local_pickup_method_ids );
+		$this->asset_data_registry->add( 'collectableMethodIds', LocalPickupUtils::get_local_pickup_method_ids() );
+
+		$shipping_methods_count = wc_get_shipping_method_count( true, true );
+
+		var_dump( $shipping_methods_count );
 
 		// Local pickup is included with legacy shipping methods since they do not support shipping zones.
-		if ( $local_pickup_enabled ) {
+		if ( $pickup_location_settings['enabled'] ) {
 			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 1 );
 		} else {
 			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 0 );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -436,14 +436,18 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'localPickupText', $pickup_location_settings['title'] );
 		$this->asset_data_registry->add( 'collectableMethodIds', LocalPickupUtils::get_local_pickup_method_ids() );
 
-		$shipping_methods_count = wc_get_shipping_method_count( true, true );
-
 		// Local pickup is included with legacy shipping methods since they do not support shipping zones.
-		if ( $pickup_location_settings['enabled'] ) {
-			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 1 );
-		} else {
-			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 0 );
-		}
+		$local_pickup_count = count(
+			array_filter(
+				WC()->shipping()->get_shipping_methods(),
+				function ( $method ) {
+					return isset( $method->enabled ) && 'yes' === $method->enabled && ! $method->supports( 'shipping-zones' ) && $method->supports( 'local-pickup' );
+				}
+			)
+		);
+
+		$shipping_methods_count = wc_get_shipping_method_count( true, true ) - $local_pickup_count;
+		$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 0 );
 
 		$is_block_editor = $this->is_block_editor();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -438,8 +438,6 @@ class Checkout extends AbstractBlock {
 
 		$shipping_methods_count = wc_get_shipping_method_count( true, true );
 
-		var_dump( $shipping_methods_count );
-
 		// Local pickup is included with legacy shipping methods since they do not support shipping zones.
 		if ( $pickup_location_settings['enabled'] ) {
 			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 1 );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -432,18 +432,21 @@ class Checkout extends AbstractBlock {
 
 		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings();
 		$local_pickup_method_ids  = LocalPickupUtils::get_local_pickup_method_ids();
+		$local_pickup_enabled     = $pickup_location_settings['enabled'];
+		$shipping_methods_count   = wc_get_shipping_method_count( true, true );
 
-		$this->asset_data_registry->add( 'localPickupEnabled', $pickup_location_settings['enabled'] );
+		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled );
 		$this->asset_data_registry->add( 'localPickupText', $pickup_location_settings['title'] );
 		$this->asset_data_registry->add( 'collectableMethodIds', $local_pickup_method_ids );
 
-		$is_block_editor = $this->is_block_editor();
-
-		// Hydrate the following data depending on admin or frontend context.
-		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'shippingMethodsExist' ) ) {
-			$methods_exist = wc_get_shipping_method_count( false, true ) > 0;
-			$this->asset_data_registry->add( 'shippingMethodsExist', $methods_exist );
+		// Local pickup is included with legacy shipping methods since they do not support shipping zones.
+		if ( $local_pickup_enabled ) {
+			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 1 );
+		} else {
+			$this->asset_data_registry->add( 'shippingMethodsExist', $shipping_methods_count > 0 );
 		}
+
+		$is_block_editor = $this->is_block_editor();
 
 		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'globalShippingMethods' ) ) {
 			$shipping_methods           = WC()->shipping()->get_shipping_methods();

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-totals-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-totals-test.php
@@ -6,6 +6,14 @@
 class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
 
 	/**
+	 * tearDown.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
+
+	/**
 	 * Tests whether discount tax is rounded properly in cart.
 	 *
 	 * @link https://github.com/woocommerce/woocommerce/issues/23916.
@@ -33,7 +41,7 @@ class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
 		$product_1990 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 1990 ) );
 		$product_3390 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 3390 ) );
 		$product_6200 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 6200 ) );
-		$coupon = WC_Helper_Coupon::create_coupon( 'flat2000', array( 'coupon_amount' => 2000 ) );
+		$coupon       = WC_Helper_Coupon::create_coupon( 'flat2000', array( 'coupon_amount' => 2000 ) );
 
 		WC()->cart->add_to_cart( $product_240->get_id(), 1 );
 		WC()->cart->add_to_cart( $product_1250->get_id(), 1 );

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -12,6 +12,13 @@ use Automattic\WooCommerce\Enums\OrderStatus;
  * Class WC_Order_Functions_Test
  */
 class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
+	/**
+	 * tearDown.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
 
 	/**
 	 * Test that wc_restock_refunded_items() preserves order item stock metadata.

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -38,6 +38,14 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	);
 
 	/**
+	 * tearDown.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
+
+	/**
 	 * Helper function to simulate creating order from cart.
 	 *
 	 * @param string $status Status for the newly created order.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/MiniCart.php
@@ -28,7 +28,7 @@ class MiniCart extends \WP_UnitTestCase {
 				)
 			),
 		);
-		wc_empty_cart();
+		WC()->cart->empty_cart();
 		add_filter( 'woocommerce_is_rest_api_request', '__return_false', 1 );
 	}
 
@@ -36,8 +36,9 @@ class MiniCart extends \WP_UnitTestCase {
 	 * Tear down test. Called after every test.
 	 * @return void
 	 */
-	protected function tearDown(): void {
+	public function tearDown(): void {
 		parent::tearDown();
+		WC()->cart->empty_cart();
 		remove_filter( 'woocommerce_is_rest_api_request', '__return_false', 1 );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
@@ -92,6 +92,15 @@ class Totals extends \WP_UnitTestCase {
 		wc()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
 		wc()->cart->add_to_cart( $this->products[1]->get_id(), 1 );
 	}
+
+	/**
+	 * tearDown.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
+
 	/**
 	 * We ensure deep sort works with all sort of arrays.
 	 */
@@ -165,4 +174,3 @@ class Totals extends \WP_UnitTestCase {
 		WC()->session = $old_session;
 	}
 }
-

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -100,6 +100,7 @@ class AdditionalFields extends MockeryTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		unset( WC()->countries->locale );
+		WC()->cart->empty_cart();
 		remove_all_filters( 'woocommerce_get_country_locale' );
 		global $wp_rest_server;
 		$wp_rest_server = null;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ControllerTestCase.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ControllerTestCase.php
@@ -52,6 +52,7 @@ abstract class ControllerTestCase extends \WP_Test_REST_TestCase {
 		/** @var \WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = null;
+		WC()->cart->empty_cart();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/CartControllerTests.php
@@ -12,6 +12,14 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 class CartControllerTests extends TestCase {
 	/**
+	 * tearDown.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
+
+	/**
 	 * Test the normalize_cart method.
 	 */
 	public function test_normalize_cart() {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -109,7 +109,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		remove_all_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending' );
 		remove_all_filters( 'woocommerce_load_order_cogs_value' );
 		remove_all_filters( 'woocommerce_save_order_cogs_value' );
-
+		wc()->cart->empty_cart();
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

On checkout, if local pickup is enabled we show a toggle between delivery and collection:

![Screenshot 2025-01-07 at 15 08 34](https://github.com/user-attachments/assets/51e16254-b65d-4d01-b38a-098865528b65)

If local pickup is disabled, this toggle is hidden. This however was not the case if delivery was disabled but local pickup was enabled. This PR fixes this.

Now, if you have only local pickup configured, there will be no toggle visible. Uses the existing `wc_get_shipping_method_count` core functionality to determine if shipping methods are configured or not.

This PR fixes some styling issues in the pickup area also so the spacing matches payment methods.

Closes #48509

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Shipping
2. Remove all shipping methods and zones
3. Go to WooCommerce > Settings > Shipping > Local PIckup. Enable it and setup some pickup locations.
4. As a customer, add something to cart and go to checkout. Confirm you only see local pickup methods and there is no delivery/collection toggle.
5. Go to WooCommerce > Settings > Shipping
6. Add a shipping method to any zone and save.
7. As a customer, add something to cart and go to checkout. Confirm there is a delivery/collection toggle and it functions accordingly.
8. Go to WooCommerce > Settings > Shipping. 
9. Toggle the "enabled" checkbox off and save.
10. As a customer, add something to cart and go to checkout. Confirm you only see local pickup methods and there is no delivery/collection toggle.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
