### PR TITLE
Update uses of `CHECKOUT_STORE_KEY` and use the `StoreDescriptor` instead

### DIFF
--- a/docs/cart-and-checkout-blocks/checkout-payment-methods/checkout-flow-and-events.md
+++ b/docs/cart-and-checkout-blocks/checkout-payment-methods/checkout-flow-and-events.md
@@ -41,11 +41,11 @@ You can use them in your component like so
 
 ```jsx
 const { useSelect } = window.wp.data;
-const { CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;
+const { checkoutStore } = window.wc.wcBlocksData;
 
 const MyComponent = ( props ) => {
 	const isComplete = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isComplete()
+		select( checkoutStore ).isComplete()
 	);
 	// do something with isComplete
 };

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -298,7 +298,7 @@
               "menu_title": "Checkout Flow and Events",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/checkout-payment-methods/checkout-flow-and-events.md",
-              "hash": "dcc4af69b2614b0722431f81a312558bf3c5fa349021849d241bf896e02813a7",
+              "hash": "8759412c671ef972d4ce737f14f786387a9cd8ea628a65bff13a2648245b407c",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/checkout-payment-methods/checkout-flow-and-events.md",
               "id": "499384cbb48ed96a2e12653cd68bd82d123a20a1",
               "links": {
@@ -1915,5 +1915,5 @@
       "categories": []
     }
   ],
-  "hash": "35c7649104b1618028b6e2dcaeb2cd79bcc1b12af5b3b6506d2ca3809f277541"
+  "hash": "edfbe17385c28e672d0777fdb92141c0b6e5f820e05d3726f081aa136ad91522"
 }

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -12,7 +12,7 @@ import {
 	ShippingCalculatorContext,
 } from '@woocommerce/base-components/cart-checkout';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { createInterpolateElement, useContext } from '@wordpress/element';
 
 /**
@@ -22,8 +22,9 @@ import { getPickupLocation } from './utils';
 
 export const ShippingAddress = (): JSX.Element => {
 	const { shippingRates, shippingAddress } = useStoreCart();
-	const prefersCollection = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).prefersCollection()
+	const prefersCollection = useSelect(
+		( select ) => select( checkoutStore ).prefersCollection(),
+		[]
 	);
 
 	const hasRates = hasShippingRate( shippingRates );

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -22,9 +22,8 @@ import { getPickupLocation } from './utils';
 
 export const ShippingAddress = (): JSX.Element => {
 	const { shippingRates, shippingAddress } = useStoreCart();
-	const prefersCollection = useSelect(
-		( select ) => select( checkoutStore ).prefersCollection(),
-		[]
+	const prefersCollection = useSelect( ( select ) =>
+		select( checkoutStore ).prefersCollection()
 	);
 
 	const hasRates = hasShippingRate( shippingRates );

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen, within } from '@testing-library/react';
 import ShippingAddress from '@woocommerce/base-components/cart-checkout/totals/shipping/shipping-address';
-import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
 import { ShippingCalculatorContext } from '@woocommerce/base-components/cart-checkout';
 import { dispatch } from '@wordpress/data';
 import { previewCart } from '@woocommerce/resource-previews';
@@ -95,7 +95,7 @@ describe( 'ShippingAddress', () => {
 	} );
 
 	it( 'Renders pickup location if shopper prefers collection', async () => {
-		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
+		dispatch( checkoutStore ).setPrefersCollection( true );
 
 		// Deselect the default selected rate and select pickup_location:1 rate.
 		const currentlySelectedIndex =
@@ -140,7 +140,7 @@ describe( 'ShippingAddress', () => {
 	} );
 
 	it( `renders an address if one is set in the methods metadata`, async () => {
-		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
+		dispatch( checkoutStore ).setPrefersCollection( true );
 
 		// Deselect the default selected rate and select pickup_location:1 rate.
 		const currentlySelectedIndex =
@@ -184,7 +184,7 @@ describe( 'ShippingAddress', () => {
 		).toBeInTheDocument();
 	} );
 	it( 'renders no address if one is not set in the methods metadata', async () => {
-		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
+		dispatch( checkoutStore ).setPrefersCollection( true );
 
 		// Deselect the default selected rate and select pickup_location:1 rate.
 		const currentlySelectedIndex =

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/test/use-store-cart-item-quantity.js
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/test/use-store-cart-item-quantity.js
@@ -18,8 +18,7 @@ jest.mock( '../use-store-cart', () => ( {
 
 jest.mock( '@woocommerce/block-data', () => ( {
 	__esModule: true,
-	CART_STORE_KEY: 'test/cart/store',
-	CHECKOUT_STORE_KEY: 'test/checkout/store',
+	...jest.requireActual( '@woocommerce/block-data' ),
 } ) );
 
 // Make debounce instantaneous.

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	CART_STORE_KEY,
 	validationStore,
-	CHECKOUT_STORE_KEY,
+	checkoutStore,
 } from '@woocommerce/block-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import type { StoreCartCoupon, ApiErrorResponse } from '@woocommerce/types';
@@ -42,8 +42,9 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 		} );
 
 	const { applyCoupon, removeCoupon } = useDispatch( CART_STORE_KEY );
-	const orderId = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).getOrderId()
+	const orderId = useSelect(
+		( select ) => select( checkoutStore ).getOrderId(),
+		[]
 	);
 
 	// Return cart, checkout or generic error message.

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -42,9 +42,8 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 		} );
 
 	const { applyCoupon, removeCoupon } = useDispatch( CART_STORE_KEY );
-	const orderId = useSelect(
-		( select ) => select( checkoutStore ).getOrderId(),
-		[]
+	const orderId = useSelect( ( select ) =>
+		select( checkoutStore ).getOrderId()
 	);
 
 	// Return cart, checkout or generic error message.

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -5,7 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useState, useEffect } from '@wordpress/element';
 import {
 	CART_STORE_KEY,
-	CHECKOUT_STORE_KEY,
+	checkoutStore,
 	processErrorResponse,
 } from '@woocommerce/block-data';
 import { useDebounce } from 'use-debounce';
@@ -57,7 +57,7 @@ export const useStoreCartItemQuantity = (
 		verifiedCartItem;
 	const { cartErrors } = useStoreCart();
 	const { __internalIncrementCalculating, __internalDecrementCalculating } =
-		useDispatch( CHECKOUT_STORE_KEY );
+		useDispatch( checkoutStore );
 
 	// Store quantity in hook state. This is used to keep the UI updated while server request is updated.
 	const [ quantity, setQuantity ] = useState< number >( cartItemQuantity );

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
@@ -12,7 +12,7 @@ import LoadingMask from '@woocommerce/base-components/loading-mask';
 import type { PaymentMethodInterface } from '@woocommerce/types';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	CHECKOUT_STORE_KEY,
+	checkoutStore,
 	PAYMENT_STORE_KEY,
 	CART_STORE_KEY,
 } from '@woocommerce/block-data';
@@ -47,7 +47,7 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 
 	const { isCalculating, isComplete, isIdle, isProcessing, customerId } =
 		useSelect( ( select ) => {
-			const store = select( CHECKOUT_STORE_KEY );
+			const store = select( checkoutStore );
 			return {
 				isComplete: store.isComplete(),
 				isIdle: store.isIdle(),

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -10,7 +10,7 @@ import {
 } from '@woocommerce/settings';
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -51,20 +51,23 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		prefersCollection,
 		editingBillingAddress,
 		editingShippingAddress,
-	} = useSelect( ( select ) => ( {
-		useShippingAsBilling:
-			select( CHECKOUT_STORE_KEY ).getUseShippingAsBilling(),
-		prefersCollection: select( CHECKOUT_STORE_KEY ).prefersCollection(),
-		editingBillingAddress:
-			select( CHECKOUT_STORE_KEY ).getEditingBillingAddress(),
-		editingShippingAddress:
-			select( CHECKOUT_STORE_KEY ).getEditingShippingAddress(),
-	} ) );
+	} = useSelect(
+		( select ) => ( {
+			useShippingAsBilling:
+				select( checkoutStore ).getUseShippingAsBilling(),
+			prefersCollection: select( checkoutStore ).prefersCollection(),
+			editingBillingAddress:
+				select( checkoutStore ).getEditingBillingAddress(),
+			editingShippingAddress:
+				select( checkoutStore ).getEditingShippingAddress(),
+		} ),
+		[]
+	);
 	const {
 		__internalSetUseShippingAsBilling,
 		setEditingBillingAddress,
 		setEditingShippingAddress,
-	} = useDispatch( CHECKOUT_STORE_KEY );
+	} = useDispatch( checkoutStore );
 	const {
 		billingAddress,
 		setBillingAddress,

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-address.ts
@@ -51,18 +51,14 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		prefersCollection,
 		editingBillingAddress,
 		editingShippingAddress,
-	} = useSelect(
-		( select ) => ( {
-			useShippingAsBilling:
-				select( checkoutStore ).getUseShippingAsBilling(),
-			prefersCollection: select( checkoutStore ).prefersCollection(),
-			editingBillingAddress:
-				select( checkoutStore ).getEditingBillingAddress(),
-			editingShippingAddress:
-				select( checkoutStore ).getEditingShippingAddress(),
-		} ),
-		[]
-	);
+	} = useSelect( ( select ) => ( {
+		useShippingAsBilling: select( checkoutStore ).getUseShippingAsBilling(),
+		prefersCollection: select( checkoutStore ).prefersCollection(),
+		editingBillingAddress:
+			select( checkoutStore ).getEditingBillingAddress(),
+		editingShippingAddress:
+			select( checkoutStore ).getEditingShippingAddress(),
+	} ) );
 	const {
 		__internalSetUseShippingAsBilling,
 		setEditingBillingAddress,

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-extension-data.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-extension-data.ts
@@ -22,9 +22,8 @@ export const useCheckoutExtensionData = (): {
 	) => void;
 } => {
 	const { __internalSetExtensionData } = useDispatch( checkoutStore );
-	const extensionData = useSelect(
-		( select ) => select( checkoutStore ).getExtensionData(),
-		[]
+	const extensionData = useSelect( ( select ) =>
+		select( checkoutStore ).getExtensionData()
 	);
 	const extensionDataRef = useRef( extensionData );
 

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-extension-data.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-extension-data.ts
@@ -3,7 +3,7 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -21,9 +21,10 @@ export const useCheckoutExtensionData = (): {
 		value: unknown
 	) => void;
 } => {
-	const { __internalSetExtensionData } = useDispatch( CHECKOUT_STORE_KEY );
-	const extensionData = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).getExtensionData()
+	const { __internalSetExtensionData } = useDispatch( checkoutStore );
+	const extensionData = useSelect(
+		( select ) => select( checkoutStore ).getExtensionData(),
+		[]
 	);
 	const extensionDataRef = useRef( extensionData );
 

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js
@@ -32,7 +32,7 @@ export const useCheckoutSubmit = () => {
 			isComplete: store.isComplete(),
 			hasError: store.hasError(),
 		};
-	}, [] );
+	} );
 	const { activePaymentMethod, isExpressPaymentMethodActive } = useSelect(
 		( select ) => {
 			const store = select( PAYMENT_STORE_KEY );

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CHECKOUT_STORE_KEY, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -23,7 +23,7 @@ export const useCheckoutSubmit = () => {
 		isComplete,
 		hasError,
 	} = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			isCalculating: store.isCalculating(),
 			isBeforeProcessing: store.isBeforeProcessing(),
@@ -32,7 +32,7 @@ export const useCheckoutSubmit = () => {
 			isComplete: store.isComplete(),
 			hasError: store.hasError(),
 		};
-	} );
+	}, [] );
 	const { activePaymentMethod, isExpressPaymentMethodActive } = useSelect(
 		( select ) => {
 			const store = select( PAYMENT_STORE_KEY );

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -21,19 +21,15 @@ export const useShowShippingTotalWarning = () => {
 	const { shippingRates, hasSelectedLocalPickup } = useShippingData();
 	const hasRates = hasShippingRate( shippingRates );
 	const { prefersCollection, isRateBeingSelected, shippingNotices } =
-		useSelect(
-			( select ) => {
-				return {
-					prefersCollection:
-						select( CHECKOUT_STORE_KEY ).prefersCollection(),
-					isRateBeingSelected:
-						select( CART_STORE_KEY ).isShippingRateBeingSelected(),
-					shippingNotices:
-						select( noticesStore ).getNotices( context ),
-				};
-			},
-			[ context ]
-		);
+		useSelect( ( select ) => {
+			return {
+				prefersCollection:
+					select( CHECKOUT_STORE_KEY ).prefersCollection(),
+				isRateBeingSelected:
+					select( CART_STORE_KEY ).isShippingRateBeingSelected(),
+				shippingNotices: select( noticesStore ).getNotices( context ),
+			};
+		}, [] );
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
 		}, [] );
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -30,8 +30,6 @@ export const useShowShippingTotalWarning = () => {
 			};
 		}, [] );
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
-		}, [] );
-	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
 
 	useEffect( () => {
 		const isShowingNotice =

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { hasShippingRate } from '@woocommerce/base-utils';
@@ -23,8 +23,7 @@ export const useShowShippingTotalWarning = () => {
 	const { prefersCollection, isRateBeingSelected, shippingNotices } =
 		useSelect( ( select ) => {
 			return {
-				prefersCollection:
-					select( CHECKOUT_STORE_KEY ).prefersCollection(),
+				prefersCollection: select( checkoutStore ).prefersCollection(),
 				isRateBeingSelected:
 					select( CART_STORE_KEY ).isShippingRateBeingSelected(),
 				shippingNotices: select( noticesStore ).getNotices( context ),

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -21,15 +21,19 @@ export const useShowShippingTotalWarning = () => {
 	const { shippingRates, hasSelectedLocalPickup } = useShippingData();
 	const hasRates = hasShippingRate( shippingRates );
 	const { prefersCollection, isRateBeingSelected, shippingNotices } =
-		useSelect( ( select ) => {
-			return {
-				prefersCollection:
-					select( CHECKOUT_STORE_KEY ).prefersCollection(),
-				isRateBeingSelected:
-					select( CART_STORE_KEY ).isShippingRateBeingSelected(),
-				shippingNotices: select( noticesStore ).getNotices( context ),
-			};
-		} );
+		useSelect(
+			( select ) => {
+				return {
+					prefersCollection:
+						select( CHECKOUT_STORE_KEY ).prefersCollection(),
+					isRateBeingSelected:
+						select( CART_STORE_KEY ).isShippingRateBeingSelected(),
+					shippingNotices:
+						select( noticesStore ).getNotices( context ),
+				};
+			},
+			[ context ]
+		);
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
 		}, [] );
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );

--- a/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -29,6 +29,8 @@ export const useShowShippingTotalWarning = () => {
 					select( CART_STORE_KEY ).isShippingRateBeingSelected(),
 				shippingNotices: select( noticesStore ).getNotices( context ),
 			};
+		} );
+	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
 		}, [] );
 	const { createInfoNotice, removeNotice } = useDispatch( noticesStore );
 

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -19,6 +19,8 @@ import {
 	PAYMENT_STORE_KEY,
 	validationStore,
 } from '@woocommerce/block-data';
+import { store as noticesStore } from '@wordpress/notices';
+import type { WPNotice } from '@wordpress/notices/build-types/store/selectors';
 
 /**
  * Internal dependencies
@@ -152,16 +154,16 @@ export const CheckoutEventsProvider = ( {
 
 	const checkoutNotices = useSelect(
 		( select ) => {
-			const { getNotices } = select( 'core/notices' );
+			const { getNotices } = select( noticesStore );
 			return checkoutContexts.reduce( ( acc, context ) => {
 				return [ ...acc, ...getNotices( context ) ];
-			}, [] );
+			}, [] as WPNotice[] );
 		},
 		[ checkoutContexts ]
 	);
 
 	const { paymentNotices, expressPaymentNotices } = useSelect( ( select ) => {
-		const { getNotices } = select( 'core/notices' );
+		const { getNotices } = select( noticesStore );
 		return {
 			paymentNotices: getNotices( noticeContexts.PAYMENTS ),
 			expressPaymentNotices: getNotices(

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -137,7 +137,7 @@ export const CheckoutEventsProvider = ( {
 			checkoutOrderNotes: store.getOrderNotes(),
 			checkoutCustomerId: store.getCustomerId(),
 		};
-	}, [] );
+	} );
 
 	if ( redirectUrl && redirectUrl !== checkoutRedirectUrl ) {
 		__internalSetRedirectUrl( redirectUrl );

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -15,7 +15,7 @@ import { usePrevious } from '@woocommerce/base-hooks';
 import deprecated from '@wordpress/deprecated';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
-	CHECKOUT_STORE_KEY,
+	checkoutStore,
 	PAYMENT_STORE_KEY,
 	validationStore,
 } from '@woocommerce/block-data';
@@ -112,7 +112,7 @@ export const CheckoutEventsProvider = ( {
 		__internalEmitValidateEvent,
 		__internalEmitAfterProcessingEvents,
 		__internalSetBeforeProcessing,
-	} = useDispatch( CHECKOUT_STORE_KEY );
+	} = useDispatch( checkoutStore );
 
 	const {
 		checkoutRedirectUrl,
@@ -124,7 +124,7 @@ export const CheckoutEventsProvider = ( {
 		checkoutOrderNotes,
 		checkoutCustomerId,
 	} = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			checkoutRedirectUrl: store.getRedirectUrl(),
 			checkoutStatus: store.getCheckoutStatus(),
@@ -135,7 +135,7 @@ export const CheckoutEventsProvider = ( {
 			checkoutOrderNotes: store.getOrderNotes(),
 			checkoutCustomerId: store.getCustomerId(),
 		};
-	} );
+	}, [] );
 
 	if ( redirectUrl && redirectUrl !== checkoutRedirectUrl ) {
 		__internalSetRedirectUrl( redirectUrl );

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -76,7 +76,7 @@ const CheckoutProcessor = () => {
 			redirectUrl: store.getRedirectUrl(),
 			shouldCreateAccount: store.getShouldCreateAccount(),
 		};
-	}, [] );
+	} );
 
 	const { __internalSetHasError, __internalProcessCheckoutResponse } =
 		useDispatch( checkoutStore );

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -16,7 +16,7 @@ import {
 } from '@woocommerce/base-utils';
 import { useDispatch, useSelect, select as selectStore } from '@wordpress/data';
 import {
-	CHECKOUT_STORE_KEY,
+	checkoutStore,
 	PAYMENT_STORE_KEY,
 	validationStore,
 	CART_STORE_KEY,
@@ -62,7 +62,7 @@ const CheckoutProcessor = () => {
 		redirectUrl,
 		shouldCreateAccount,
 	} = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			additionalFields: store.getAdditionalFields(),
 			customerId: store.getCustomerId(),
@@ -76,10 +76,10 @@ const CheckoutProcessor = () => {
 			redirectUrl: store.getRedirectUrl(),
 			shouldCreateAccount: store.getShouldCreateAccount(),
 		};
-	} );
+	}, [] );
 
 	const { __internalSetHasError, __internalProcessCheckoutResponse } =
-		useDispatch( CHECKOUT_STORE_KEY );
+		useDispatch( checkoutStore );
 
 	const hasValidationErrors = useSelect(
 		( select ) => select( validationStore ).hasValidationErrors

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
-	CHECKOUT_STORE_KEY,
+	checkoutStore,
 	PAYMENT_STORE_KEY,
 	validationStore,
 } from '@woocommerce/block-data';
@@ -57,14 +57,14 @@ export const PaymentEventsProvider = ( {
 		isCalculating: checkoutIsCalculating,
 		hasError: checkoutHasError,
 	} = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			isProcessing: store.isProcessing(),
 			isIdle: store.isIdle(),
 			hasError: store.hasError(),
 			isCalculating: store.isCalculating(),
 		};
-	} );
+	}, [] );
 	const { isPaymentReady } = useSelect( ( select ) => {
 		const store = select( PAYMENT_STORE_KEY );
 

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/payment-events/index.tsx
@@ -64,7 +64,7 @@ export const PaymentEventsProvider = ( {
 			hasError: store.hasError(),
 			isCalculating: store.isCalculating(),
 		};
-	}, [] );
+	} );
 	const { isPaymentReady } = useSelect( ( select ) => {
 		const store = select( PAYMENT_STORE_KEY );
 

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/shipping/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/shipping/index.tsx
@@ -10,7 +10,7 @@ import {
 	useRef,
 } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -45,7 +45,7 @@ export const ShippingDataProvider = ( {
 	children,
 }: ShippingDataProviderProps ) => {
 	const { __internalIncrementCalculating, __internalDecrementCalculating } =
-		useDispatch( CHECKOUT_STORE_KEY );
+		useDispatch( checkoutStore );
 	const { shippingRates, isLoadingRates, cartErrors } = useStoreCart();
 	const { selectedRates, isSelectingRate } = useShippingData();
 	const [ shippingErrorStatus, dispatchErrorStatus ] = useReducer(

--- a/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/context/providers/cart-checkout/utils.ts
@@ -3,7 +3,7 @@
  */
 import triggerFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Utility function for preparing payment data for the request.
@@ -29,7 +29,7 @@ export const preparePaymentData = (
 };
 
 /**
- * Process headers from an API response an dispatch updates.
+ * Process headers from an API response and dispatch updates.
  */
 export const processCheckoutResponseHeaders = (
 	headers: Headers | undefined
@@ -37,7 +37,7 @@ export const processCheckoutResponseHeaders = (
 	if ( ! headers ) {
 		return;
 	}
-	const { __internalSetCustomerId } = dispatch( CHECKOUT_STORE_KEY );
+	const { __internalSetCustomerId } = dispatch( checkoutStore );
 
 	if (
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
@@ -7,7 +7,7 @@ import { noticeContexts } from '@woocommerce/base-context';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ const CartExpressPayment = () => {
 		isComplete,
 		hasError,
 	} = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			isCalculating: store.isCalculating(),
 			isProcessing: store.isProcessing(),
@@ -34,7 +34,7 @@ const CartExpressPayment = () => {
 			isComplete: store.isComplete(),
 			hasError: store.hasError(),
 		};
-	} );
+	}, [] );
 	const isExpressPaymentMethodActive = useSelect( ( select ) =>
 		select( PAYMENT_STORE_KEY ).isExpressPaymentMethodActive()
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
@@ -34,7 +34,7 @@ const CartExpressPayment = () => {
 			isComplete: store.isComplete(),
 			hasError: store.hasError(),
 		};
-	}, [] );
+	} );
 	const isExpressPaymentMethodActive = useSelect( ( select ) =>
 		select( PAYMENT_STORE_KEY ).isExpressPaymentMethodActive()
 	);

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/checkout-express-payment.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/checkout-express-payment.tsx
@@ -6,7 +6,7 @@ import { useEditorContext, noticeContexts } from '@woocommerce/base-context';
 import { Title, StoreNoticesContainer } from '@woocommerce/blocks-components';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
-import { CHECKOUT_STORE_KEY, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -24,7 +24,7 @@ const CheckoutExpressPayment = () => {
 		isComplete,
 		hasError,
 	} = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			isCalculating: store.isCalculating(),
 			isProcessing: store.isProcessing(),

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -5,7 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { useEditorContext } from '@woocommerce/base-context';
 import { CheckboxControl } from '@woocommerce/blocks-components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { checkoutStore, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import {
+	checkoutStore as checkoutStoreDescriptor,
+	PAYMENT_STORE_KEY,
+} from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -33,7 +36,7 @@ const PaymentMethodCard = ( {
 	const { isEditor } = useEditorContext();
 	const { shouldSavePaymentMethod, customerId } = useSelect( ( select ) => {
 		const paymentMethodStore = select( PAYMENT_STORE_KEY );
-		const checkoutStore = select( checkoutStore );
+		const checkoutStore = select( checkoutStoreDescriptor );
 		return {
 			shouldSavePaymentMethod:
 				paymentMethodStore.getShouldSavePaymentMethod(),

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useEditorContext } from '@woocommerce/base-context';
 import { CheckboxControl } from '@woocommerce/blocks-components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore, PAYMENT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -33,13 +33,13 @@ const PaymentMethodCard = ( {
 	const { isEditor } = useEditorContext();
 	const { shouldSavePaymentMethod, customerId } = useSelect( ( select ) => {
 		const paymentMethodStore = select( PAYMENT_STORE_KEY );
-		const checkoutStore = select( CHECKOUT_STORE_KEY );
+		const checkoutStore = select( checkoutStore );
 		return {
 			shouldSavePaymentMethod:
 				paymentMethodStore.getShouldSavePaymentMethod(),
 			customerId: checkoutStore.getCustomerId(),
 		};
-	} );
+	}, [] );
 	const { __internalSetShouldSavePaymentMethod } =
 		useDispatch( PAYMENT_STORE_KEY );
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -42,7 +42,7 @@ const PaymentMethodCard = ( {
 				paymentMethodStore.getShouldSavePaymentMethod(),
 			customerId: checkoutStore.getCustomerId(),
 		};
-	}, [] );
+	} );
 	const { __internalSetShouldSavePaymentMethod } =
 		useDispatch( PAYMENT_STORE_KEY );
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -31,9 +31,8 @@ const Block = ( {
 	buttonLabel: string;
 } ): JSX.Element => {
 	const link = getSetting< string >( 'page-' + checkoutPageId, false );
-	const isCalculating = useSelect(
-		( select ) => select( checkoutStore ).isCalculating(),
-		[]
+	const isCalculating = useSelect( ( select ) =>
+		select( checkoutStore ).isCalculating()
 	);
 
 	const [ positionReferenceElement, positionRelativeToViewport ] =

--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -8,7 +8,7 @@ import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import { usePositionRelativeToViewport } from '@woocommerce/base-hooks';
 import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
-import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
 import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import { isErrorResponse } from '@woocommerce/base-context';
 import { useCartEventsContext } from '@woocommerce/base-context/providers';
@@ -31,8 +31,9 @@ const Block = ( {
 	buttonLabel: string;
 } ): JSX.Element => {
 	const link = getSetting< string >( 'page-' + checkoutPageId, false );
-	const isCalculating = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isCalculating()
+	const isCalculating = useSelect(
+		( select ) => select( checkoutStore ).isCalculating(),
+		[]
 	);
 
 	const [ positionReferenceElement, positionRelativeToViewport ] =

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -16,7 +16,7 @@ import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY, validationStore } from '@woocommerce/block-data';
+import { checkoutStore, validationStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -47,12 +47,12 @@ const Checkout = ( {
 	children: React.ReactChildren;
 } ): JSX.Element => {
 	const { hasOrder, customerId } = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			hasOrder: store.hasOrder(),
 			customerId: store.getCustomerId(),
 		};
-	} );
+	}, [] );
 	const { cartItems, cartIsLoading } = useStoreCart();
 
 	const { showFormStepNumbers } = attributes;
@@ -91,7 +91,7 @@ const ScrollOnError = ( {
 } ): null => {
 	const { hasError: checkoutHasError, isIdle: checkoutIsIdle } = useSelect(
 		( select ) => {
-			const store = select( CHECKOUT_STORE_KEY );
+			const store = select( checkoutStore );
 			return {
 				isIdle: store.isIdle(),
 				hasError: store.hasError(),

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/block.tsx
@@ -52,7 +52,7 @@ const Checkout = ( {
 			hasOrder: store.hasOrder(),
 			customerId: store.getCustomerId(),
 		};
-	}, [] );
+	} );
 	const { cartItems, cartIsLoading } = useStoreCart();
 
 	const { showFormStepNumbers } = attributes;

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -15,7 +15,7 @@ const Block: FunctionComponent = () => {
 		return {
 			additionalFields: store.getAdditionalFields(),
 		};
-	}, [] );
+	} );
 
 	const { setAdditionalFields } = useDispatch( checkoutStore );
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/block.tsx
@@ -4,20 +4,20 @@
 import { noticeContexts } from '@woocommerce/base-context';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { ORDER_FORM_KEYS } from '@woocommerce/block-settings';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import type { FunctionComponent } from 'react';
 
 const Block: FunctionComponent = () => {
 	const { additionalFields } = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			additionalFields: store.getAdditionalFields(),
 		};
-	} );
+	}, [] );
 
-	const { setAdditionalFields } = useDispatch( CHECKOUT_STORE_KEY );
+	const { setAdditionalFields } = useDispatch( checkoutStore );
 
 	const onChangeForm = ( additionalValues ) => {
 		setAdditionalFields( additionalValues );

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-additional-information-block/frontend.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { FormStep } from '@woocommerce/blocks-components';
 import { ORDER_FORM_KEYS } from '@woocommerce/block-settings';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
@@ -28,7 +28,7 @@ const FrontendBlock = ( {
 } ) => {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const checkoutIsProcessing = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isProcessing()
+		select( checkoutStore ).isProcessing()
 	);
 
 	if ( ORDER_FORM_KEYS.length === 0 ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -6,7 +6,7 @@ import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ const FrontendBlock = ( {
 } ): JSX.Element | null => {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const checkoutIsProcessing = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isProcessing()
+		select( checkoutStore ).isProcessing()
 	);
 	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
 		useCheckoutAddress();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
@@ -30,7 +30,7 @@ const CreateAccountUI = (): React.ReactElement | null => {
 		return {
 			shouldCreateAccount: store.getShouldCreateAccount(),
 		};
-	}, [] );
+	} );
 	const { __internalSetShouldCreateAccount, __internalSetCustomerPassword } =
 		useDispatch( checkoutStore );
 
@@ -92,7 +92,7 @@ const Block = (): JSX.Element => {
 			additionalFields: store.getAdditionalFields(),
 			customerId: store.getCustomerId(),
 		};
-	}, [] );
+	} );
 
 	const { setAdditionalFields } = useDispatch( checkoutStore );
 	const { billingAddress, setEmail } = useCheckoutAddress();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
@@ -13,7 +13,7 @@ import {
 	CheckboxControl,
 } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { CONTACT_FORM_KEYS } from '@woocommerce/block-settings';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 
@@ -26,13 +26,13 @@ const guestCheckoutNoticeId = 'wc-guest-checkout-notice';
 
 const CreateAccountUI = (): React.ReactElement | null => {
 	const { shouldCreateAccount } = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			shouldCreateAccount: store.getShouldCreateAccount(),
 		};
-	} );
+	}, [] );
 	const { __internalSetShouldCreateAccount, __internalSetCustomerPassword } =
-		useDispatch( CHECKOUT_STORE_KEY );
+		useDispatch( checkoutStore );
 
 	// Work out what fields need to be displayed for the current shopper.
 	const allowGuestCheckout = getSetting( 'checkoutAllowsGuest', false );
@@ -87,14 +87,14 @@ const CreateAccountUI = (): React.ReactElement | null => {
 
 const Block = (): JSX.Element => {
 	const { additionalFields, customerId } = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			additionalFields: store.getAdditionalFields(),
 			customerId: store.getCustomerId(),
 		};
-	} );
+	}, [] );
 
-	const { setAdditionalFields } = useDispatch( CHECKOUT_STORE_KEY );
+	const { setAdditionalFields } = useDispatch( checkoutStore );
 	const { billingAddress, setEmail } = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
 	const onChangeEmail = ( value: string ) => {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
@@ -15,7 +15,7 @@ const CreatePassword = () => {
 		return {
 			customerPassword: store.getCustomerPassword(),
 		};
-	}, [] );
+	} );
 	const { __internalSetCustomerPassword } = useDispatch( checkoutStore );
 
 	return (

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
@@ -5,18 +5,18 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { ValidatedTextInput } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import PasswordStrengthMeter from '@woocommerce/base-components/cart-checkout/password-strength-meter';
 
 const CreatePassword = () => {
 	const [ passwordStrength, setPasswordStrength ] = useState( 0 );
 	const { customerPassword } = useSelect( ( select ) => {
-		const store = select( CHECKOUT_STORE_KEY );
+		const store = select( checkoutStore );
 		return {
 			customerPassword: store.getCustomerPassword(),
 		};
-	} );
-	const { __internalSetCustomerPassword } = useDispatch( CHECKOUT_STORE_KEY );
+	}, [] );
+	const { __internalSetCustomerPassword } = useDispatch( checkoutStore );
 
 	return (
 		<ValidatedTextInput

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
@@ -27,9 +27,8 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ) => {
-	const checkoutIsProcessing = useSelect(
-		( select ) => select( checkoutStore ).isProcessing(),
-		[]
+	const checkoutIsProcessing = useSelect( ( select ) =>
+		select( checkoutStore ).isProcessing()
 	);
 
 	const { showFormStepNumbers } = useCheckoutBlockContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
@@ -27,8 +27,9 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ) => {
-	const checkoutIsProcessing = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isProcessing()
+	const checkoutIsProcessing = useSelect(
+		( select ) => select( checkoutStore ).isProcessing(),
+		[]
 	);
 
 	const { showFormStepNumbers } = useCheckoutBlockContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/login-prompt.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/login-prompt.js
@@ -12,9 +12,8 @@ const LOGIN_TO_CHECKOUT_URL = `${ LOGIN_URL }?redirect_to=${ encodeURIComponent(
 ) }`;
 
 const LoginPrompt = () => {
-	const customerId = useSelect(
-		( select ) => select( checkoutStore ).getCustomerId(),
-		[]
+	const customerId = useSelect( ( select ) =>
+		select( checkoutStore ).getCustomerId()
 	);
 
 	if ( ! getSetting( 'checkoutShowLoginReminder', true ) || customerId ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/login-prompt.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/login-prompt.js
@@ -5,15 +5,16 @@ import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { LOGIN_URL } from '@woocommerce/block-settings';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 const LOGIN_TO_CHECKOUT_URL = `${ LOGIN_URL }?redirect_to=${ encodeURIComponent(
 	window.location.href
 ) }`;
 
 const LoginPrompt = () => {
-	const customerId = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).getCustomerId()
+	const customerId = useSelect(
+		( select ) => select( checkoutStore ).getCustomerId(),
+		[]
 	);
 
 	if ( ! getSetting( 'checkoutShowLoginReminder', true ) || customerId ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -17,14 +17,15 @@ const Block = ( { className }: { className?: string } ): JSX.Element => {
 	const { needsShipping } = useShippingData();
 	const { isProcessing: checkoutIsProcessing, orderNotes } = useSelect(
 		( select ) => {
-			const store = select( CHECKOUT_STORE_KEY );
+			const store = select( checkoutStore );
 			return {
 				isProcessing: store.isProcessing(),
 				orderNotes: store.getOrderNotes(),
 			};
-		}
+		},
+		[]
 	);
-	const { __internalSetOrderNotes } = useDispatch( CHECKOUT_STORE_KEY );
+	const { __internalSetOrderNotes } = useDispatch( checkoutStore );
 
 	return (
 		<FormStep

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/block.tsx
@@ -22,8 +22,7 @@ const Block = ( { className }: { className?: string } ): JSX.Element => {
 				isProcessing: store.isProcessing(),
 				orderNotes: store.getOrderNotes(),
 			};
-		},
-		[]
+		}
 	);
 	const { __internalSetOrderNotes } = useDispatch( checkoutStore );
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx
@@ -20,9 +20,8 @@ const Block = ( {
 } ): JSX.Element | null => {
 	const { cartNeedsShipping, shippingRates, shippingAddress } =
 		useStoreCart();
-	const prefersCollection = useSelect(
-		( select ) => select( checkoutStore ).prefersCollection(),
-		[]
+	const prefersCollection = useSelect( ( select ) =>
+		select( checkoutStore ).prefersCollection()
 	);
 
 	if ( ! cartNeedsShipping ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx
@@ -6,7 +6,7 @@ import { TotalsShipping } from '@woocommerce/base-components/cart-checkout';
 import { useStoreCart } from '@woocommerce/base-context';
 import { TotalsWrapper } from '@woocommerce/blocks-checkout';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import {
 	filterShippingRatesByPrefersCollection,
 	isAddressComplete,
@@ -20,8 +20,9 @@ const Block = ( {
 } ): JSX.Element | null => {
 	const { cartNeedsShipping, shippingRates, shippingAddress } =
 		useStoreCart();
-	const prefersCollection = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).prefersCollection()
+	const prefersCollection = useSelect(
+		( select ) => select( checkoutStore ).prefersCollection(),
+		[]
 	);
 
 	if ( ! cartNeedsShipping ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -31,9 +31,8 @@ const FrontendBlock = ( {
 	className?: string;
 } ) => {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
-	const checkoutIsProcessing = useSelect(
-		( select ) => select( checkoutStore ).isProcessing(),
-		[]
+	const checkoutIsProcessing = useSelect( ( select ) =>
+		select( checkoutStore ).isProcessing()
 	);
 	const { cartNeedsPayment } = useStoreCart();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -9,7 +9,7 @@ import {
 	StoreNoticesContainer,
 } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { noticeContexts } from '@woocommerce/base-context';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
@@ -31,8 +31,9 @@ const FrontendBlock = ( {
 	className?: string;
 } ) => {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
-	const checkoutIsProcessing = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isProcessing()
+	const checkoutIsProcessing = useSelect(
+		( select ) => select( checkoutStore ).isProcessing(),
+		[]
 	);
 	const { cartNeedsPayment } = useStoreCart();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { useBlockProps } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 
 /**
@@ -32,11 +32,11 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
 	const { prefersCollection } = useSelect( ( select ) => {
-		const checkoutStore = select( CHECKOUT_STORE_KEY );
+		const checkoutStore = select( checkoutStoreDescriptor );
 		return {
 			prefersCollection: checkoutStore.prefersCollection(),
 		};
-	} );
+	}, [] );
 	const { className } = attributes;
 
 	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
@@ -36,7 +36,7 @@ export const Edit = ( {
 		return {
 			prefersCollection: checkoutStore.prefersCollection(),
 		};
-	}, [] );
+	} );
 	const { className } = attributes;
 
 	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStoreDescriptor } from '@woocommerce/block-data';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
@@ -29,12 +29,13 @@ const FrontendBlock = ( {
 } ) => {
 	const { checkoutIsProcessing, prefersCollection } = useSelect(
 		( select ) => {
-			const checkoutStore = select( CHECKOUT_STORE_KEY );
+			const checkoutStore = select( checkoutStoreDescriptor );
 			return {
 				checkoutIsProcessing: checkoutStore.isProcessing(),
 				prefersCollection: checkoutStore.prefersCollection(),
 			};
-		}
+		},
+		[]
 	);
 
 	const { showFormStepNumbers } = useCheckoutBlockContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
@@ -34,8 +34,7 @@ const FrontendBlock = ( {
 				checkoutIsProcessing: checkoutStore.isProcessing(),
 				prefersCollection: checkoutStore.prefersCollection(),
 			};
-		},
-		[]
+		}
 	);
 
 	const { showFormStepNumbers } = useCheckoutBlockContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
-import { checkoutStoreDescriptor } from '@woocommerce/block-data';
+import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
@@ -25,9 +25,8 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ) => {
-	const checkoutIsProcessing = useSelect(
-		( select ) => select( checkoutStore ).isProcessing(),
-		[]
+	const checkoutIsProcessing = useSelect( ( select ) =>
+		select( checkoutStore ).isProcessing()
 	);
 	const { showShippingFields } = useCheckoutAddress();
 	const { showFormStepNumbers } = useCheckoutBlockContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
@@ -6,7 +6,7 @@ import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 /**
  * Internal dependencies
  */
@@ -25,8 +25,9 @@ const FrontendBlock = ( {
 	children: JSX.Element;
 	className?: string;
 } ) => {
-	const checkoutIsProcessing = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isProcessing()
+	const checkoutIsProcessing = useSelect(
+		( select ) => select( checkoutStore ).isProcessing(),
+		[]
 	);
 	const { showShippingFields } = useCheckoutAddress();
 	const { showFormStepNumbers } = useCheckoutBlockContext();

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -17,7 +17,7 @@ import { Button } from '@ariakit/react';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import ExternalLinkCard from '@woocommerce/editor-components/external-link-card';
 import { useEffect } from '@wordpress/element';
 
@@ -170,9 +170,9 @@ export const Edit = ( {
 		// each time the attribute changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ setAttributes ] );
-	const { setPrefersCollection } = useDispatch( CHECKOUT_STORE_KEY );
+	const { setPrefersCollection } = useDispatch( checkoutStore );
 	const { prefersCollection } = useSelect( ( select ) => {
-		const checkoutStore = select( CHECKOUT_STORE_KEY );
+		const checkoutStore = select( checkoutStore );
 		return {
 			prefersCollection: checkoutStore.prefersCollection(),
 		};

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -176,7 +176,7 @@ export const Edit = ( {
 		return {
 			prefersCollection: checkoutStore.prefersCollection(),
 		};
-	}, [] );
+	} );
 	const { showPrice, showIcon, className, localPickupText, shippingText } =
 		attributes;
 	const {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -17,7 +17,7 @@ import { Button } from '@ariakit/react';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { checkoutStore } from '@woocommerce/block-data';
+import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import ExternalLinkCard from '@woocommerce/editor-components/external-link-card';
 import { useEffect } from '@wordpress/element';
 
@@ -170,13 +170,13 @@ export const Edit = ( {
 		// each time the attribute changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ setAttributes ] );
-	const { setPrefersCollection } = useDispatch( checkoutStore );
+	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
 	const { prefersCollection } = useSelect( ( select ) => {
-		const checkoutStore = select( checkoutStore );
+		const checkoutStore = select( checkoutStoreDescriptor );
 		return {
 			prefersCollection: checkoutStore.prefersCollection(),
 		};
-	} );
+	}, [] );
 	const { showPrice, showIcon, className, localPickupText, shippingText } =
 		attributes;
 	const {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -49,7 +49,7 @@ const FrontendBlock = ( {
 		},
 		[]
 	);
-	const { setPrefersCollection } = useDispatch( checkoutStore );
+	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
 	const {
 		shippingRates,
 		needsShipping,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -46,8 +46,7 @@ const FrontendBlock = ( {
 				checkoutIsProcessing: checkoutStore.isProcessing(),
 				prefersCollection: checkoutStore.prefersCollection(),
 			};
-		},
-		[]
+		}
 	);
 	const { setPrefersCollection } = useDispatch( checkoutStoreDescriptor );
 	const {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore as checkoutStoreDescriptor } from '@woocommerce/block-data';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import {
 	LOCAL_PICKUP_ENABLED,
@@ -41,14 +41,15 @@ const FrontendBlock = ( {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
 	const { checkoutIsProcessing, prefersCollection } = useSelect(
 		( select ) => {
-			const checkoutStore = select( CHECKOUT_STORE_KEY );
+			const checkoutStore = select( checkoutStoreDescriptor );
 			return {
 				checkoutIsProcessing: checkoutStore.isProcessing(),
 				prefersCollection: checkoutStore.prefersCollection(),
 			};
-		}
+		},
+		[]
 	);
-	const { setPrefersCollection } = useDispatch( CHECKOUT_STORE_KEY );
+	const { setPrefersCollection } = useDispatch( checkoutStore );
 	const {
 		shippingRates,
 		needsShipping,

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -27,9 +27,8 @@ const FrontendBlock = ( {
 	className?: string;
 } ) => {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
-	const checkoutIsProcessing = useSelect(
-		( select ) => select( checkoutStore ).isProcessing(),
-		[]
+	const checkoutIsProcessing = useSelect( ( select ) =>
+		select( checkoutStore ).isProcessing()
 	);
 	const { showShippingMethods } = useCheckoutAddress();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -6,7 +6,7 @@ import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { checkoutStore } from '@woocommerce/block-data';
 import { useCheckoutBlockContext } from '@woocommerce/blocks/checkout/context';
 
 /**
@@ -27,8 +27,9 @@ const FrontendBlock = ( {
 	className?: string;
 } ) => {
 	const { showFormStepNumbers } = useCheckoutBlockContext();
-	const checkoutIsProcessing = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isProcessing()
+	const checkoutIsProcessing = useSelect(
+		( select ) => select( checkoutStore ).isProcessing(),
+		[]
 	);
 	const { showShippingMethods } = useCheckoutAddress();
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/test/block.js
@@ -4,7 +4,7 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { previewCart } from '@woocommerce/resource-previews';
 import { dispatch } from '@wordpress/data';
-import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
 import { default as fetchMock } from 'jest-fetch-mock';
 import { allSettings } from '@woocommerce/settings';
 
@@ -299,7 +299,7 @@ describe( 'Testing Checkout', () => {
 			// Set required settings
 			allSettings.checkoutAllowsGuest = true;
 			allSettings.checkoutAllowsSignup = true;
-			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 0 );
+			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
 		} );
 
 		// Render the CheckoutBlock
@@ -322,7 +322,7 @@ describe( 'Testing Checkout', () => {
 			// Restore initial settings
 			allSettings.checkoutAllowsGuest = undefined;
 			allSettings.checkoutAllowsSignup = undefined;
-			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
+			dispatch( checkoutStore ).__internalSetCustomerId( 1 );
 		} );
 	} );
 
@@ -368,7 +368,7 @@ describe( 'Testing Checkout', () => {
 		await act( async () => {
 			allSettings.checkoutAllowsGuest = true;
 			allSettings.checkoutAllowsSignup = true;
-			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 0 );
+			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
 		} );
 
 		// Render the CheckoutBlock
@@ -385,7 +385,7 @@ describe( 'Testing Checkout', () => {
 		await act( async () => {
 			allSettings.checkoutAllowsGuest = true;
 			allSettings.checkoutAllowsSignup = true;
-			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
+			dispatch( checkoutStore ).__internalSetCustomerId( 1 );
 		} );
 
 		rerender( <CheckoutBlock /> );
@@ -398,7 +398,7 @@ describe( 'Testing Checkout', () => {
 			// Restore initial settings
 			allSettings.checkoutAllowsGuest = undefined;
 			allSettings.checkoutAllowsSignup = undefined;
-			dispatch( CHECKOUT_STORE_KEY ).__internalSetCustomerId( 1 );
+			dispatch( checkoutStore ).__internalSetCustomerId( 1 );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-blocks/docs/internal-developers/block-client-apis/checkout/checkout-flow-and-events.md
+++ b/plugins/woocommerce-blocks/docs/internal-developers/block-client-apis/checkout/checkout-flow-and-events.md
@@ -59,11 +59,11 @@ You can use them in your component like so
 
 ```jsx
 const { useSelect } = window.wp.data;
-const { CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;
+const { checkoutStore } = window.wc.wcBlocksData;
 
 const MyComponent = ( props ) => {
 	const isComplete = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isComplete()
+		select( checkoutStore ).isComplete()
 	);
 	// do something with isComplete
 };

--- a/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/checkout.md
+++ b/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/data-store/checkout.md
@@ -39,10 +39,16 @@ The Checkout Store provides a collection of selectors to access and manage data 
 
 ## Usage
 
-To utilize this store you will import the `CHECKOUT_STORE_KEY` in any module referencing it. Assuming `@woocommerce/block-data` is registered as an external pointing to `wc.wcBlocksData` you can import the key via:
+To utilize this store you will import the `checkoutStore` `StoreDescriptor` in any module referencing it. Assuming `@woocommerce/block-data` is registered as an external pointing to `wc.wcBlocksData` you can import the `StoreDescriptor` via:
 
 ```js
-const { CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;
+const { checkoutStore } = '@woocommerce/block-data'
+```
+
+If it is not you can import it via:
+
+```js
+const { checkoutStore } = window.wc.wcBlocksData
 ```
 
 ## Selectors
@@ -58,7 +64,7 @@ Returns the WordPress user ID of the customer whose order is currently processed
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const customerId = store.getCustomerId();
 ```
 
@@ -73,7 +79,7 @@ Returns the WooCommerce order ID of the order that is currently being processed 
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const orderId = store.getOrderId();
 ```
 
@@ -88,7 +94,7 @@ Returns the order notes.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const orderNotes = store.getOrderNotes();
 ```
 
@@ -103,7 +109,7 @@ Returns the URL to redirect to after checkout is complete.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const redirectUrl = store.getRedirectUrl();
 ```
 
@@ -126,7 +132,7 @@ Returns the extra data registered by extensions.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const extensionData = store.getExtensionData();
 ```
 
@@ -141,7 +147,7 @@ Returns the current status of the checkout process.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const checkoutStatus = store.getCheckoutStatus();
 ```
 
@@ -156,7 +162,7 @@ Returns true if the shopper has opted to create an account with their order.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const shouldCreateAccount = store.getShouldCreateAccount();
 ```
 
@@ -171,7 +177,7 @@ Returns true if the shopper has opted to use their shipping address as their bil
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const useShippingAsBilling = store.getUseShippingAsBilling();
 ```
 
@@ -186,7 +192,7 @@ Returns true if the billing address is being edited.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const editingBillingAddress = store.getEditingBillingAddress();
 ```
 
@@ -201,7 +207,7 @@ Returns true if the shipping address is being edited.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const editingShippingAddress = store.getEditingShippingAddress();
 ```
 
@@ -216,7 +222,7 @@ Returns true if an error occurred, and false otherwise.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const hasError = store.hasError();
 ```
 
@@ -231,7 +237,7 @@ Returns true if a draft order had been created, and false otherwise.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const hasOrder = store.hasOrder();
 ```
 
@@ -246,7 +252,7 @@ When the checkout status is `IDLE` this flag is true. Checkout will be this stat
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const isIdle = store.isIdle();
 ```
 
@@ -261,7 +267,7 @@ When the checkout status is `BEFORE_PROCESSING` this flag is true. Checkout will
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const isBeforeProcessing = store.isBeforeProcessing();
 ```
 
@@ -276,7 +282,7 @@ When the checkout status is `PROCESSING` this flag is true. Checkout will be thi
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const isProcessing = store.isProcessing();
 ```
 
@@ -291,7 +297,7 @@ When the checkout status is `AFTER_PROCESSING` this flag is true. Checkout will 
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const isAfterProcessing = store.isAfterProcessing();
 ```
 
@@ -306,7 +312,7 @@ When the checkout status is `COMPLETE` this flag is true. Checkout will have thi
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const isComplete = store.isComplete();
 ```
 
@@ -321,7 +327,7 @@ This is true when the total is being re-calculated for the order. There are nume
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const isCalculating = store.isCalculating();
 ```
 
@@ -336,7 +342,7 @@ Returns true if the customer prefers to collect their order, and false otherwise
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = select( CHECKOUT_STORE_KEY );
+const store = select( checkoutStore );
 const prefersCollection = store.prefersCollection();
 ```
 
@@ -353,7 +359,7 @@ Sets the `prefersCollection` flag to true or false.
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = dispatch( CHECKOUT_STORE_KEY );
+const store = dispatch( checkoutStore );
 store.setPrefersCollection( true );
 ```
 
@@ -368,7 +374,7 @@ Set the billing address to editing state or collapsed state. Note that if the ad
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = dispatch( CHECKOUT_STORE_KEY );
+const store = dispatch( checkoutStore );
 store.setEditingBillingAddress( true );
 ```
 
@@ -383,7 +389,7 @@ Set the shipping address to editing state or collapsed state. Note that if the a
 #### _Example_ <!-- omit in toc -->
 
 ```js
-const store = dispatch( CHECKOUT_STORE_KEY );
+const store = dispatch( checkoutStore );
 store.setEditingShippingAddress( true );
 ```
 

--- a/plugins/woocommerce/changelog/update-checkout-data-store-types
+++ b/plugins/woocommerce/changelog/update-checkout-data-store-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update consumers of the wc/store/checkout data store to use the StoreDescriptor rather than the key to access it


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is based on https://github.com/woocommerce/woocommerce/pull/54380 `fix/shipping-total-warning`

Code in `plugins/woocommerce/client/legacy/js/frontend/order-attribution.js` was not changed as the script doesn't have `wc-blocks-checkout` as a dependency, so it wouldn't be able to get the store descriptor, moreover this is a JS file so wouldn't have the benefit of the types anyway.



<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### `useShowShippingTotalWarning`

1. Go to WC -> Settings -> General. Set Default Customer Location to "No location by default"
2. Go to WC -> Settings -> Shipping -> Local Pickup. Enable Local Pickup and add some zones.
3. In incognito, add an item to your cart and go to the Checkout block.
4. Select Pickup, then switch back to Shipping. Ensure a notice appears above the order summary:

<img width="277" alt="image" src="https://github.com/user-attachments/assets/83ccac73-be6b-4c8f-9b0a-ac173ae32d95" />


#### `ShippingAddress`

1. Go to WC -> Settings -> Shipping -> Local Pickup. Enable Local Pickup and add some zones.
2. Go to WC -> Settings -> Shipping ->  Shipping Settings -> check "Enable the shipping calculator on the cart page"
3. Set up a shipping zone with valid methods.
4. Add an item to your cart and go to the Cart block.
5. In the sidebar, choose a local pickup method as the shipping method. Ensure you see "Collection from _pickup location_" in the sidebar.
6. In the sidebar, expand the shipping calculator (Click the address of the local pickup place)
7. Enter an address that has shipping methods set up into the shipping calculator on the Cart page and submit it.
8. Choose one of the _shipping_ options. 
9. Ensure you see "Delivers to _your address_"

#### Checkout processing

1. Install Stripe and set it up.
2. Go to WC -> Settings -> Shipping -> Local Pickup. Enable Local Pickup and add some zones.
3. Add a coupon to your store.
4. Add an item to your cart and go to the Checkout block.
5. Add the coupon to your order and while it is processing, try changing/interacting with the following (you may need to add some sleeps in your Checkout route if this goes too quickly for you). You should have to wait until processing is complete until you can interact with these.
  - Changing between Ship and Pickup.
  - Entering Shipping/Billing address
  - Changing payment method
  - Changing Shipping method
  - Interacting with the Place order button
6. Place an order using Stripe, then place one using COD.
7. Ensure the order is placed without errors.

#### `useStoreCartItemQuantity` & Proceed to Checkout block

1. Add 2 items to your cart and go to the Cart block.
2. Ensure you can change the quantity of each independently and changing one quantity does not affect the other.
3. While quantity calculations are happening, ensure the "Proceed to Checkout" button becomes disabled (it might not fade out) and cannot be clicked.

#### `useStoreCartCoupons`

(Taken from #43872)

1. Go to Marketing > Coupons
2. Create a new coupon restricted to the email [allow@yay.com](mailto:allow@yay.com) (make sure this email is not associated with your account), with any discount amount
4. Create another coupon named "test" without restrictions, with any discount amount
5. Add some items to your cart.
6. Go to the Blocks Cart page
8. Apply the coupon "test" and verify it gets applied and the totals update
11. Apply the restricted coupon and verify it doesn't get applied, and the proper error is displayed
12. Go to the Blocks Checkout page
13. Fill the email field to something else than "[allow@yay.com](mailto:allow@yay.com)"
14. Apply the restricted coupon and verify it doesn't get applied, and the proper error is displayed
15. Change the email field to "[allow@yay.com](mailto:allow@yay.com)"
16. Apply the restricted coupon and verify it gets applied correctly
17. Place the order and verify applied discounts were effective

#### `usePaymentMethodInterface`

1. Modify `assets/js/extensions/payment-methods/bacs/index.js` to the following:

```js
/**
 * External dependencies
 */
import { registerPaymentMethod } from '@woocommerce/blocks-registry';
import { __ } from '@wordpress/i18n';
import { getPaymentMethodData } from '@woocommerce/settings';
import { decodeEntities } from '@wordpress/html-entities';
import { sanitizeHTML } from '@woocommerce/utils';
import { RawHTML, useEffect } from '@wordpress/element';

/**
 * Internal dependencies
 */
import { PAYMENT_METHOD_NAME } from './constants';

const settings = getPaymentMethodData( 'bacs', {} );
const defaultLabel = __( 'Direct bank transfer', 'woocommerce' );
const label = decodeEntities( settings?.title || '' ) || defaultLabel;

/**
 * Content component
 */
const Content = ( { checkoutStatus, paymentStatus } ) => {
	console.log( { checkoutStatus, paymentStatus } );
	return <RawHTML>{ sanitizeHTML( settings.description || '' ) }</RawHTML>;
};

/**
 * Label component
 *
 * @param {*} props Props from payment API.
 */
const Label = ( props ) => {
	const { PaymentMethodLabel } = props.components;
	return <PaymentMethodLabel text={ label } />;
};

/**
 * Bank transfer (BACS) payment method config object.
 */
const bankTransferPaymentMethod = {
	name: PAYMENT_METHOD_NAME,
	label: <Label />,
	content: <Content />,
	edit: <Content />,
	canMakePayment: () => true,
	ariaLabel: label,
	supports: {
		features: settings?.supports ?? [],
	},
};

registerPaymentMethod( bankTransferPaymentMethod );

```

2. Go to WC -> Settings -> Payments and Enable BACS.
3. Add an item to your cart and go to the Checkout block.
4. Open your JS console and enable "Preserve log".
5. Submit the checkout and you should notice a console log of the checkout and payment statuses.
6. Notice they changes as the checkout processes.
8. Ensure checkout status starts with `isIdle` true and then `isCalculating` after entering your address, then `isProcessing` when pressing "Place order" and then `isComplete` when the order is complete.
9. The payment status should follow a similar pattern. (Testing all routes is not required, we just need to make sure thr store is working).

#### `useCheckoutAddress`

1. Go to WC -> Settings -> Shipping -> Local Pickup and enable local pickup. Add some locations.
2. Add an item to your cart and go to the Checkout block.
3. Ensure you can toggle between "Ship" and "Pickup".
4. Choose "Ship"
5. Ensure you can toggle the `Use same address for billing` checkbox and it shows/hides the billing address as appropriate.
6. Check out and then add another item to your cart. Return to the Checkout block.
7. Ensure your shipping address is saved as a card, edit it and ensure the form shows.
8. Repeat with a virtual product, (To test the same functionality with the Billing Address)

#### `useCheckoutExtensionData`

1. Add an item to your cart then go to the Checkout page.
2. In the JS console enter: `wp.data.select( wc.wcBlocksData.checkoutStore ).getExtensionData()['woocommerce/order-attribution']`
3. Ensure the order attribution data is logged and no errors occur.

#### `CheckoutEventsProvider`

1. Install and set up Stripe.
2. Go to the Checkout block and try to place an order with an invalid card. ([Stripe test cards](https://docs.stripe.com/testing#declined-payments))
3. Ensure checkout fails and a notice is displayed.
4. Check out with a valid card and ensure the notice disappears and checkout is successful.

#### `CheckoutProcessor`

1. As a logged in user, add an item to your cart and go to the Checkout block.
2. Add some order notes. Uncheck the order notes checkbox and then check it again.
3. Verify the text you entered in step 2 is still there. Place the order.
4. Ensure the order notes are visible on the order confirmation screen.
5. Ensure the order is correctly attached to the account you ordered with.

#### `PaymentMethodCard`

1. Install and set up Stripe
2. As a logged in user, add an item to your cart and go to the Checkout block.
3. Select Stripe as your payment method.
4. Ensure you see a checkbox for saving the method to your account.
6. Log out, repeat the steps and ensure you _don't_ see the checkbox.

#### Order requiring login

1. Go to WC -> Settings -> Accounts & Privacy. Disable `Enable guest checkout (recommended)`. and `Allow customers to create an account: During checkout`. Disable `Enable log-in during checkout`.
2. As a logged out user, add an item to your cart and go to the Checkout block.
3. Ensure you see an error `You must be logged in to checkout. Click here to log in.`
4.  Go to WC -> Settings -> Accounts & Privacy. Enable `Allow customers to create an account: During checkout`
5. As a logged out user, add an item to your cart and go to the Checkout block ensure you can log in with email and password.
7. Log back out.
8. Go to WC -> Settings -> Accounts & Privacy. Enable `Enable guest checkout (recommended)` and enable `Enable log-in during checkout` and disable `Send password setup link (recommended)`
9. As a logged out user, add an item to your cart and go to the Checkout block.
10. Verify you have the option to log in, but don't click it. Place the order without logging in.
11. On the order confirmation screen, set your account password, ensuring the strength meter works.

#### Additional fields

1. Install and activate [additional-checkout-fields-tester-main.zip](https://github.com/user-attachments/files/18443878/additional-checkout-fields-tester-main.6.zip)
2. Add an item to your cart and go to the Checkout block. Ensure you see aadditional fields in the contact information block, in the addresses, and an "Additional information" section at the bottom of the block.



### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
