### PR TITLE
Revert #51185

### DIFF
--- a/plugins/woocommerce/changelog/revert-51185
+++ b/plugins/woocommerce/changelog/revert-51185
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This reverts functionality slated for release in 9.6, so it actually removes a changelog entry, and doesn't requite its own
+
+

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1599,13 +1599,4 @@ jQuery( function ( $ ) {
 	wc_meta_boxes_order_notes.init();
 	wc_meta_boxes_order_downloads.init();
 	wc_meta_boxes_order_custom_meta.init();
-
-	// this allows third party plugin to call woocommerce function
-	window.wcOrderMetaBoxes = {
-		wc_meta_boxes_order: wc_meta_boxes_order,
-		wc_meta_boxes_order_items: wc_meta_boxes_order_items,
-		wc_meta_boxes_order_notes: wc_meta_boxes_order_notes,
-		wc_meta_boxes_order_downloads: wc_meta_boxes_order_downloads,
-		wc_meta_boxes_order_custom_meta: wc_meta_boxes_order_custom_meta,
-	};
 });

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -416,7 +416,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Enhancement - Hide Knowledge Base when the marketplace suggestions option is disabled. [#52715](https://github.com/woocommerce/woocommerce/pull/52715)
 * Enhancement - Improve embedded CES layout rendering with element checks and code refactor [#52729](https://github.com/woocommerce/woocommerce/pull/52729)
 * Enhancement - Introduce dedicated payment extension suggestions incentives providers and expose them through the Payments settings API. [#53317](https://github.com/woocommerce/woocommerce/pull/53317)
-* Enhancement - Make the scripts that initialize the meta boxes on the Edit Order screen accessible to third parties [#51185](https://github.com/woocommerce/woocommerce/pull/51185)
 * Enhancement - Pass product instance into `woocommerce_product_read` action as second argument [#51851](https://github.com/woocommerce/woocommerce/pull/51851)
 * Enhancement - Prevent the variation list from being displayed as an HTML list if there is only one attribute on the Mini Cart Modal [#52924](https://github.com/woocommerce/woocommerce/pull/52924)
 * Enhancement - Redirect to the connection approval screen when the connection is initiated from WooCommerce.com. [#53445](https://github.com/woocommerce/woocommerce/pull/53445)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There are some concerns about de-encapsulating the objects in the meta-boxes-order.js script and making them globally available. In the PR that made this change, the goal was to be able to re-initialize elements in the UI that had been replaced and had their event listeners deleted. There are other ways to accomplish this without exposing the script objects, so we should go back to the drawing board and try something different.

### How to test the changes in this Pull Request:

Check the original changeset from https://github.com/woocommerce/woocommerce/pull/51185 and make sure it all has been completely removed. Since it was only additive, and no other PRs depend on it, removing the added code should not cause any regressions.