### PR TITLE
Only calls misc recommendations API when the current user can install plugin

### DIFF
--- a/plugins/woocommerce/changelog/54602-fix-do-not-call-misc-recommendations-api-when-user-cannot-install-plugin
+++ b/plugins/woocommerce/changelog/54602-fix-do-not-call-misc-recommendations-api-when-user-cannot-install-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only calls misc recommendations API when the current user can install plugin.

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -128,10 +128,12 @@ export const useOrderAttributionInstallBanner = () => {
 				loadingRecommendations: ! hasFinishedResolution(
 					'getMiscRecommendations'
 				),
-				recommendations: getMiscRecommendations(),
+				recommendations: canUserInstallPlugins
+					? getMiscRecommendations()
+					: [],
 			};
 		},
-		[]
+		[ canUserInstallPlugins ]
 	);
 
 	const percentages = useMemo( () => {

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -125,9 +125,9 @@ export const useOrderAttributionInstallBanner = () => {
 				select( STORE_KEY );
 
 			return {
-				loadingRecommendations: ! hasFinishedResolution(
-					'getMiscRecommendations'
-				),
+				loadingRecommendations:
+					! canUserInstallPlugins ||
+					! hasFinishedResolution( 'getMiscRecommendations' ),
 				recommendations: canUserInstallPlugins
 					? getMiscRecommendations()
 					: [],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54596.

This PR adds a check so it will only call misc recommendations API when the current user can install plugins.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build WC using this branch
2. Go to `WooCommece > Settings > Advanced > Features`, and enable the **Order Attribution** feature
3. Create a user with "Shop manager"'s role
4. Login to wp-admin using the shop manager account
5. Go to `WooCommece > Orders`, and click any order to enter the order editor
6. From the developer console's "Network" tab, the `/wc-admin/marketing/misc-recommendations` API should not be called
7. The error notice `There was an error loading misc recommendations` should not appear
8. Go to `Analytics > Overview`
9. From the developer console's "Network" tab, the `/wc-admin/marketing/misc-recommendations` API should not be called
10. The error notice `There was an error loading misc recommendations` should not appear
11. Login using the admin account
12. Repeat step 5 and step 8, the misc recommendations API should be called and the promotion banner should appear

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Only calls misc recommendations API when the current user can install plugin.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
