### PR TITLE
Fix: Maintain “Add to Cart” Button Width Consistency on Shop Page with Gutenberg Plugin

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -15,6 +15,7 @@
 		text-align: center;
 		// Set button font size so it inherits from parent.
 		font-size: 1em;
+		width: auto;
 
 		&.loading {
 			opacity: 0.25;

--- a/plugins/woocommerce/changelog/54368-fix-53928-globalstep-add-to-cart-button-width-increases-on-shop-page-when-gutenberg-plugin-is-active
+++ b/plugins/woocommerce/changelog/54368-fix-53928-globalstep-add-to-cart-button-width-increases-on-shop-page-when-gutenberg-plugin-is-active
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Maintain “Add to Cart” Button Width Consistency on Shop Page with Gutenberg Plugin


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix "Add to cart" button width inconsistency on Shop page when Gutenberg plugin is active. The button width increases unexpectedly when Gutenberg is enabled. This PR adds explicit width: auto styling to maintain consistent button width regardless of Gutenberg's presence.

Main reason for this issue is that Gutenberg plugin adds extra class `.wp-block-button__link` to the button element, which has `width: 100%` CSS property.

Closes #53928.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to the Shop page with Gutenberg plugin deactivated and note the width of the "Add to cart" button
2. Activate the Gutenberg plugin and refresh the Shop page
3. Verify that the "Add to cart" button width remains consistent and does not expand compared to step 1

The image below shows the issue this PR fixes, where the button width incorrectly expanded with Gutenberg active:
![image](https://github.com/user-attachments/assets/bd436b1c-4984-4d07-865a-c2847a08808b)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Maintain “Add to Cart” Button Width Consistency on Shop Page with Gutenberg Plugin
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>