### PR TITLE
[Experimental] Product filters unlock blocks and disabled checkbox list

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/edit.tsx
@@ -26,24 +26,13 @@ const Edit = ( props: EditProps ) => {
 		{
 			allowedBlocks: getAllowedBlocks( EXCLUDED_BLOCKS ),
 			template: [
-				[
-					'woocommerce/product-filter-removable-chips',
-					{
-						lock: {
-							remove: true,
-						},
-					},
-				],
+				[ 'woocommerce/product-filter-removable-chips' ],
 				...( clearButton
 					? [
 							[
 								'woocommerce/product-filter-clear-button',
 								{
 									clearType: 'all',
-									lock: {
-										remove: true,
-										move: false,
-									},
 								},
 							],
 					  ]

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/inspector.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/inspector.tsx
@@ -32,10 +32,7 @@ export const Inspector = ( {
 
 		if ( clearButtonBlock && ! clearButton ) {
 			dispatch( 'core/block-editor' ).updateBlockAttributes(
-				clearButtonBlock.clientId,
-				{
-					lock: {},
-				}
+				clearButtonBlock.clientId
 			);
 
 			dispatch( 'core/block-editor' ).removeBlock(
@@ -48,7 +45,6 @@ export const Inspector = ( {
 		} else if ( ! clearButtonBlock && clearButton ) {
 			dispatch( 'core/block-editor' ).insertBlock(
 				createBlock( 'woocommerce/product-filter-clear-button', {
-					lock: { move: false, remove: true },
 					clearType: 'all',
 				} ),
 				1,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -164,26 +164,11 @@ const Edit = ( props: EditProps ) => {
 							},
 						],
 						clearButton
-							? [
-									'woocommerce/product-filter-clear-button',
-									{
-										lock: {
-											remove: true,
-											move: false,
-										},
-									},
-							  ]
+							? [ 'woocommerce/product-filter-clear-button' ]
 							: null,
 					].filter( Boolean ) as unknown as TemplateArray,
 				],
-				[
-					displayStyle,
-					{
-						lock: {
-							remove: true,
-						},
-					},
-				],
+				[ displayStyle ],
 			],
 		}
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -3,7 +3,7 @@
  */
 import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/components';
+import { Icon, Disabled } from '@wordpress/components';
 import { checkMark } from '@woocommerce/icons';
 import { useMemo } from '@wordpress/element';
 import {
@@ -81,45 +81,50 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 	return (
 		<>
 			<div { ...blockProps }>
-				<ul className="wc-block-product-filter-checkbox-list__list">
-					{ isLoading && loadingState }
-					{ ! isLoading &&
-						( isLongList
-							? items.slice( 0, threshold )
-							: items
-						).map( ( item, index ) => (
-							<li
-								key={ index }
-								className="wc-block-product-filter-checkbox-list__item"
-							>
-								<label
-									htmlFor={ `interactive-checkbox-${ index }` }
-									className=" wc-block-product-filter-checkbox-list__label"
+				<Disabled>
+					<ul className="wc-block-product-filter-checkbox-list__list">
+						{ isLoading && loadingState }
+						{ ! isLoading &&
+							( isLongList
+								? items.slice( 0, threshold )
+								: items
+							).map( ( item, index ) => (
+								<li
+									key={ index }
+									className="wc-block-product-filter-checkbox-list__item"
 								>
-									<span className="wc-block-product-filter-checkbox-list__input-wrapper">
-										<input
-											name={ `interactive-checkbox-${ index }` }
-											type="checkbox"
-											className="wc-block-product-filter-checkbox-list__input"
-											defaultChecked={ !! item.selected }
-										/>
-										<Icon
-											className="wc-block-product-filter-checkbox-list__mark"
-											icon={ checkMark }
-										/>
-									</span>
-									<span className="wc-block-product-filter-checkbox-list__text">
-										{ item.label }
-									</span>
-								</label>
-							</li>
-						) ) }
-				</ul>
-				{ ! isLoading && isLongList && (
-					<button className="wc-block-product-filter-checkbox-list__show-more">
-						{ __( 'Show more…', 'woocommerce' ) }
-					</button>
-				) }
+									<label
+										htmlFor={ `interactive-checkbox-${ index }` }
+										className=" wc-block-product-filter-checkbox-list__label"
+									>
+										<span className="wc-block-product-filter-checkbox-list__input-wrapper">
+											<input
+												name={ `interactive-checkbox-${ index }` }
+												type="checkbox"
+												className="wc-block-product-filter-checkbox-list__input"
+												defaultChecked={
+													!! item.selected ||
+													index === 1
+												}
+											/>
+											<Icon
+												className="wc-block-product-filter-checkbox-list__mark"
+												icon={ checkMark }
+											/>
+										</span>
+										<span className="wc-block-product-filter-checkbox-list__text">
+											{ item.label }
+										</span>
+									</label>
+								</li>
+							) ) }
+					</ul>
+					{ ! isLoading && isLongList && (
+						<button className="wc-block-product-filter-checkbox-list__show-more">
+							{ __( 'Show more…', 'woocommerce' ) }
+						</button>
+					) }
+				</Disabled>
 			</div>
 			<InspectorControls group="color">
 				{ colorGradientSettings.hasColorsOrGradients && (

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/edit.tsx
@@ -45,7 +45,6 @@ const Edit = ( props: EditProps ) => {
 					],
 				],
 			] }
-			templateLock="insert"
 		/>
 	);
 };

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/edit.tsx
@@ -95,12 +95,6 @@ const Edit = ( props: BlockEditProps< BlockAttributes > ) => {
 									clearButton
 										? [
 												'woocommerce/product-filter-clear-button',
-												{
-													lock: {
-														remove: true,
-														move: false,
-													},
-												},
 										  ]
 										: null,
 								].filter( Boolean ) as unknown as TemplateArray,

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -70,23 +70,12 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 						clearButton
 							? [
 									'woocommerce/product-filter-clear-button',
-									{
-										lock: {
-											remove: true,
-											move: false,
-										},
-									},
 							  ]
 							: null,
 					].filter( Boolean ) as unknown as TemplateArray,
 				],
 				[
 					'woocommerce/product-filter-checkbox-list',
-					{
-						lock: {
-							remove: true,
-						},
-					},
 				],
 			],
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -50,25 +50,12 @@ const Edit = ( props: EditProps ) => {
 							},
 						],
 						clearButton
-							? [
-									'woocommerce/product-filter-clear-button',
-									{
-										lock: {
-											remove: true,
-											move: false,
-										},
-									},
-							  ]
+							? [ 'woocommerce/product-filter-clear-button' ]
 							: null,
 					].filter( Boolean ) as unknown as TemplateArray,
 				],
 				[
 					'woocommerce/product-filter-checkbox-list',
-					{
-						lock: {
-							remove: true,
-						},
-					},
 				],
 			],
 		}

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/utils/toggle-product-filter-clear-button-visibility.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/utils/toggle-product-filter-clear-button-visibility.ts
@@ -16,10 +16,6 @@ import { getProductFilterClearButtonBlock } from './get-product-filter-clear-but
 import { getInnerBlockByName } from './get-inner-block-by-name';
 import { getClientIdByBlockName } from './get-client-id-by-block-name';
 
-const clearButtonDefaultAttributes = {
-	lock: { remove: true, move: false },
-};
-
 interface ToggleProductFilterClearButtonVisibility extends Function {
 	previousClearButtonBlockPosition?: BlockPosition | undefined;
 }
@@ -80,7 +76,6 @@ export const toggleProductFilterClearButtonVisibilityFactory = () => {
 				insertBlock(
 					createBlock(
 						'woocommerce/product-filter-clear-button',
-						clearButtonDefaultAttributes
 					),
 					clearButtonBlockPosition,
 					clearButtonParentBlockId,
@@ -107,7 +102,6 @@ export const toggleProductFilterClearButtonVisibilityFactory = () => {
 			insertBlock(
 				createBlock(
 					'woocommerce/product-filter-clear-button',
-					clearButtonDefaultAttributes
 				),
 				positionIndexToInsertBlock,
 				parentClientIdToInsertBlock,
@@ -136,10 +130,7 @@ export const toggleProductFilterClearButtonVisibilityFactory = () => {
 				filterBlockHeader.innerBlocks.length;
 			if ( Boolean( filterBlockHeading ) ) {
 				insertBlock(
-					createBlock(
-						'woocommerce/product-filter-clear-button',
-						clearButtonDefaultAttributes
-					),
+					createBlock( 'woocommerce/product-filter-clear-button' ),
 					lastFilterBlockHeaderPosition,
 					filterBlockHeader?.clientId,
 					false
@@ -153,10 +144,7 @@ export const toggleProductFilterClearButtonVisibilityFactory = () => {
 
 		function insertClearButtonToTheFirstPosition() {
 			insertBlock(
-				createBlock(
-					'woocommerce/product-filter-clear-button',
-					clearButtonDefaultAttributes
-				),
+				createBlock( 'woocommerce/product-filter-clear-button' ),
 				0,
 				clientId,
 				false
@@ -171,9 +159,7 @@ export const toggleProductFilterClearButtonVisibilityFactory = () => {
 			showClearButton === false &&
 			Boolean( clearButtonBlock?.clientId )
 		) {
-			updateBlockAttributes( clearButtonBlock?.clientId, {
-				lock: { remove: false, move: false },
-			} );
+			updateBlockAttributes( clearButtonBlock?.clientId );
 			removeBlock( clearButtonBlock?.clientId, false );
 			setPreviousClearButtonBlockPosition(
 				currentClearButtonBlockPosition

--- a/plugins/woocommerce/changelog/54539-product-filters-unlock
+++ b/plugins/woocommerce/changelog/54539-product-filters-unlock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Experimental: Product filters unlock and disable checkbox list
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/52884, https://github.com/woocommerce/woocommerce/issues/52854

This PR addresses two small issues.

- Remove all locked blocks
- Make the checkbox list unclickable and select one checkbox by default.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Edit the template.
3. With the block inserter, add Product Filters (Experimental) block to the template.
4. In the editor list view, ensure you no longer see any locked blocks.
5. For the attributes filter block with checkbox list, ensure you cannot check any of the checkboxes and also ensure you see at least one checkbox is checked.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Experimental: Product filters unlock and disable checkbox list
</details>
