### PR TITLE
Disable the Store Notice when switching to a block theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-54237-disable-store-notice-switch-block-theme
+++ b/plugins/woocommerce/changelog/fix-54237-disable-store-notice-switch-block-theme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disable the Store Notice when switching to a block theme

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4205,6 +4205,60 @@ function wc_set_hooked_blocks_version() {
 }
 
 /**
+ * Attach functions that listen to theme switches.
+ *
+ * @since 9.7.0
+ *
+ * @param string    $old_name Old theme name.
+ * @param \WP_Theme $old_theme Instance of the old theme.
+ * @return void
+ */
+function wc_after_switch_theme( $old_name, $old_theme ) {
+	wc_set_hooked_blocks_version_on_theme_switch( $old_name, $old_theme );
+	wc_update_store_notice_visible_on_theme_switch( $old_name, $old_theme );
+}
+
+/**
+ * Update the Store Notice visibility when switching themes:
+ * - When switching from a classic theme to a block theme, disable it.
+ * - When switching from a block theme to a classic theme, re-enable only if it was enabled when switching from a classic theme to a block theme.
+ *
+ * @since 9.7.0
+ *
+ * @param string    $old_name Old theme name.
+ * @param \WP_Theme $old_theme Instance of the old theme.
+ * @return void
+ */
+function wc_update_store_notice_visible_on_theme_switch( $old_name, $old_theme ) {
+	$enable_store_notice_in_classic_theme_option = 'woocommerce_enable_store_notice_in_classic_theme';
+	$is_store_notice_active_option               = 'woocommerce_demo_store';
+
+	if ( ! $old_theme->is_block_theme() && wc_current_theme_is_fse_theme() ) {
+		/*
+		 * When switching from a classic theme to a block theme, check if the store notice is active,
+		 * if it is, disable it but set an option to re-enable it when switching back to a classic theme.
+		 */
+		$store_notice_is_active = get_option( $is_store_notice_active_option, 'no' );
+
+		if ( 'yes' === $store_notice_is_active ) {
+			add_option( $enable_store_notice_in_classic_theme_option, 'yes' );
+			update_option( $is_store_notice_active_option, 'no' );
+		}
+	} elseif ( $old_theme->is_block_theme() && ! wc_current_theme_is_fse_theme() ) {
+		/*
+		 * When switching from a block theme to a clasic theme, check if we have set the option to
+		 * re-enale the store notice. If so, re-enable it.
+		 */
+		$enable_store_notice_in_classic_theme = get_option( $enable_store_notice_in_classic_theme_option, 'no' );
+
+		if ( 'yes' === $enable_store_notice_in_classic_theme ) {
+			delete_option( $enable_store_notice_in_classic_theme_option );
+			update_option( $is_store_notice_active_option, 'yes' );
+		}
+	}
+}
+
+/**
  * If the user switches from a classic to a block theme and they haven't already got a woocommerce_hooked_blocks_version,
  * set the version of the hooked blocks in the database, or as "no" to disable all block hooks then set as the latest WC version.
  *

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4220,8 +4220,9 @@ function wc_after_switch_theme( $old_name, $old_theme ) {
 
 /**
  * Update the Store Notice visibility when switching themes:
- * - When switching from a classic theme to a block theme, disable it.
- * - When switching from a block theme to a classic theme, re-enable only if it was enabled when switching from a classic theme to a block theme.
+ * - When switching from a classic theme to a block theme, disable the Store Notice.
+ * - When switching from a block theme to a classic theme, re-enable the Store Notice
+ *   only if it was enabled last time there was a switchi from a classic theme to a block theme.
  *
  * @since 9.7.0
  *
@@ -4241,19 +4242,19 @@ function wc_update_store_notice_visible_on_theme_switch( $old_name, $old_theme )
 		$store_notice_is_active = get_option( $is_store_notice_active_option, 'no' );
 
 		if ( 'yes' === $store_notice_is_active ) {
-			add_option( $enable_store_notice_in_classic_theme_option, 'yes' );
 			update_option( $is_store_notice_active_option, 'no' );
+			add_option( $enable_store_notice_in_classic_theme_option, 'yes' );
 		}
 	} elseif ( $old_theme->is_block_theme() && ! wc_current_theme_is_fse_theme() ) {
 		/*
 		 * When switching from a block theme to a clasic theme, check if we have set the option to
-		 * re-enale the store notice. If so, re-enable it.
+		 * re-enable the store notice. If so, re-enable it.
 		 */
 		$enable_store_notice_in_classic_theme = get_option( $enable_store_notice_in_classic_theme_option, 'no' );
 
 		if ( 'yes' === $enable_store_notice_in_classic_theme ) {
-			delete_option( $enable_store_notice_in_classic_theme_option );
 			update_option( $is_store_notice_active_option, 'yes' );
+			delete_option( $enable_store_notice_in_classic_theme_option );
 		}
 	}
 }

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4239,21 +4239,19 @@ function wc_update_store_notice_visible_on_theme_switch( $old_name, $old_theme )
 		 * When switching from a classic theme to a block theme, check if the store notice is active,
 		 * if it is, disable it but set an option to re-enable it when switching back to a classic theme.
 		 */
-		$store_notice_is_active = get_option( $is_store_notice_active_option, 'no' );
-
-		if ( 'yes' === $store_notice_is_active ) {
-			update_option( $is_store_notice_active_option, 'no' );
-			add_option( $enable_store_notice_in_classic_theme_option, 'yes' );
+		if ( is_store_notice_showing() ) {
+			update_option( $is_store_notice_active_option, wc_bool_to_string( false ) );
+			add_option( $enable_store_notice_in_classic_theme_option, wc_bool_to_string( true ) );
 		}
 	} elseif ( $old_theme->is_block_theme() && ! wc_current_theme_is_fse_theme() ) {
 		/*
 		 * When switching from a block theme to a clasic theme, check if we have set the option to
 		 * re-enable the store notice. If so, re-enable it.
 		 */
-		$enable_store_notice_in_classic_theme = get_option( $enable_store_notice_in_classic_theme_option, 'no' );
+		$enable_store_notice_in_classic_theme = wc_string_to_bool( get_option( $enable_store_notice_in_classic_theme_option, 'no' ) );
 
-		if ( 'yes' === $enable_store_notice_in_classic_theme ) {
-			update_option( $is_store_notice_active_option, 'yes' );
+		if ( $enable_store_notice_in_classic_theme ) {
+			update_option( $is_store_notice_active_option, wc_bool_to_string( true ) );
 			delete_option( $enable_store_notice_in_classic_theme_option );
 		}
 	}

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -323,4 +323,4 @@ add_action( 'woocommerce_before_reset_password_form', 'woocommerce_output_all_no
 /**
  * Hooked blocks.
  */
-add_action( 'after_switch_theme', 'wc_set_hooked_blocks_version_on_theme_switch', 10, 2 );
+add_action( 'after_switch_theme', 'wc_after_switch_theme', 10, 2 );

--- a/plugins/woocommerce/tests/php/src/Database/StoreNoticeOnThemeSwitch.php
+++ b/plugins/woocommerce/tests/php/src/Database/StoreNoticeOnThemeSwitch.php
@@ -1,0 +1,74 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Database;
+
+use WC_Install;
+
+/**
+ * Tests for the block hooks versioning we set in the DB.
+ */
+class StoreNoticeOnThemeSwitch extends \WC_Unit_Test_Case {
+	/**
+	 * Option name for storing whether the Store Notice was active in a classic theme.
+	 *
+	 * @var string
+	 */
+	protected static $enable_store_notice_in_classic_theme_option = 'woocommerce_enable_store_notice_in_classic_theme';
+
+	/**
+	 * Option name for storing whether the Store Notice is active.
+	 *
+	 * @var string
+	 */
+	protected static $is_store_notice_active_option = 'woocommerce_demo_store';
+
+	/**
+	 * Run before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		switch_theme( 'storefront' );
+		delete_option( self::$enable_store_notice_in_classic_theme_option );
+		delete_option( self::$is_store_notice_active_option );
+	}
+
+	/**
+	 * Test the Store Notice gets disabled when switching from a classic theme to a block theme
+	 * and then re-enabled when switching back to a classic theme.
+	 *
+	 * @return void
+	 */
+	public function test_store_notice_is_disabled_when_switching_from_classic_to_block_theme() {
+		update_option( self::$is_store_notice_active_option, 'yes' );
+		switch_theme( 'twentytwentyfour' );
+		// This fires the 'after_switch_theme' action.
+		check_theme_switched();
+
+		$this->assertEquals( 'no', get_option( self::$is_store_notice_active_option ), 'Store Notice should be disabled when switching from a classic theme to a block theme.' );
+
+		switch_theme( 'storefront' );
+		check_theme_switched();
+
+		$this->assertEquals( 'yes', get_option( self::$is_store_notice_active_option ), 'Store Notice should be enabled when switching back to a classic theme that had the Store Notice enabled.' );
+	}
+
+	/**
+	 * Test the Store Notice gets disabled when switching from a classic theme to a block theme
+	 * and then re-enabled when switching back to a classic theme.
+	 *
+	 * @return void
+	 */
+	public function test_store_notice_is_not_enabled_when_switching_back_to_classic_theme() {
+		update_option( self::$is_store_notice_active_option, 'no' );
+		switch_theme( 'twentytwentyfour' );
+		check_theme_switched();
+
+		$this->assertEquals( 'no', get_option( self::$is_store_notice_active_option ), 'Store Notice should be disabled when switching from a classic theme to a block theme.' );
+
+		switch_theme( 'storefront' );
+		check_theme_switched();
+
+		$this->assertEquals( 'no', get_option( self::$is_store_notice_active_option ), 'Store Notice should not be enabled when switching back to a classic theme that had the Store Notice disabled.' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/54237.

This PR makes it so:

* when switching from a classic theme to a block theme:
  * if the Store Notice is inactive, we do nothing
  * if the Store Notice is active, we deactivate it and save and option to flag that we will need to reactivate it when switching back to a classic theme (`woocommerce_enable_store_notice_in_classic_theme`)
* when switching from a block theme to a classic theme:
  * if `woocommerce_enable_store_notice_in_classic_theme` is not set, we do nothing
  * if `woocommerce_enable_store_notice_in_classic_theme` is set to `yes`, we re-enable the Store Notice

In other words, we disable the Store Notice when switching to a block theme and reactivate it when switching to a classic theme (assuming it was active).

### How to test the changes in this Pull Request:

1. Switch your theme to a classic theme (ie: Storefront) and go to Appearance > Customizer > WooCommerce > Store Notice and enable it. Click on _Publish_ to save.
2. Verify the store notice is visible on the frontend.
3. Switch to a block theme (ie: Twenty Twenty Five).
4. Verify the store notice is no longer visible on the frontend.
5. Switch back to a classic theme.
6. Verify the store notice is visible again on the frontend.
7. Go to Appearance > Customizer > WooCommerce > Store Notice and disable it. Click on _Publish_ to save.
8. Switch to a block theme.
9. Switch back to a classic theme.
10. Verify the store notice isn't visible on the frontend (it wasn't reactivated by mistake).