### PR TITLE
Revert "Clear" Button from <button> to <a> Tag for Improved Theme Compatibility while maintaining accessibility improvements #54309

### DIFF
--- a/plugins/woocommerce/changelog/54320-fix-revert-clear-button-to-link-with-a11y-2
+++ b/plugins/woocommerce/changelog/54320-fix-revert-clear-button-to-link-with-a11y-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Revert "Clear" Button from <button> to <a> Tag for Improved Theme Compatibility while maintaining accessibility improvements

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -573,7 +573,7 @@ table.variations {
 	}
 }
 
-button.reset_variations {
+a.reset_variations {
 	margin-left: 0.5em;
 }
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -310,7 +310,7 @@
 
 		}
 
-		button.reset_variations {
+		a.reset_variations {
 			margin-left: 0.5em;
 		}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -311,7 +311,7 @@ $tt2-gray: #f7f7f7;
 
 		}
 
-		button.reset_variations {
+		a.reset_variations {
 			margin-left: 0.5em;
 		}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -477,7 +477,7 @@ table.variations {
 	}
 }
 
-button.reset_variations {
+a.reset_variations {
 	margin-left: 0.5em;
 }
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -389,9 +389,8 @@ p.demo_store,
 			}
 
 			.variations {
-				border: 0;
 				margin-bottom: 1em;
-				border-spacing: 0;
+				border: 0;
 				width: 100%;
 
 				td,
@@ -435,7 +434,6 @@ p.demo_store,
 			}
 
 			.reset_variations {
-				display: none;
 				visibility: hidden;
 				font-size: 0.83em;
 			}

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -608,9 +608,10 @@
 
 	/**
 	 * Handle reset key down event for accessibility.
+	 * @param {KeyboardEvent} event - The keyboard event object
 	 */
 	VariationForm.prototype.onResetKeyDown = function ( event ) {
-		if ( event.keyCode === 32 || event.keyCode === 13 ) {
+		if ( event.code === 'Enter' || event.code === 'Space' ) {
 			event.preventDefault();
 			event.data.variationForm.onReset( event );
 		}

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -44,6 +44,12 @@
 		$form.on( 'found_variation.wc-variation-form', { variationForm: self }, self.onFoundVariation );
 		$form.on( 'check_variations.wc-variation-form', { variationForm: self }, self.onFindVariation );
 		$form.on( 'update_variation_values.wc-variation-form', { variationForm: self }, self.onUpdateAttributes );
+		$form.on(
+			'keydown.wc-variation-form',
+			'.reset_variations',
+			{ variationForm: self },
+			self.onResetKeyDown
+		);
 
 		// Init after gallery.
 		setTimeout( function() {
@@ -570,18 +576,15 @@
 	};
 
 	/**
-	 * Show or hide the reset button.
+	 * Show or hide the reset link.
 	 */
 	VariationForm.prototype.toggleResetLink = function( on ) {
-		this.$resetAlert.text( '' );
 		if ( on ) {
 			if ( this.$resetVariations.css( 'visibility' ) === 'hidden' ) {
 				this.$resetVariations.css( 'visibility', 'visible' ).hide().fadeIn();
-				this.$resetVariations.css( 'display', 'inline-block' );
 			}
 		} else {
 			this.$resetVariations.css( 'visibility', 'hidden' );
-			this.$resetVariations.css( 'display', 'none' );
 		}
 	};
 
@@ -601,6 +604,16 @@
 			.next( 'div' )
 			.find( '.wc-no-matching-variations' )
 			.slideDown( 200 );
+	};
+
+	/**
+	 * Handle reset key down event for accessibility.
+	 */
+	VariationForm.prototype.onResetKeyDown = function ( event ) {
+		if ( event.keyCode === 32 || event.keyCode === 13 ) {
+			event.preventDefault();
+			event.data.variationForm.onReset( event );
+		}
 	};
 
 	/**

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -45,7 +45,14 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 										'product'   => $product,
 									)
 								);
-								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#" aria-label="' . esc_html__( 'Clear options', 'woocommerce' ) . '">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';
+								/**
+								 * Filters the reset variation button.
+								 *
+								 * @since 2.5.0
+								 *
+								 * @param string  $button The reset variation button HTML.
+								 */
+								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#" aria-label="' . esc_attr__( 'Clear options', 'woocommerce' ) . '">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';
 							?>
 						</td>
 					</tr>

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -45,7 +45,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 										'product'   => $product,
 									)
 								);
-								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';
+								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#" aria-label="' . esc_html__( 'Clear options', 'woocommerce' ) . '">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';
 							?>
 						</td>
 					</tr>

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variable.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.5.0
+ * @version 9.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -31,7 +31,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 	<?php if ( empty( $available_variations ) && false !== $available_variations ) : ?>
 		<p class="stock out-of-stock"><?php echo esc_html( apply_filters( 'woocommerce_out_of_stock_message', __( 'This product is currently out of stock and unavailable.', 'woocommerce' ) ) ); ?></p>
 	<?php else : ?>
-		<table class="variations" role="presentation">
+		<table class="variations" cellspacing="0" role="presentation">
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
 					<tr>
@@ -45,20 +45,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 										'product'   => $product,
 									)
 								);
-							?>
-						</td>
-					</tr>
-					<tr>
-						<td colspan="2">
-							<?php
-							/**
-							 * Filters the reset variation button.
-							 *
-							 * @since 2.5.0
-							 *
-							 * @param string  $button The reset variation button HTML.
-							 */
-							echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<button class="reset_variations"  aria-label="' . esc_html__( 'Clear options', 'woocommerce' ) . '">' . esc_html__( 'Clear', 'woocommerce' ) . '</button>' ) ) : '';
+								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';
 							?>
 						</td>
 					</tr>

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/product-variable.spec.js
@@ -510,7 +510,7 @@ test.describe(
 				Number( productPrice * 1.25 )
 			);
 
-			await page.locator( 'button.reset_variations' ).click();
+			await page.locator( 'a.reset_variations' ).click();
 
 			// Verify the reset by attempting to add the product to the cart
 			page.on( 'dialog', async ( dialog ) => {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In WooCommerce 9.5, PR #50183 changed the "Clear" button on single product pages for variable products from an `<a>` tag to a `<button>` tag. While this improved accessibility, it is causing (widespread) visual issues, the Clear button now appears more prominent than the Add to Cart button. After internal discussion on Slack (p1736320650381359-slack-C02FL3X7KR6), it was decided to change the Clear button back to an `<a>` tag.

In summary:
- Replaced `<button>` tag with `<a>` tag and added `role="button"` for accessibility.
- Added keyboard event handling (Enter/Space) to match button behavior i.e. user will be able to use Enter or Space to clear the selection.
- Most of changes made in PR #50183 are preserved. For example, clearing attribute values will add a screen reader text "Your selection has been reset. Please select some product options before adding this product to your cart."

![image](https://github.com/user-attachments/assets/9759269d-d4f8-4bfe-b521-97781726bf65)

It was also raised on woo-dev slack channel (p1736165110941609-slack-C7U3Y3VMY).

Closes #54085

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Verify that the "Clear" button is an `<a>` tag

1. Go to frontend of any variable product. For example, Hoodie (in case you are using sample products)
2. Select some variation attributes. For example, select "Red" for "Color".
3. Verify that the "Clear" button is an `<a>` tag. See before vs this PR screenshot below.
![image](https://github.com/user-attachments/assets/9759269d-d4f8-4bfe-b521-97781726bf65)

#### Scenario: Testing for regression

> [!NOTE]
> This PR reverts the change from PR #50183 that converted the "Clear" link from an `<a>` tag back to a `<button>` tag. We need to verify that this reversion maintains the same functionality and accessibility improvements that were introduced in #50183.

1. Activate screen reader of your choice.
	- Tip: You can use shortcut “Cmd + F5” to enable VoiceOver on Mac.
2. Go to frontend of any variable product. For example, Hoodie (in case you are using sample products)
3. Tab to variation attributes, use your arrows and space bar to make a selection. For example, select "Red" for "Color".
4. Tab to the "Clear" button.
5. Verify that you can use either Enter or Spacebar to clear the selection.
6. Verify that you hear a message "Your selection has been reset. Please select some product options before adding this product to your cart."

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Revert "Clear" Button from <button> to <a> Tag for Improved Theme Compatibility while maintaining accessibility improvements

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>