### PR TITLE
Update woocommerce-analytics plugin URL to the one in .Org

### DIFF
--- a/plugins/woocommerce/changelog/54618-update-woocommerce-analytics-plugin-url
+++ b/plugins/woocommerce/changelog/54618-update-woocommerce-analytics-plugin-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update woocommerce-analytics plugin URL to the one in .org

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/order-attribution-install-banner.js
@@ -21,7 +21,7 @@ import {
 import './style.scss';
 
 const WC_ANALYTICS_PRODUCT_URL =
-	'https://woocommerce.com/products/woocommerce-analytics';
+	'https://wordpress.org/plugins/woocommerce-analytics';
 
 /**
  * The banner to prompt users to install the Order Attribution extension.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

pfKYZu-2g8-p2

This PR changes the WooCommerce Analytics plugin's URL in the promotion banners from WC marketplace (https://woocommerce.com/products/woocommerce-analytics) to the one in .Org (https://wordpress.org/plugins/woocommerce-analytics). The reason for the change is to aid with the install process and try reduce potential drop-offs in the funnel.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build WC using this branch.
2. Update the option `woocommerce_remote_variant_assignment` to `1` so the banner will appear by running `wp option update woocommerce_remote_variant_assignment 1`
3. Make sure the plugin `woocommerce-analytics` is not installed
4. Go to `Analytics > Overview`, see the plugin promotion banner
5. Click `Try it now`, you should see the the URL https://wordpress.org/plugins/woocommerce-analytics is opened in a new tab
6. Back to `Analytics > Overview`, click `Dismiss`, you should see a badge in the top-right corner with the text `Try Order Attribution`
7. Click `Try Order Attribution`, you should see the the URL https://wordpress.org/plugins/woocommerce-analytics is opened in a new tab
8. Go to `WooCommerce > Orders` and click any order to enter order editor
9. Click `Install the extension` under the order attribution meta box in the right hand side, you should see the the URL https://wordpress.org/plugins/woocommerce-analytics is opened in a new tab

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update woocommerce-analytics plugin URL to the one in .org

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>