### PR TITLE
Update $slug.php.mustache

### DIFF
--- a/packages/js/create-woo-extension/$slug.php.mustache
+++ b/packages/js/create-woo-extension/$slug.php.mustache
@@ -26,6 +26,8 @@ if ( ! defined( 'MAIN_PLUGIN_FILE' ) ) {
 
 require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
 
+require_once plugin_dir_path( __FILE__ ) . '/includes/Admin/Setup.php';
+
 use {{slugPascalCase}}\Admin\Setup;
 
 // phpcs:disable WordPress.Files.FileName


### PR DESCRIPTION
fix import Setup file

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Was fixed import issues that happens in Linux.
Tested with `Ubuntu 22.04` and `Debian 12`

![image](https://github.com/user-attachments/assets/bb4c4c24-bb3b-46fa-a4ac-39d6ed241320)

