### PR TITLE
Enhancement: Improve UX by showing price validation warnings before bulk updates for variations

### DIFF
--- a/plugins/woocommerce/changelog/54266-enhance-bulk-price-validation-warning
+++ b/plugins/woocommerce/changelog/54266-enhance-bulk-price-validation-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Enhancement: Improve UX by showing price validation warnings before bulk updates for variations

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1228,9 +1228,12 @@ jQuery( function ( $ ) {
 				case 'variable_regular_price_decrease':
 				case 'variable_sale_price_increase':
 				case 'variable_sale_price_decrease':
-					value = window.prompt(
-						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent
-					);
+					const message =
+						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent +
+						'\n\n' +
+						woocommerce_admin_meta_boxes_variations.i18n_sale_price_warning;
+
+					value = window.prompt( message );
 
 					if ( value != null ) {
 						if ( value.indexOf( '%' ) >= 0 ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1228,12 +1228,27 @@ jQuery( function ( $ ) {
 				case 'variable_regular_price_decrease':
 				case 'variable_sale_price_increase':
 				case 'variable_sale_price_decrease':
-					const message =
-						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent +
-						'\n\n' +
-						woocommerce_admin_meta_boxes_variations.i18n_sale_price_warning;
+					let promptMessage =
+						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent;
 
-					value = window.prompt( message );
+					/**
+					 * There are two cases where sale price becomes more than regular price:
+					 * 1. When regular price is decreased
+					 * 2. When sale price is increased
+					 *
+					 * In both cases, we need to show the warning message.
+					 */
+					if (
+						do_variation_action ===
+							'variable_regular_price_decrease' ||
+						do_variation_action === 'variable_sale_price_increase'
+					) {
+						promptMessage +=
+							'\n\n' +
+							woocommerce_admin_meta_boxes_variations.i18n_sale_price_warning;
+					}
+
+					value = window.prompt( promptMessage );
 
 					if ( value != null ) {
 						if ( value.indexOf( '%' ) >= 0 ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -306,6 +306,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_enter_a_value'                  => esc_js( __( 'Enter a value', 'woocommerce' ) ),
 					'i18n_enter_menu_order'               => esc_js( __( 'Variation menu order (determines position in the list of variations)', 'woocommerce' ) ),
 					'i18n_enter_a_value_fixed_or_percent' => esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ),
+					'i18n_sale_price_warning'            => esc_js( __( 'Warning: Sale prices will be removed if they are not lower than regular prices.', 'woocommerce' ) ),
 					'i18n_delete_all_variations'          => esc_js( __( 'Are you sure you want to delete all variations? This cannot be undone.', 'woocommerce' ) ),
 					'i18n_last_warning'                   => esc_js( __( 'Last warning, are you sure?', 'woocommerce' ) ),
 					'i18n_choose_image'                   => esc_js( __( 'Choose an image', 'woocommerce' ) ),


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Context: https://github.com/woocommerce/woocommerce/pull/54202#pullrequestreview-2532742828

This PR improves the user experience during bulk price adjustments for variations by adding a clear warning about sale price validation rules. When users attempt to modify prices in bulk, they'll now see an upfront warning that explains how sale prices are validated against regular prices.

This helps prevent user confusion by explaining the validation rules before prices are modified, rather than after invalid prices are automatically removed.

We need to show this message only if there is the possibility that the sale price could become more than the regular price. This happens in two cases:
- Increase sale price
- Decrease regular price

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create a variable product with multiple variations
2. Set regular price and sale price for a variation. For example, set regular price to $50 and sale price to $45.
3. Click on "Bulk actions" dropdown and select "Increase sale prices (fixed amount or percentage)"
4. Verify that: In alert, you can see a warning message with text "Warning: Sale prices will be removed if they are not lower than regular prices."
![image](https://github.com/user-attachments/assets/4f730ee4-e9c0-4294-b019-d47d2e4438bd)

5. Enter a value (e.g. "10") and click OK
6. Verify that:
	- Sale price is removed for variations where because of bulk operation sale prices becomes higher than regular prices
7. Perform the same steps i.e. step 1-5 for "Decrease regular prices (fixed amount or percentage)"

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Enhancement: Improve UX by showing price validation warnings before bulk updates for variations
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
