### PR TITLE
Update link to e2e documentation

### DIFF
--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Tests
 
-This document discusses unit tests. See [the e2e README](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md) to learn how to setup testing environment for running e2e tests and run them.
+This document discusses unit tests. See [the e2e-pw README](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/README.md) to learn how to setup testing environment for running e2e tests and run them.
 
 ## Table of contents
 


### PR DESCRIPTION
Fixing old link in docs giving 404
