### PR TITLE
Add a snackbar as a default error notice

### DIFF
--- a/plugins/woocommerce/changelog/54523-add-notice-manage-gateway
+++ b/plugins/woocommerce/changelog/54523-add-notice-manage-gateway
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a default error snack bar when enabling payment gateways.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -129,6 +129,23 @@ export const EnableGatewayButton = ( {
 							window.location.href = onboardingHref;
 							return;
 						}
+					} else {
+						createErrorNotice(
+							__(
+								'The provider could not be enabled. Check the Manage page for details.',
+								'woocommerce'
+							),
+							{
+								type: 'snackbar',
+								explicitDismiss: true,
+								actions: [
+									{
+										label: __( 'Manage', 'woocommerce' ),
+										url: settingsHref,
+									},
+								],
+							}
+						);
 					}
 				}
 				// If no redirect occured, the data needs to be refreshed.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54292

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Pre-requisites for local testing:**

- Have woocommerce installed locally and synced within WooPayments. See Pe4Hk0-3f-p2 for details.
- Enable the feature flag to see reactified settings page. pe4Hk0-1ly-p2.
- Check out this branch.
- Run pnpm i && pnpm run build

**Testing steps:**

1. Get the PR
2. Install Paymob or Payfast from the plugins directory
3. Go to WooCommerce > Settings > Payments
4. Try to Enable Paymob/Payfast
5. You should see a notice with an error

<img width="615" alt="Screenshot 2025-01-15 at 10 18 55" src="https://github.com/user-attachments/assets/8afacb33-92e2-4a24-82f1-5b3fbe316059" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a default error snack bar when enabling payment gateways.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
