### PR TITLE
Update uses of `VALIDATION_STORE_KEY` and use the `StoreDescriptor` instead

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/validate-country.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/validate-country.ts
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { type ShippingAddress } from '@woocommerce/settings';
 import { select, dispatch } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 
 // If it's the shipping address form and the user starts entering address
 // values without having set the country first, show an error.
@@ -14,18 +14,18 @@ const validateCountry = (
 ): void => {
 	const validationErrorId = `${ addressType }_country`;
 	const hasValidationError =
-		select( VALIDATION_STORE_KEY ).getValidationError( validationErrorId );
+		select( validationStore ).getValidationError( validationErrorId );
 
 	if (
 		! values.country &&
 		( values.city || values.state || values.postcode )
 	) {
 		if ( hasValidationError ) {
-			dispatch( VALIDATION_STORE_KEY ).showValidationError(
+			dispatch( validationStore ).showValidationError(
 				validationErrorId
 			);
 		} else {
-			dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+			dispatch( validationStore ).setValidationErrors( {
 				[ validationErrorId ]: {
 					message: __( 'Please select your country', 'woocommerce' ),
 					hidden: false,
@@ -35,9 +35,7 @@ const validateCountry = (
 	}
 
 	if ( hasValidationError && values.country ) {
-		dispatch( VALIDATION_STORE_KEY ).clearValidationError(
-			validationErrorId
-		);
+		dispatch( validationStore ).clearValidationError( validationErrorId );
 	}
 };
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/validate-state.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/validate-state.ts
@@ -3,7 +3,7 @@
  */
 import { dispatch, select } from '@wordpress/data';
 import { KeyedFormField, ShippingAddress } from '@woocommerce/settings';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { __, sprintf } from '@wordpress/i18n';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -32,7 +32,7 @@ export const validateState = (
 ) => {
 	const validationErrorId = `${ addressType }_state`;
 	const hasValidationError =
-		select( VALIDATION_STORE_KEY ).getValidationError( validationErrorId );
+		select( validationStore ).getValidationError( validationErrorId );
 	const isRequired = stateField.required;
 
 	const lastAddress =
@@ -46,12 +46,12 @@ export const validateState = (
 	if ( hasValidationError ) {
 		if ( ! isRequired || values.state ) {
 			// Validation error has been set, but it's no longer required, or the state was provided, clear the error.
-			dispatch( VALIDATION_STORE_KEY ).clearValidationError(
+			dispatch( validationStore ).clearValidationError(
 				validationErrorId
 			);
 		} else if ( ! addressChanged ) {
 			// Validation error has been set, there has not been an address change so show the error.
-			dispatch( VALIDATION_STORE_KEY ).showValidationError(
+			dispatch( validationStore ).showValidationError(
 				validationErrorId
 			);
 		}
@@ -62,7 +62,7 @@ export const validateState = (
 		values.country
 	) {
 		// No validation has been set yet, if it's required, there is a country set and no state, set the error.
-		dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+		dispatch( validationStore ).setValidationErrors( {
 			[ validationErrorId ]: {
 				message: sprintf(
 					/* translators: %s will be the state field label in lowercase e.g. "state" */

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
@@ -38,8 +38,7 @@ const ShippingCalculatorAddress = ( {
 				isCustomerDataUpdating:
 					select( CART_STORE_KEY ).isCustomerDataUpdating(),
 			};
-		},
-		[]
+		}
 	);
 
 	const validateSubmit = () => {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
@@ -6,7 +6,7 @@ import Button from '@woocommerce/base-components/button';
 import { useState } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import type { ShippingAddress, FormFields } from '@woocommerce/settings';
-import { VALIDATION_STORE_KEY, CART_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore, CART_STORE_KEY } from '@woocommerce/block-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useFocusReturn } from '@woocommerce/base-utils';
 /**
@@ -28,17 +28,18 @@ const ShippingCalculatorAddress = ( {
 	addressFields,
 }: ShippingCalculatorAddressProps ): JSX.Element => {
 	const [ address, setAddress ] = useState( initialAddress );
-	const { showAllValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
+	const { showAllValidationErrors } = useDispatch( validationStore );
 	const focusReturnRef = useFocusReturn();
 	const { hasValidationErrors, isCustomerDataUpdating } = useSelect(
 		( select ) => {
 			return {
 				hasValidationErrors:
-					select( VALIDATION_STORE_KEY ).hasValidationErrors,
+					select( validationStore ).hasValidationErrors,
 				isCustomerDataUpdating:
 					select( CART_STORE_KEY ).isCustomerDataUpdating(),
 			};
-		}
+		},
+		[]
 	);
 
 	const validateSubmit = () => {

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -12,7 +12,7 @@ import {
 	Panel,
 } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import type { MouseEvent, MouseEventHandler } from 'react';
 
 /**
@@ -49,12 +49,15 @@ export const TotalsCoupon = ( {
 	const [ isCouponFormVisible, setIsCouponFormVisible ] =
 		useState( displayCouponForm );
 	const textInputId = `wc-block-components-totals-coupon__input-${ instanceId }`;
-	const { validationErrorId } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
-		return {
-			validationErrorId: store.getValidationErrorId( instanceId ),
-		};
-	} );
+	const { validationErrorId } = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return {
+				validationErrorId: store.getValidationErrorId( instanceId ),
+			};
+		},
+		[ instanceId ]
+	);
 	const inputRef = useRef< ValidatedTextInputHandle >( null );
 
 	const handleCouponSubmit: MouseEventHandler< HTMLButtonElement > = (

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -49,15 +49,12 @@ export const TotalsCoupon = ( {
 	const [ isCouponFormVisible, setIsCouponFormVisible ] =
 		useState( displayCouponForm );
 	const textInputId = `wc-block-components-totals-coupon__input-${ instanceId }`;
-	const { validationErrorId } = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return {
-				validationErrorId: store.getValidationErrorId( instanceId ),
-			};
-		},
-		[ instanceId ]
-	);
+	const { validationErrorId } = useSelect( ( select ) => {
+		const store = select( validationStore );
+		return {
+			validationErrorId: store.getValidationErrorId( instanceId ),
+		};
+	} );
 	const inputRef = useRef< ValidatedTextInputHandle >( null );
 
 	const handleCouponSubmit: MouseEventHandler< HTMLButtonElement > = (

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/stories/index.stories.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/stories/index.stories.tsx
@@ -5,7 +5,7 @@ import { useArgs } from '@storybook/client-api';
 import type { Story, Meta } from '@storybook/react';
 import { INTERACTION_TIMEOUT } from '@woocommerce/storybook-controls';
 import { useDispatch } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -51,7 +51,7 @@ LoadingState.args = {
 };
 
 export const ErrorState: Story< TotalsCouponProps > = ( args ) => {
-	const { setValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
+	const { setValidationErrors } = useDispatch( validationStore );
 
 	setValidationErrors( { coupon: INVALID_COUPON_ERROR } );
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
@@ -4,7 +4,7 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ describe( 'TotalsCoupon', () => {
 			screen.queryByText( 'Invalid coupon code' )
 		).not.toBeInTheDocument();
 
-		const { setValidationErrors } = dispatch( VALIDATION_STORE_KEY );
+		const { setValidationErrors } = dispatch( validationStore );
 		act( () => {
 			setValidationErrors( {
 				coupon: {

--- a/plugins/woocommerce-blocks/assets/js/base/components/country-input/stories/index.stories.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/country-input/stories/index.stories.tsx
@@ -4,7 +4,7 @@
 import type { Story, Meta } from '@storybook/react';
 import { useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ const Template: Story< CountryInputWithCountriesProps > = ( args ) => {
 		''
 	);
 	const { clearValidationError, showValidationError } =
-		useDispatch( VALIDATION_STORE_KEY );
+		useDispatch( validationStore );
 
 	useEffect( () => {
 		showValidationError( 'country' );

--- a/plugins/woocommerce-blocks/assets/js/base/components/select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/select/index.tsx
@@ -6,7 +6,7 @@ import { useCallback, useId, useMemo, useEffect } from '@wordpress/element';
 import { sprintf, __, getLocaleData } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import clsx from 'clsx';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { ValidationInputError } from '@woocommerce/blocks-components';
 
 /**
@@ -84,15 +84,18 @@ export const Select = ( props: SelectProps ) => {
 	}, [ required, value, emptyOption, options ] );
 
 	const { setValidationErrors, clearValidationError } =
-		useDispatch( VALIDATION_STORE_KEY );
+		useDispatch( validationStore );
 
-	const { error, validationErrorId } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
-		return {
-			error: store.getValidationError( errorId ),
-			validationErrorId: store.getValidationErrorId( errorId ),
-		};
-	} );
+	const { error, validationErrorId } = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return {
+				error: store.getValidationError( errorId ),
+				validationErrorId: store.getValidationErrorId( errorId ),
+			};
+		},
+		[ errorId ]
+	);
 
 	useEffect( () => {
 		if ( ! required || value ) {
@@ -117,14 +120,17 @@ export const Select = ( props: SelectProps ) => {
 		setValidationErrors,
 	] );
 
-	const validationError = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
-		return (
-			store.getValidationError( errorId || '' ) || {
-				hidden: true,
-			}
-		);
-	} );
+	const validationError = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return (
+				store.getValidationError( errorId || '' ) || {
+					hidden: true,
+				}
+			);
+		},
+		[ errorId ]
+	);
 
 	return (
 		<div

--- a/plugins/woocommerce-blocks/assets/js/base/components/select/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/select/index.tsx
@@ -86,16 +86,13 @@ export const Select = ( props: SelectProps ) => {
 	const { setValidationErrors, clearValidationError } =
 		useDispatch( validationStore );
 
-	const { error, validationErrorId } = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return {
-				error: store.getValidationError( errorId ),
-				validationErrorId: store.getValidationErrorId( errorId ),
-			};
-		},
-		[ errorId ]
-	);
+	const { error, validationErrorId } = useSelect( ( select ) => {
+		const store = select( validationStore );
+		return {
+			error: store.getValidationError( errorId ),
+			validationErrorId: store.getValidationErrorId( errorId ),
+		};
+	} );
 
 	useEffect( () => {
 		if ( ! required || value ) {
@@ -120,17 +117,14 @@ export const Select = ( props: SelectProps ) => {
 		setValidationErrors,
 	] );
 
-	const validationError = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return (
-				store.getValidationError( errorId || '' ) || {
-					hidden: true,
-				}
-			);
-		},
-		[ errorId ]
-	);
+	const validationError = useSelect( ( select ) => {
+		const store = select( validationStore );
+		return (
+			store.getValidationError( errorId || '' ) || {
+				hidden: true,
+			}
+		);
+	} );
 
 	return (
 		<div

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -39,7 +39,7 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 				isApplyingCoupon: store.isApplyingCoupon(),
 				isRemovingCoupon: store.isRemovingCoupon(),
 			};
-		}, [] );
+		} );
 
 	const { applyCoupon, removeCoupon } = useDispatch( CART_STORE_KEY );
 	const orderId = useSelect( ( select ) =>

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	CART_STORE_KEY,
-	VALIDATION_STORE_KEY,
+	validationStore,
 	CHECKOUT_STORE_KEY,
 } from '@woocommerce/block-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -26,23 +26,20 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 	const { cartCoupons, cartIsLoading } = useStoreCart();
 	const { createErrorNotice } = useDispatch( 'core/notices' );
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { setValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
+	const { setValidationErrors } = useDispatch( validationStore );
 
 	const {
 		isApplyingCoupon,
 		isRemovingCoupon,
 	}: Pick< StoreCartCoupon, 'isApplyingCoupon' | 'isRemovingCoupon' > =
-		useSelect(
-			( select ) => {
-				const store = select( CART_STORE_KEY );
+		useSelect( ( select ) => {
+			const store = select( CART_STORE_KEY );
 
-				return {
-					isApplyingCoupon: store.isApplyingCoupon(),
-					isRemovingCoupon: store.isRemovingCoupon(),
-				};
-			},
-			[ createErrorNotice, createNotice ]
-		);
+			return {
+				isApplyingCoupon: store.isApplyingCoupon(),
+				isRemovingCoupon: store.isRemovingCoupon(),
+			};
+		}, [] );
 
 	const { applyCoupon, removeCoupon } = useDispatch( CART_STORE_KEY );
 	const orderId = useSelect( ( select ) =>

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-validation.ts
@@ -28,8 +28,7 @@ export const useValidation = (): ValidationData => {
 						`${ prefix }-${ validationErrorId }`
 					),
 			};
-		},
-		[]
+		}
 	);
 
 	return {

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-validation.ts
@@ -7,20 +7,20 @@ import type {
 	ValidationContextError,
 } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 
 /**
  * Custom hook for setting for adding errors to the validation system.
  */
 export const useValidation = (): ValidationData => {
 	const { clearValidationError, hideValidationError, setValidationErrors } =
-		useDispatch( VALIDATION_STORE_KEY );
+		useDispatch( validationStore );
 
 	const prefix = 'extensions-errors';
 
 	const { hasValidationErrors, getValidationError } = useSelect(
 		( mapSelect ) => {
-			const store = mapSelect( VALIDATION_STORE_KEY );
+			const store = mapSelect( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
 				getValidationError: ( validationErrorId: string ) =>
@@ -28,7 +28,8 @@ export const useValidation = (): ValidationData => {
 						`${ prefix }-${ validationErrorId }`
 					),
 			};
-		}
+		},
+		[]
 	);
 
 	return {

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -17,7 +17,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	PAYMENT_STORE_KEY,
-	VALIDATION_STORE_KEY,
+	validationStore,
 } from '@woocommerce/block-data';
 
 /**
@@ -141,7 +141,7 @@ export const CheckoutEventsProvider = ( {
 		__internalSetRedirectUrl( redirectUrl );
 	}
 
-	const { setValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
+	const { setValidationErrors } = useDispatch( validationStore );
 	const { dispatchCheckoutEvent } = useStoreEvents();
 
 	const checkoutContexts = Object.values( noticeContexts ).filter(

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -82,8 +82,7 @@ const CheckoutProcessor = () => {
 		useDispatch( CHECKOUT_STORE_KEY );
 
 	const hasValidationErrors = useSelect(
-		( select ) => select( validationStore ).hasValidationErrors,
-		[]
+		( select ) => select( validationStore ).hasValidationErrors
 	);
 	const { shippingErrorStatus } = useShippingDataContext();
 

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -18,7 +18,7 @@ import { useDispatch, useSelect, select as selectStore } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	PAYMENT_STORE_KEY,
-	VALIDATION_STORE_KEY,
+	validationStore,
 	CART_STORE_KEY,
 	processErrorResponse,
 } from '@woocommerce/block-data';
@@ -82,7 +82,8 @@ const CheckoutProcessor = () => {
 		useDispatch( CHECKOUT_STORE_KEY );
 
 	const hasValidationErrors = useSelect(
-		( select ) => select( VALIDATION_STORE_KEY ).hasValidationErrors
+		( select ) => select( validationStore ).hasValidationErrors,
+		[]
 	);
 	const { shippingErrorStatus } = useShippingDataContext();
 
@@ -168,7 +169,7 @@ const CheckoutProcessor = () => {
 		if ( hasValidationErrors() ) {
 			// If there is a shipping rates validation error, return the error message to be displayed.
 			if (
-				selectStore( VALIDATION_STORE_KEY ).getValidationError(
+				selectStore( validationStore ).getValidationError(
 					'shipping-rates-error'
 				) !== undefined
 			) {

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
@@ -13,7 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	PAYMENT_STORE_KEY,
-	VALIDATION_STORE_KEY,
+	validationStore,
 } from '@woocommerce/block-data';
 import deprecated from '@wordpress/deprecated';
 
@@ -78,7 +78,7 @@ export const PaymentEventsProvider = ( {
 		};
 	} );
 
-	const { setValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
+	const { setValidationErrors } = useDispatch( validationStore );
 	const [ observers, observerDispatch ] = useReducer( emitReducer, {} );
 	const { onPaymentSetup } = useEventEmitters( observerDispatch );
 	const currentObservers = useRef( observers );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -16,10 +16,7 @@ import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	CHECKOUT_STORE_KEY,
-	VALIDATION_STORE_KEY,
-} from '@woocommerce/block-data';
+import { CHECKOUT_STORE_KEY, validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -99,15 +96,16 @@ const ScrollOnError = ( {
 				isIdle: store.isIdle(),
 				hasError: store.hasError(),
 			};
-		}
+		},
+		[]
 	);
 	const { hasValidationErrors } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
+		const store = select( validationStore );
 		return {
 			hasValidationErrors: store.hasValidationErrors(),
 		};
-	} );
-	const { showAllValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
+	}, [] );
+	const { showAllValidationErrors } = useDispatch( validationStore );
 
 	const hasErrorsToDisplay =
 		checkoutIsIdle && checkoutHasError && hasValidationErrors;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -104,7 +104,7 @@ const ScrollOnError = ( {
 		return {
 			hasValidationErrors: store.hasValidationErrors(),
 		};
-	}, [] );
+	} );
 	const { showAllValidationErrors } = useDispatch( validationStore );
 
 	const hasErrorsToDisplay =

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -6,7 +6,7 @@ import { Form } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
 import type { AddressFormValues } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { ADDRESS_FORM_KEYS } from '@woocommerce/block-settings';
 
 /**
@@ -27,21 +27,24 @@ const CustomerAddress = () => {
 	const { dispatchCheckoutEvent } = useStoreEvents();
 
 	// Forces editing state if store has errors.
-	const { hasValidationErrors, invalidProps } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
-		return {
-			hasValidationErrors: store.hasValidationErrors(),
-			invalidProps: Object.keys( billingAddress )
-				.filter( ( key ) => {
-					return (
-						key !== 'email' &&
-						store.getValidationError( 'billing_' + key ) !==
-							undefined
-					);
-				} )
-				.filter( Boolean ),
-		};
-	} );
+	const { hasValidationErrors, invalidProps } = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return {
+				hasValidationErrors: store.hasValidationErrors(),
+				invalidProps: Object.keys( billingAddress )
+					.filter( ( key ) => {
+						return (
+							key !== 'email' &&
+							store.getValidationError( 'billing_' + key ) !==
+								undefined
+						);
+					} )
+					.filter( Boolean ),
+			};
+		},
+		[ billingAddress ]
+	);
 
 	useEffect( () => {
 		if ( invalidProps.length > 0 && editing === false ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -27,24 +27,21 @@ const CustomerAddress = () => {
 	const { dispatchCheckoutEvent } = useStoreEvents();
 
 	// Forces editing state if store has errors.
-	const { hasValidationErrors, invalidProps } = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return {
-				hasValidationErrors: store.hasValidationErrors(),
-				invalidProps: Object.keys( billingAddress )
-					.filter( ( key ) => {
-						return (
-							key !== 'email' &&
-							store.getValidationError( 'billing_' + key ) !==
-								undefined
-						);
-					} )
-					.filter( Boolean ),
-			};
-		},
-		[ billingAddress ]
-	);
+	const { hasValidationErrors, invalidProps } = useSelect( ( select ) => {
+		const store = select( validationStore );
+		return {
+			hasValidationErrors: store.hasValidationErrors(),
+			invalidProps: Object.keys( billingAddress )
+				.filter( ( key ) => {
+					return (
+						key !== 'email' &&
+						store.getValidationError( 'billing_' + key ) !==
+							undefined
+					);
+				} )
+				.filter( Boolean ),
+		};
+	} );
 
 	useEffect( () => {
 		if ( invalidProps.length > 0 && editing === false ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -6,7 +6,7 @@ import { Form } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
 import type { AddressFormValues } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { ADDRESS_FORM_KEYS } from '@woocommerce/block-settings';
 
 /**
@@ -28,7 +28,7 @@ const CustomerAddress = () => {
 
 	// Forces editing state if store has errors.
 	const { hasValidationErrors, invalidProps } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
+		const store = select( validationStore );
 		return {
 			hasValidationErrors: store.hasValidationErrors(),
 			invalidProps: Object.keys( shippingAddress )

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -6,7 +6,7 @@ import { useShippingData } from '@woocommerce/base-context/hooks';
 import clsx from 'clsx';
 import { Icon, store, shipping } from '@wordpress/icons';
 import { useEffect } from '@wordpress/element';
-import { CART_STORE_KEY, VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, validationStore } from '@woocommerce/block-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { isPackageRateCollectable } from '@woocommerce/base-utils';
 import { getSetting } from '@woocommerce/settings';
@@ -103,7 +103,7 @@ const ShippingSelector = ( {
 		! hasShippableRates;
 	const hasShippingPrices = rate.min !== undefined && rate.max !== undefined;
 	const { setValidationErrors, clearValidationError } =
-		useDispatch( VALIDATION_STORE_KEY );
+		useDispatch( validationStore );
 	useEffect( () => {
 		if ( checked === 'shipping' && ! hasShippingPrices ) {
 			setValidationErrors( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx
@@ -37,14 +37,11 @@ const FrontendBlock = ( {
 	const { setValidationErrors, clearValidationError } =
 		useDispatch( validationStore );
 
-	const error = useSelect(
-		( select ) => {
-			return select( validationStore ).getValidationError(
-				validationErrorId
-			);
-		},
-		[ validationErrorId ]
-	);
+	const error = useSelect( ( select ) => {
+		return select( validationStore ).getValidationError(
+			validationErrorId
+		);
+	} );
 	const hasError = !! ( error?.message && ! error?.hidden );
 
 	// Track validation errors for this input.

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx
@@ -8,7 +8,7 @@ import { CheckboxControl } from '@woocommerce/blocks-components';
 import { useCheckoutSubmit } from '@woocommerce/base-context/hooks';
 import { withInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -35,13 +35,16 @@ const FrontendBlock = ( {
 
 	const validationErrorId = 'terms-and-conditions-' + instanceId;
 	const { setValidationErrors, clearValidationError } =
-		useDispatch( VALIDATION_STORE_KEY );
+		useDispatch( validationStore );
 
-	const error = useSelect( ( select ) => {
-		return select( VALIDATION_STORE_KEY ).getValidationError(
-			validationErrorId
-		);
-	} );
+	const error = useSelect(
+		( select ) => {
+			return select( validationStore ).getValidationError(
+				validationErrorId
+			);
+		},
+		[ validationErrorId ]
+	);
 	const hasError = !! ( error?.message && ! error?.hidden );
 
 	// Track validation errors for this input.

--- a/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
@@ -12,7 +12,7 @@ import {
 import { PRIVACY_URL, TERMS_URL } from '@woocommerce/block-settings';
 import { ValidatedTextInput, Spinner } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { getSetting } from '@woocommerce/settings';
 
 const termsPageLink = TERMS_URL ? (
@@ -93,7 +93,7 @@ const Form = ( {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ password, setPassword ] = useState( '' );
 	const hasValidationError = useSelect( ( select ) =>
-		select( VALIDATION_STORE_KEY ).getValidationError( 'account-password' )
+		select( validationStore ).getValidationError( 'account-password' )
 	);
 	const customerEmail =
 		blockAttributes?.customerEmail ||

--- a/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
@@ -14,14 +14,14 @@ import {
 /**
  * Internal dependencies
  */
-import { STORE_KEY as VALIDATION_STORE_KEY } from '../validation/constants';
+import { store as validationStoreDescriptor } from '../validation';
 
 export const mapCartResponseToCart = ( responseCart: CartResponse ): Cart => {
 	return camelCaseKeys( responseCart ) as unknown as Cart;
 };
 
 export const shippingAddressHasValidationErrors = () => {
-	const validationStore = select( VALIDATION_STORE_KEY );
+	const validationStore = select( validationStoreDescriptor );
 	// Check if the shipping address form has validation errors - if not then we know the full required
 	// address has been pushed to the server.
 	const stateValidationErrors =
@@ -97,7 +97,7 @@ export const validateDirtyProps = ( dirtyProps: {
 	billingAddress: BaseAddressKey[];
 	shippingAddress: BaseAddressKey[];
 } ): boolean => {
-	const validationStore = select( VALIDATION_STORE_KEY );
+	const validationStore = select( validationStoreDescriptor );
 
 	const invalidProps = [
 		...dirtyProps.billingAddress.filter( ( key ) => {

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/validation.md
@@ -43,10 +43,10 @@ When the checkout process begins, it will check if this data store has any entri
 
 ## Usage
 
-To utilize this store you will import the `VALIDATION_STORE_KEY` in any module referencing it. Assuming `@woocommerce/block-data` is registered as an external pointing to `wc.wcBlocksData` you can import the key via:
+To utilize this store you will import the `validationStore` `StoreDescriptor` in any module referencing it. Assuming `@woocommerce/block-data` is registered as an external pointing to `wc.wcBlocksData` you can import the `StoreDescriptor` via:
 
 ```js
-const { VALIDATION_STORE_KEY } = window.wc.wcBlocksData;
+const { validationStore } = window.wc.wcBlocksData;
 ```
 
 ## Example
@@ -121,7 +121,7 @@ export const ValidationInputError = ( {
 	elementId = '',
 }: ValidationInputErrorProps ): JSX.Element | null => {
 	const { validationError, validationErrorId } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
+		const store = select( validationStore );
 		return {
 			validationError: store.getValidationError( propertyName ),
 			validationErrorId: store.getValidationErrorId( elementId ),
@@ -169,7 +169,7 @@ Clears a validation error.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = dispatch( VALIDATION_STORE_KEY );
+const store = dispatch( validationStore );
 store.clearValidationError( 'billing-first-name' );
 ```
 
@@ -186,7 +186,7 @@ Clears multiple validation errors at once. If no error IDs are passed, all valid
 1. This will clear only the validation errors passed in the array.
 
 ```js
-const store = dispatch( VALIDATION_STORE_KEY );
+const store = dispatch( validationStore );
 store.clearValidationErrors( [
 	'billing-first-name',
 	'billing-last-name',
@@ -197,7 +197,7 @@ store.clearValidationErrors( [
 2. This will clear all validation errors.
 
 ```js
-const store = dispatch( VALIDATION_STORE_KEY );
+const store = dispatch( validationStore );
 store.clearValidationErrors();
 ```
 
@@ -213,7 +213,7 @@ Sets the validation errors. The entries in _errors_ will be _added_ to the list 
 
 ```js
 const { dispatch } = wp.data;
-const { setValidationErrors } = dispatch( VALIDATION_STORE_KEY );
+const { setValidationErrors } = dispatch( validationStore );
 
 setValidationErrors( {
 	'billing-first-name': {
@@ -239,7 +239,7 @@ Hides a validation error by setting the `hidden` property to `true`. This will _
 
 ```js
 const { dispatch } = wp.data;
-const { hideValidationError } = dispatch( VALIDATION_STORE_KEY );
+const { hideValidationError } = dispatch( validationStore );
 
 hideValidationError( 'billing-first-name' );
 ```
@@ -256,7 +256,7 @@ Shows a validation error by setting the `hidden` property to `false`.
 
 ```js
 const { dispatch } = wp.data;
-const { showValidationError } = dispatch( VALIDATION_STORE_KEY );
+const { showValidationError } = dispatch( validationStore );
 
 showValidationError( 'billing-first-name' );
 ```
@@ -269,7 +269,7 @@ Shows all validation errors by setting the `hidden` property to `false`.
 
 ```js
 const { dispatch } = wp.data;
-const { showAllValidationErrors } = dispatch( VALIDATION_STORE_KEY );
+const { showAllValidationErrors } = dispatch( validationStore );
 
 showAllValidationErrors();
 ```
@@ -281,7 +281,7 @@ Clears all validation errors by removing them from the store.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const { clearAllValidationErrors } = dispatch( VALIDATION_STORE_KEY );
+const { clearAllValidationErrors } = dispatch( validationStore );
 clearAllValidationErrors();
 ```
 
@@ -302,7 +302,7 @@ Returns the validation error.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( VALIDATION_STORE_KEY );
+const store = select( validationStore );
 const billingFirstNameError = store.getValidationError( 'billing-first-name' );
 ```
 
@@ -321,7 +321,7 @@ Gets a validation error ID for use in HTML which can be used as a CSS selector, 
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( VALIDATION_STORE_KEY );
+const store = select( validationStore );
 const billingFirstNameErrorId =
 	store.getValidationErrorId( 'billing-first-name' );
 ```
@@ -337,7 +337,7 @@ Returns true if validation errors occurred, and false otherwise.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( VALIDATION_STORE_KEY );
+const store = select( validationStore );
 const hasValidationErrors = store.hasValidationErrors();
 ```
 

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/validation.md
@@ -193,7 +193,7 @@ store.clearValidationErrors( [
 	'terms-and-conditions',
 ] );
 ```
-
+<!-- markdownlint-disable MD029 -->
 2. This will clear all validation errors.
 
 ```js

--- a/plugins/woocommerce-blocks/packages/components/text-input/test/validated-text-input.tsx
+++ b/plugins/woocommerce-blocks/packages/components/text-input/test/validated-text-input.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { act, render, screen } from '@testing-library/react';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
-import { dispatch, select } from '@wordpress/data';
+import { validationStore } from '@woocommerce/block-data';
+import { dispatch, select, StoreDescriptor } from '@wordpress/data';
 import userEvent from '@testing-library/user-event';
 import { useState } from '@wordpress/element';
 import * as wpData from '@wordpress/data';
@@ -37,7 +37,7 @@ describe( 'ValidatedTextInput', () => {
 		);
 
 		await act( () =>
-			dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+			dispatch( validationStore ).setValidationErrors( {
 				'test-input': {
 					message: 'Error message',
 					hidden: false,
@@ -46,7 +46,7 @@ describe( 'ValidatedTextInput', () => {
 		);
 
 		await expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'test-input' )
+			select( validationStore ).getValidationError( 'test-input' )
 		).not.toBe( undefined );
 
 		const textInputElement = await screen.getByLabelText( 'Test Input' );
@@ -56,7 +56,7 @@ describe( 'ValidatedTextInput', () => {
 		} );
 
 		expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'test-input' )
+			select( validationStore ).getValidationError( 'test-input' )
 		).toBe( undefined );
 	} );
 	it( 'Hides related validation error on change when id is not specified', async () => {
@@ -71,7 +71,7 @@ describe( 'ValidatedTextInput', () => {
 		);
 
 		await act( () =>
-			dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+			dispatch( validationStore ).setValidationErrors( {
 				'textinput-1': {
 					message: 'Error message',
 					hidden: false,
@@ -79,7 +79,7 @@ describe( 'ValidatedTextInput', () => {
 			} )
 		);
 		await expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'textinput-1' )
+			select( validationStore ).getValidationError( 'textinput-1' )
 		).not.toBe( undefined );
 		const textInputElement = await screen.getByLabelText( 'Test Input' );
 
@@ -88,7 +88,7 @@ describe( 'ValidatedTextInput', () => {
 		} );
 
 		await expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'textinput-1' )
+			select( validationStore ).getValidationError( 'textinput-1' )
 		).toBe( undefined );
 	} );
 	it( 'Displays a passed error message', async () => {
@@ -103,7 +103,7 @@ describe( 'ValidatedTextInput', () => {
 			/>
 		);
 		await act( () =>
-			dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+			dispatch( validationStore ).setValidationErrors( {
 				'textinput-2': {
 					message: 'Error message in data store',
 					hidden: false,
@@ -132,7 +132,7 @@ describe( 'ValidatedTextInput', () => {
 			/>
 		);
 		await act( () =>
-			dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+			dispatch( validationStore ).setValidationErrors( {
 				'textinput-3': {
 					message: 'Error message 3',
 					hidden: false,
@@ -162,7 +162,7 @@ describe( 'ValidatedTextInput', () => {
 			</>
 		);
 		await act( () =>
-			dispatch( VALIDATION_STORE_KEY ).setValidationErrors( {
+			dispatch( validationStore ).setValidationErrors( {
 				'textinput-2': {
 					message: 'Error message in data store',
 					hidden: false,
@@ -199,7 +199,7 @@ describe( 'ValidatedTextInput', () => {
 		} );
 
 		await expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'test-input' )
+			select( validationStore ).getValidationError( 'test-input' )
 		).not.toBe( undefined );
 
 		await act( async () => {
@@ -209,7 +209,7 @@ describe( 'ValidatedTextInput', () => {
 
 		await expect( textInputElement.value ).toBe( 'Valid Value' );
 		await expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'test-input' )
+			select( validationStore ).getValidationError( 'test-input' )
 		).toBe( undefined );
 	} );
 	it( 'Shows a custom error message for an invalid required input', async () => {
@@ -243,19 +243,21 @@ describe( 'ValidatedTextInput', () => {
 	describe( 'correctly validates on mount', () => {
 		it( 'validates when focusOnMount is true and validateOnMount is not set', async () => {
 			const setValidationErrors = jest.fn();
-			wpData.useDispatch.mockImplementation( ( storeName: string ) => {
-				if ( storeName === VALIDATION_STORE_KEY ) {
-					return {
-						...jest
-							.requireActual( '@wordpress/data' )
-							.useDispatch( storeName ),
-						setValidationErrors,
-					};
+			wpData.useDispatch.mockImplementation(
+				( store: StoreDescriptor | string ) => {
+					if ( store === validationStore ) {
+						return {
+							...jest
+								.requireActual( '@wordpress/data' )
+								.useDispatch( store ),
+							setValidationErrors,
+						};
+					}
+					return jest
+						.requireActual( '@wordpress/data' )
+						.useDispatch( store );
 				}
-				return jest
-					.requireActual( '@wordpress/data' )
-					.useDispatch( storeName );
-			} );
+			);
 
 			const TestComponent = () => {
 				const [ inputValue, setInputValue ] = useState( '' );
@@ -285,19 +287,21 @@ describe( 'ValidatedTextInput', () => {
 		} );
 		it( 'validates when focusOnMount is false, regardless of validateOnMount value', async () => {
 			const setValidationErrors = jest.fn();
-			wpData.useDispatch.mockImplementation( ( storeName: string ) => {
-				if ( storeName === VALIDATION_STORE_KEY ) {
-					return {
-						...jest
-							.requireActual( '@wordpress/data' )
-							.useDispatch( storeName ),
-						setValidationErrors,
-					};
+			wpData.useDispatch.mockImplementation(
+				( store: StoreDescriptor | string ) => {
+					if ( store === validationStore ) {
+						return {
+							...jest
+								.requireActual( '@wordpress/data' )
+								.useDispatch( store ),
+							setValidationErrors,
+						};
+					}
+					return jest
+						.requireActual( '@wordpress/data' )
+						.useDispatch( store );
 				}
-				return jest
-					.requireActual( '@wordpress/data' )
-					.useDispatch( storeName );
-			} );
+			);
 
 			const TestComponent = ( { validateOnMount = false } ) => {
 				const [ inputValue, setInputValue ] = useState( '' );
@@ -327,19 +331,21 @@ describe( 'ValidatedTextInput', () => {
 		} );
 		it( 'does not validate when validateOnMount is false and focusOnMount is true', async () => {
 			const setValidationErrors = jest.fn();
-			wpData.useDispatch.mockImplementation( ( storeName: string ) => {
-				if ( storeName === VALIDATION_STORE_KEY ) {
-					return {
-						...jest
-							.requireActual( '@wordpress/data' )
-							.useDispatch( storeName ),
-						setValidationErrors,
-					};
+			wpData.useDispatch.mockImplementation(
+				( store: StoreDescriptor | string ) => {
+					if ( store === validationStore ) {
+						return {
+							...jest
+								.requireActual( '@wordpress/data' )
+								.useDispatch( store ),
+							setValidationErrors,
+						};
+					}
+					return jest
+						.requireActual( '@wordpress/data' )
+						.useDispatch( store );
 				}
-				return jest
-					.requireActual( '@wordpress/data' )
-					.useDispatch( storeName );
-			} );
+			);
 
 			const TestComponent = () => {
 				const [ inputValue, setInputValue ] = useState( '' );

--- a/plugins/woocommerce-blocks/packages/components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce-blocks/packages/components/text-input/validated-text-input.tsx
@@ -100,8 +100,7 @@ const ValidatedTextInput = forwardRef<
 					validationErrorId:
 						store.getValidationErrorId( errorIdString ),
 				};
-			},
-			[ errorIdString ]
+			}
 		);
 
 		const validateInput = useCallback(

--- a/plugins/woocommerce-blocks/packages/components/text-input/validated-text-input.tsx
+++ b/plugins/woocommerce-blocks/packages/components/text-input/validated-text-input.tsx
@@ -12,7 +12,7 @@ import {
 import clsx from 'clsx';
 import { isObject } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { usePrevious } from '@woocommerce/base-hooks';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -82,7 +82,7 @@ const ValidatedTextInput = forwardRef<
 			setValidationErrors,
 			hideValidationError,
 			clearValidationError,
-		} = useDispatch( VALIDATION_STORE_KEY );
+		} = useDispatch( validationStore );
 
 		// Ref for validation callback.
 		const customValidationRef = useRef( customValidation );
@@ -94,13 +94,14 @@ const ValidatedTextInput = forwardRef<
 
 		const { validationError, validationErrorId } = useSelect(
 			( select ) => {
-				const store = select( VALIDATION_STORE_KEY );
+				const store = select( validationStore );
 				return {
 					validationError: store.getValidationError( errorIdString ),
 					validationErrorId:
 						store.getValidationErrorId( errorIdString ),
 				};
-			}
+			},
+			[ errorIdString ]
 		);
 
 		const validateInput = useCallback(

--- a/plugins/woocommerce-blocks/packages/components/validation-input-error/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/validation-input-error/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { validationStore } from '@woocommerce/block-data';
 import { Icon, warning } from '@wordpress/icons';
 
 /**
@@ -21,13 +21,16 @@ export const ValidationInputError = ( {
 	propertyName = '',
 	elementId = '',
 }: ValidationInputErrorProps ): JSX.Element | null => {
-	const { validationError, validationErrorId } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
-		return {
-			validationError: store.getValidationError( propertyName ),
-			validationErrorId: store.getValidationErrorId( elementId ),
-		};
-	} );
+	const { validationError, validationErrorId } = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return {
+				validationError: store.getValidationError( propertyName ),
+				validationErrorId: store.getValidationErrorId( elementId ),
+			};
+		},
+		[ elementId, propertyName ]
+	);
 
 	if ( ! errorMessage || typeof errorMessage !== 'string' ) {
 		if ( validationError?.message && ! validationError?.hidden ) {

--- a/plugins/woocommerce-blocks/packages/components/validation-input-error/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/validation-input-error/index.tsx
@@ -21,16 +21,13 @@ export const ValidationInputError = ( {
 	propertyName = '',
 	elementId = '',
 }: ValidationInputErrorProps ): JSX.Element | null => {
-	const { validationError, validationErrorId } = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return {
-				validationError: store.getValidationError( propertyName ),
-				validationErrorId: store.getValidationErrorId( elementId ),
-			};
-		},
-		[ elementId, propertyName ]
-	);
+	const { validationError, validationErrorId } = useSelect( ( select ) => {
+		const store = select( validationStore );
+		return {
+			validationError: store.getValidationError( propertyName ),
+			validationErrorId: store.getValidationErrorId( elementId ),
+		};
+	} );
 
 	if ( ! errorMessage || typeof errorMessage !== 'string' ) {
 		if ( validationError?.message && ! validationError?.hidden ) {

--- a/plugins/woocommerce/changelog/update-validation-data-store-types
+++ b/plugins/woocommerce/changelog/update-validation-data-store-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WC Blocks to use the StoreDescriptor when accessing the validation data store. The documentation for the validation data store is also updated.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates instances where we used the key to access the validation data store and instead uses the `StoreDescription`. It also adds dependency arrays to `useSelect` calls as is the best practice.

I left instances of `VALIDATION_STORE_KEY` in [`FormSubmit`](https://github.com/woocommerce/woocommerce/blob/aba5aa590e70c684d3bd246931986be7272bc688/plugins/woocommerce-blocks/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js#L23) and [`AddToCartFormStateContextProvider`](https://github.com/woocommerce/woocommerce/blob/ec9b7852f9ecfe98a0bce387eac7fb0c64eee61e/plugins/woocommerce-blocks/assets/js/base/context/providers/add-to-cart-form/form-state/index.js#L18) since these are JS files anyway and wouldn't benefit from TS, but also because I couldn't test the changes. Maybe someone from @woocommerce/woo-fse  could help me out on how to test those?

The testing steps here are quite extensive, so I recommend two people review this. @samueljseay since you are chosen as the main reviewer, I suggest you delegate half the testing steps to someone else.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54428

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


#### `checkout-shipping-method-block` 1

1. Go to WC -> Settings -> Shipping -> Local Pickup and enable it. Add some local pickup options.
2. Ensure you have some regular shipping methods set up too, remember which country has available options.
3. Remove the "Rest of the world" options, ensure no options are enabled for this zone.
4. Add an item to your cart and go to the Checkout block.
5. In the shipping method selection, choose "Shipping". Change address to a location with no shipping options.
6. Try to check out. Ensure you see an error: `Sorry, this order requires a shipping option.` and that you cannot check out.
7. Change address to one with valid shipping options and check out successfully.

https://www.loom.com/share/7c9571e30cd24cb9a049024ebce9317e

#### `checkout-shipping-method-block` 2

*This test is required because this block uses the validation data store to determine whether to show "calculated with an address" or a value in the "Shipping" selector. If the address has validation errors, then it'll show the message, if not it'll show the lowest price.*

1. Go to WC -> Settings -> Shipping -> Local Pickup and enable it. Add some local pickup options.
3. Ensure you have some regular shipping methods set up too, remember which country has available options.
4. Edit your Checkout block, select the "Shipping / Local pickup" selectors and enable the "Show costs" option

<img width="1063" alt="Screenshot 2025-01-14 at 14 36 16" src="https://github.com/user-attachments/assets/c03f1739-6a1a-419c-b4ef-c4626c6afcee" />

9. Log out and add an item to the cart and go to the Checkout block.
10. Ensure that the Shipping selector says "calculated with an address" and that the local pickup one says "FREE"
11. Enter an address for a country with shipping methods (that you set up in step 2).
12. Ensure the "Shipping" selector shows "FROM xxx" where xxx is the lowest price

#### `validateCountry` and `validateState`

1. Go to WC -> Settings -> General. Set `Default customer location` to "No location by default".
2. Log out and add an item to your cart, then go to the Checkout block.
3. Try to check out without selecting a country
4. Ensure you see an error on the country input.
5. Choose USA and ensure the error disappears
6. Try to check out without entering a state.
7. Ensure you see an error on the state input.
8. Select a state, enter a full address and ensure you can check out.

#### `ValidationInputError`

1. Go to the Checkout block, execute the following code in the console:

```js
const container = document.createElement('div');
document.body.appendChild(container);
const ValidationInputError = window.wc.blocksCheckout.ValidationInputError;
const root = ReactDOM.createRoot(container);
root.render(React.createElement(ValidationInputError, { propertyName: 'test-error' } ) ) ;
wp.data.dispatch( wc.wcBlocksData.validationStore ).setValidationErrors( {'test-error': { message: 'Test error', hidden: false } } )
```

2. Scroll to the bottom of the page and ensure you see a red error message.
3. Execute `wp.data.dispatch( wc.wcBlocksData.validationStore ).clearValidationErrors()`
4. Ensure it disappears.

#### `ShippingCalculatorAddress`

1. Go to WC -> Settings -> Shipping Settings -> check Enable the shipping calculator on the Cart Page.
2. Log out and go to the Cart block.
3. Open the shipping calculator and enter each text box except `Country`
4. When you leave the field, ensure you see an error like so:

<img width="415" alt="image" src="https://github.com/user-attachments/assets/2e895633-698e-4086-bdb8-464590bb595f" />

5. Enter text into each box, ensuring the error disappears on each one, but leave `Country` without a value. Press `Check delivery options`.
6. Ensure there is an error on `Country`.
7. Select a country and ensure the error disappears. 
8. Press `Check delivery options`. Ensure the form is hidden without errors.

#### `TotalsCoupon`

1. Go to the Cart block, enter an invalid coupon and press submit.
2. Ensure you see an error message.
3. Leave the input and ensure the message disappears.
4. Repeat on the Checkout block.

#### `ValidatedTextInput`

1. Add an item to your cart and go to the Checkout block.
2. In the shipping address, enter text in the `Address` field then leave the field.
3. Ensure no error appears. Go back and delete the text then leave the field.
4. Ensure an error appears:

<img width="810" alt="image" src="https://github.com/user-attachments/assets/f625d8ed-8f99-4f76-9ef9-a6cdc6be8b22" />

5. Repeat for first name, last name, postcode, and state (choose UK to enter a state as text).
6. Repeat on billing address.

#### `Select`

1. Install Additional Checkout Fields Tester
[additional-checkout-fields-tester-main (6).zip](https://github.com/user-attachments/files/18413698/additional-checkout-fields-tester-main.6.zip)
2. Log out, add an item to your cart and go to the Checkout page.
3. Fill in all details except the `What is your main role at your company?` select.
4. Try to check out, ensure that field shows an error.
5. Select an option and ensure the error disappears and you can check out.

#### `useValidation`

1. Download and install WooCommerce EU VAT Number.
2. Go to WC -> Settings and check ` Enable tax rates and calculations`
3. Add an item to your cart and go to the Checkout block.
4. Change your country to France (or any other EU country) and scroll to the bottom of the page, the EU VAT Input should be there.
5. Enter invalid text into the box and ensure a validation error shows.
6. Enter a valid VAT Number for the country (e.g. `FR09445330103` for France) Ensure the error disappears.

#### `CheckoutEventsContext`

1. Go to `assets/js/extensions/payment-methods/bacs/index.js` change the contents to:

```js
/**
 * External dependencies
 */
import { registerPaymentMethod } from '@woocommerce/blocks-registry';
import { __ } from '@wordpress/i18n';
import { getPaymentMethodData } from '@woocommerce/settings';
import { decodeEntities } from '@wordpress/html-entities';
import { sanitizeHTML } from '@woocommerce/utils';
import { RawHTML, useEffect } from '@wordpress/element';

/**
 * Internal dependencies
 */
import { PAYMENT_METHOD_NAME } from './constants';

const settings = getPaymentMethodData( 'bacs', {} );
const defaultLabel = __( 'Direct bank transfer', 'woocommerce' );
const label = decodeEntities( settings?.title || '' ) || defaultLabel;

/**
 * Content component
 */
const Content = ( { eventRegistration } ) => {
	useEffect( () => {
		const unsubscribe = eventRegistration.onCheckoutValidation( () => {
			return {
				type: 'failure',
				errorMessage: 'error!',
				validationErrors: {
					shipping_first_name: {
						message: 'Shipping first name should become invalid',
						hidden: false,
					},
				},
			};
		} );
		return unsubscribe;
	}, [] );
	return <RawHTML>{ sanitizeHTML( settings.description || '' ) }</RawHTML>;
};

/**
 * Label component
 *
 * @param {*} props Props from payment API.
 */
const Label = ( props ) => {
	const { PaymentMethodLabel } = props.components;
	return <PaymentMethodLabel text={ label } />;
};

/**
 * Bank transfer (BACS) payment method config object.
 */
const bankTransferPaymentMethod = {
	name: PAYMENT_METHOD_NAME,
	label: <Label />,
	content: <Content />,
	edit: <Content />,
	canMakePayment: () => true,
	ariaLabel: label,
	supports: {
		features: settings?.supports ?? [],
	},
};

registerPaymentMethod( bankTransferPaymentMethod );
```

2. Go to WC -> Settings -> Payment and enable BACS.
3. Add an item to the cart and go to the Checkout block.
4. Open the shipping address.
5. Try to place the order with BACS as your payment method.
6. Ensure you see a validation error on the First Name field.
7. In the code above, replace `type: 'failure'` with `type: 'error'` and replace `onCheckoutValidation` with `onPaymentProcessing`.
8. Repeat steps 4, 5, and 6.

#### Checkout terms block

1. Go to the Checkout block in the editor
2. Click on the `You must accept our Terms and Conditions and PrivacyPolicy to continue with your purchase.` block and in the inspector enable `Require checkbox`.
3. Add an item to your cart and go to the Checkout block.
4. Try to check out without ticking the terms and conditions box.
5. Ensure the text goes red and you can't check out.
6. Check the box and ensure you can check out successfully.

#### Force editing shipping/billing cards

1. Place an order as a logged in customer.
2. As an admin, edit the customer (WP -> Users) and delete their "City" in _billing_ address.
3. Log back in as the user and go to the Checkout block. Ensure the Billing Address is expanded and is not displaying as a card.
4. As an admin, edit the customer (WP -> Users) and delete their "City" in _shipping_ address.
5. Log back in as the user and go to the Checkout block. Ensure the Shipping Address is expanded and is not displaying as a card.

#### Delayed account creation form

1. Go to WC -> Settings -> Accounts & Privacy.
2. Check `Enable guest checkout (recommended)` and `Allow customers to create an account -> After checkout`
3. Uncheck `Send password setup link (recommended)`
4. As a logged-out user, add an item to your cart and go to the Checkout block.
5. Place the order.
6. On the order confirmation screen click into the password box then out of it without entering anything. Ensure you see an error.
7. Enter a strong password and ensure the error goes away and you can create the account.

#### `validateDirtyProps`

1. Add an item to your cart and go to the Checkout block.
2. Open the network tab of dev tools.
3. In the shipping address, fill in a full address and watch a batch request be made to update the address.
4. Edit the Address field to be empty.
5. Ensure no batch request is made.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
