### PR TITLE
Ensure multi-line order notes display correctly

### DIFF
--- a/plugins/woocommerce/changelog/fix-multi-line-order-notes
+++ b/plugins/woocommerce/changelog/fix-multi-line-order-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow order notes to be split onto multiple lines and display correctly in admin and in emails.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -561,7 +561,7 @@ class WC_Meta_Box_Order_Data {
 							}
 
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $order->get_customer_note() ) { // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-								echo '<p class="order_note"><strong>' . esc_html( __( 'Customer provided note:', 'woocommerce' ) ) . '</strong> ' . wp_kses( nl2br( esc_html( $order->get_customer_note() ) ), array() ) . '</p>';
+								echo '<p class="order_note"><strong>' . esc_html( __( 'Customer provided note:', 'woocommerce' ) ) . '</strong> ' . wp_kses( nl2br( esc_html( $order->get_customer_note() ) ), array( 'br' => array() ) ) . '</p>';
 							}
 							?>
 						</div>
@@ -614,7 +614,7 @@ class WC_Meta_Box_Order_Data {
 								?>
 								<p class="form-field form-field-wide">
 									<label for="customer_note"><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?>:</label>
-									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses( $order->get_customer_note(), array() ); ?></textarea>
+									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses( $order->get_customer_note(), array( 'br' => array() ) ); ?></textarea>
 								</p>
 							<?php endif; ?>
 						</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Totals.php
@@ -225,7 +225,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 					'<p class="wc-block-order-confirmation-order-note__label">' .
 						esc_html__( 'Note:', 'woocommerce' ) .
 					'</p>' .
-					'<p>' . wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), [] ) . '</p>' .
+					'<p>' . wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), [ 'br' => [] ] ) . '</p>' .
 				'</div>';
 	}
 }

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -129,7 +129,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				<tr class="order-customer-note">
 					<td class="td text-align-left" colspan="3">
 						<b><?php esc_html_e( 'Customer note', 'woocommerce' ); ?></b><br>
-						<?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array() ); ?>
+						<?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
 					</td>
 				</tr>
 				<?php

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -43,7 +43,7 @@ if ( $item_totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array( 'br' => array() ) ) . "\n";
 }
 
 if ( $sent_to_admin ) {

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -43,7 +43,7 @@ if ( $item_totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array( 'br' => array() ) ) . "\n";
+	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
 }
 
 if ( $sent_to_admin ) {

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -127,7 +127,7 @@ if ( $show_downloads ) {
 			<?php if ( $order->get_customer_note() ) : ?>
 				<tr>
 					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td><?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array() ); ?></td>
+					<td><?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?></td>
 				</tr>
 			<?php endif; ?>
 		</tfoot>

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -103,9 +103,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function test_order_notes_linebreaks() {
 		$data = array(
 			'ship_to_different_address' => false,
-			'order_comments'            => 'A string
-			with linebreaks
-			in it.',
+			'order_comments'            => 'A string' . PHP_EOL . 'with linebreaks' . PHP_EOL . 'in it.',
 			'payment_method'            => WC_Gateway_BACS::ID,
 		);
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -121,7 +121,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 				'show_downloads' => false,
 			)
 		);
-		// The \n are necessary because those characters actually exist in the template.
+		// The preg_replace is necessary because the template outputs a lot of whitespace, we can just make sure the <br /> tags are there as the other whitespace doesn't matter.
 		$this->assertStringContainsString( 'A string<br />with linebreaks<br />in it.', preg_replace('/[\t|\\n]+/', '', $content) );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -122,7 +122,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			)
 		);
 		// The preg_replace is necessary because the template outputs a lot of whitespace, we can just make sure the <br /> tags are there as the other whitespace doesn't matter.
-		$this->assertStringContainsString( 'A string<br />with linebreaks<br />in it.', preg_replace('/[\t|\\n]+/', '', $content) );
+		$this->assertStringContainsString( 'A string<br />with linebreaks<br />in it.', preg_replace( '/[\t|\\n]+/', '', $content ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -120,7 +120,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			)
 		);
 		// The preg_replace is necessary because the template outputs a lot of whitespace, we can just make sure the <br /> tags are there as the other whitespace doesn't matter.
-		$this->assertStringContainsString( 'A string<br />with linebreaks<br />in it.', preg_replace( '/[\t|\\n]+/', '', $content ) );
+		$this->assertStringContainsString( 'A string<br />with linebreaks<br />in it.', preg_replace( '/[\t\n\r]+/', '', $content ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -98,6 +98,34 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox the customer notes can have linebreaks.
+	 */
+	public function test_order_notes_linebreaks() {
+		$data = array(
+			'ship_to_different_address' => false,
+			'order_comments'            => 'A string
+			with linebreaks
+			in it.',
+			'payment_method'            => WC_Gateway_BACS::ID,
+		);
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+		$result = $this->sut->create_order( $data );
+
+		$content = wc_get_template_html(
+			'order/order-details.php',
+			array(
+				'order_id'       => $result,
+				'show_downloads' => false,
+			)
+		);
+		// The \n are necessary because those characters actually exist in the template.
+		$this->assertStringContainsString( 'A string<br />with linebreaks<br />in it.', preg_replace('/[\t|\\n]+/', '', $content) );
+	}
+
+	/**
 	 * @testdox 'validate_posted_data' doesn't add errors for existing billing/shipping countries.
 	 *
 	 * @testWith [true]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the uses of `wp_kses` when filtering the order notes to allow `<br />` tags through. This allows mutli-line order notes to be submitted, whereas previously they would become a single line.

There are no security implications of allowing this linebreak character through. 

Added a new PHP unit test to check this functionality is working correctly.

Closes #54452

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an item to your cart and go to the Checkout block.
2. Fill in your details and at the bottom check the `Add a note to your order` box.
3. Enter some text in this box using the return key to create multiple lines of text.
4. Place the order.
5. Verify the multi-line note is visible on the order confirmation screen.
6. Verify the multi-line note is visible on the order dashboard in WP Admin.
7. Verify the multi-line note is visible on the order confirmation emails sent both to the merchant and the shopper.
8. Repeat the test using the Shortcode checkout.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
