### PR TITLE
Update Store Notices data store use to use `StoreDescriptor` instead of key

### DIFF
--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/store-notices.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/store-notices.md
@@ -77,7 +77,9 @@ This action will register a new container.
 #### _Example_ <!-- omit in toc -->
 
 ```javascript
-dispatch( registerContainer( 'someContainerContext' ) );
+import { storeNoticesStore } from '@woocommerce/block-data';
+
+dispatch( storeNoticesStore ).registerContainer( 'someContainerContext' );
 ```
 
 ### unregisterContainer( containerContext )
@@ -97,7 +99,9 @@ This action will unregister an existing container.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-dispatch( unregisterContainer( 'someContainerContext' ) );
+import { storeNoticesStore } from '@woocommerce/block-data';
+
+dispatch( storeNoticesStore ).unregisterContainer( 'someContainerContext' );
 ```
 
 ## Selectors

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/store-notices.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/store-notices.md
@@ -17,10 +17,16 @@ The Store Notices Store allows to register and unregister containers for notices
 
 ## Usage
 
-To utilize this store you will import the `STORE_NOTICES_STORE_KEY` in any module referencing it. Assuming `@woocommerce/block-data` is registered as an external pointing to `wc.wcBlocksData` you can import the key via:
+To utilize this store you will import the `storeNoticesStore` `StoreDescriptor` in any module referencing it. Assuming `@woocommerce/block-data` is registered as an external pointing to `wc.wcBlocksData` you can import the `StoreDescriptor` via:
 
 ```js
-const { STORE_NOTICES_STORE_KEY } = window.wc.wcBlocksData;
+import { storeNoticesStore } from '@woocommerce/block-data';
+```
+
+If it's not, then access it from the window like so:
+
+```js
+const { storeNoticesStore } = window.wc.wcBlocksData;
 ```
 
 ## Example
@@ -28,10 +34,12 @@ const { STORE_NOTICES_STORE_KEY } = window.wc.wcBlocksData;
 The following code snippet demonstrates how to register a container for notices.
 
 ```js
+import { store as noticesStore } from '@wordpress/notices';
+
 export default function Block( attributes ) {
 	const context = 'your-namespace/custom-form-step';
 
-	dispatch( 'core/notices' ).createNotice(
+	dispatch( noticesStore ).createNotice(
 		'error',
 		'This is an example of an error notice.',
 		{ context }
@@ -105,7 +113,9 @@ Returns the list of currently registered containers from the state.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( 'wc/store/store-notices' );
+import { storeNoticesStore } from '@woocommerce/block-data';
+
+const store = select( storeNoticesStore );
 const registeredContainers = store.getRegisteredContainers();
 ```
 

--- a/plugins/woocommerce-blocks/packages/components/store-notices-container/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/store-notices-container/index.tsx
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	PAYMENT_STORE_KEY,
-	STORE_NOTICES_STORE_KEY,
-} from '@woocommerce/block-data';
+import { PAYMENT_STORE_KEY, storeNoticesStore } from '@woocommerce/block-data';
 import { getNoticeContexts } from '@woocommerce/base-utils';
 import type { Notice } from '@wordpress/notices';
 import { useMemo, useEffect } from '@wordpress/element';
@@ -31,16 +28,14 @@ const StoreNoticesContainer = ( {
 	context = '',
 	additionalNotices = [],
 }: StoreNoticesContainerProps ): JSX.Element | null => {
-	const { registerContainer, unregisterContainer } = useDispatch(
-		STORE_NOTICES_STORE_KEY
-	);
+	const { registerContainer, unregisterContainer } =
+		useDispatch( storeNoticesStore );
 	const { suppressNotices, registeredContainers } = useSelect(
 		( select ) => ( {
 			suppressNotices:
 				select( PAYMENT_STORE_KEY ).isExpressPaymentMethodActive(),
-			registeredContainers: select(
-				STORE_NOTICES_STORE_KEY
-			).getRegisteredContainers(),
+			registeredContainers:
+				select( storeNoticesStore ).getRegisteredContainers(),
 		} )
 	);
 	const contexts = useMemo< string[] >(

--- a/plugins/woocommerce/changelog/fix-store-notices-data-store
+++ b/plugins/woocommerce/changelog/fix-store-notices-data-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update consumers of the wc/store/store-notices data store to use the StoreDescriptor rather than the key to access it


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates uses of `wc/store/store-notices` to use the StoreDescriptor instead of store name, follow up to (and based on) https://github.com/woocommerce/woocommerce/pull/54331

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install Stripe
2. Go to the Cart block, open your JS console and type `wp.data.dispatch( wp.notices.store ).createInfoNotice( 'This is a notice', { context: 'wc/cart' } )` Expect to see a notice in the cart.
3. Go to the Checkout block, repeat step 2 (**use `wc/cart`** not checkout)
4. Reload and type `wp.data.dispatch( wp.notices.store ).createInfoNotice( 'This is a notice', { context: 'wc/checkout' } )` and `wp.data.dispatch( wp.notices.store ).createInfoNotice( 'This is a notice', { context: 'wc/checkout/shipping-methods' } )`
5. Ensure you see a notice at the top of the cart and one in the shipping methods.
6. Type `wp.data.select( wc.wcBlocksData.storeNoticesStore ).getRegisteredContainers()` and then try adding a notice to each of these registered containers. Note, there is a bug with the `woocommerce/checkout-totals-block` container, so don't try that one (PR: will fix this)
7. Try using one of Stripe's cards that fails (https://docs.stripe.com/testing#declined-payments) - ensure a notice appears (this will appear at the top level).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
