### PR TITLE
[dev] git-hooks: prompt outdated composer version

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -8,6 +8,7 @@ on:
             - '**/changelog/**'
             - '**/tests/**'
             - '**/*.md'
+            - '.husky/**'
             - '.github/**'
             - '!.github/workflows/pr-build-live-branch.yml'
 

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -32,7 +32,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
 		twelveMonthsAgo=$( date +%F -d '1 months ago' )
-		if [ "$currentComposerDate" < "$twelveMonthsAgo" ]; then
+		if [ $currentComposerDate < $twelveMonthsAgo ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
 		    printf "${orangeColoured}composer version (build at $currentComposerDate vs $twelveMonthsAgo) is ok, no update needed.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -32,7 +32,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
 		twelveMonthsAgo=$( date +%F -d '3 months ago' )
-		if [ $date < $twelveMonthsAgo ]; then
+		if [ "$date" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
 		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -12,7 +12,7 @@ orangeColoured='\033[1;33m'
 # '1' is a branch checkout
 if [ "$CHECKOUT_TYPE" = '1' ]; then
 	# Prompt about pnpm versions mismatch when switching between branches.
-	currentPnpmVersion=$( ( command -v pnpm > /dev/null && pnpm -v 2>/dev/null ) || echo 'n/a' )
+	currentPnpmVersion=$( ( command -v pnpm > /dev/null && pnpm --version 2>/dev/null ) || echo 'n/a' )
 	targetPnpmVersion=$( grep packageManager package.json | sed -nr 's/.+packageManager.+pnpm@([[:digit:].]+).+/\1/p' )
 	if [ "$currentPnpmVersion" != "$targetPnpmVersion" ]; then
 		printf "${orangeColoured}pnpm versions mismatch: in use '$currentPnpmVersion', needed '$targetPnpmVersion'. If you are working on something in this branch, here are some hints on how to solve this:\n"
@@ -27,4 +27,15 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 		printf "${whiteColoured}    %s\n" $changedManifests
 		printf "${orangeColoured}If you are working on something in this branch, ensure to refresh dependencies with 'pnpm install --frozen-lockfile'\n"
 	fi
+
+	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
+	f [ -n "$currentComposerDate" ]; then
+		currentComposerDate=$( date +%F -d $currentComposerDate )
+		twelveMonthsAgo=$( date +%F -d '12 months ago' )
+
+		printf "${orangeColoured}Composer date $currentComposerDate, 12mo date $twelveMonthsAgo\n"
+
+		# if [ $date < $twelveMonthsAgo ]; then
+		# fi
+    fi
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -30,12 +30,12 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
-		currentComposerDate=$( date +%F -d $currentComposerDate +"%Y%m%d" )
-		twelveMonthsAgo=$( date +%F -d '1 months ago' +"%Y%m%d" )
+		currentComposerDate=$( date +%F -d $currentComposerDate )
+		twelveMonthsAgo=$( date +%F -d '1 months ago' )
 		if [ "$currentComposerDate" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
-		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"
+		    printf "${orangeColoured}composer version (build at $currentComposerDate vs $twelveMonthsAgo) is ok, no update needed.\n"
 		fi
     fi
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -30,12 +30,12 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
-		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '1 months ago' )
+		currentComposerDate=$( date +%Y%m%d -d $currentComposerDate )
+		twelveMonthsAgo=$( date +%Y%m%d -d '1 months ago' )
 		if [ $currentComposerDate < $twelveMonthsAgo ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
-		    printf "${orangeColoured}composer version (build at $currentComposerDate vs $twelveMonthsAgo) is ok, no update needed.\n"
+		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"
 		fi
     fi
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -30,8 +30,8 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
-		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '1 months ago' )
+		currentComposerDate=$( date +%F -d $currentComposerDate +"%Y%m%d" )
+		twelveMonthsAgo=$( date +%F -d '1 months ago' +"%Y%m%d" )
 		if [ "$currentComposerDate" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,7 +31,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '6 months ago' )
+		twelveMonthsAgo=$( date +%F -d '3 months ago' )
 		if [ $date < $twelveMonthsAgo ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,7 +31,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '6 months ago' )
+		twelveMonthsAgo=$( date +%F -d '3 months ago' )
 		if [ "$currentComposerDate" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,7 +31,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '3 months ago' )
+		twelveMonthsAgo=$( date +%F -d '1 months ago' )
 		if [ "$currentComposerDate" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,7 +31,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '12 months ago' )
+		twelveMonthsAgo=$( date +%F -d '6 months ago' )
 		if [ $date < $twelveMonthsAgo ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,7 +31,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		current=$( date +%Y%m%d -d $currentComposerDate )
-		threshold=$( date +%Y%m%d -d '3 months ago' )
+		threshold=$( date +%Y%m%d -d '12 months ago' )
 		if [ $current -lt $threshold ]; then
 			version=$( ( composer --version 2>/dev/null | awk '{print $3}' ) || echo '' )
 			printf "${orangeColoured}composer version (v$version build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -30,8 +30,8 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
-		current=$( php -r "echo date( 'Y:m:d', strtotime( '$currentComposerDate' ) );" )
-		threshold=$( php -r "echo date( 'Y:m:d', strtotime( '-12 months' ) );" )
+		current=$( php -r "echo date( 'Ymd', strtotime( '$currentComposerDate' ) );" )
+		threshold=$( php -r "echo date( 'Ymd', strtotime( '-12 months' ) );" )
 		if [ $current -lt $threshold ]; then
 			version=$( ( composer --version 2>/dev/null | awk '{print $3}' ) || echo '' )
 			printf "${orangeColoured}composer version (v$version build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -33,7 +33,8 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 		current=$( date +%Y%m%d -d $currentComposerDate )
 		threshold=$( date +%Y%m%d -d '3 months ago' )
 		if [ $current -lt $threshold ]; then
-			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
+			version=$( ( composer --version 2>/dev/null | awk '{print $3}' ) || echo '' )
+			printf "${orangeColoured}composer version (v$version build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		fi
     fi
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -29,7 +29,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	fi
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
-	f [ -n "$currentComposerDate" ]; then
+	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
 		twelveMonthsAgo=$( date +%F -d '12 months ago' )
 

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -32,7 +32,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%Y%m%d -d $currentComposerDate )
 		twelveMonthsAgo=$( date +%Y%m%d -d '1 months ago' )
-		if [ $currentComposerDate < $twelveMonthsAgo ]; then
+		if [ $currentComposerDate -lt $twelveMonthsAgo ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
 		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,7 +31,7 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '3 months ago' )
+		twelveMonthsAgo=$( date +%F -d '1 months ago' )
 		if [ "$date" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -31,8 +31,8 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%F -d '1 months ago' )
-		if [ "$date" < "$twelveMonthsAgo" ]; then
+		twelveMonthsAgo=$( date +%F -d '6 months ago' )
+		if [ "$currentComposerDate" < "$twelveMonthsAgo" ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
 		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -30,9 +30,9 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
-		currentComposerDate=$( date +%Y%m%d -d $currentComposerDate )
-		twelveMonthsAgo=$( date +%Y%m%d -d '1 months ago' )
-		if [ $currentComposerDate -lt $twelveMonthsAgo ]; then
+		current=$( date +%Y%m%d -d $currentComposerDate )
+		threshold=$( date +%Y%m%d -d '3 months ago' )
+		if [ $current -lt $threshold ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
 		else
 		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -34,8 +34,6 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 		threshold=$( date +%Y%m%d -d '3 months ago' )
 		if [ $current -lt $threshold ]; then
 			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
-		else
-		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"
 		fi
     fi
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -30,8 +30,8 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 
 	currentComposerDate=$( ( command -v composer > /dev/null && ( composer --version 2>/dev/null | awk '{print $4}' ) ) || echo '' )
 	if [ -n "$currentComposerDate" ]; then
-		current=$( date +%Y%m%d -d $currentComposerDate )
-		threshold=$( date +%Y%m%d -d '12 months ago' )
+		current=$( php -r "echo date( 'Y:m:d', strtotime( '$currentComposerDate' ) );" )
+		threshold=$( php -r "echo date( 'Y:m:d', strtotime( '-12 months' ) );" )
 		if [ $current -lt $threshold ]; then
 			version=$( ( composer --version 2>/dev/null | awk '{print $3}' ) || echo '' )
 			printf "${orangeColoured}composer version (v$version build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -32,10 +32,10 @@ if [ "$CHECKOUT_TYPE" = '1' ]; then
 	if [ -n "$currentComposerDate" ]; then
 		currentComposerDate=$( date +%F -d $currentComposerDate )
 		twelveMonthsAgo=$( date +%F -d '12 months ago' )
-
-		printf "${orangeColoured}Composer date $currentComposerDate, 12mo date $twelveMonthsAgo\n"
-
-		# if [ $date < $twelveMonthsAgo ]; then
-		# fi
+		if [ $date < $twelveMonthsAgo ]; then
+			printf "${orangeColoured}composer version (build at $currentComposerDate) is older than twelve months, ensure to update it with 'composer self-update'.\n"
+		else
+		    printf "${orangeColoured}composer version (build at $currentComposerDate) is ok, no update needed.\n"
+		fi
     fi
 fi


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1735923523653149-slack-C03CPM3UXDJ

Updated a git-hook to prompt an outdated composer (12 months, on screenshot I modified the threshold for testing purposes):
![Screenshot from 2025-01-07 17-28-53](https://github.com/user-attachments/assets/7781161d-0374-413f-8f61-b08e2dc8503c)

### How to test the changes in this Pull Request:

- CI-check shall pass
- Switch between the branch and `trunk` locally and ensure the prompt appears if local composer version is outdated.