### PR TITLE
Add real local pickup preview data to Checkout Block Editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
@@ -23,6 +23,22 @@ jest.mock( '@woocommerce/settings', () => {
 			if ( setting === 'collectableMethodIds' ) {
 				return [ 'pickup_location' ];
 			}
+			if ( setting === 'localPickupLocations' ) {
+				return {
+					'1': {
+						enabled: true,
+						name: 'Local pickup #1',
+						formatted_address: '123 Easy Street',
+						details: 'Details for Local pickup #1',
+					},
+					'2': {
+						enabled: true,
+						name: 'Local pickup #2',
+						formatted_address: '456 Main St',
+						details: 'Details for Local pickup #2',
+					},
+				};
+			}
 			return originalModule.getSetting( setting, ...rest );
 		},
 	};

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
@@ -8,6 +8,7 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useSelect } from '@wordpress/data';
 import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -52,7 +53,9 @@ export const Edit = ( {
 				className
 			) }
 		>
-			<Block />
+			<Disabled>
+				<Block />
+			</Disabled>
 			<AdditionalFields block={ innerBlockAreas.PICKUP_LOCATION } />
 		</FormStepBlock>
 	);

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -29,8 +29,8 @@ const localPickupRates = localPickupLocations
 				delivery_time: '',
 				price: '0',
 				taxes: '0',
-				rate_id: `pickup_location:${ index }`,
-				instance_id: index,
+				rate_id: `pickup_location:${ index + 1 }`,
+				instance_id: index + 1,
 				meta_data: [
 					{
 						key: 'pickup_location',

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -20,34 +20,36 @@ const localPickupLocations = getSetting<
 	}[]
 >( 'localPickupLocations', {} );
 
-const localPickupRates = Object.values( localPickupLocations ).map(
-	( location, index: number ) => ( {
-		...API_SITE_CURRENCY,
-		name: __( 'Local pickup #1', 'woocommerce' ),
-		description: '',
-		delivery_time: '',
-		price: '0',
-		taxes: '0',
-		rate_id: `pickup_location:${ index }`,
-		instance_id: index,
-		meta_data: [
-			{
-				key: 'pickup_location',
-				value: location.name,
-			},
-			{
-				key: 'pickup_address',
-				value: location.formatted_address,
-			},
-			{
-				key: 'pickup_details',
-				value: location.details,
-			},
-		],
-		method_id: 'pickup_location',
-		selected: false,
-	} )
-);
+const localPickupRates = localPickupLocations
+	? Object.values( localPickupLocations ).map(
+			( location, index: number ) => ( {
+				...API_SITE_CURRENCY,
+				name: __( 'Local pickup #1', 'woocommerce' ),
+				description: '',
+				delivery_time: '',
+				price: '0',
+				taxes: '0',
+				rate_id: `pickup_location:${ index }`,
+				instance_id: index,
+				meta_data: [
+					{
+						key: 'pickup_location',
+						value: location.name,
+					},
+					{
+						key: 'pickup_address',
+						value: location.formatted_address,
+					},
+					{
+						key: 'pickup_details',
+						value: location.details,
+					},
+				],
+				method_id: 'pickup_location',
+				selected: false,
+			} )
+	  )
+	: [];
 
 export const previewShippingRates: CartResponseShippingRate[] = [
 	{

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -20,6 +20,8 @@ const localPickupLocations = getSetting<
 	}[]
 >( 'localPickupLocations', {} );
 
+const localPickupCost = getSetting< string >( 'localPickupCost', '' );
+
 const localPickupRates = localPickupLocations
 	? Object.values( localPickupLocations ).map(
 			( location, index: number ) => ( {
@@ -27,7 +29,7 @@ const localPickupRates = localPickupLocations
 				name: __( 'Local pickup #1', 'woocommerce' ),
 				description: '',
 				delivery_time: '',
-				price: '0',
+				price: displayForMinorUnit( localPickupCost, 0 ) || '0',
 				taxes: '0',
 				rate_id: `pickup_location:${ index + 1 }`,
 				instance_id: index + 1,

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -3,11 +3,46 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import type { CartResponseShippingRate } from '@woocommerce/types';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import { API_SITE_CURRENCY, displayForMinorUnit } from './utils';
+
+// Get local pickup locations from the settings and format into some preview shipping rates for the response.
+const localPickupLocations = getSetting<
+	{
+		enabled: boolean;
+		name: string;
+		formatted_address: string;
+	}[]
+>( 'localPickupLocations', {} );
+
+const localPickupRates = Object.values( localPickupLocations ).map(
+	( location, index: number ) => ( {
+		...API_SITE_CURRENCY,
+		name: __( 'Local pickup #1', 'woocommerce' ),
+		description: '',
+		delivery_time: '',
+		price: '0',
+		taxes: '0',
+		rate_id: `pickup_location:${ index }`,
+		instance_id: index,
+		meta_data: [
+			{
+				key: 'pickup_location',
+				value: location.name,
+			},
+			{
+				key: 'pickup_address',
+				value: location.formatted_address,
+			},
+		],
+		method_id: 'pickup_location',
+		selected: false,
+	} )
+);
 
 export const previewShippingRates: CartResponseShippingRate[] = [
 	{
@@ -68,50 +103,7 @@ export const previewShippingRates: CartResponseShippingRate[] = [
 				method_id: 'flat_rate',
 				selected: true,
 			},
-			{
-				...API_SITE_CURRENCY,
-				name: __( 'Local pickup #1', 'woocommerce' ),
-				description: '',
-				delivery_time: '',
-				price: '0',
-				taxes: '0',
-				rate_id: 'pickup_location:1',
-				instance_id: 1,
-				meta_data: [
-					{
-						key: 'pickup_location',
-						value: 'New York',
-					},
-					{
-						key: 'pickup_address',
-						value: '123 Easy Street, New York, 12345',
-					},
-				],
-				method_id: 'pickup_location',
-				selected: false,
-			},
-			{
-				...API_SITE_CURRENCY,
-				name: __( 'Local pickup #2', 'woocommerce' ),
-				description: '',
-				delivery_time: '',
-				price: '0',
-				taxes: '0',
-				rate_id: 'pickup_location:2',
-				instance_id: 1,
-				meta_data: [
-					{
-						key: 'pickup_location',
-						value: 'Los Angeles',
-					},
-					{
-						key: 'pickup_address',
-						value: '123 Easy Street, Los Angeles, California, 90210',
-					},
-				],
-				method_id: 'pickup_location',
-				selected: false,
-			},
+			...localPickupRates,
 		],
 	},
 ];

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -11,16 +11,18 @@ import { getSetting } from '@woocommerce/settings';
 import { API_SITE_CURRENCY, displayForMinorUnit } from './utils';
 
 // Get local pickup locations from the settings and format into some preview shipping rates for the response.
-const localPickupLocations = getSetting<
-	{
-		enabled: boolean;
-		name: string;
-		formatted_address: string;
-		details: string;
-	}[]
->( 'localPickupLocations', {} );
-
+const localPickupEnabled = getSetting< boolean >( 'localPickupEnabled', false );
 const localPickupCost = getSetting< string >( 'localPickupCost', '' );
+const localPickupLocations = localPickupEnabled
+	? getSetting<
+			{
+				enabled: boolean;
+				name: string;
+				formatted_address: string;
+				details: string;
+			}[]
+	  >( 'localPickupLocations', [] )
+	: [];
 
 const localPickupRates = localPickupLocations
 	? Object.values( localPickupLocations ).map(

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -16,6 +16,7 @@ const localPickupLocations = getSetting<
 		enabled: boolean;
 		name: string;
 		formatted_address: string;
+		details: string;
 	}[]
 >( 'localPickupLocations', {} );
 
@@ -37,6 +38,10 @@ const localPickupRates = Object.values( localPickupLocations ).map(
 			{
 				key: 'pickup_address',
 				value: location.formatted_address,
+			},
+			{
+				key: 'pickup_details',
+				value: location.details,
 			},
 		],
 		method_id: 'pickup_location',

--- a/plugins/woocommerce-blocks/assets/js/previews/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/utils.ts
@@ -19,16 +19,18 @@ export const API_SITE_CURRENCY = {
 /**
  * Preview data is defined with 2dp. This converts to selected currency settings.
  */
-export const displayForMinorUnit = ( value: string ): string => {
+export const displayForMinorUnit = ( value: string, precision = 2 ): string => {
 	const minorUnit = SITE_CURRENCY.minorUnit;
 
 	// Preview data is defined with 2 dp.
-	if ( minorUnit === 2 ) {
+	if ( minorUnit === precision || ! value ) {
 		return value;
 	}
 
 	const multiplier = Math.pow( 10, minorUnit );
-	const intValue = Math.round( parseInt( value, 10 ) / Math.pow( 10, 2 ) );
+	const intValue = Math.round(
+		parseInt( value, 10 ) / Math.pow( 10, precision )
+	);
 
 	return ( intValue * multiplier ).toString();
 };

--- a/plugins/woocommerce/changelog/add-local-pickup-preview-data-42098
+++ b/plugins/woocommerce/changelog/add-local-pickup-preview-data-42098
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Added real data previews for Local Pickup rates in the checkout block editor

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -112,6 +112,18 @@ abstract class AbstractBlock {
 	}
 
 	/**
+	 * Are we currently on the admin block editor screen?
+	 */
+	protected function is_block_editor() {
+		if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+		$screen = get_current_screen();
+
+		return $screen && $screen->is_block_editor();
+	}
+
+	/**
 	 * Initialize this block type.
 	 *
 	 * - Hook into WP lifecycle.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -252,6 +252,27 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'localPickupEnabled', $pickup_location_settings['enabled'] );
 		$this->asset_data_registry->add( 'collectableMethodIds', $local_pickup_method_ids );
 
+		$is_block_editor = $this->is_block_editor();
+
+		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'localPickupLocations' ) ) {
+			// Locations are passed to the client in admin to show a realistic preview in the editor.
+			$this->asset_data_registry->add(
+				'localPickupLocations',
+				array_filter(
+					array_map(
+						function ( $location ) {
+							if ( ! $location['enabled'] ) {
+								return null;
+							}
+							$location['formatted_address'] = wc()->countries->get_formatted_address( $location['address'], ', ' );
+							return $location;
+						},
+						get_option( 'pickup_location_pickup_locations', array() )
+					)
+				)
+			);
+		}
+
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -435,6 +435,7 @@ class Checkout extends AbstractBlock {
 
 		$this->asset_data_registry->add( 'localPickupEnabled', $pickup_location_settings['enabled'] );
 		$this->asset_data_registry->add( 'localPickupText', $pickup_location_settings['title'] );
+		$this->asset_data_registry->add( 'localPickupCost', $pickup_location_settings['cost'] );
 		$this->asset_data_registry->add( 'collectableMethodIds', $local_pickup_method_ids );
 
 		// Local pickup is included with legacy shipping methods since they do not support shipping zones.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -452,6 +452,19 @@ class Checkout extends AbstractBlock {
 
 		$is_block_editor = $this->is_block_editor();
 
+		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'localPickupLocations' ) ) {
+			$this->asset_data_registry->add(
+				'localPickupLocations',
+				array_map(
+					function ( $location ) {
+						$location['formatted_address'] = wc()->countries->get_formatted_address( $location['address'], ', ' );
+						return $location;
+					},
+					get_option( 'pickup_location_pickup_locations', array() )
+				)
+			);
+		}
+
 		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'globalShippingMethods' ) ) {
 			$shipping_methods           = WC()->shipping()->get_shipping_methods();
 			$formatted_shipping_methods = array_reduce(
@@ -548,18 +561,6 @@ class Checkout extends AbstractBlock {
 				return 'yes' === $payment_gateway->enabled;
 			}
 		);
-	}
-
-	/**
-	 * Are we currently on the admin block editor screen?
-	 */
-	protected function is_block_editor() {
-		if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-		$screen = get_current_screen();
-
-		return $screen && $screen->is_block_editor();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/LocalPickupUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/LocalPickupUtils.php
@@ -16,8 +16,10 @@ class LocalPickupUtils {
 		$pickup_location_settings = get_option(
 			'woocommerce_pickup_location_settings',
 			[
-				'enabled' => 'no',
-				'title'   => __( 'Pickup', 'woocommerce' ),
+				'enabled'    => 'no',
+				'title'      => __( 'Pickup', 'woocommerce' ),
+				'cost'       => '',
+				'tax_status' => 'taxable',
 			]
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the local pickup section in the editor to show real store data instead of sample data. This also means that if local pickup is not configured (no locations) the preview is helpful.

Closes #42098

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open up 2 tabs for easy testing. WC > Settings > Shipping > Local Pickup, and the editor for the Checkout Block
2. Disable Local Pickup. Confirm there is no local pickup in the editor preview.
3. Enable Local Pickup without any pickup locations. Confirm there is no local pickup in the editor preview.
4. Create some pickup locations. Confirm they are shown in the editor preview.
5. Toggle the "enabled" checkbox for all locations. Confirm there is no local pickup in the editor preview.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
