### PR TITLE
[e2e tests] Fix site reset incorrectly reported as successful in global setup

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-53107
+++ b/plugins/woocommerce/changelog/e2e-fix-53107
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix incorrect site reset reporting in global setup

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -36,7 +36,12 @@ module.exports = async ( config ) => {
 						},
 					}
 				);
-				console.log( 'Reset successful:', response.status() );
+
+				if ( response.ok() ) {
+					console.log( 'Reset successful:', response.status() );
+				} else {
+					console.error( 'ERROR! Reset failed:', response.status() );
+				}
 			} catch ( error ) {
 				console.error(
 					'Reset failed:',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53107

Fixes the incorrect logging of site reset as successful when the response is a not ok code.

### How to test the changes in this Pull Request:

Run any e2e test against a site that has the cleanup plugin missing or deactivated. The reset should fail in the global setup, with a 404 response. The reset failure is logged as error.