### PR TITLE
Fix horizontal scrollbar with email preview in Calypso

### DIFF
--- a/plugins/woocommerce/changelog/53908-calypso-email-preview
+++ b/plugins/woocommerce/changelog/53908-calypso-email-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix horizontal scrollbar in Emails settings in Calypso

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -33,12 +33,15 @@ type EmailPreviewFillProps = {
 	settingsIds: string[];
 };
 
+const wpMenuWidth = document.getElementById( 'adminmenu' )?.clientWidth || 160;
+// Calculation: WP menu + email settings + email preview + padding
+const FLOATING_PREVIEW_WIDTH_LIMIT = wpMenuWidth + 666 + 684 + 40;
+
 const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 	emailTypes,
 	previewUrl,
 	settingsIds,
 } ) => {
-	const FLOATING_PREVIEW_WIDTH_LIMIT = 1550;
 	const [ deviceType, setDeviceType ] =
 		useState< string >( DEVICE_TYPE_DESKTOP );
 	const isSingleEmail = emailTypes.length === 1;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In Calypso, due to the wider WordPress menu, the email preview was causing horizontal scrollbar to appear. 

WordPress.org
<img width="1400" alt="Screenshot 2025-01-16 at 10 09 26" src="https://github.com/user-attachments/assets/b44e3623-255d-4fa5-8979-50dc635a6b9b" />
WordPress.com
<img width="1539" alt="Screenshot 2025-01-16 at 10 13 30" src="https://github.com/user-attachments/assets/bf44e7f6-4c4b-4345-83d2-8d9f2583a350" />

This PR changes the limit when the email preview can be floating next to email settings to take menu width into account.

Closes #53908.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Either test directly on the WordPress.com website, or update the CSS on any other website to change the width of the WordPress menu. 
2. Enable the `Email improvements` experimental feature in **WooCommerce > Settings > Advanced > Features**.
3. Go to **WooCommerce > Settings > Email**.
4. Change the browser width so that the email preview is shown next to the email settings, instead of below them. Ensure, that there is no horizontal scrollbar and when the browser is shrunk, the email preview moves below settings. 

<!-- End testing instructions -->
