### PR TITLE
Fix cart and checkout page detection logic for edge cases

### DIFF
--- a/plugins/woocommerce/changelog/fix-53592-cart-shortcode-detection
+++ b/plugins/woocommerce/changelog/fix-53592-cart-shortcode-detection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Fix cart and checkout block/shortcode detection in status report and frontend.

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -887,8 +887,7 @@ if ( 0 < $mu_plugins_count ) :
 
 				$additional_info = '';
 
-				// We only state the used type on the Checkout and the Cart page.
-				if ( in_array( $_page['block'], array( 'woocommerce/checkout', 'woocommerce/cart' ), true ) ) {
+				if ( ! empty( $_page['shortcode'] ) || ! empty( $_page['block'] ) ) {
 					// We check first if, in a blocks theme, the template content does not load the page content.
 					if ( CartCheckoutUtils::is_overriden_by_custom_template_content( $_page['block'] ) ) {
 						$additional_info = __( "This page's content is overridden by custom template content", 'woocommerce' );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
 use Automattic\WooCommerce\Utilities\{ LoggingUtil, OrderUtil, PluginUtil };
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 
 /**
  * System status controller class.
@@ -1441,29 +1442,64 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		// WC pages to check against.
 		$check_pages = array(
 			_x( 'Shop base', 'Page setting', 'woocommerce' ) => array(
-				'option'    => 'woocommerce_shop_page_id',
-				'shortcode' => '',
-				'block'     => '',
+				'option' => 'woocommerce_shop_page_id',
 			),
 			_x( 'Cart', 'Page setting', 'woocommerce' ) => array(
-				'option'    => 'woocommerce_cart_page_id',
-				'shortcode' => '[' . apply_filters_deprecated( 'woocommerce_cart_shortcode_tag', array( 'woocommerce_cart' ), '8.3.0', 'woocommerce_create_pages' ) . ']',
-				'block'     => 'woocommerce/cart',
+				'option'             => 'woocommerce_cart_page_id',
+				'shortcode'          => '[' . apply_filters_deprecated( 'woocommerce_cart_shortcode_tag', array( 'woocommerce_cart' ), '8.3.0', 'woocommerce_create_pages' ) . ']',
+				'block'              => 'woocommerce/cart',
+				'shortcode_callback' => function ( $page ) {
+					if ( $page ) {
+						$shortcode = apply_filters_deprecated( 'woocommerce_cart_shortcode_tag', array( 'woocommerce_cart' ), '8.3.0', 'woocommerce_create_pages' );
+						if ( has_shortcode( $page->post_content, $shortcode ) ) {
+							return $shortcode;
+						}
+					}
+					return false;
+				},
+				'block_callback'     => function ( $page ) {
+					if ( $page ) {
+						if ( has_block( 'woocommerce/cart', $page->post_content ) ) {
+							return 'woocommerce/cart';
+						}
+						if ( CartCheckoutUtils::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart', $page->post_content ) ) {
+							return 'woocommerce/classic-shortcode';
+						}
+					}
+					return false;
+				},
 			),
 			_x( 'Checkout', 'Page setting', 'woocommerce' ) => array(
-				'option'    => 'woocommerce_checkout_page_id',
-				'shortcode' => '[' . apply_filters_deprecated( 'woocommerce_checkout_shortcode_tag', array( 'woocommerce_checkout' ), '8.3.0', 'woocommerce_create_pages' ) . ']',
-				'block'     => 'woocommerce/checkout',
+				'option'             => 'woocommerce_checkout_page_id',
+				'shortcode'          => '[' . apply_filters_deprecated( 'woocommerce_checkout_shortcode_tag', array( 'woocommerce_checkout' ), '8.3.0', 'woocommerce_create_pages' ) . ']',
+				'block'              => 'woocommerce/checkout',
+				'shortcode_callback' => function ( $page ) {
+					if ( $page ) {
+						$shortcode = apply_filters_deprecated( 'woocommerce_checkout_shortcode_tag', array( 'woocommerce_checkout' ), '8.3.0', 'woocommerce_create_pages' );
+						if ( has_shortcode( $page->post_content, $shortcode ) ) {
+							return $shortcode;
+						}
+					}
+					return false;
+				},
+				'block_callback'     => function ( $page ) {
+					if ( $page ) {
+						if ( has_block( 'woocommerce/checkout', $page->post_content ) ) {
+							return 'woocommerce/checkout';
+						}
+						if ( CartCheckoutUtils::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout', $page->post_content ) ) {
+							return 'woocommerce/classic-shortcode';
+						}
+					}
+					return false;
+				},
 			),
 			_x( 'My account', 'Page setting', 'woocommerce' ) => array(
 				'option'    => 'woocommerce_myaccount_page_id',
 				'shortcode' => '[' . apply_filters( 'woocommerce_my_account_shortcode_tag', 'woocommerce_my_account' ) . ']',
-				'block'     => '',
 			),
 			_x( 'Terms and conditions', 'Page setting', 'woocommerce' ) => array(
-				'option'    => 'woocommerce_terms_page_id',
-				'shortcode' => '',
-				'block'     => '',
+				'option' => 'woocommerce_terms_page_id',
 			),
 		);
 
@@ -1477,6 +1513,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			$shortcode_required = false;
 			$block_present      = false;
 			$block_required     = false;
+			$block              = false;
+			$shortcode          = false;
 			$page               = false;
 
 			// Page checks.
@@ -1494,22 +1532,27 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			}
 
 			// Shortcode checks.
-			if ( $values['shortcode'] && $page ) {
+			if ( $page && isset( $values['shortcode_callback'], $values['shortcode'] ) ) {
 				$shortcode_required = true;
-				if ( has_shortcode( $page->post_content, trim( $values['shortcode'], '[]' ) ) ) {
-					$shortcode_present = true;
-				}
-
-				// Compatibility with the classic shortcode block which can be used instead of shortcodes.
-				if ( ! $shortcode_present && ( 'woocommerce/checkout' === $values['block'] || 'woocommerce/cart' === $values['block'] ) ) {
-					$shortcode_present = has_block( 'woocommerce/classic-shortcode', $page->post_content );
-				}
+				$result             = $values['shortcode_callback']( $page );
+				$shortcode          = $result ? $result : $values['shortcode'];
+				$shortcode_present  = (bool) $result;
+			} elseif ( $page && isset( $values['shortcode'] ) ) {
+				$shortcode          = $values['shortcode'];
+				$shortcode_required = true;
+				$shortcode_present  = has_shortcode( $page->post_content, trim( $shortcode, '[]' ) );
 			}
 
 			// Block checks.
-			if ( $values['block'] && $page ) {
+			if ( $page && isset( $values['block_callback'], $values['block'] ) ) {
 				$block_required = true;
-				$block_present  = has_block( $values['block'], $page->post_content );
+				$result         = $values['block_callback']( $page );
+				$block          = $result ? $result : $values['block'];
+				$block_present  = (bool) $result;
+			} elseif ( $page && isset( $values['block'] ) ) {
+				$block          = $values['block'];
+				$block_required = true;
+				$block_present  = has_block( $block, $page->post_content );
 			}
 
 			// Wrap up our findings into an output array.
@@ -1519,8 +1562,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				'page_set'           => $page_set,
 				'page_exists'        => $page_exists,
 				'page_visible'       => $page_visible,
-				'shortcode'          => $values['shortcode'],
-				'block'              => $values['block'],
+				'shortcode'          => $shortcode,
+				'block'              => $block,
 				'shortcode_required' => $shortcode_required,
 				'shortcode_present'  => $shortcode_present,
 				'block_present'      => $block_present,

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -93,9 +94,13 @@ if ( ! function_exists( 'is_cart' ) ) {
 	 * @return bool
 	 */
 	function is_cart() {
-		$page_id = wc_get_page_id( 'cart' );
-
-		return ( $page_id && is_page( $page_id ) ) || Constants::is_defined( 'WOOCOMMERCE_CART' ) || wc_post_content_has_shortcode( 'woocommerce_cart' );
+		/**
+		 * Filter to allow for custom logic to determine if the cart page is being viewed.
+		 *
+		 * @since 2.4.0
+		 * @param bool $is_cart Whether the cart page is being viewed.
+		 */
+		return apply_filters( 'woocommerce_is_cart', false ) || Constants::is_defined( 'WOOCOMMERCE_CART' ) || CartCheckoutUtils::is_cart_page();
 	}
 }
 
@@ -107,9 +112,13 @@ if ( ! function_exists( 'is_checkout' ) ) {
 	 * @return bool
 	 */
 	function is_checkout() {
-		$page_id = wc_get_page_id( 'checkout' );
-
-		return ( $page_id && is_page( $page_id ) ) || wc_post_content_has_shortcode( 'woocommerce_checkout' ) || apply_filters( 'woocommerce_is_checkout', false ) || Constants::is_defined( 'WOOCOMMERCE_CHECKOUT' );
+		/**
+		 * Filter to allow for custom logic to determine if the checkout page is being viewed.
+		 *
+		 * @since 2.4.0
+		 * @param bool $is_checkout Whether the checkout page is being viewed.
+		 */
+		return apply_filters( 'woocommerce_is_checkout', false ) || Constants::is_defined( 'WOOCOMMERCE_CHECKOUT' ) || CartCheckoutUtils::is_checkout_page();
 	}
 }
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -10,6 +10,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Utilities\NumberUtil;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -1556,11 +1557,7 @@ function wc_get_cart_url() {
 	global $post;
 
 	// We don't use is_cart() here because that also checks for a defined constant. We are only interested in the page.
-	$page_id      = wc_get_page_id( 'cart' );
-	$is_cart_page = $page_id && is_page( $page_id );
-
-	// If this isn't the cart page, but the page does contain the cart shortcode, we'll return the current page permalink.
-	if ( ! $is_cart_page && is_a( $post, 'WP_Post' ) && wc_post_content_has_shortcode( 'woocommerce_cart' ) ) {
+	if ( CartCheckoutUtils::is_cart_page() ) {
 		$cart_url = get_permalink( $post->ID );
 	} else {
 		$cart_url = wc_get_page_permalink( 'cart' );

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -61,18 +61,6 @@ final class BlockTypesController {
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
-		add_filter(
-			'woocommerce_is_checkout',
-			function ( $ret ) {
-				return $ret || $this->has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout' );
-			}
-		);
-		add_filter(
-			'woocommerce_is_cart',
-			function ( $ret ) {
-				return $ret || $this->has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart' );
-			}
-		);
 	}
 
 	/**
@@ -112,34 +100,6 @@ final class BlockTypesController {
 			}
 		);
 		return $this->registered_blocks_with_woocommerce_parents;
-	}
-
-	/**
-	 * Check if the current post has a block with a specific attribute value.
-	 *
-	 * @param string $block_id The block ID to check for.
-	 * @param string $attribute The attribute to check.
-	 * @param string $value The value to check for.
-	 * @return boolean
-	 */
-	private function has_block_variation( $block_id, $attribute, $value ) {
-		$post = get_post();
-
-		if ( ! $post ) {
-			return false;
-		}
-
-		if ( has_block( $block_id, $post->ID ) ) {
-			$blocks = (array) parse_blocks( $post->post_content );
-
-			foreach ( $blocks as $block ) {
-				if ( isset( $block['attrs'][ $attribute ] ) && $value === $block['attrs'][ $attribute ] ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -5,6 +5,79 @@ namespace Automattic\WooCommerce\Blocks\Utils;
  * Class containing utility methods for dealing with the Cart and Checkout blocks.
  */
 class CartCheckoutUtils {
+	/**
+	 * Returns true if:
+	 * - The cart page is being viewed.
+	 * - The page contains a cart block, cart shortcode or classic shortcode block with the cart attribute.
+	 *
+	 * @return bool
+	 */
+	public static function is_cart_page() {
+		global $post;
+
+		$page_id      = wc_get_page_id( 'cart' );
+		$is_cart_page = $page_id && is_page( $page_id );
+
+		if ( $is_cart_page ) {
+			return true;
+		}
+
+		// Check page contents for block/shortcode.
+		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_cart' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart' ) );
+	}
+
+	/**
+	 * Returns true if:
+	 * - The checkout page is being viewed.
+	 * - The page contains a checkout block, checkout shortcode or classic shortcode block with the checkout attribute.
+	 *
+	 * @return bool
+	 */
+	public static function is_checkout_page() {
+		global $post;
+
+		$page_id          = wc_get_page_id( 'checkout' );
+		$is_checkout_page = $page_id && is_page( $page_id );
+
+		if ( $is_checkout_page ) {
+			return true;
+		}
+
+		// Check page contents for block/shortcode.
+		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_checkout' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout' ) );
+	}
+
+	/**
+	 * Check if the current post has a block with a specific attribute value.
+	 *
+	 * @param string $block_id The block ID to check for.
+	 * @param string $attribute The attribute to check.
+	 * @param string $value The value to check for.
+	 * @return boolean
+	 */
+	private static function has_block_variation( $block_id, $attribute, $value ) {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		if ( has_block( $block_id, $post->ID ) ) {
+			$blocks = (array) parse_blocks( $post->post_content );
+
+			foreach ( $blocks as $block ) {
+				if ( isset( $block['attrs'][ $attribute ] ) && $value === $block['attrs'][ $attribute ] ) {
+					return true;
+				}
+				// Cart is default so it will be empty.
+				if ( 'woocommerce/classic-shortcode' === $block_id && 'shortcode' === $attribute && 'cart' === $value && ! isset( $block['attrs']['shortcode'] ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 
 	/**
 	 * Checks if the default cart page is using the Cart block.

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -23,7 +23,7 @@ class CartCheckoutUtils {
 		}
 
 		// Check page contents for block/shortcode.
-		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_cart' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart' ) );
+		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_cart' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart', $post->post_content ) );
 	}
 
 	/**
@@ -44,26 +44,24 @@ class CartCheckoutUtils {
 		}
 
 		// Check page contents for block/shortcode.
-		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_checkout' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout' ) );
+		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_checkout' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout', $post->post_content ) );
 	}
 
 	/**
-	 * Check if the current post has a block with a specific attribute value.
+	 * Check if the post content contains a block with a specific attribute value.
 	 *
 	 * @param string $block_id The block ID to check for.
 	 * @param string $attribute The attribute to check.
 	 * @param string $value The value to check for.
 	 * @return boolean
 	 */
-	private static function has_block_variation( $block_id, $attribute, $value ) {
-		$post = get_post();
-
-		if ( ! $post ) {
+	public static function has_block_variation( $block_id, $attribute, $value, $post_content ) {
+		if ( ! $post_content ) {
 			return false;
 		}
 
-		if ( has_block( $block_id, $post->ID ) ) {
-			$blocks = (array) parse_blocks( $post->post_content );
+		if ( has_block( $block_id, $post_content ) ) {
+			$blocks = (array) parse_blocks( $post_content );
 
 			foreach ( $blocks as $block ) {
 				if ( isset( $block['attrs'][ $attribute ] ) && $value === $block['attrs'][ $attribute ] ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes 2 similar issues relating to cart and checkout page detection, namely:

1. The cart page not being correctly detected resulting in page content disappearing after AJAX requests.
2. The system status report not correctly reporting mistakes if the wrong shortcode/block is used on a cart or checkout page.

![Screenshot 2025-01-09 at 15 27 05](https://github.com/user-attachments/assets/03d7b8f2-4e77-48ea-9bdf-bab1a2db28ce)

Fixes #53592
Fixes #53628

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Remove the cart page from WooCommerce -> Advanced settings.
2. Change the cart block to Classic Cart block.
3. On Cart page, hit apply coupon
4. The page content should refresh but should not disappear.

To test the status page,

1. To ease testing, open up a tab with WooCommerce > Settings > Advanced, WooCommerce > Status, and the cart page open in the editor
2. Ensure cart and checkout pages are set under **advanced**. You should see the status report is happy with this.
3. Edit the cart page and use a cart block. Check the status report states `Contains the woocommerce/cart block`
4. Edit the cart page and convert the cart block into a classic shortcode block (via the transform menu). Check the status report states `Contains the woocommerce/classic-shortcode block`
5. Edit the cart page and go into the HTML editor. Change the block markup and set the "shortcode" attribute on the classic shortcode block manually, editing it to read "checkout" instead of "cart". Save. Check the status report indicates an error on this page due to missing shortcode/block.
6.  Edit the cart page and delete all blocks. Insert a "shortcode" block and manually input `[woocommerce_cart]`. Check that the status page indicates you're using the shortcode.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
