### PR TITLE
Refactor coming soon templates to use dynamic font families

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/entire-site.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/coming-soon/entire-site.scss
@@ -109,10 +109,6 @@ body:has(.woocommerce-coming-soon-banner) {
 .woocommerce-coming-soon-minimal-left-image {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 
-	.wp-block-site-title {
-		font-family: Inter, sans-serif;
-	}
-
 	&__content {
 		.wp-block-columns-is-layout-flex {
 			justify-content: center;
@@ -123,7 +119,6 @@ body:has(.woocommerce-coming-soon-banner) {
 // Modern black template styles
 .woocommerce-coming-soon-modern-black {
 	--wp--preset--color--contrast: #fff;
-	font-family: Inter, sans-serif;
 }
 
 // Split right image template styles

--- a/plugins/woocommerce/changelog/54521-update-coming-soon-template-dynamic-font
+++ b/plugins/woocommerce/changelog/54521-update-coming-soon-template-dynamic-font
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Updated "Coming Soon" templates to dynamically adapt font families based on the active theme, with specific behavior for TwentyTwentyFour and non-block themes

--- a/plugins/woocommerce/patterns/page-coming-soon-default.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-default.php
@@ -8,14 +8,12 @@
  * Feature Flag: coming-soon-newsletter-template
  */
 
-$current_theme     = wp_get_theme()->get_stylesheet();
-$inter_font_family = 'inter';
-$cardo_font_family = 'cardo';
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
-if ( 'twentytwentyfour' === $current_theme ) {
-	$inter_font_family = 'body';
-	$cardo_font_family = 'heading';
-}
+$fonts               = ComingSoonTemplate::get_font_families();
+$heading_font_family = $fonts['heading'];
+$body_font_family    = $fonts['body'];
+
 ?>
 
 <!-- wp:woocommerce/coming-soon {"comingSoonPatternId":"page-coming-soon-default","className":"woocommerce-coming-soon-entire-site","style":{"color":{"background":"#bea0f2"}}} -->
@@ -27,7 +25,7 @@ if ( 'twentytwentyfour' === $current_theme ) {
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-group">
-<!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"20px","letterSpacing":"0px"},"color":{"text":"#000000"},"elements":{"link":{"color":{"text":"#000000"}}}},"fontFamily":"<?php echo esc_html( $inter_font_family ); ?>"} /-->
+<!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"20px","letterSpacing":"0px"},"color":{"text":"#000000"},"elements":{"link":{"color":{"text":"#000000"}}}},"fontFamily":"<?php echo esc_html( $body_font_family ); ?>"} /-->
 </div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
@@ -35,15 +33,15 @@ if ( 'twentytwentyfour' === $current_theme ) {
 <!-- wp:group {"style":{"spacing":{"blockGap":"48px"}},"className":"woocommerce-coming-soon-social-login","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group woocommerce-coming-soon-social-login">
 <!-- wp:template-part {"slug":"coming-soon-social-links","theme":"woocommerce/woocommerce","tagName":"div"} /-->
-<!-- wp:loginout {"style":{"elements":{"link":{"color":{"text":"#ffffff"}}},"color":{"background":"#000000"},"spacing":{"padding":{"top":"12px","bottom":"12px","left":"16px","right":"16px"}},"typography":{"fontSize":"14px","lineHeight":"1.2"},"border":{"radius":"6px"}}} /-->
+<!-- wp:loginout {"style":{"elements":{"link":{"color":{"text":"#ffffff"}}},"color":{"background":"#000000"},"fontFamily":"<?php echo esc_html( $body_font_family ); ?>","spacing":{"padding":{"top":"12px","bottom":"12px","left":"16px","right":"16px"}},"typography":{"fontSize":"14px","lineHeight":"1.2"},"border":{"radius":"6px"}}} /-->
 </div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
-<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"align":"wide","className":"woocommerce-coming-soon-banner","fontFamily":"<?php echo esc_html( $cardo_font_family ); ?>"} -->
-<h1 class="wp-block-heading alignwide has-text-align-center woocommerce-coming-soon-banner has-<?php echo esc_html( $cardo_font_family ); ?>-font-family"><?php echo esc_html__( "Pardon our dust! We're working on something amazing — check back soon!", 'woocommerce' ); ?></h1>
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"align":"wide","className":"woocommerce-coming-soon-banner","fontFamily":"<?php echo esc_html( $heading_font_family ); ?>"} -->
+<h1 class="wp-block-heading alignwide has-text-align-center woocommerce-coming-soon-banner has-<?php echo esc_html( $heading_font_family ); ?>-font-family"><?php echo esc_html__( "Pardon our dust! We're working on something amazing — check back soon!", 'woocommerce' ); ?></h1>
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 

--- a/plugins/woocommerce/patterns/page-coming-soon-image-gallery.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-image-gallery.php
@@ -9,15 +9,11 @@
  */
 
 use Automattic\WooCommerce\Blocks\AIContent\PatternsHelper;
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
-$current_theme     = wp_get_theme()->get_stylesheet();
-$inter_font_family = 'inter';
-$cardo_font_family = 'cardo';
-
-if ( 'twentytwentyfour' === $current_theme ) {
-	$inter_font_family = 'body';
-	$cardo_font_family = 'heading';
-}
+$fonts               = ComingSoonTemplate::get_font_families();
+$heading_font_family = $fonts['heading'];
+$body_font_family    = $fonts['body'];
 
 $featured_image_urls = array(
 	PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern-placeholders/gallery-1.jpg' ),
@@ -42,14 +38,14 @@ $featured_image_urls = array(
 				<div class="wp-block-group"><!-- wp:site-logo {"width":60} /-->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
-					<div class="wp-block-group"><!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"20px","letterSpacing":"0px"},"color":{"text":"#000000"},"elements":{"link":{"color":{"text":"#000000"}}}},"fontFamily":"<?php echo esc_html( $inter_font_family ); ?>"} /--></div>
+					<div class="wp-block-group"><!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"20px","letterSpacing":"0px"},"color":{"text":"#000000"},"elements":{"link":{"color":{"text":"#000000"}}}},"fontFamily":"<?php echo esc_html( $body_font_family ); ?>"} /--></div>
 					<!-- /wp:group --></div>
 				<!-- /wp:group -->
 
 				<!-- wp:group {"className":"woocommerce-coming-soon-social-login","style":{"spacing":{"blockGap":"48px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group woocommerce-coming-soon-social-login"><!-- wp:template-part {"slug":"coming-soon-social-links","theme":"woocommerce/woocommerce","tagName":"div"} /-->
 
-					<!-- wp:loginout {"style":{"elements":{"link":{"color":{"text":"#ffffff"}}},"color":{"background":"#000000"},"spacing":{"padding":{"top":"12px","bottom":"12px","left":"16px","right":"16px"}},"typography":{"fontSize":"14px","lineHeight":"1.2"},"border":{"radius":"6px"}}} /--></div>
+					<!-- wp:loginout {"style":{"elements":{"link":{"color":{"text":"#ffffff"}}},"color":{"background":"#000000"},"fontFamily":"<?php echo esc_html( $body_font_family ); ?>","spacing":{"padding":{"top":"12px","bottom":"12px","left":"16px","right":"16px"}},"typography":{"fontSize":"14px","lineHeight":"1.2"},"border":{"radius":"6px"}}} /--></div>
 				<!-- /wp:group --></div>
 			<!-- /wp:group --></div>
 		<!-- /wp:group -->
@@ -58,8 +54,8 @@ $featured_image_urls = array(
 		<div class="wp-block-group alignwide">
 			<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"100px","bottom":"100px"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 			<div class="wp-block-group alignwide">
-				<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"48px","lineHeight":"1.3","fontStyle":"normal","fontWeight":"400"},"spacing":{"padding":{"top":"100px","bottom":"100px"}}},"fontFamily":"heading"} -->
-					<h1 class="wp-block-heading has-heading-font-family" style="padding-top:100px;padding-bottom:100px;font-size:48px;font-style:normal;font-weight:400;line-height:1.3"><em>Great things are coming soon</em></h1>
+				<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"48px","lineHeight":"1.3","fontStyle":"normal","fontWeight":"400"},"spacing":{"padding":{"top":"100px","bottom":"100px"}}},"fontFamily":"<?php echo esc_html( $heading_font_family ); ?>"} -->
+					<h1 class="wp-block-heading has-<?php echo esc_html( $heading_font_family ); ?>-font-family" style="padding-top:100px;padding-bottom:100px;font-size:48px;font-style:normal;font-weight:400;line-height:1.3"><em><?php echo esc_html__( 'Great things are coming soon', 'woocommerce' ); ?></em></h1>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:group -->

--- a/plugins/woocommerce/patterns/page-coming-soon-minimal-left-image.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-minimal-left-image.php
@@ -9,15 +9,12 @@
  */
 
 use Automattic\WooCommerce\Blocks\AIContent\PatternsHelper;
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
-$current_theme     = wp_get_theme()->get_stylesheet();
-$inter_font_family = 'inter';
-$cardo_font_family = 'cardo';
-
-if ( 'twentytwentyfour' === $current_theme ) {
-	$inter_font_family = 'body';
-	$cardo_font_family = 'heading';
-}
+$fonts                 = ComingSoonTemplate::get_font_families();
+$heading_font_family   = $fonts['heading'];
+$body_font_family      = $fonts['body'];
+$paragraph_font_family = isset( $fonts['paragraph'] ) ? $fonts['paragraph'] : null;
 
 $default_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern-placeholders/green-glass-jars-on-stairs.jpg' );
 
@@ -41,7 +38,7 @@ $store_description = ! empty( $site_tagline )
 				<div class="wp-block-group"><!-- wp:site-logo {"width":60} /-->
 
 					<!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
-					<div class="wp-block-group"><!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"20px","letterSpacing":"0px"},"color":{"text":"#000000"},"elements":{"link":{"color":{"text":"#000000"}}}},"fontFamily":"<?php echo esc_html( $inter_font_family ); ?>"} /--></div>
+					<div class="wp-block-group"><!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"20px","letterSpacing":"0px"},"color":{"text":"#000000"},"elements":{"link":{"color":{"text":"#000000"}}}},"fontFamily":"<?php echo esc_html( $body_font_family ); ?>"} /--></div>
 					<!-- /wp:group --></div>
 				<!-- /wp:group -->
 
@@ -65,14 +62,16 @@ $store_description = ! empty( $site_tagline )
 
 					<!-- wp:column {"verticalAlignment":"stretch","width":"453px","className":"woocommerce-coming-soon-minimal-left-image__content-text","style":{"spacing":{"blockGap":"0","padding":{"right":"0","left":"0","bottom":"0","top":"53px"}}},"layout":{"type":"default"}} -->
 					<div class="wp-block-column is-vertically-aligned-stretch woocommerce-coming-soon-minimal-left-image__content-text" style="padding-top:53px;padding-right:0;padding-bottom:0;padding-left:0;flex-basis:453px"><!-- wp:group {"style":{"dimensions":{"minHeight":"100%"},"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","flexWrap":"nowrap","verticalAlignment":"space-between"}} -->
-						<div class="wp-block-group" style="min-height:100%"><!-- wp:heading {"level":1,"className":"is-style-default","style":{"elements":{"link":{"color":{"text":"#000"}}},"color":{"text":"#000"},"typography":{"fontSize":"38px","lineHeight":"1.19"},"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontFamily":"heading"} -->
-						<h1 class="wp-block-heading is-style-default has-text-color has-link-color has-heading-font-family" style="color:#000;margin-bottom:var(--wp--preset--spacing--30);font-size:38px;line-height:1.19"><?php echo esc_html__( 'Something big is brewing! Our store is in the works – Launching shortly!', 'woocommerce' ); ?></h1>
+						<div class="wp-block-group" style="min-height:100%"><!-- wp:heading {"level":1,"className":"is-style-default","style":{"elements":{"link":{"color":{"text":"#000"}}},"color":{"text":"#000"},"typography":{"fontSize":"38px","lineHeight":"1.19"},"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontFamily":"<?php echo esc_html( $heading_font_family ); ?>"} -->
+						<h1 class="wp-block-heading is-style-default has-text-color has-link-color has-<?php echo esc_html( $heading_font_family ); ?>-font-family" style="color:#000;margin-bottom:var(--wp--preset--spacing--30);font-size:38px;line-height:1.19"><?php echo esc_html__( 'Something big is brewing! Our store is in the works – Launching shortly!', 'woocommerce' ); ?></h1>
 						<!-- /wp:heading -->
 
 <!-- wp:group {"layout":{"type":"constrained","justifyContent":"left","contentSize":"338px"}} -->
-							<div class="wp-block-group"><!-- wp:paragraph {"style":{"color":{"text":"#000"},"elements":{"link":{"color":{"text":"#000"}}},"typography":{"lineHeight":"1.6","letterSpacing":"0px"}}} -->
-								<p class="has-text-color has-link-color" style="color:#000;letter-spacing:0px;line-height:1.6"><?php echo esc_html( $store_description ); ?></p>
-							<!-- /wp:paragraph --></div>
+							<div class="wp-block-group">
+								<!-- wp:paragraph {"style":{"color":{"text":"#000"},"elements":{"link":{"color":{"text":"#000"}}},"typography":{"lineHeight":"1.6","letterSpacing":"0px"}},"fontFamily":"<?php echo esc_html( $paragraph_font_family ?? '' ); ?>"} -->
+								<p class="has-text-color has-link-color has-<?php echo esc_html( $paragraph_font_family ?? '' ); ?>-font-family" style="color:#000;letter-spacing:0px;line-height:1.6"><?php echo esc_html( $store_description ); ?></p>
+								<!-- /wp:paragraph -->
+							</div>
 							<!-- /wp:group --></div>
 						<!-- /wp:group --></div>
 					<!-- /wp:column -->

--- a/plugins/woocommerce/patterns/page-coming-soon-modern-black.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-modern-black.php
@@ -39,8 +39,8 @@ $email         = get_option( 'admin_email', 'marianne.renoir@mail.com' );
 			<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_attr( $heading_font_family ); ?>-font-family" style="margin-top:0;margin-bottom:153px;font-size:100px;font-style:normal;font-weight:400;line-height:1.19"><?php echo esc_html( _x( 'Stay tuned.', 'Coming Soon template heading', 'woocommerce' ) ); ?></h1>
 		<!-- /wp:heading -->
 
-		<!-- wp:paragraph {"align":"center","style":{"color":{"text":"#a7aaad"},"elements":{"link":{"color":{"text":"#a7aaad"}}},"typography":{"fontSize":"14px"}}} -->
-			<p class="has-text-align-center has-text-color has-link-color" style="color:#a7aaad;font-size:14px"><?php echo esc_html( $email ); ?></p>
+		<!-- wp:paragraph {"align":"center","style":{"color":{"text":"#a7aaad"},"elements":{"link":{"color":{"text":"#a7aaad"}}},"typography":{"fontSize":"14px"}},"fontFamily":"<?php echo esc_attr( $body_font_family ); ?>"} -->
+			<p class="has-text-align-center has-text-color has-link-color has-<?php echo esc_attr( $body_font_family ); ?>-font-family" style="color:#a7aaad;font-size:14px"><?php echo esc_html( $email ); ?></p>
 		<!-- /wp:paragraph --></div>
 		<!-- /wp:group --></div>
 	<!-- /wp:group --></div></div>

--- a/plugins/woocommerce/patterns/page-coming-soon-modern-black.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-modern-black.php
@@ -10,14 +10,12 @@
 
 use Automattic\WooCommerce\Blocks\AIContent\PatternsHelper;
 
-$current_theme     = wp_get_theme()->get_stylesheet();
-$inter_font_family = 'inter';
-$cardo_font_family = 'cardo';
+$current_theme = wp_get_theme()->get_stylesheet();
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
-if ( 'twentytwentyfour' === $current_theme ) {
-	$inter_font_family = 'body';
-	$cardo_font_family = 'heading';
-}
+$fonts               = ComingSoonTemplate::get_font_families();
+$heading_font_family = $fonts['heading'];
+$body_font_family    = $fonts['body'];
 
 $default_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern-placeholders/music-black-and-white-white-photography-darkness-black.jpg' );
 $email         = get_option( 'admin_email', 'marianne.renoir@mail.com' );
@@ -29,7 +27,7 @@ $email         = get_option( 'admin_email', 'marianne.renoir@mail.com' );
 		<div class="wp-block-group alignwide" style="min-height:100vh;margin-top:0;margin-bottom:0px;padding-top:0;padding-right:0;padding-bottom:46px;padding-left:0"><!-- wp:group {"align":"wide","style":{"layout":{"selfStretch":"fit","flexSize":null},"dimensions":{"minHeight":""},"spacing":{"padding":{"bottom":"8px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 			<div class="wp-block-group alignwide" style="padding-bottom:8px"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex","orientation":"horizontal"}} -->
 				<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0px"}}} -->
-					<div class="wp-block-group"><!-- wp:site-title {"level":0,"style":{"elements":{"link":{"color":{"text":"#ffffff"}}},"typography":{"fontSize":"18px","fontStyle":"normal","fontWeight":"500","letterSpacing":"-0.36px","textTransform":"capitalize"}},"textColor":"#ffffff","fontFamily":"<?php echo esc_attr( $inter_font_family ); ?>"} /--></div>
+					<div class="wp-block-group"><!-- wp:site-title {"level":0,"style":{"elements":{"link":{"color":{"text":"#ffffff"}}},"typography":{"fontSize":"18px","fontStyle":"normal","fontWeight":"500","letterSpacing":"-0.36px","textTransform":"capitalize"}},"textColor":"#ffffff","fontFamily":"<?php echo esc_attr( $body_font_family ); ?>"} /--></div>
 				<!-- /wp:group --></div>
 			<!-- /wp:group -->
 
@@ -37,8 +35,8 @@ $email         = get_option( 'admin_email', 'marianne.renoir@mail.com' );
 		<!-- /wp:group -->
 
 		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0px","bottom":"0px","right":"0","left":"0"},"margin":{"bottom":"0"},"blockGap":"0px"},"dimensions":{"minHeight":"650px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","verticalAlignment":"bottom"}} -->
-		<div class="wp-block-group alignwide" style="min-height:650px;margin-bottom:0;padding-top:0px;padding-right:0;padding-bottom:0px;padding-left:0"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"bottom":"153px","top":"0"}},"typography":{"fontSize":"100px","lineHeight":"1.19","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"heading"} -->
-			<h1 class="wp-block-heading has-text-align-center has-heading-font-family" style="margin-top:0;margin-bottom:153px;font-size:100px;font-style:normal;font-weight:400;line-height:1.19"><?php echo esc_html( _x( 'Stay tuned.', 'Coming Soon template heading', 'woocommerce' ) ); ?></h1>
+		<div class="wp-block-group alignwide" style="min-height:650px;margin-bottom:0;padding-top:0px;padding-right:0;padding-bottom:0px;padding-left:0"><!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"bottom":"153px","top":"0"}},"typography":{"fontSize":"100px","lineHeight":"1.19","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"<?php echo esc_attr( $heading_font_family ); ?>"} -->
+			<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_attr( $heading_font_family ); ?>-font-family" style="margin-top:0;margin-bottom:153px;font-size:100px;font-style:normal;font-weight:400;line-height:1.19"><?php echo esc_html( _x( 'Stay tuned.', 'Coming Soon template heading', 'woocommerce' ) ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"color":{"text":"#a7aaad"},"elements":{"link":{"color":{"text":"#a7aaad"}}},"typography":{"fontSize":"14px"}}} -->

--- a/plugins/woocommerce/patterns/page-coming-soon-split-right-image.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-split-right-image.php
@@ -9,15 +9,12 @@
  */
 
 use Automattic\WooCommerce\Blocks\AIContent\PatternsHelper;
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
-$current_theme     = wp_get_theme()->get_stylesheet();
-$inter_font_family = 'inter';
-$cardo_font_family = 'cardo';
-
-if ( 'twentytwentyfour' === $current_theme ) {
-	$inter_font_family = 'body';
-	$cardo_font_family = 'heading';
-}
+$fonts                 = ComingSoonTemplate::get_font_families();
+$heading_font_family   = $fonts['heading'];
+$body_font_family      = $fonts['body'];
+$paragraph_font_family = isset( $fonts['paragraph'] ) ? $fonts['paragraph'] : null;
 
 $left_image  = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern-placeholders/wheel-leaf-bicycle-bike-vehicle-spoke.jpg' );
 $right_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern-placeholders/orange-wall-with-bicycle.jpg' );
@@ -27,14 +24,14 @@ $right_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern
 <div class="wp-block-woocommerce-coming-soon woocommerce-coming-soon-split-right-image has-background" style="background-color:#f9f9f9">
 	<!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"},"spacing":{"padding":{"top":"0px","bottom":"0px"},"blockGap":"0px"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group" style="min-height:100vh;padding-top:0px;padding-bottom:0px"><!-- wp:group {"style":{"dimensions":{"minHeight":"117px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
-		<div class="wp-block-group" style="min-height:117px"><!-- wp:site-title {"textAlign":"center","style":{"typography":{"fontSize":"18px","letterSpacing":"2.7px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"<?php echo esc_attr( $inter_font_family ); ?>"} /--></div>
+		<div class="wp-block-group" style="min-height:117px"><!-- wp:site-title {"textAlign":"center","style":{"typography":{"fontSize":"18px","letterSpacing":"2.7px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"<?php echo esc_attr( $body_font_family ); ?>"} /--></div>
 		<!-- /wp:group -->
 
 		<!-- wp:columns {"className":"woocommerce-split-right-image-content","style":{"spacing":{"blockGap":{"top":"0px","left":"0px"},"margin":{"top":"0px","bottom":"0px"}},"layout":{"selfStretch":"fill","flexSize":null}}} -->
 		<div class="wp-block-columns woocommerce-split-right-image-content" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"verticalAlignment":"center","layout":{"type":"default"}} -->
 			<div class="wp-block-column is-vertically-aligned-center"><!-- wp:group {"layout":{"type":"constrained","contentSize":"259px"}} -->
-				<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"14px","letterSpacing":"2.1px","fontStyle":"normal","fontWeight":"700","textTransform":"uppercase"}},"fontFamily":"<?php echo esc_attr( $inter_font_family ); ?>"} -->
-					<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_attr( $inter_font_family ); ?>-font-family" style="font-size:14px;font-style:normal;font-weight:700;letter-spacing:2.1px;text-transform:uppercase"><?php echo esc_html_x( 'opening soon', 'Used in the heading of the coming soon page', 'woocommerce' ); ?></h1>
+				<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"14px","letterSpacing":"2.1px","fontStyle":"normal","fontWeight":"700","textTransform":"uppercase"}},"fontFamily":"<?php echo esc_attr( $body_font_family ); ?>"} -->
+					<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_attr( $body_font_family ); ?>-font-family" style="font-size:14px;font-style:normal;font-weight:700;letter-spacing:2.1px;text-transform:uppercase"><?php echo esc_html_x( 'opening soon', 'Used in the heading of the coming soon page', 'woocommerce' ); ?></h1>
 					<!-- /wp:heading -->
 					<!-- wp:group {"style":{"spacing":{"margin":{"top":"32px","bottom":"32px"}}},"layout":{"type":"constrained"}} -->
 					<div class="wp-block-group" style="margin-top:32px;margin-bottom:32px">
@@ -44,7 +41,7 @@ $right_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern
 					<!-- /wp:group -->
 
 					<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"13px","lineHeight":"1.6","letterSpacing":"-0.13px","fontStyle":"normal","fontWeight":"400"},"color":{"text":"#2f2f2f"},"elements":{"link":{"color":{"text":"#2f2f2f"}}},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
-					<p class="has-text-align-center has-text-color has-link-color" style="color:#2f2f2f;margin-top:0px;margin-bottom:0px;font-size:13px;font-style:normal;font-weight:400;letter-spacing:-0.13px;line-height:1.6"><?php echo esc_html_x( 'Dedicated to providing top-quality bikes, accessories, and expert advice for riders of all experience levels. Stay tuned.', 'Used in the paragraph of the coming soon page', 'woocommerce' ); ?></p>
+					<p class="has-text-align-center has-text-color has-link-color<?php echo $paragraph_font_family ? ' has-' . esc_attr( $paragraph_font_family ) . '-font-family' : ''; ?>" style="color:#2f2f2f;margin-top:0px;margin-bottom:0px;font-size:13px;font-style:normal;font-weight:400;letter-spacing:-0.13px;line-height:1.6"><?php echo esc_html_x( 'Dedicated to providing top-quality bikes, accessories, and expert advice for riders of all experience levels. Stay tuned.', 'Used in the paragraph of the coming soon page', 'woocommerce' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"top":"24px","bottom":"32px"},"blockGap":"0"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"constrained","justifyContent":"center"}} -->
@@ -55,8 +52,8 @@ $right_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern
 
 			<!-- wp:column {"verticalAlignment":"stretch","layout":{"type":"default"}} -->
 			<div class="wp-block-column is-vertically-aligned-stretch"><!-- wp:cover {"url":"<?php echo esc_url( $right_image ); ?>","id":34,"dimRatio":0,"customOverlayColor":"#cd7550","isUserOverlayColor":false,"focalPoint":{"x":0.5,"y":0.8},"minHeight":100,"minHeightUnit":"%","isDark":false,"className":"woocommerce-split-right-image-cover","style":{"spacing":{"padding":{"top":"126px","bottom":"126px","left":"76px","right":"75px"}}},"layout":{"type":"default"}} -->
-				<div class="wp-block-cover is-light woocommerce-split-right-image-cover" style="padding-top:126px;padding-right:75px;padding-bottom:126px;padding-left:76px;min-height:100%"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background-color:#cd7550"></span><img class="wp-block-cover__image-background wp-image-34" alt="" src="<?php echo esc_url( $right_image ); ?>" style="object-position:50% 80%" data-object-fit="cover" data-object-position="50% 80%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","style":{"typography":{"fontSize":"75px","fontStyle":"normal","fontWeight":"400","lineHeight":"1.3"},"color":{"text":"#ffffff80"},"elements":{"link":{"color":{"text":"#ffffff80"}}}},"fontFamily":"<?php echo esc_attr( $cardo_font_family ); ?>"} -->
-					<p class="has-text-align-center has-text-color has-link-color has-<?php echo esc_attr( $cardo_font_family ); ?>-font-family" style="color:#ffffff80;font-size:75px;font-style:normal;font-weight:400;line-height:1.3"><em><?php echo esc_html_x( 'Where cycling dreams take flight.', 'Used in the heading of the coming soon page', 'woocommerce' ); ?></em></p>
+				<div class="wp-block-cover is-light woocommerce-split-right-image-cover" style="padding-top:126px;padding-right:75px;padding-bottom:126px;padding-left:76px;min-height:100%"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background-color:#cd7550"></span><img class="wp-block-cover__image-background wp-image-34" alt="" src="<?php echo esc_url( $right_image ); ?>" style="object-position:50% 80%" data-object-fit="cover" data-object-position="50% 80%"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","style":{"typography":{"fontSize":"75px","fontStyle":"normal","fontWeight":"400","lineHeight":"1.3"},"color":{"text":"#ffffff80"},"elements":{"link":{"color":{"text":"#ffffff80"}}}},"fontFamily":"<?php echo esc_attr( $heading_font_family ); ?>"} -->
+					<p class="has-text-align-center has-text-color has-link-color has-<?php echo esc_attr( $heading_font_family ); ?>-font-family" style="color:#ffffff80;font-size:75px;font-style:normal;font-weight:400;line-height:1.3"><em><?php echo esc_html_x( 'Where cycling dreams take flight.', 'Used in the heading of the coming soon page', 'woocommerce' ); ?></em></p>
 					<!-- /wp:paragraph --></div></div>
 				<!-- /wp:cover --></div>
 			<!-- /wp:column --></div>

--- a/plugins/woocommerce/patterns/page-coming-soon-with-header-footer.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-with-header-footer.php
@@ -8,14 +8,12 @@
  * Feature Flag: coming-soon-newsletter-template
  */
 
-$current_theme     = wp_get_theme()->get_stylesheet();
-$inter_font_family = 'inter';
-$cardo_font_family = 'cardo';
+use Automattic\WooCommerce\Blocks\Templates\ComingSoonTemplate;
 
-if ( 'twentytwentyfour' === $current_theme ) {
-	$inter_font_family = 'body';
-	$cardo_font_family = 'heading';
-}
+$fonts               = ComingSoonTemplate::get_font_families();
+$heading_font_family = $fonts['heading'];
+$body_font_family    = $fonts['body'];
+
 
 ?>
 
@@ -33,16 +31,16 @@ if ( wc_current_theme_is_fse_theme() ) {
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"textAlign":"center","level":1,"fontFamily":"<?php echo esc_html( $cardo_font_family ); ?>"} -->
-<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_html( $cardo_font_family ); ?>-font-family"><?php echo esc_html__( 'Great things are on the horizon', 'woocommerce' ); ?></h1>
+<!-- wp:heading {"textAlign":"center","level":1,"fontFamily":"<?php echo esc_html( $heading_font_family ); ?>"} -->
+<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_html( $heading_font_family ); ?>-font-family"><?php echo esc_html__( 'Great things are on the horizon', 'woocommerce' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"10px"} -->
 <div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:paragraph {"align":"center","fontFamily":"<?php echo esc_html( $inter_font_family ); ?>"} -->
-<p class="has-text-align-center has-<?php echo esc_html( $inter_font_family ); ?>-font-family"><?php echo esc_html__( 'Something big is brewing! Our store is in the works and will be launching soon!', 'woocommerce' ); ?></p>
+<!-- wp:paragraph {"align":"center","fontFamily":"<?php echo esc_html( $body_font_family ); ?>"} -->
+<p class="has-text-align-center has-<?php echo esc_html( $body_font_family ); ?>-font-family"><?php echo esc_html__( 'Something big is brewing! Our store is in the works and will be launching soon!', 'woocommerce' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer -->

--- a/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
@@ -78,21 +78,28 @@ class ComingSoonTemplate extends AbstractPageTemplate {
 			);
 		}
 
-		if ( ! class_exists( '\WP_Font_Face_Resolver' ) ) {
-			require_once ABSPATH . WPINC . '/fonts/class-wp-font-face-resolver.php';
+		if ( ! function_exists( 'wp_get_global_settings' ) ) {
+			require_once ABSPATH . WPINC . '/global-styles-and-settings.php';
 		}
 
-		$theme_fonts = \WP_Font_Face_Resolver::get_fonts_from_theme_json();
-		if ( is_array( $theme_fonts ) && count( $theme_fonts ) > 0 ) {
-			// Override default fonts if available in theme.json.
-			if ( isset( $theme_fonts[0][0]['font-family'] ) && ! empty( $theme_fonts[0][0]['font-family'] ) ) {
-				// Convert the font family to lowercase and replace spaces with hyphens.
-				$default_fonts['heading'] = strtolower( str_replace( ' ', '-', $theme_fonts[0][0]['font-family'] ) );
-			}
-			if ( isset( $theme_fonts[1][0]['font-family'] ) && ! empty( $theme_fonts[1][0]['font-family'] ) ) {
-				$default_fonts['body']      = strtolower( str_replace( ' ', '-', $theme_fonts[1][0]['font-family'] ) );
-				$default_fonts['paragraph'] = $default_fonts['body'];
-			}
+		$settings = wp_get_global_settings();
+		if (
+			! isset( $settings['typography']['fontFamilies']['theme'] )
+			|| ! is_array( $settings['typography']['fontFamilies']['theme'] )
+		) {
+			return $default_fonts;
+		}
+
+		$theme_fonts = $settings['typography']['fontFamilies']['theme'];
+
+		// Override default fonts if available in theme.json.
+		if ( isset( $theme_fonts[0]['slug'] ) && ! empty( $theme_fonts[0]['slug'] ) ) {
+			// Convert the font family to lowercase and replace spaces with hyphens.
+			$default_fonts['heading'] = strtolower( str_replace( ' ', '-', $theme_fonts[0]['slug'] ) );
+		}
+		if ( isset( $theme_fonts[1]['slug'] ) && ! empty( $theme_fonts[1]['slug'] ) ) {
+			$default_fonts['body']      = strtolower( str_replace( ' ', '-', $theme_fonts[1]['slug'] ) );
+			$default_fonts['paragraph'] = $default_fonts['body'];
 		}
 
 		return $default_fonts;

--- a/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
@@ -50,4 +50,51 @@ class ComingSoonTemplate extends AbstractPageTemplate {
 	protected function is_active_template() {
 		return false;
 	}
+
+	/**
+	 * Returns the font family for the body and heading.
+	 *
+	 * When the current theme is not an FSE theme, we use the default fonts.
+	 * When the current theme is an FSE theme, we use the fonts from the theme.json file if available except for the 'twentytwentyfour' theme.
+	 *
+	 * @return array
+	 */
+	public static function get_font_families() {
+		$default_fonts = array(
+			'heading' => 'cardo',
+			'body'    => 'inter',
+		);
+
+		if ( ! wc_current_theme_is_fse_theme() ) {
+			return $default_fonts;
+		}
+
+		$current_theme = wp_get_theme()->get_stylesheet();
+
+		if ( 'twentytwentyfour' === $current_theme ) {
+			return array(
+				'heading' => 'heading',
+				'body'    => 'body',
+			);
+		}
+
+		if ( ! class_exists( '\WP_Font_Face_Resolver' ) ) {
+			require_once ABSPATH . WPINC . '/fonts/class-wp-font-face-resolver.php';
+		}
+
+		$theme_fonts = \WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		if ( is_array( $theme_fonts ) && count( $theme_fonts ) > 0 ) {
+			// Override default fonts if available in theme.json.
+			if ( isset( $theme_fonts[0][0]['font-family'] ) && ! empty( $theme_fonts[0][0]['font-family'] ) ) {
+				// Convert the font family to lowercase and replace spaces with hyphens.
+				$default_fonts['heading'] = strtolower( str_replace( ' ', '-', $theme_fonts[0][0]['font-family'] ) );
+			}
+			if ( isset( $theme_fonts[1][0]['font-family'] ) && ! empty( $theme_fonts[1][0]['font-family'] ) ) {
+				$default_fonts['body']      = strtolower( str_replace( ' ', '-', $theme_fonts[1][0]['font-family'] ) );
+				$default_fonts['paragraph'] = $default_fonts['body'];
+			}
+		}
+
+		return $default_fonts;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
@@ -79,7 +79,7 @@ class ComingSoonTemplate extends AbstractPageTemplate {
 		}
 
 		if ( ! function_exists( 'wp_get_global_settings' ) ) {
-			require_once ABSPATH . WPINC . '/global-styles-and-settings.php';
+			return $default_fonts;
 		}
 
 		$settings = wp_get_global_settings();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54049

This PR updates the "Coming Soon" templates to dynamically apply the font family based on the active theme. It ensures that the fonts for headings and paragraphs adapt to the current block theme’s typography while maintaining specific behavior for non-block themes and the TwentyTwentyFour theme.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with `coming-soon-newsletter-template` feature flag enabled.
2. Enable coming soon mode in site visibility settings.
3. Test different themes:

-   TwentyTwentyFour Theme:
    -   Activate the TwentyTwentyFour theme.
    -   Go to `Appearance > Editor > Templates > Coming soon`
    -   Select any template from the sidebar panel  (Template > Design)
    -   Verify that headings and paragraphs in "Coming Soon" templates use Cardo or Inter or SF_Pro (--apple-system) fonts.

![Screenshot 2025-01-15 at 16 57 20](https://github.com/user-attachments/assets/090147ae-fa2b-463a-bfa9-f0def6880737)


-   Block Themes:
    -   Activate a block theme (other than TwentyTwentyFour)
    -   Navigate to the "Coming Soon" template editor.
    -   Verify that headings and paragraphs use the theme's defined fonts.


When using Next Bakery Theme:

![Screenshot 2025-01-15 at 16 56 32](https://github.com/user-attachments/assets/d3afc7d5-ecc1-4edb-bf63-743676f70495) 


-   Non-Block Themes:
    -   Go to `Appearance > Editor > Templates` and reset the coming soon template.
    -   Activate a non-block theme.
    -   Go to the site's front page in an incognito window and verify that headings and paragraphs use Cardo or Inter fonts, consistent with the TwentyTwentyFour theme styling.

`Template part has been deleted or is unavailable: coming-soon-social-links` is a bug that we should fix in another PR.

![Screenshot 2025-01-15 at 17 01 17](https://github.com/user-attachments/assets/09e71c76-1a9b-482b-8e02-73e33ab53c94)



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Updated "Coming Soon" templates to dynamically adapt font families based on the active theme, with specific behavior for TwentyTwentyFour and non-block themes

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
