### PR TITLE
Address PHP notices from `WC_Tracker`

### DIFF
--- a/plugins/woocommerce/changelog/fix-54175
+++ b/plugins/woocommerce/changelog/fix-54175
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent some possible warnings in `WC_Tracker`.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -206,7 +206,7 @@ class WC_Admin_Status {
 	 * @return array
 	 */
 	public static function scan_template_files( $template_path ) {
-		$files  = @scandir( $template_path ); // @codingStandardsIgnoreLine.
+		$files  = is_string( $template_path ) ? @scandir( $template_path ) : array(); // @codingStandardsIgnoreLine.
 		$result = array();
 
 		if ( ! empty( $files ) ) {

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -1018,7 +1018,7 @@ class WC_Tracker {
 		 *
 		 * @since 2.3.0
 		 */
-		$template_paths = apply_filters( 'woocommerce_template_overrides_scan_paths', array( 'WooCommerce' => WC()->plugin_path() . '/templates/' ) );
+		$template_paths = (array) apply_filters( 'woocommerce_template_overrides_scan_paths', array( 'WooCommerce' => WC()->plugin_path() . '/templates/' ) );
 		$scanned_files  = array();
 
 		require_once WC()->plugin_path() . '/includes/admin/class-wc-admin-status.php';

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -693,7 +693,7 @@ class WC_Tracker {
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$orders_and_gateway_details = $wpdb->get_results(
 				"
-				SELECT payment_method AS gateway, currency AS currency, SUM( total_amount ) AS totals, count( id ) AS counts
+				SELECT IFNULL(payment_method, '') AS gateway, currency AS currency, SUM( total_amount ) AS totals, count( id ) AS counts
 				FROM $orders_table
 				WHERE status IN ( 'wc-completed', 'wc-processing', 'wc-refunded' )
 				GROUP BY gateway, currency;
@@ -708,7 +708,7 @@ class WC_Tracker {
 				FROM (
 					SELECT
 						orders.id AS order_id,
-						MAX(CASE WHEN meta_key = '_payment_method' THEN meta_value END) gateway,
+						IFNULL(MAX(CASE WHEN meta_key = '_payment_method' THEN meta_value END), '') gateway,
 						MAX(CASE WHEN meta_key = '_order_total' THEN meta_value END) total,
 						MAX(CASE WHEN meta_key = '_order_currency' THEN meta_value END) currency
 					FROM
@@ -736,7 +736,7 @@ class WC_Tracker {
 			array_reduce(
 				$orders_and_gateway_details,
 				function ( $result, $item ) {
-					$item->gateway = preg_replace( '/\s+/', ' ', $item->gateway );
+					$item->gateway = preg_replace( '/\s+/', ' ', $item->gateway ?? '' );
 
 					// Introduce currency as a prefix for the key.
 					$key = $item->currency . '==' . $item->gateway;
@@ -794,9 +794,9 @@ class WC_Tracker {
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$orders_origin = $wpdb->get_results(
 				"
-				SELECT created_via as origin, COUNT( order_id ) as count
+				SELECT IFNULL(created_via, '') as origin, COUNT( order_id ) as count
 				FROM $op_table_name
-				GROUP BY created_via;
+				GROUP BY origin;
 				"
 			);
 			// phpcs:enable
@@ -804,7 +804,7 @@ class WC_Tracker {
 			$orders_origin = $wpdb->get_results(
 				"
 				SELECT
-					meta_value as origin, COUNT( DISTINCT ( orders.id ) ) as count
+					IFNULL(meta_value, '') as origin, COUNT( DISTINCT ( orders.id ) ) as count
 				FROM
 					$wpdb->posts orders
 				LEFT JOIN
@@ -812,7 +812,7 @@ class WC_Tracker {
 				WHERE
 					meta_key = '_created_via'
 				GROUP BY
-					meta_value;
+					origin;
 			"
 			);
 		}
@@ -839,7 +839,7 @@ class WC_Tracker {
 
 		// Aggregate using group_key.
 		foreach ( $orders_and_origins as $origin ) {
-			$key = strtolower( $origin->group_key );
+			$key = strtolower( $origin->group_key ?? '' );
 
 			if ( array_key_exists( $key, $orders_by_origin ) ) {
 				$orders_by_origin[ $key ] = $orders_by_origin[ $key ] + (int) $origin->count;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses some PHP deprecation warnings (and a fatal) that can be produced by code in `WC_Tracker` under not-so-unusual circumstances. Refer to the testing instructions below for details on which warnings and how to reproduce.

Closes #54175, #46560 and #51336.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Given we're fixing fatals/notices it's useful to compare the results of running the same code between current `trunk` and this particular branch in order to confirm the fix. We'll use WP-CLI and manually run `WC_Tracker::get_tracking_data()` to simulate tracking without having to enable it nor deal with cron jobs.

Make sure logging is enabled for your site, and that currency is USD and HPOS is enabled in WC > Settings. Ideally, start with a site with no orders.

#### scandir() fatal error (issue #51336)
1. Check out `trunk` and use `wp shell` to run the following commands:

   ```
   wp> add_filter( 'woocommerce_template_overrides_scan_paths', function( $r ) { $r['foo'] = ['bar']; return $r; } );
   wp> WC_Tracker::get_tracking_data()
   ```
1. Confirm that the shell is terminated and you see a fatal error similar to:
   ```
   Fatal error: Uncaught TypeError: scandir(): Argument #1 ($directory) must be of type string, array given in [...]/woocommerce/plugins/woocommerce/includes/admin/class-wc-admin-status.php:209
   ```
1. Check out this branch (`fix/54175`) and repeat the above steps.
1. Confirm that this time no fatal error occurs and the output is actually valid tracking data for your site.

#### Presence of both NULL and empty values for order `payment_method` and/or `created_via` produce warnings (issues #54175 and #46560)
1. We're going to create orders that have NULL as `payment_method` and `created_via` and others that have it set to an empty string. Both values are allowed by our database schema, but code inside `WC_Tracker` is confused by this in a way that can produce warnings. To create these orders:
    1. Drop the following PHP snippet inside a .php file anywhere in your filesystem.
		```php
		<?php
		foreach ( range( 1, 4 ) as $_ ):
			$o = new \WC_Order();
			$o->set_status( 'wc-completed' );
			$o->set_total( $_ * 100.0 );
			$o->save();
		
			if ( 0 !== $_ % 2 ): continue; endif;
		
			$GLOBALS['wpdb']->update(
				$GLOBALS['wpdb']->prefix . 'wc_order_operational_data',
				array( 'created_via' => NULL ),
				array( 'order_id' => $o->get_id() )
			);
		
			$GLOBALS['wpdb']->update(
				$GLOBALS['wpdb']->prefix . 'wc_orders',
				array( 'payment_method' => NULL ),
				array( 'id' => $o->get_id() )
			);
		endforeach;
		```
    3. Run the file above with `wp eval-file /path/to/your/php/file.php`.
    4. Confirm that you have 4 new orders on your admin summing a total of 1,000 USD.
1. Check out `trunk`.
1. Use `wp shell` to run the following commands:
   ```
   wp> WC_Tracker::get_tracking_data()['orders']['gateway__USD_total']
   => string(12) "600.00000000"
   wp> WC_Tracker::get_tracking_data()['orders']['created_via']['']
   => int(2)
   ```
1. Either directly inside of WP-CLI or in your logs, you should be able to find the following PHP deprecation notices:
   ```
   PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in [...]/woocommerce/plugins/woocommerce/includes/class-wc-tracker.php on line 739
   PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in [...]/woocommerce/plugins/woocommerce/includes/class-wc-tracker.php on line 842
   ```
1. Notice also how tracking data is incomplete: despite the order totals adding to 1,000 USD, `WC_Tracker` is only seeing 600 USD. Similarly, for the `created_via` property, `WC_Tracker` is only counting 2 of the orders.
1. Checkout this branch (`fix/54175`).
1. Repeat step 3 and confirm that this time:
   i. No PHP deprecation notice appears.
   ii. Totals in WP-CLI's output are now correct (`1000.00000000` and `4`).
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
