### PR TITLE
Fix incorrect button state in Payments Settings NOX when enabling offline payment method / payment gateway after reordering

### DIFF
--- a/plugins/woocommerce/changelog/fix-54367-refresh-payment-settings-providers-after-sorting
+++ b/plugins/woocommerce/changelog/fix-54367-refresh-payment-settings-providers-after-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect button state in Payments Settings NOX when enabling offline payment method / payment gateway after reordering

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -157,6 +157,13 @@ export const SettingsPaymentsMain = () => {
 		} );
 	}, [] );
 
+	/**
+	 * Clear sortedProviders when data store updates.
+	 */
+	useEffect( () => {
+		setSortedProviders( null );
+	}, [ providers ] );
+
 	function handleOrderingUpdate( sorted: PaymentProvider[] ) {
 		// Extract the existing _order values in the sorted order
 		const updatedOrderValues = sorted

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-offline.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-offline.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	type OfflinePaymentMethodProvider,
 	PAYMENT_SETTINGS_STORE_NAME,
@@ -40,6 +40,13 @@ export const SettingsPaymentsOffline = () => {
 	// State to hold the sorted gateways in case of changing the order, otherwise it will be null
 	const [ sortedOfflinePaymentGateways, setSortedOfflinePaymentGateways ] =
 		useState< OfflinePaymentMethodProvider[] | null >( null );
+
+	/**
+	 * Clear sortedOfflinePaymentGateways when data store updates.
+	 */
+	useEffect( () => {
+		setSortedOfflinePaymentGateways( null );
+	}, [ offlinePaymentGateways ] );
 
 	/**
 	 * Handles updating the order of offline payment gateways.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses the issue with the Enable button for Offline Payment Methods in NOX. When enabling an offline payment method, the button label fails to update and reflect the change correctly. This issue specifically occurs when the payment method has been reordered before being enabled. The button remains in its original state, even though the action has been performed. The same issue is happening for non-offline payment providers page.

The issue lies in how the `offlinePaymentGateways` prop is [handled](https://github.com/woocommerce/woocommerce/blob/ae9fae0e0ffd217525e9e4461ef635b3374c24aa/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-offline.tsx#L78-L78) after sorting. When we set the sorted gateways to `sortedOfflinePaymentGateways` state, it bypasses the `offlinePaymentGateways` from the store. As a result, when the `invalidateResolutionForStoreSelector` call refreshes the data, it doesn't update the `sortedOfflinePaymentGateways` state, causing stale data.

Closes #54367.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja site with WooCommerce on this PR's live branch and WooCommerce Beta Tester (here is [a direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=fix/54367-refresh-payment-settings-providers-after-sorting))
1. Go to the newly created site WP admin dashboard.
1. Go to Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature. 
1. Go through the WooCommerce profiler (click on the "WooCommerce" menu item if it doesn't start automatically), click on "Skip guided setup", and choose **United States** as your store's location.
1. Click on the "Payments" main menu item and you should see the new Payments settings page.
1. Click Take offline payments menu item and you'll be navigated to the offline payments methods page
1.  Re-order a Payment Method with the drag handle on the left.
1. Enable the Payment Method.
![image](https://github.com/user-attachments/assets/28b1aa07-ddcc-40f1-929c-c1efc2f0b09c)
1. Verify the button changed its state to Manage.
1. Repeat the same for the payments providers page. For PayPal the button should change to Complete setup.
![image](https://github.com/user-attachments/assets/9ef6a354-0fff-4572-bf35-b0355d2d088f)
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
