### PR TITLE
Decode error messages caused by the Add to Cart button block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -7,6 +7,7 @@ import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { Cart } from '@woocommerce/type-defs/cart';
 import { createRoot } from '@wordpress/element';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
+import { decodeEntities } from '@wordpress/html-entities';
 
 interface Context {
 	isLoading: boolean;
@@ -158,8 +159,10 @@ const { state } = store< Store >( 'woocommerce/product-button', {
 					storeNoticeBlock ??
 					document.querySelector( storeNoticeClass );
 
+				const message = ( error as Error ).message;
+
 				if ( domNode ) {
-					injectNotice( domNode, ( error as Error ).message );
+					injectNotice( domNode, decodeEntities( message ) );
 				}
 
 				// We don't care about errors blocking execution, but will

--- a/plugins/woocommerce/changelog/fix-product-button-decore-errors
+++ b/plugins/woocommerce/changelog/fix-product-button-decore-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Decode error messages caused by the Add to Cart button block


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes it so error messages caused by the Add to Cart button block and returned by the server are decoded before being rendered. Fixing things like `&quot;` into `"`.

### How to test the changes in this Pull Request:

1. Load the `/shop` page of your store (assuming it uses the _Product Collection_ block).
2. Without closing that tab, go to the admin and modify a product which was in stock to make it so it's out of stock.
3. In the `/shop` tab, without reloading, try to add to the cart the product you just marked as out of stock.
4. Verify the error is rendered with the correct characters.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/94c72cd8-6512-4eaf-8a37-eeb4c98d1bdb) | ![imatge](https://github.com/user-attachments/assets/38ca7781-f00f-4b5d-8593-96b3561309d3)