### PR TITLE
[dev] CI: disable pr-assess-bundle-size workflow for draft PRs.

### DIFF
--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -35,6 +35,7 @@ env:
 jobs:
     build:
         name: Check Asset Sizes
+        if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1736337198313399-slack-C07JJG089M0

In this PR we disable the  `pr-assess-bundle-size.yml` workflow for draft PRs to reduce the time used by CI.

The rationale behind this PR is that draft PRs are used for experimentation and the workflow should be triggered as PR is ready for review, as part of review process.

### How to test the changes in this Pull Request:

- CI-checks shall pass