### PR TITLE
Product Gallery: Only load image when user hovers.

### DIFF
--- a/plugins/woocommerce/changelog/update-gallery-zoom-only-load-image-on-demand
+++ b/plugins/woocommerce/changelog/update-gallery-zoom-only-load-image-on-demand
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Only download full resolution image on hover

--- a/plugins/woocommerce/client/legacy/js/zoom/jquery.zoom.js
+++ b/plugins/woocommerce/client/legacy/js/zoom/jquery.zoom.js
@@ -236,6 +236,7 @@
 					// and trigger mouseenter event to start zoom
 					img.onload = function() {
 						setupZoomOnload();
+						// Simulate mouseenter event to start zoom
 						$source.trigger('mouseenter.zoom');
 					}
 					img.src = settings.url;

--- a/plugins/woocommerce/client/legacy/js/zoom/jquery.zoom.js
+++ b/plugins/woocommerce/client/legacy/js/zoom/jquery.zoom.js
@@ -13,7 +13,7 @@
 		touch: true, // enables a touch fallback
 		onZoomIn: false,
 		onZoomOut: false,
-		magnify: 1
+		magnify: 1,
 	};
 
 	// Core Zoom Logic, independent of event listeners.
@@ -115,7 +115,7 @@
 				$img.remove();
 			}.bind(this, target.style.position, target.style.overflow));
 
-			img.onload = function () {
+			function setupZoomOnload() {
 				var zoom = $.zoom(target, source, img, settings.magnify);
 
 				function start(e) {
@@ -225,11 +225,27 @@
 				if ('function' === typeof settings.callback) {
 					settings.callback.call(img);
 				}
-			};
+			}
 
 			img.setAttribute('role', 'presentation');
 			img.alt = settings.alt || '';
-			img.src = settings.url;
+			
+			if (settings.on === 'mouseover') {
+				$source.one('mouseenter.zoom touchstart.zoom', function() {
+					// Only load image on mouseenter or touchstart
+					// and trigger mouseenter event to start zoom
+					img.onload = function() {
+						setupZoomOnload();
+						$source.trigger('mouseenter.zoom');
+					}
+					img.src = settings.url;
+				});
+			} else {
+				img.onload = function() {
+					setupZoomOnload();
+				}
+				img.src = settings.url;
+			}
 		});
 	};
 

--- a/plugins/woocommerce/client/legacy/js/zoom/jquery.zoom.js
+++ b/plugins/woocommerce/client/legacy/js/zoom/jquery.zoom.js
@@ -236,8 +236,8 @@
 					// and trigger mouseenter event to start zoom
 					img.onload = function() {
 						setupZoomOnload();
-						// Simulate mouseenter event to start zoom
-						$source.trigger('mouseenter.zoom');
+						// Simulate both mouseenter and touchstart events to start zoom
+						$source.trigger('mouseenter.zoom touchstart.zoom');
 					}
 					img.src = settings.url;
 				});


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR optimizes the image zoom functionality by implementing lazy loading for high-resolution zoom images. Instead of loading the full-resolution image immediately on page load, it now only loads when a user indicates intent to zoom by hovering over the image.

### Changes
- Modified the zoom initialization logic to defer loading of the high-resolution image until the first mouseenter/touchstart event
- Added trigger for mouseenter.zoom event after image load to ensure smooth zoom activation
- Maintains existing zoom behavior while reducing initial page load

### Benefits
- Reduces initial page load time and bandwidth usage
- Improves performance for users who don't interact with the zoom feature
- Particularly beneficial for pages with multiple zoomable product images

Closes https://github.com/woocommerce/woocommerce/issues/54186

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

### Prerequisites
- High-resolution images (2000px+ width)
- Browser with developer tools
- Access to mobile device

### Test Steps

1. Image Setup
   - Upload multiple high-resolution images (minimum 2000px width) as a product's main image and gallery images

2. Initial Load Verification
   - Open browser's Network tab
   - Load the product page
   - Verify only WP's resized images load initially, not the original high-res versions

3. Zoom Functionality Check
   - Hover over each image 
   - Verify in Network tab that full resolution images only download upon hover
   - Test all product gallery images
   - Check for smooth zoom behavior on both desktop and mobile

4. Theme Compatibility
   - Test on block theme first
   - Switch to classic theme (like Storefront)
   - Verify no regressions in either theme

5. Mobile Device Testing
   - For testing the initial page load only contains WP resized images for mobile devices I think its fine to emulate in a browser. When testing for zoom/gallery regressions use a physical device
   - Create and upload site ZIP to test environment
   - Test on physical mobile device
   - Check zoom behavior across all gallery images

### Expected Results
- Initial page load should only include optimized images
- Full-resolution images should load only on zoom interaction
- Zoom functionality should work smoothly across all themes and browsers
- Mobile zoom behavior should not have any regressions

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
