### PR TITLE
Add "Estimated Delivery Date" Field to Product Settings and Display on Storefront

### DIFF
--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -193,3 +193,18 @@ do_action( 'woocommerce_before_cart' ); ?>
 </div>
 
 <?php do_action( 'woocommerce_after_cart' ); ?>
+
+<?php
+// Loop through cart items to display the estimated delivery date for each product
+foreach (WC()->cart->get_cart() as $cart_item) {
+    $product_id = $cart_item['product_id'];
+    $estimated_delivery_date = get_post_meta($product_id, '_estimated_delivery_date', true);
+
+    if ($estimated_delivery_date) {
+        echo '<p class="cart-estimated-delivery">' . 
+             sprintf(esc_html__('Estimated Delivery Date: %s', 'woocommerce'), 
+             esc_html($estimated_delivery_date)) . 
+             '</p>';
+    }
+}
+?>


### PR DESCRIPTION
This pull request introduces a new feature to WooCommerce: the ability to set and display an estimated delivery date for individual products. The feature enhances customer experience by providing clear expectations for product delivery timelines.

Key Features:
Product Settings:

Added a new field in the product settings (General tab) to allow store admins to specify an estimated delivery date for each product.
The date is saved as post meta (_estimated_delivery_date).
Front-End Display:

The estimated delivery date is displayed on the product detail page, cart page, and checkout page for relevant products.
Translation Ready:

All strings are prepared for localization using WooCommerce's text domain.
Improved UX:

Helps customers make informed decisions by providing clear delivery timelines.
Reduces customer inquiries about delivery expectations.
Files Updated:
Admin Interface:
woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
Front-End Display:
woocommerce/templates/single-product/meta.php
woocommerce/templates/cart/cart.php
woocommerce/templates/checkout/review-order.php
Testing Notes:
Ensure the field appears in the admin product settings and saves correctly.
Confirm the date displays correctly on:
Single product pages.
Cart and checkout pages.
Test functionality with different themes and ensure compatibility.
Verify translation readiness for the added strings.
This enhancement is backward-compatible and should not affect existing WooCommerce functionality.