### PR TITLE
Reduce scope of globalized order metabox functions

### DIFF
--- a/plugins/woocommerce/changelog/update-order-meta-box-initialize
+++ b/plugins/woocommerce/changelog/update-order-meta-box-initialize
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: This modifies some new functionality that hasn't been released yet
+
+

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1600,12 +1600,12 @@ jQuery( function ( $ ) {
 	wc_meta_boxes_order_downloads.init();
 	wc_meta_boxes_order_custom_meta.init();
 
-	// this allows third party plugin to call woocommerce function
-	window.wcOrderMetaBoxes = {
-		wc_meta_boxes_order: wc_meta_boxes_order,
-		wc_meta_boxes_order_items: wc_meta_boxes_order_items,
-		wc_meta_boxes_order_notes: wc_meta_boxes_order_notes,
-		wc_meta_boxes_order_downloads: wc_meta_boxes_order_downloads,
-		wc_meta_boxes_order_custom_meta: wc_meta_boxes_order_custom_meta,
+	// This allows third party plugins to re-initialize meta boxes if they change them.
+	window.wcOrderMetaBoxesInit = {
+		wc_meta_boxes_order: wc_meta_boxes_order.init.bind( wc_meta_boxes_order ),
+		wc_meta_boxes_order_items: wc_meta_boxes_order_items.init.bind( wc_meta_boxes_order_items ),
+		wc_meta_boxes_order_notes: wc_meta_boxes_order_notes.init.bind( wc_meta_boxes_order_notes ),
+		wc_meta_boxes_order_downloads: wc_meta_boxes_order_downloads.init.bind( wc_meta_boxes_order_downloads ),
+		wc_meta_boxes_order_custom_meta: wc_meta_boxes_order_custom_meta.init.bind( wc_meta_boxes_order_custom_meta ),
 	};
 });


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #51185 we exported the order metabox scripts outside of their encapsulation in order to let 3rd party scripts re-initialize UI elements if they were modified. However, this also opened up many other methods to the global scope that don't need to be global. This amends that change so that only the init methods are available globally.

### How to test the changes in this Pull Request:

Follow the testing instructions in #51185 and make sure they still work, except use [this modified version](https://gist.github.com/coreymckrill/eae1fcacc3c2c9291f3d22ad875afb48) of the test script.