### PR TITLE
Maintain aspect ratio and design size for images in "Coming Soon" templates

### DIFF
--- a/plugins/woocommerce/changelog/update-coming-soon-template-images
+++ b/plugins/woocommerce/changelog/update-coming-soon-template-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Updated aspect ratio and scaling for images in the 'minimal left image' and 'split right image' patterns

--- a/plugins/woocommerce/patterns/page-coming-soon-minimal-left-image.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-minimal-left-image.php
@@ -57,9 +57,11 @@ $store_description = ! empty( $site_tagline )
 		<div class="wp-block-group alignfull woocommerce-coming-soon-minimal-left-image__content" style="margin-top:120px;margin-bottom:120px;padding-top:0;padding-bottom:0"><!-- wp:group {"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group"><!-- wp:columns {"className":"alignfull","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":{"top":"0","left":"60px"},"margin":{"top":"0px","bottom":"0px"}},"layout":{"selfStretch":"fit","flexSize":null}}} -->
 				<div class="wp-block-columns alignfull" style="margin-top:0px;margin-bottom:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"verticalAlignment":"bottom","width":"481px","className":"woocommerce-coming-soon-minimal-left-image__content-image","layout":{"type":"default"}} -->
-					<div class="wp-block-column is-vertically-aligned-bottom woocommerce-coming-soon-minimal-left-image__content-image" style="flex-basis:481px"><!-- wp:image {"scale":"cover","style":{"border":{"radius":"16px"}}} -->
-						<figure class="wp-block-image has-custom-border"><img src="<?php echo esc_url( $default_image ); ?>" alt="Decorative Image" style="border-radius:16px;object-fit:cover"/></figure>
-						<!-- /wp:image --></div>
+					<div class="wp-block-column is-vertically-aligned-bottom woocommerce-coming-soon-minimal-left-image__content-image" style="flex-basis:481px">
+						<!-- wp:image {"aspectRatio":"481/576","scale":"cover","style":{"border":{"radius":"16px"}}} -->
+						<figure class="wp-block-image has-custom-border"><img src="<?php echo esc_url( $default_image ); ?>" alt="Decorative Image" style="border-radius:16px;aspect-ratio:481/576;object-fit:cover"/></figure>
+						<!-- /wp:image -->
+					</div>
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"stretch","width":"453px","className":"woocommerce-coming-soon-minimal-left-image__content-text","style":{"spacing":{"blockGap":"0","padding":{"right":"0","left":"0","bottom":"0","top":"53px"}}},"layout":{"type":"default"}} -->

--- a/plugins/woocommerce/patterns/page-coming-soon-split-right-image.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-split-right-image.php
@@ -37,8 +37,9 @@ $right_image = PatternsHelper::get_image_url( $images, 0, 'assets/images/pattern
 					<h1 class="wp-block-heading has-text-align-center has-<?php echo esc_attr( $inter_font_family ); ?>-font-family" style="font-size:14px;font-style:normal;font-weight:700;letter-spacing:2.1px;text-transform:uppercase"><?php echo esc_html_x( 'opening soon', 'Used in the heading of the coming soon page', 'woocommerce' ); ?></h1>
 					<!-- /wp:heading -->
 					<!-- wp:group {"style":{"spacing":{"margin":{"top":"32px","bottom":"32px"}}},"layout":{"type":"constrained"}} -->
-					<div class="wp-block-group" style="margin-top:32px;margin-bottom:32px"><!-- wp:image {"id":33,"width":"259px","sizeSlug":"full","linkDestination":"none"} -->
-						<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( $left_image ); ?>" alt="" class="wp-image-33" style="width:259px"/></figure>
+					<div class="wp-block-group" style="margin-top:32px;margin-bottom:32px">
+						<!-- wp:image {"id":33,"width":"259px","height":"285px","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
+						<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( $left_image ); ?>" alt="" class="wp-image-33" style="object-fit:cover;width:259px;height:285px"/></figure>
 						<!-- /wp:image --></div>
 					<!-- /wp:group -->
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/54051

This PR ensures that images in specific "Coming Soon" patterns maintain their original aspect ratio while adhering to the intended design size. The update prevents image blocks from resizing disproportionately when images are replaced, preserving the visual consistency of the templates.

For `Coming Soon Minimal Left Image` pattern, the image aspect ratio is set to `481/576`. For `Coming Soon Split Right Image` pattern, I simply set the width/height to fixed sizes since the image is small. We don't need to make it responsive.

Figma: 0BWMerqRR1f468EwC7g5tg-fi-3708_131102

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with `coming-soon-newsletter-template` feature flag enabled.
2. Enable coming soon mode in site visibility settings.
3. Go to `Appearance > Editor > Templates > Coming soon`
4. Select `Coming Soon Minimal Left Image`  template from the sidebar panel (Template > Design)
5. Select the image block and replace the image with a different image.
6. Confirm that the image maintains its original aspect ratio.
7. Select `Coming Soon Split Right Image` template
8. Select the left image block and replace the image with a different image.
9. Confirm that the image maintains its original aspect ratio.


https://github.com/user-attachments/assets/f02b10c7-f604-4cfb-ae96-46849068951f


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>