### PR TITLE
[e2e tests] Enable parallelism: use 2 workers per shard in CI

### DIFF
--- a/plugins/woocommerce/changelog/e2e-try-multiple-workers
+++ b/plugins/woocommerce/changelog/e2e-try-multiple-workers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: bump number of workers in CI to run tests in parallel

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -70,7 +70,7 @@ const config = {
 	testDir: `${ testsRootPath }/tests`,
 	retries: CI ? 1 : 0,
 	repeatEach: REPEAT_EACH ? Number( REPEAT_EACH ) : 1,
-	workers: 1,
+	workers: CI ? 2 : 1,
 	reportSlowTests: { max: 5, threshold: 30 * 1000 }, // 30 seconds threshold
 	reporter,
 	maxFailures: E2E_MAX_FAILURES ? Number( E2E_MAX_FAILURES ) : 0,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: https://github.com/woocommerce/woocommerce/issues/49544

### How to test the changes in this Pull Request:

Check e2e tests jobs in CI:
- each shard should run 2 workers in parallel - this should reduce the execution time for each shard
- tests should pass
