### PR TITLE
Adjust changelog

### DIFF
--- a/plugins/woocommerce/changelog/383-fix-limited-usage-coupons
+++ b/plugins/woocommerce/changelog/383-fix-limited-usage-coupons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed a bug where limited usage coupons would experience conflicts when applied simultaneously.

--- a/plugins/woocommerce/changelog/pr-54267
+++ b/plugins/woocommerce/changelog/pr-54267
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Enhance the security of the customers API


### PR DESCRIPTION
[Automation failed](https://github.com/woocommerce/woocommerce/actions/runs/12672429538/job/35316443465) to produce PRs for trunk and frozen release branch after generating the changelog for release 9.5.2.

This PR removes the lingering changelog files from trunk.