### PR TITLE
Harden type in BlockRegistrationManager

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -64,13 +64,8 @@ export class BlockRegistrationManager {
 	/** Singleton instance of the manager */
 	private static instance: BlockRegistrationManager;
 	/** Map storing block configurations keyed by block name or variation name */
-	private blocks: Map<
-		string,
-		ProductBlockSettings & {
-			blockName: string;
-			settings: Partial< BlockConfiguration< BlockAttributes > >;
-		}
-	> = new Map();
+	private blocks: Map< string, ProductBlockConfig< BlockAttributes > > =
+		new Map();
 	/** Current template ID being edited */
 	private currentTemplateId: string | undefined;
 	/** Flag indicating if the manager has been initialized */

--- a/plugins/woocommerce/changelog/fix-block-registration-manager-harden-type
+++ b/plugins/woocommerce/changelog/fix-block-registration-manager-harden-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Harden type in BlockRegistrationManager


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/54117. After merging that PR I realized we could directly use `ProductBlockConfig` in one of the type definitions to harden and simplify it.

### How to test the changes in this Pull Request:

This PR only includes changes to types, so there are no user-facing changes.

1. Open `plugins/woocommerce-blocks/assets/js/atomic/utils/register-product-block-type.ts`.
2. Verify there are no TypeScript errors introduced by this PR.