### PR TITLE
Create a common component for upgrade/downgrade notices in blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/upgrade.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/upgrade.tsx
@@ -82,10 +82,12 @@ const UpgradeNotice = ( { clientId }: { clientId: string } ) => {
 
 	return (
 		<UpgradeDowngradeNotice
-			notice={ notice }
+			isDismissible={ false }
 			actionLabel={ buttonLabel }
 			onActionClick={ handleClick }
-		/>
+		>
+			{ notice }
+		</UpgradeDowngradeNotice>
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/upgrade.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/summary/upgrade.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-import { Notice, Button } from '@wordpress/components';
 import {
 	store as blockEditorStore,
 	InspectorControls,
@@ -21,6 +20,7 @@ import {
 import { type EditorBlock } from '@woocommerce/types';
 import { VARIATION_NAME as PQ_PRODUCT_SUMMARY_VARIATION_NAME } from '@woocommerce/blocks/product-query/variations/elements/product-summary';
 import { VARIATION_NAME as PC_PRODUCT_SUMMARY_VARIATION_NAME } from '@woocommerce/blocks/product-collection/variations/elements/product-summary';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 
 const CORE_NAME = 'core/post-excerpt';
 
@@ -81,14 +81,11 @@ const UpgradeNotice = ( { clientId }: { clientId: string } ) => {
 	};
 
 	return (
-		<Notice isDismissible={ false }>
-			<>{ notice }</>
-			<br />
-			<br />
-			<Button variant="link" onClick={ handleClick }>
-				{ buttonLabel }
-			</Button>
-		</Notice>
+		<UpgradeDowngradeNotice
+			notice={ notice }
+			actionLabel={ buttonLabel }
+			onActionClick={ handleClick }
+		/>
 	);
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Notice, Button } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { createBlock } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 import { findBlock } from '@woocommerce/utils';
 
 /**
@@ -70,13 +70,10 @@ export const DowngradeNotice = ( {
 	};
 
 	return (
-		<Notice isDismissible={ false }>
-			<>{ notice }</>
-			<br />
-			<br />
-			<Button variant="link" onClick={ handleClick }>
-				{ buttonLabel }
-			</Button>
-		</Notice>
+		<UpgradeDowngradeNotice
+			notice={ notice }
+			actionLabel={ buttonLabel }
+			onActionClick={ handleClick }
+		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -71,9 +71,11 @@ export const DowngradeNotice = ( {
 
 	return (
 		<UpgradeDowngradeNotice
-			notice={ notice }
+			isDismissible={ false }
 			actionLabel={ buttonLabel }
 			onActionClick={ handleClick }
-		/>
+		>
+			{ notice }
+		</UpgradeDowngradeNotice>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/upgrade-notice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/upgrade-notice.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Notice, Button } from '@wordpress/components';
 import { useLocalStorageState } from '@woocommerce/base-hooks';
 import {
 	createInterpolateElement,
@@ -15,6 +14,7 @@ import {
 	incrementUpgradeStatusDisplayCount,
 } from '@woocommerce/blocks/migration-products-to-product-collection';
 import { recordEvent } from '@woocommerce/tracks';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 
 const notice = createInterpolateElement(
 	__(
@@ -75,14 +75,13 @@ const UpgradeNotice = ( { revertMigration }: UpgradeNoticeProps ) => {
 	}, [ canCountDisplays ] );
 
 	return status === 'notseen' ? (
-		<Notice onRemove={ handleRemove }>
-			<>{ notice } </>
-			<br />
-			<br />
-			<Button variant="link" onClick={ handleRevert }>
-				{ buttonLabel }
-			</Button>
-		</Notice>
+		<UpgradeDowngradeNotice
+			actionLabel={ buttonLabel }
+			onActionClick={ handleRevert }
+			onRemove={ handleRemove }
+		>
+			{ notice }
+		</UpgradeDowngradeNotice>
 	) : null;
 };
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Notice, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { dispatch, select } from '@wordpress/data';
+import { UpgradeDowngradeNotice as Notice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 import { findBlock } from '@woocommerce/utils';
 import {
 	createBlock,
@@ -89,13 +89,10 @@ export const UpgradeNotice = ( {
 	};
 
 	return (
-		<Notice isDismissible={ false }>
-			<>{ notice }</>
-			<br />
-			<br />
-			<Button variant="link" onClick={ handleClick }>
-				{ buttonLabel }
-			</Button>
-		</Notice>
+		<Notice
+			notice={ notice }
+			actionLabel={ buttonLabel }
+			onActionClick={ handleClick }
+		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -90,9 +90,11 @@ export const UpgradeNotice = ( {
 
 	return (
 		<Notice
-			notice={ notice }
+			isDismissible={ false }
 			actionLabel={ buttonLabel }
 			onActionClick={ handleClick }
-		/>
+		>
+			{ notice }
+		</Notice>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/upgrade-notice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-query/inspector-controls/upgrade-notice.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Notice, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
+import { UpgradeDowngradeNotice } from '@woocommerce/editor-components/upgrade-downgrade-notice';
 
 export const UpgradeNotice = ( props: { upgradeBlock: () => void } ) => {
 	const notice = createInterpolateElement(
@@ -32,13 +32,12 @@ export const UpgradeNotice = ( props: { upgradeBlock: () => void } ) => {
 	};
 
 	return (
-		<Notice isDismissible={ false }>
-			<>{ notice }</>
-			<br />
-			<br />
-			<Button variant="link" onClick={ handleClick }>
-				{ buttonLabel }
-			</Button>
-		</Notice>
+		<UpgradeDowngradeNotice
+			isDismissible={ false }
+			actionLabel={ buttonLabel }
+			onActionClick={ handleClick }
+		>
+			{ notice }
+		</UpgradeDowngradeNotice>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/UpgradeDowngradeNotice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/UpgradeDowngradeNotice.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { UpgradeDowngradeNoticeProps } from './types';
+import './style.scss';
+
+export function UpgradeDowngradeNotice( {
+	notice,
+	actionLabel,
+	onActionClick,
+}: UpgradeDowngradeNoticeProps ) {
+	return (
+		<Notice
+			isDismissible={ false }
+			className="wc-block-upgrade-downgrade-notice"
+			actions={ [
+				{
+					label: actionLabel,
+					onClick: onActionClick,
+					noDefaultClasses: true,
+					// @ts-expect-error the 'variant' prop does exists.
+					variant: 'link',
+				},
+			] }
+		>
+			<div className="wc-block-upgrade-downgrade-notice__text">
+				{ notice }
+			</div>
+		</Notice>
+	);
+}

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/UpgradeDowngradeNotice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/UpgradeDowngradeNotice.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Notice } from '@wordpress/components';
+import { clsx } from 'clsx';
 
 /**
  * Internal dependencies
@@ -10,14 +11,16 @@ import type { UpgradeDowngradeNoticeProps } from './types';
 import './style.scss';
 
 export function UpgradeDowngradeNotice( {
-	notice,
+	children,
+	className,
 	actionLabel,
 	onActionClick,
+	...props
 }: UpgradeDowngradeNoticeProps ) {
 	return (
 		<Notice
-			isDismissible={ false }
-			className="wc-block-upgrade-downgrade-notice"
+			{ ...props }
+			className={ clsx( 'wc-block-upgrade-downgrade-notice', className ) }
 			actions={ [
 				{
 					label: actionLabel,
@@ -29,7 +32,7 @@ export function UpgradeDowngradeNotice( {
 			] }
 		>
 			<div className="wc-block-upgrade-downgrade-notice__text">
-				{ notice }
+				{ children }
 			</div>
 		</Notice>
 	);

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/UpgradeDowngradeNotice.tsx
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/UpgradeDowngradeNotice.tsx
@@ -20,7 +20,10 @@ export function UpgradeDowngradeNotice( {
 	return (
 		<Notice
 			{ ...props }
-			className={ clsx( 'wc-block-upgrade-downgrade-notice', className ) }
+			className={ clsx(
+				'wc-block-editor-components-upgrade-downgrade-notice',
+				className
+			) }
 			actions={ [
 				{
 					label: actionLabel,
@@ -31,7 +34,7 @@ export function UpgradeDowngradeNotice( {
 				},
 			] }
 		>
-			<div className="wc-block-upgrade-downgrade-notice__text">
+			<div className="wc-block-editor-components-upgrade-downgrade-notice__text">
 				{ children }
 			</div>
 		</Notice>

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/index.ts
@@ -1,0 +1,2 @@
+export * from './UpgradeDowngradeNotice';
+export type * from './types';

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/style.scss
@@ -1,4 +1,4 @@
-.wc-block-upgrade-downgrade-notice {
+.wc-block-editor-components-upgrade-downgrade-notice {
 	.components-notice__content {
 		display: flex;
 		flex-direction: column;

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/style.scss
@@ -1,0 +1,13 @@
+.wc-block-upgrade-downgrade-notice {
+	.components-notice__content {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-20;
+	}
+
+	.components-notice__actions {
+		.components-notice__action.components-button {
+			margin-left: 0;
+		}
+	}
+}

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/types.ts
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import type { ReactNode } from 'react';
+import { Notice } from '@wordpress/components';
 
-export type UpgradeDowngradeNoticeProps = {
-	notice: ReactNode;
+export type UpgradeDowngradeNoticeProps = Omit< Notice.Props, 'actions' > & {
 	actionLabel: string;
 	onActionClick(): void;
 };

--- a/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/editor-components/upgrade-downgrade-notice/types.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+export type UpgradeDowngradeNoticeProps = {
+	notice: ReactNode;
+	actionLabel: string;
+	onActionClick(): void;
+};

--- a/plugins/woocommerce/changelog/add-54076
+++ b/plugins/woocommerce/changelog/add-54076
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Create a common component for upgrade/downgrade notices in blocks


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54076

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Add to Cart (experimental, don't test while testing the release)
1. Go to `/wp-admin/site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fsingle-product&canvas=edit`
2. Select the Add to Cart block 
<img width="719" alt="image" src="https://github.com/user-attachments/assets/cd09e547-a7ce-479b-9280-a84ff7d256d8" />

3. In the Block Inspector an Upgrade notice should appear.
4. Clicking the `Upgrade to the blockified Add to Cart with Options block` action from the Notice the Add to Cart block should change to the new version as well as the notice. 
<img width="703" alt="image" src="https://github.com/user-attachments/assets/3727b784-f40c-49a5-b348-b4902403eaf4" />

5. Clicking the `Switch back` action should revert the Add to Cart to the point 2.

#### Product Summary
1. Go to `/wp-admin/site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fsingle-product&canvas=edit`
2. Select the Product Summary block 
<img width="706" alt="image" src="https://github.com/user-attachments/assets/47ae7cf5-606d-492b-9662-97b366dbbe09" />

3. In the Block Inspector an Upgrade notice should appear.
4. Clicking the `Upgrade now (just this block)` action from the Notice the Product Summary block should change to the new version and the notice should disappear. 
<img width="710" alt="image" src="https://github.com/user-attachments/assets/2a8cce02-3642-4db6-b10f-7e97e762dff5" />

#### Product Query
1. Go to `/wp-admin/post-new.php`
2. Copy and paste this code into the post `Code editor` to insert the Product (Beta) block:
```html
<!-- wp:query {"queryId":2,"query":{"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","outofstock","onbackorder"],"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{}},"namespace":"woocommerce/product-query"} -->
<div class="wp-block-query"><!-- wp:post-template {"className":"products-block-post-template","layout":{"type":"grid","columnCount":3},"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->

<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->

<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->

<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->
```
3. Select the Products (Beta) block 
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/0a5296e5-7d6d-4e91-a379-f27db95589fd" />

4. In the Block Inspector an Upgrade notice should appear.
5. Click on it.
6. Verify the block was converted to the Product Collection block, and there is a downgrade notice:
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/36249c39-dda2-4bd4-a358-c6594e24ccb4" />

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
