### PR TITLE
Enable DB auto-update by default

### DIFF
--- a/plugins/woocommerce/changelog/fix-54250
+++ b/plugins/woocommerce/changelog/fix-54250
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Perform database updates automatically by default.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -666,8 +666,7 @@ class WC_Install {
 
 	/**
 	 * Is DB auto-update enabled? This controls whether database updates are applied without prompting the admin.
-	 * This is the default behavior since version 9.7.0 and can be overridden via filter
-	 * 'woocommerce_enable_auto_update_db' or by setting the constant WC_DISABLE_DB_AUTO_UPDATE to `true`.
+	 * This is the default behavior since 9.8.0 and can be overridden via filter 'woocommerce_enable_auto_update_db'.
 	 *
 	 * @since 9.7.0
 	 *
@@ -679,9 +678,7 @@ class WC_Install {
 		 *
 		 * @since 3.2.0
 		 */
-		return
-			! Constants::is_true( 'WC_DISABLE_DB_AUTO_UPDATE' )
-			&& (bool) apply_filters( 'woocommerce_enable_auto_update_db', true );
+		return (bool) apply_filters( 'woocommerce_enable_auto_update_db', true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -666,9 +666,9 @@ class WC_Install {
 
 	/**
 	 * Is DB auto-update enabled? This controls whether database updates are applied without prompting the admin.
-	 * This is the default behavior since 9.8.0 and can be overridden via filter 'woocommerce_enable_auto_update_db'.
+	 * This is the default behavior since 9.9.0 and can be overridden via filter 'woocommerce_enable_auto_update_db'.
 	 *
-	 * @since 9.8.0
+	 * @since 9.9.0
 	 *
 	 * @return bool TRUE if database auto-updates are enabled. FALSE otherwise.
 	 */
@@ -764,7 +764,7 @@ class WC_Install {
 			 * Filters the maximum delay in seconds to apply to the scheduling of database updates when automatic
 			 * updates are enabled.
 			 *
-			 * @since 9.8.0
+			 * @since 9.9.0
 			 *
 			 * @param int $delay The maximum delay in seconds. Default is 1800 (30 minutes).
 			 */

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -680,7 +680,7 @@ class WC_Install {
 		 */
 		return (bool) apply_filters(
 			'woocommerce_enable_auto_update_db',
-			! defined( 'WC_DISABLE_DB_AUTO_UPDATE' ) || false === (bool) WC_DISABLE_DB_AUTO_UPDATE
+			! Constants::is_true( 'WC_DISABLE_DB_AUTO_UPDATE' )
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -663,6 +663,27 @@ class WC_Install {
 	}
 
 	/**
+	 * Is DB auto-update enabled? This controls whether database updates are applied without prompting the admin.
+	 * This is the default behavior since version 9.7.0 and can be overridden via filter
+	 * 'woocommerce_enable_auto_update_db' or by setting the constant WC_DISABLE_DB_AUTO_UPDATE to `true`.
+	 *
+	 * @since 9.7.0
+	 *
+	 * @return bool TRUE if database auto-updates are enabled. FALSE otherwise.
+	 */
+	public static function is_db_auto_update_enabled(): bool {
+		/**
+		 * Allow WooCommerce to auto-update without prompting the user.
+		 *
+		 * @since 3.2.0
+		 */
+		return (bool) apply_filters(
+			'woocommerce_enable_auto_update_db',
+			! defined( 'WC_DISABLE_DB_AUTO_UPDATE' ) || false === (bool) WC_DISABLE_DB_AUTO_UPDATE
+		);
+	}
+
+	/**
 	 * See if we need to set redirect transients for activation or not.
 	 *
 	 * @since 4.6.0
@@ -685,7 +706,7 @@ class WC_Install {
 			 *
 			 * @since 3.2.0
 			 */
-			if ( apply_filters( 'woocommerce_enable_auto_update_db', true ) ) {
+			if ( self::is_db_auto_update_enabled() ) {
 				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update', true );

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -455,6 +455,7 @@ class WC_Install {
 	public static function install_actions() {
 		if ( ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok.
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
+			wc_get_logger()->info( 'Manual database update triggered.', array( 'source' => 'install' ) );
 			self::update();
 			WC_Admin_Notices::add_notice( 'update', true );
 
@@ -707,6 +708,7 @@ class WC_Install {
 			 * @since 3.2.0
 			 */
 			if ( self::is_db_auto_update_enabled() ) {
+				wc_get_logger()->info( 'Automatic database update triggered.', array( 'source' => 'install' ) );
 				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update', true );
@@ -749,8 +751,13 @@ class WC_Install {
 	 */
 	private static function update() {
 		$current_db_version = get_option( 'woocommerce_db_version' );
+		$current_wc_version = WC()->version;
 		$loop               = 0;
 
+		wc_get_logger()->info(
+			sprintf( 'Scheduling database updates (from %s to %s)...', $current_db_version, $current_wc_version ),
+			array( 'source' => 'install' )
+		);
 		foreach ( self::get_db_update_callbacks() as $version => $update_callbacks ) {
 			if ( version_compare( $current_db_version, $version, '<' ) ) {
 				foreach ( $update_callbacks as $update_callback ) {
@@ -764,11 +771,15 @@ class WC_Install {
 					);
 					++$loop;
 				}
+
+				wc_get_logger()->info(
+					sprintf( '  Updates from version %s scheduled.', $current_db_version, $version ),
+					array( 'source' => 'install' )
+				);
 			}
 		}
 
 		// After the callbacks finish, update the db version to the current WC version.
-		$current_wc_version = WC()->version;
 		if ( version_compare( $current_db_version, $current_wc_version, '<' ) &&
 			! WC()->queue()->get_next( 'woocommerce_update_db_to_current_version' ) ) {
 			WC()->queue()->schedule_single(
@@ -780,6 +791,8 @@ class WC_Install {
 				'woocommerce-db-updates'
 			);
 		}
+
+		wc_get_logger()->info( 'Database updates scheduled.', array( 'source' => 'install' )  );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -679,10 +679,9 @@ class WC_Install {
 		 *
 		 * @since 3.2.0
 		 */
-		return (bool) apply_filters(
-			'woocommerce_enable_auto_update_db',
+		return
 			! Constants::is_true( 'WC_DISABLE_DB_AUTO_UPDATE' )
-		);
+			&& (bool) apply_filters( 'woocommerce_enable_auto_update_db', true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -668,7 +668,7 @@ class WC_Install {
 	 * Is DB auto-update enabled? This controls whether database updates are applied without prompting the admin.
 	 * This is the default behavior since 9.8.0 and can be overridden via filter 'woocommerce_enable_auto_update_db'.
 	 *
-	 * @since 9.7.0
+	 * @since 9.8.0
 	 *
 	 * @return bool TRUE if database auto-updates are enabled. FALSE otherwise.
 	 */

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -706,7 +706,7 @@ class WC_Install {
 			 */
 			if ( self::is_db_auto_update_enabled() ) {
 				wc_get_logger()->info( 'Automatic database update triggered.', array( 'source' => 'wc-updater' ) );
-				self::update( true );
+				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update', true );
 			}
@@ -748,7 +748,7 @@ class WC_Install {
 	 *
 	 * @param bool $schedule_with_delay Whether updates are scheduled to run with a random delay (of up to 15 mins).
 	 */
-	private static function update( bool $schedule_with_delay = false ) {
+	private static function update() {
 		$current_db_version = get_option( 'woocommerce_db_version' );
 		$current_wc_version = WC()->version;
 		$scheduled_time     = time();
@@ -758,25 +758,22 @@ class WC_Install {
 			array( 'source' => 'wc-updater' )
 		);
 
-		// We add some randomness here to prevent overloading servers after an upate has been installed.
-		if ( $schedule_with_delay ) {
+		if ( self::is_db_auto_update_enabled() ) {
 			/**
-			 * Filters the maximum delay in seconds to apply to the scheduling of database updates when automatic
-			 * updates are enabled.
+			 * Filters the delay in seconds to apply to the scheduling of database updates when automatic updates are
+			 * enabled.
 			 *
 			 * @since 9.9.0
 			 *
-			 * @param int $delay The maximum delay in seconds. Default is 1800 (30 minutes).
+			 * @param int $delay Delay to add. Default is 0 (updates will run as soon as possible).
 			 */
-			$scheduled_time_delay = absint( apply_filters( 'woocommerce_db_update_schedule_delay', 30 * MINUTE_IN_SECONDS ) );
-			$scheduled_time_delay = wp_rand( 0, $scheduled_time_delay );
+			$scheduled_time_delay = absint( apply_filters( 'woocommerce_db_update_schedule_delay', 0 ) );
 
 			if ( $scheduled_time_delay > 0 ) {
 				wc_get_logger()->info(
 					sprintf( '  Updates will begin running in approximately %s.', human_time_diff( 0, $scheduled_time_delay ) ),
 					array( 'source' => 'wc-updater' )
 				);
-
 				$scheduled_time += $scheduled_time_delay;
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -789,7 +789,7 @@ class WC_Install {
 			);
 		}
 
-		wc_get_logger()->info( 'Database updates scheduled.', array( 'source' => 'wc-updater' )  );
+		wc_get_logger()->info( 'Database updates scheduled.', array( 'source' => 'wc-updater' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -685,7 +685,7 @@ class WC_Install {
 			 *
 			 * @since 3.2.0
 			 */
-			if ( apply_filters( 'woocommerce_enable_auto_update_db', false ) ) {
+			if ( apply_filters( 'woocommerce_enable_auto_update_db', true ) ) {
 				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update', true );

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -455,7 +455,7 @@ class WC_Install {
 	public static function install_actions() {
 		if ( ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok.
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
-			wc_get_logger()->info( 'Manual database update triggered.', array( 'source' => 'install' ) );
+			wc_get_logger()->info( 'Manual database update triggered.', array( 'source' => 'wc-updater' ) );
 			self::update();
 			WC_Admin_Notices::add_notice( 'update', true );
 
@@ -708,7 +708,7 @@ class WC_Install {
 			 * @since 3.2.0
 			 */
 			if ( self::is_db_auto_update_enabled() ) {
-				wc_get_logger()->info( 'Automatic database update triggered.', array( 'source' => 'install' ) );
+				wc_get_logger()->info( 'Automatic database update triggered.', array( 'source' => 'wc-updater' ) );
 				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update', true );
@@ -756,7 +756,7 @@ class WC_Install {
 
 		wc_get_logger()->info(
 			sprintf( 'Scheduling database updates (from %s to %s)...', $current_db_version, $current_wc_version ),
-			array( 'source' => 'install' )
+			array( 'source' => 'wc-updater' )
 		);
 		foreach ( self::get_db_update_callbacks() as $version => $update_callbacks ) {
 			if ( version_compare( $current_db_version, $version, '<' ) ) {
@@ -773,8 +773,8 @@ class WC_Install {
 				}
 
 				wc_get_logger()->info(
-					sprintf( '  Updates from version %s scheduled.', $current_db_version, $version ),
-					array( 'source' => 'install' )
+					sprintf( '  Updates from version %s scheduled.', $version ),
+					array( 'source' => 'wc-updater' )
 				);
 			}
 		}
@@ -792,7 +792,7 @@ class WC_Install {
 			);
 		}
 
-		wc_get_logger()->info( 'Database updates scheduled.', array( 'source' => 'install' )  );
+		wc_get_logger()->info( 'Database updates scheduled.', array( 'source' => 'wc-updater' )  );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -763,7 +763,7 @@ class WC_Install {
 			 *
 			 * @since 9.9.0
 			 *
-			 * @param int $delay Delay to add. Default is 0 (updates will run as soon as possible).
+			 * @param int $delay Delay to add (in seconds). Default is 0 (updates will run as soon as possible).
 			 */
 			$scheduled_time_delay = absint( apply_filters( 'woocommerce_db_update_schedule_delay', 0 ) );
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -745,8 +745,6 @@ class WC_Install {
 
 	/**
 	 * Push all needed DB updates to the queue for processing.
-	 *
-	 * @param bool $schedule_with_delay Whether updates are scheduled to run with a random delay (of up to 15 mins).
 	 */
 	private static function update() {
 		$current_db_version = get_option( 'woocommerce_db_version' );

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -387,8 +387,9 @@ class WC_Install {
 	 */
 	public static function wc_admin_db_update_notice() {
 		if (
-			WC()->is_wc_admin_active() &&
-			false !== get_option( 'woocommerce_admin_install_timestamp' )
+			WC()->is_wc_admin_active()
+			&& false !== get_option( 'woocommerce_admin_install_timestamp' )
+			&& ! self::is_db_auto_update_enabled()
 		) {
 			new WC_Notes_Run_Db_Update();
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -251,9 +251,9 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 *           [false]
 	 *           [null]
 	 *
-	 * @since 9.8.0
+	 * @since 9.9.0
 	 *
-	 * @param bool|null $auto_update Whether to enable auto-updates (TRUE) or not. NULL doesn't override the defaults.
+	 * @param bool|null $auto_update Whether to enable auto-updates (TRUE) or not. NULL means use the defaults.
 	 */
 	public function test_db_auto_updates( ?bool $auto_update = null ): void {
 		$options = array( 'woocommerce_db_version', 'woocommerce_version' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -278,5 +278,4 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 			$this->assertFalse( $update_scheduled );
 		}
 	}
-
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -251,7 +251,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 *           [false]
 	 *           [null]
 	 *
-	 * @since 9.7.0
+	 * @since 9.8.0
 	 *
 	 * @param bool|null $auto_update Whether to enable auto-updates (TRUE) or not. NULL doesn't override the defaults.
 	 */

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -1,6 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
@@ -278,33 +277,6 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		} else {
 			$this->assertFalse( $update_scheduled );
 		}
-	}
-
-	/**
-	 * Tests the 'woocommerce_enable_auto_update_db' filter alongside the constant WC_DISABLE_DB_AUTO_UPDATE.
-	 *
-	 * @since 9.7.0
-	 */
-	public function test_db_auto_updates_constant(): void {
-		// Default is auto-updates.
-		$this->assertTrue( \WC_Install::is_db_auto_update_enabled() );
-
-		// Filter can be used to disable this behavior.
-		add_filter( 'woocommerce_enable_auto_update_db', fn() => false );
-		$this->assertFalse( \WC_Install::is_db_auto_update_enabled() );
-		remove_all_filters( 'woocommerce_enable_auto_update_db' );
-
-		// A constant can be used to disable this behavior.
-		Constants::set_constant( 'WC_DISABLE_DB_AUTO_UPDATE', true );
-		$this->assertFalse( \WC_Install::is_db_auto_update_enabled() );
-
-		// Not even the filter can override the constant...
-		add_filter( 'woocommerce_enable_auto_update_db', fn() => true );
-		$this->assertFalse( \WC_Install::is_db_auto_update_enabled() );
-
-		// ... unless the constant is set to `false`.
-		Constants::set_constant( 'WC_DISABLE_DB_AUTO_UPDATE', false );
-		$this->assertTrue( \WC_Install::is_db_auto_update_enabled() );
 	}
 
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR implements database auto-updating by default. This implies that upgrade routines included in any version of WC will be scheduled automatically without admin intervention, something that was only possible by overriding the default behavior via the `woocommerce_enable_auto_update_db` filter. See #54268 for some discussion around this.

Summary of the changes introduced in this PR:

- Filter `woocommerce_enable_auto_update_db` can still be used to prevent auto-db updates by ensuring its result is `false`.
- When auto updates are enabled (the new default), the filter `woocommerce_db_update_schedule_delay` can be used to add a delay (in seconds) to the time the updates are scheduled to run. This delay is, by default, `0`, which means updates will run as soon as possible (likely during the next page load).
   Users/hosts can use this filter to make sure updates are scheduled in the future.
- Logging has been added to various parts of the update process, both for manual or auto updates. Log file `wc-updater` will be written to with entries indicating the time the updates are scheduled to run as well as details on the "version" jump:

   ```
   Automatic database update triggered.
   Scheduling database updates (from 9.2.0 to 9.7.0)...
       Updates will begin running in approximately 9 minutes.
       Updates from version 9.3.0 scheduled.
       Updates from version 9.4.0 scheduled.
       Updates from version 9.5.0 scheduled.
   Database updates scheduled.
   ```


Closes #54250.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Pre-requisites
1. Drop the following PHP snippet as a .php file inside `wp-content/mu-plugins`. This will disable Action Scheduler from automatically running updates, allowing us to check that they are indeed being scheduled:
   ```php
   <?php
   add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );
   add_action( 'init', fn () => remove_action( ActionScheduler_QueueRunner::WP_CRON_HOOK, [ ActionScheduler_QueueRunner::instance(), 'run' ] ) );
   ```

#### Test the new default behavior
1. Run the following WP-CLI commands to "simulate" WC being updated from 9.2.0 to the current version:
   ```
   wp transient delete wc_installing
   wp option set woocommerce_db_version 9.2.0
   wp option set woocommerce_version 9.2.0
   ```
1. Visit any page on the admin.
1. Run the following command to check that the updates with group `woocommerce-db-updates` were scheduled without user intervention:
   ```
   wp action-scheduler action list --group=woocommerce-db-updates --status=pending --per_page=0
   ```
   Alternatively, check this in WC > Status > Scheduled Actions > Pending instead.
1. Confirm also that these actions were scheduled for as soon as possible (i.e. current time or slightly i the past).
1. Go to WC > Status > Logs and select the `wc-updater` log file.
1. Confirm that the log file includes the following entries:
   ```
   Automatic database update triggered.
   Scheduling database updates (from 9.2.0 to 9.7.0)...
      Updates will begin running in approximately 9 minutes.
      Updates from version 9.3.0 scheduled.
      Updates from version 9.4.0 scheduled.
      Updates from version 9.5.0 scheduled.
   Database updates scheduled.
   ```
1. Run all the pending migration routines at once by running the following command:
   ```
   wp action-scheduler action run $(wp action-scheduler action list --group=woocommerce-db-updates --status=pending --format=ids --per_page=0)
   ```
1. Confirm that there are no more pending actions in the group `woocommerce-db-updates` by running `wp action-scheduler action list --group=woocommerce-db-updates --status=pending` again.
1. Enable the following snippet on your site, and repeat the steps above. Confirm that this time (in step 4) the updates are scheduled to run in "20 minutes from now".
   ```php
   <?php
   add_filter( 'woocommerce_db_update_schedule_delay', fn() => 20 * 60 );
   ```

#### Use the filter to bring back the old behavior (requiring confirmation)
1. Add the following snippet to the mu-plugin file you previously created or to a different one:
   ```php
   <?php
   add_filter( 'woocommerce_enable_auto_update_db', '__return_false' );
   ```
1. Run the following WP-CLI commands to "simulate" WC being updated from 9.2.0 to the current version:
   ```
   wp transient delete wc_installing
   wp option set woocommerce_db_version 9.2.0
   wp option set woocommerce_version 9.2.0
   ```
1. Visit any page on the admin.
1. Confirm that no actions in group `woocommerce-db-updates` were automatically scheduled by running the following command:
   ```
   wp action-scheduler action list --group=woocommerce-db-updates --status=pending
   ```
1. Confirm that your admin pages show a notice on top asking to run the updates:
   <img width="1295" alt="Screenshot 2025-01-15 at 17 34 16" src="https://github.com/user-attachments/assets/498a6f23-cb3f-4e1b-bb4d-2f09434b2a39" />
1. Click the **Update WooCommerce Database** button on this notice.
1. Run the following command to confirm that this has scheduled the upgrade routines. Check that their scheduled time is your current time (with at most a few second difference).
   ```
   wp action-scheduler action list --group=woocommerce-db-updates --status=pending --per_page=0
   ```
1. Go to WC > Status > Logs and select the `wc-updater` log file.
1. Confirm that the log file includes the following entries:
   ```
   Manual database update triggered.
   Scheduling database updates (from 9.2.0 to 9.7.0)...
      Updates from version 9.3.0 scheduled.
      Updates from version 9.4.0 scheduled.
      Updates from version 9.5.0 scheduled.
   Database updates scheduled.
   ```
1. Run all the pending migration routines at once by running the following command:
   ```
   wp action-scheduler action run $(wp action-scheduler action list --group=woocommerce-db-updates --status=pending --format=ids --per_page=0)
   ```

#### After testing
1. Don't forget to remove any snippets you added, be kind to others and enjoy life.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
