### PR TITLE
Fix `InboxNoteActionButton` component regression

### DIFF
--- a/packages/js/experimental/changelog/54526-54488-admin-note-action-button-of-type-link-no-longer-works
+++ b/packages/js/experimental/changelog/54526-54488-admin-note-action-button-of-type-link-no-longer-works
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Fix `InboxNoteActionButton` component regression.
+

--- a/packages/js/experimental/src/inbox-note/action.tsx
+++ b/packages/js/experimental/src/inbox-note/action.tsx
@@ -61,7 +61,8 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 			className="woocommerce-inbox-note__action-button"
 			variant={ variant }
 			isBusy={ inAction }
-			{ ...( href ? { href } : {} ) }
+			disabled={ inAction }
+			href={ href || undefined }
 			onClick={ handleActionClick }
 		>
 			<span>{ label }</span>

--- a/packages/js/experimental/src/inbox-note/action.tsx
+++ b/packages/js/experimental/src/inbox-note/action.tsx
@@ -76,6 +76,7 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 			variant={ variant }
 			isBusy={ inAction }
 			disabled={ inAction }
+			href={ href ?? '#' }
 			onClick={ handleActionClick }
 		>
 			<span>{ label }</span>

--- a/packages/js/experimental/src/inbox-note/action.tsx
+++ b/packages/js/experimental/src/inbox-note/action.tsx
@@ -56,27 +56,12 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 		onClick();
 	};
 
-	if ( variant === 'link' ) {
-		return (
-			<Button
-				className="woocommerce-inbox-note__action-button"
-				variant={ 'link' }
-				isBusy={ inAction }
-				href={ href ?? '#' }
-				onClick={ handleActionClick }
-			>
-				<span>{ label }</span>
-			</Button>
-		);
-	}
-
 	return (
 		<Button
 			className="woocommerce-inbox-note__action-button"
 			variant={ variant }
 			isBusy={ inAction }
-			disabled={ inAction }
-			href={ href ?? '#' }
+			{ ...( href ? { href } : {} ) }
 			onClick={ handleActionClick }
 		>
 			<span>{ label }</span>

--- a/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
@@ -62,10 +62,20 @@ describe( 'InboxNoteCard', () => {
 	};
 
 	it( 'should render the defined action buttons', () => {
-		const { queryByText } = render(
+		const { queryByText, queryByRole } = render(
 			<InboxNoteCard key={ note.id } note={ note } />
 		);
+		expect(
+			queryByRole( 'link', {
+				name: 'Connect',
+			} )
+		).toHaveAttribute( 'href', 'http://test.com' );
 		expect( queryByText( 'Connect' ) ).toBeInTheDocument();
+		expect(
+			queryByRole( 'link', {
+				name: 'Learn More',
+			} )
+		).toHaveAttribute( 'href', 'http://test.com' );
 		expect( queryByText( 'Learn More' ) ).toBeInTheDocument();
 	} );
 

--- a/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
@@ -65,18 +65,79 @@ describe( 'InboxNoteCard', () => {
 		const { queryByText, queryByRole } = render(
 			<InboxNoteCard key={ note.id } note={ note } />
 		);
+
+		expect( queryByText( 'Connect' ) ).toBeInTheDocument();
+		expect( queryByText( 'Learn More' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render anchor when href is defined', () => {
+		const { queryByRole } = render(
+			<InboxNoteCard key={ note.id } note={ note } />
+		);
 		expect(
 			queryByRole( 'link', {
 				name: 'Connect',
 			} )
 		).toHaveAttribute( 'href', 'http://test.com' );
-		expect( queryByText( 'Connect' ) ).toBeInTheDocument();
+
 		expect(
 			queryByRole( 'link', {
 				name: 'Learn More',
 			} )
 		).toHaveAttribute( 'href', 'http://test.com' );
-		expect( queryByText( 'Learn More' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render button when href is not defined', () => {
+		const noteWithoutHref = {
+			...note,
+			actions: [
+				{
+					id: 1,
+					name: 'connect',
+					label: 'Connect',
+					query: '',
+					status: 'unactioned',
+					primary: false,
+					url: '',
+				},
+				{
+					id: 2,
+					name: 'learnmore',
+					label: 'Learn More',
+					query: '',
+					status: 'unactioned',
+					primary: false,
+					url: '',
+				},
+			],
+		};
+
+		const { queryByRole } = render(
+			<InboxNoteCard key={ note.id } note={ noteWithoutHref } />
+		);
+		expect(
+			queryByRole( 'link', {
+				name: 'Connect',
+			} )
+		).not.toBeInTheDocument();
+
+		expect(
+			queryByRole( 'link', {
+				name: 'Learn More',
+			} )
+		).not.toBeInTheDocument();
+
+		expect(
+			queryByRole( 'button', {
+				name: 'Connect',
+			} )
+		).toBeInTheDocument();
+
+		expect(
+			queryByRole( 'button', {
+				name: 'Learn More',
+			} )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should render a dismiss button', () => {

--- a/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
@@ -62,7 +62,7 @@ describe( 'InboxNoteCard', () => {
 	};
 
 	it( 'should render the defined action buttons', () => {
-		const { queryByText, queryByRole } = render(
+		const { queryByText } = render(
 			<InboxNoteCard key={ note.id } note={ note } />
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a small regression introduced with https://github.com/woocommerce/woocommerce/pull/54160.

Reading the docs, I discovered that `button` or `anchor` element is based on the present of the href prop:

https://github.com/WordPress/gutenberg/blob/24c4575e6af827638f7ef83cbf5190d1ad4a9280/packages/components/src/button/README.md#L71-L76

Based on this, I updated the code and add tests to avoid similar regression in the future.

Closes #54488.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit `wp-admin/admin.php?page=wc-admin`
2. Via Chrome Dev Tools inspect header and buttons for each element in the list:

![image](https://github.com/user-attachments/assets/aae5e5b9-db82-4966-8cac-8b0aee616617)

3. Ensure that when `href` is present, a `<a>` element is rendered. Otherwise, a `<button>` should be rendered
![image](https://github.com/user-attachments/assets/a63babc7-5cd5-40d6-bba0-8abf88f311c9)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fix `InboxNoteActionButton` component regression.

</details>
