### PR TITLE
Hand-Picked collection: Improve product validation in hand-picked control

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/hand-picked-products-control.tsx
@@ -95,6 +95,25 @@ export const HandPickedProductsControlField = ( {
 	);
 	const handleSearch = useDebounce( setSearchQuery, 250 );
 
+	// Filter out any selected product IDs that no longer exist
+	const validSelectedProductIds = useMemo( () => {
+		if ( ! selectedProductIds?.length || ! productsMap.size )
+			return selectedProductIds || [];
+		return selectedProductIds.filter( ( id ) => {
+			const product = productsMap.get( Number( id ) );
+			return !! product;
+		} );
+	}, [ selectedProductIds, productsMap ] );
+
+	// Updates the query attribute when invalid products are filtered out
+	useEffect( () => {
+		if ( validSelectedProductIds.length !== selectedProductIds.length ) {
+			setQueryAttribute( {
+				woocommerceHandPickedProducts: validSelectedProductIds,
+			} );
+		}
+	}, [ validSelectedProductIds, selectedProductIds, setQueryAttribute ] );
+
 	const onTokenChange = useCallback(
 		( values: string[] ) => {
 			// Map the tokens to product ids.
@@ -125,11 +144,13 @@ export const HandPickedProductsControlField = ( {
 				// Filter out products that are already selected.
 				.filter(
 					( product ) =>
-						! selectedProductIds?.includes( String( product.id ) )
+						! validSelectedProductIds?.includes(
+							String( product.id )
+						)
 				)
 				.map( ( product ) => product.name )
 		);
-	}, [ productsList, selectedProductIds ] );
+	}, [ productsList, validSelectedProductIds ] );
 
 	/**
 	 * Transforms a token into a product name.
@@ -162,7 +183,7 @@ export const HandPickedProductsControlField = ( {
 			value={
 				! productsMap.size
 					? [ __( 'Loading…', 'woocommerce' ) ]
-					: selectedProductIds || []
+					: validSelectedProductIds || []
 			}
 			__experimentalExpandOnFocus={ true }
 			__experimentalShowHowTo={ false }

--- a/plugins/woocommerce/changelog/54564-fix-54341-after-deleting-a-product-shown-in-product-collection-the-formtokenfield-in-the-selector-is-empty
+++ b/plugins/woocommerce/changelog/54564-fix-54341-after-deleting-a-product-shown-in-product-collection-the-formtokenfield-in-the-selector-is-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Empty FormTokenField display in "Hand-Picked Products" collection when selected hand-picked products are deleted.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54341

This PR improves the handling of hand-picked products in Hand-Picked Products collection by ensuring that only existing products are kept in the selection. It adds proper validation of selected products and updates the UI components to use the validated product IDs. In other words, Deleted product is removed from the selection.
![Image](https://github.com/user-attachments/assets/db4e97ad-7d10-49db-9caa-ff5678fbed05)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add new product which will be deleted later.
2. Create a new post.
3. Add Product Collection block and select `Hand-Picked Products` collection.
4. Using "HAND-PICKED" control in sidebar, select the product you just created. And save the post
5. Delete the product permanently and refresh the page you saved in step 4
6. Verify that there isn't empty chip in "HAND-PICKED" control. 
![Image](https://github.com/user-attachments/assets/db4e97ad-7d10-49db-9caa-ff5678fbed05)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix: Empty FormTokenField display in "Hand-Picked Products" collection when selected hand-picked products are deleted.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>