### PR TITLE
CFE cherry pick: Fix "Go to the Editor" CYS button (#54260)

### DIFF
--- a/plugins/woocommerce/changelog/fix-53866-cfe
+++ b/plugins/woocommerce/changelog/fix-53866-cfe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Fix redirection in "Go to the store" link

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/intro-banners.tsx
@@ -13,7 +13,7 @@ import { Link } from '@woocommerce/components';
  */
 import { Intro } from '.';
 import { IntroSiteIframe } from './intro-site-iframe';
-import { getAdminSetting } from '~/utils/admin-settings';
+import { ADMIN_URL, getAdminSetting } from '~/utils/admin-settings';
 import { navigateOrParent } from '../utils';
 import { trackEvent } from '../tracking';
 
@@ -369,7 +369,7 @@ export const NonDefaultBlockThemeBanner = () => {
 				trackEvent( 'customize_your_store_intro_customize_click', {
 					theme_type: 'block',
 				} );
-				navigateOrParent( window, 'site-editor.php' );
+				navigateOrParent( window, `${ ADMIN_URL }site-editor.php` );
 			} }
 			bannerButtonText={ __( 'Go to the Editor', 'woocommerce' ) }
 			showAIDisclaimer={ false }

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -130,6 +130,10 @@ test.describe(
 
 				await page.goto( CUSTOMIZE_STORE_URL );
 
+				await expect( page.locator( 'h1' ) ).toHaveText(
+					'Customize your theme'
+				);
+
 				const button = page.getByRole( 'button', {
 					name: 'Go to the Editor',
 				} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/intro.spec.js
@@ -123,18 +123,21 @@ test.describe(
 		);
 
 		test(
-			'it shows the "non default block theme" banner when the theme is a block theme different than TT4',
+			'it shows the "non default block theme" banner when the theme is a block theme different than TT4 and redirects to the editor',
 			{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 			async ( { page, baseURL } ) => {
 				await activateTheme( baseURL, 'twentytwentythree' );
 
 				await page.goto( CUSTOMIZE_STORE_URL );
 
-				await expect( page.locator( 'h1' ) ).toHaveText(
-					'Customize your theme'
-				);
+				const button = page.getByRole( 'button', {
+					name: 'Go to the Editor',
+				} );
+				await expect( button ).toBeVisible();
+				await button.click();
+				// Expecting heading from editor to be visible.
 				await expect(
-					page.getByRole( 'button', { name: 'Go to the Editor' } )
+					page.getByRole( 'heading', { name: 'Design' } )
 				).toBeVisible();
 			}
 		);


### PR DESCRIPTION
Manual cherry-pick of CFE https://github.com/woocommerce/woocommerce/pull/54260.

Auto cherry-pick failed due to conflicts ([comment](https://github.com/woocommerce/woocommerce/pull/54260#issuecomment-2579756035)).