### PR TITLE
Ensure GTIN,UPC, EAN, or ISBN field never starts or ends with a dash

### DIFF
--- a/plugins/woocommerce/changelog/51049-disallow-start-end-dash-for-GTIN
+++ b/plugins/woocommerce/changelog/51049-disallow-start-end-dash-for-GTIN
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure GTIN,UPC, EAN, or ISBN field never starts or ends with a dash

--- a/plugins/woocommerce/changelog/51049-disallow-start-end-dash-for-GTIN
+++ b/plugins/woocommerce/changelog/51049-disallow-start-end-dash-for-GTIN
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Ensure GTIN,UPC, EAN, or ISBN field never starts or ends with a dash

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -325,16 +325,12 @@
 				'input[type=text][name*=_global_unique_id]',
 				function () {
 					var global_unique_id = $( this ).val();
-
 					$( this ).val(
 						global_unique_id
 							.replace( /[^0-9\-]/g, '' )
 							.replace( /^-+|-+$/g, '' )
 					);
-					$( document.body ).triggerHandler( 'wc_remove_error_tip', [
-						$( this ),
-						'i18n_global_unique_id_error',
-					] );
+					$( document.body ).triggerHandler( 'wc_remove_error_tip', [ $( this ), 'i18n_global_unique_id_error' ] );
 				}
 			)
 

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -331,9 +331,9 @@
 							.replace( /^-+|-+$/g, '' )
 					);
 
-					$( document.body ).triggerHandler( 
-						'wc_remove_error_tip', 
-						[ $( this ), 'i18n_global_unique_id_error']
+					$( document.body ).triggerHandler(
+						'wc_remove_error_tip',
+						[ $( this ), 'i18n_global_unique_id_error' ]
 					);
 				}
 			)

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -325,13 +325,16 @@
 				'input[type=text][name*=_global_unique_id]',
 				function () {
 					var global_unique_id = $( this ).val();
+
 					$( this ).val(
-						global_unique_id.replace( /[^0-9\-]/g, '' )
+						global_unique_id
+							.replace( /[^0-9\-]/g, '' )
+							.replace( /^-+|-+$/g, '' )
 					);
-					$( document.body ).triggerHandler(
-						'wc_remove_error_tip',
-						[ $( this ), 'i18n_global_unique_id_error' ]
-					);
+					$( document.body ).triggerHandler( 'wc_remove_error_tip', [
+						$( this ),
+						'i18n_global_unique_id_error',
+					] );
 				}
 			)
 

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -330,7 +330,11 @@
 							.replace( /[^0-9\-]/g, '' )
 							.replace( /^-+|-+$/g, '' )
 					);
-					$( document.body ).triggerHandler( 'wc_remove_error_tip', [ $( this ), 'i18n_global_unique_id_error' ] );
+
+					$( document.body ).triggerHandler( 
+						'wc_remove_error_tip', 
+						[ $( this ), 'i18n_global_unique_id_error']
+					);
 				}
 			)
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replace starting and ending dashes for inputted values with empty strings.
   

### How to test the changes in this Pull Request:

- Create a test site.
- Install and activate all the required plugins.
- Install and activate the Woocommerce version 9.3.0.30 plugins.
- Go to a Product and add a correct GTIN in the inventory section.
- Add a GTIN with letters (e.g. ABC-123 or 123-ABC)
Observe that the value is stripped to 123, which the only acceptable characters from the inputted values


#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

