### PR TITLE
Fix missing account form styles

### DIFF
--- a/plugins/woocommerce/changelog/fix-missing-account-form-styles
+++ b/plugins/woocommerce/changelog/fix-missing-account-form-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes style regression.
+
+

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -37,6 +37,6 @@ $subtext:           #767676 !default;                                  // small,
 	--wc-subtext: #{$subtext};
 	--wc-form-border-color: rgba(32, 7, 7, 0.8);
 	--wc-form-border-radius: 4px;
-	--wc-form-color-text: inherit;
+	--wc-form-color-text: unset;
 	--wc-form-border-width: 1px;
 }

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -37,6 +37,5 @@ $subtext:           #767676 !default;                                  // small,
 	--wc-subtext: #{$subtext};
 	--wc-form-border-color: rgba(32, 7, 7, 0.8);
 	--wc-form-border-radius: 4px;
-	--wc-form-color-text: unset;
 	--wc-form-border-width: 1px;
 }

--- a/plugins/woocommerce/client/legacy/css/forms.scss
+++ b/plugins/woocommerce/client/legacy/css/forms.scss
@@ -23,7 +23,10 @@
 			}
 		}
 
-		.woocommerce-input-wrapper {
+		// Wrapper adds specificity to the styles but is not required due to some forms (account) not using the wrapper
+		// element.
+		.woocommerce-input-wrapper,
+		& {
 			.description {
 				background: #1e85be;
 				color: #fff;

--- a/plugins/woocommerce/client/legacy/css/forms.scss
+++ b/plugins/woocommerce/client/legacy/css/forms.scss
@@ -23,88 +23,82 @@
 			}
 		}
 
-		// Wrapper adds specificity to the styles but is not required due to some forms (account) not using the wrapper
-		// element.
-		.woocommerce-input-wrapper,
-		& {
-			.description {
-				background: #1e85be;
+		.woocommerce-input-wrapper .description {
+			background: #1e85be;
+			color: #fff;
+			border-radius: 3px;
+			padding: 1em;
+			margin: 0.5em 0 0;
+			clear: both;
+			display: none;
+			position: relative;
+
+			a {
 				color: #fff;
-				border-radius: 3px;
-				padding: 1em;
-				margin: 0.5em 0 0;
-				clear: both;
-				display: none;
-				position: relative;
-
-				a {
-					color: #fff;
-					text-decoration: underline;
-					border: 0;
-					box-shadow: none;
-				}
-
-				&::before {
-					left: 50%;
-					top: 0%;
-					margin-top: -4px;
-					transform: translateX(-50%) rotate(180deg);
-					content: "";
-					position: absolute;
-					border-width: 4px 6px 0 6px;
-					border-style: solid;
-					border-color: #1e85be transparent transparent transparent;
-					z-index: 100;
-					display: block;
-				}
-			}
-
-			.input-checkbox {
-				display: inline;
-				margin: -2px 8px 0 0;
-				text-align: center;
-				vertical-align: middle;
-			}
-
-			.input-text,
-			select {
-				font-family: inherit;
-				font-weight: normal;
-				letter-spacing: normal;
-				padding: .5em;
-				display: block;
-				background-color: var(--wc-form-color-background, #fff);
-				border: var(--wc-form-border-width) solid var(--wc-form-border-color);
-				border-radius: var(--wc-form-border-radius);
-				color: var(--wc-form-color-text);
-				box-sizing: border-box;
-				width: 100%;
-				margin: 0;
-				line-height: normal;
-				height: auto;
-
-				&:focus {
-					border-color: currentColor;
-				}
-			}
-
-			select {
-				cursor: pointer;
-				line-height: normal;
-				/* We hide the default chevron because it cannot be directly modified. Instead, we add a custom chevron using a background image. */
-				appearance: none;
-				padding-right: 3em;
-				background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJibGFjayIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItY2hldnJvbi1kb3duIj48cG9seWxpbmUgcG9pbnRzPSI2IDkgMTIgMTUgMTggOSI+PC9wb2x5bGluZT48L3N2Zz4=);
-				background-repeat: no-repeat;
-				background-size: 16px;
-				background-position: calc(100% - 0.5em) 50%;
-			}
-
-			textarea {
-				height: 4em;
-				line-height: 1.5;
+				text-decoration: underline;
+				border: 0;
 				box-shadow: none;
 			}
+
+			&::before {
+				left: 50%;
+				top: 0%;
+				margin-top: -4px;
+				transform: translateX(-50%) rotate(180deg);
+				content: "";
+				position: absolute;
+				border-width: 4px 6px 0 6px;
+				border-style: solid;
+				border-color: #1e85be transparent transparent transparent;
+				z-index: 100;
+				display: block;
+			}
+		}
+
+		.input-checkbox {
+			display: inline;
+			margin: -2px 8px 0 0;
+			text-align: center;
+			vertical-align: middle;
+		}
+
+		.input-text,
+		select {
+			font-family: inherit;
+			font-weight: normal;
+			letter-spacing: normal;
+			padding: .5em;
+			display: block;
+			background-color: var(--wc-form-color-background, #fff);
+			border: var(--wc-form-border-width) solid var(--wc-form-border-color);
+			border-radius: var(--wc-form-border-radius);
+			color: var(--wc-form-color-text);
+			box-sizing: border-box;
+			width: 100%;
+			margin: 0;
+			line-height: normal;
+			height: auto;
+
+			&:focus {
+				border-color: currentColor;
+			}
+		}
+
+		select {
+			cursor: pointer;
+			/* We hide the default chevron because it cannot be directly modified. Instead, we add a custom chevron using a background image. */
+			appearance: none;
+			padding-right: 3em;
+			background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJibGFjayIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItY2hldnJvbi1kb3duIj48cG9seWxpbmUgcG9pbnRzPSI2IDkgMTIgMTUgMTggOSI+PC9wb2x5bGluZT48L3N2Zz4=);
+			background-repeat: no-repeat;
+			background-size: 16px;
+			background-position: calc(100% - 0.5em) 50%;
+		}
+
+		textarea {
+			height: 4em;
+			line-height: 1.5;
+			box-shadow: none;
 		}
 
 		.required {

--- a/plugins/woocommerce/client/legacy/css/forms.scss
+++ b/plugins/woocommerce/client/legacy/css/forms.scss
@@ -72,7 +72,7 @@
 			background-color: var(--wc-form-color-background, #fff);
 			border: var(--wc-form-border-width) solid var(--wc-form-border-color);
 			border-radius: var(--wc-form-border-radius);
-			color: var(--wc-form-color-text);
+			color: var(--wc-form-color-text, #000);
 			box-sizing: border-box;
 			width: 100%;
 			margin: 0;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -64,7 +64,7 @@ body {
 
 	.show-password-input {
 		background-color: transparent !important;
-		color: var(--global--color-primary) !important;
+		color: var(--form--color-text) !important;
 		display: inherit;
 		outline-offset: 0;
 	}
@@ -1209,10 +1209,6 @@ a.reset_variations {
 				font-size: 1.5rem;
 				padding-top: 0.3rem;
 				padding-bottom: 0.3rem;
-			}
-
-			input {
-				border: 3px solid black;
 			}
 
 			.form-row {

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -463,7 +463,6 @@ a.added_to_cart {
 
 		.show-password-input {
 			// Adjust password field icon position.
-			top: 0.8em;
 			right: 1.2em;
 		}
 	}

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -450,20 +450,17 @@ a.added_to_cart {
 * My account - Login form
 */
 .woocommerce-page {
-	.woocommerce-form-login {
-		.input-text {
-			// Ensure inputs are well spaced.
-			font-size: var(--wp--preset--font-size--small);
-			padding: 0.9em 1.1em;
-		}
+	.woocommerce-form-login,
+	.woocommerce-form-register {
+		 .woocommerce-form-row {
+			.input-text {
+				// Ensure inputs are well spaced.
+				font-size: var(--wp--preset--font-size--medium);
+			}
 
-		label {
-			margin-bottom: 0.7em;
-		}
-
-		.show-password-input {
-			// Adjust password field icon position.
-			right: 1.2em;
+			label {
+				margin-bottom: 0.7em;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
@@ -435,6 +435,7 @@
 			margin-left: 0; /* reset the left margin from iconafter mixin */
 			margin-top: -2px; /* Manual vertical alignment adjustment */
 			vertical-align: middle;
+			display: inline-block;
 		}
 
 		.show-password-input.display-password::after {

--- a/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
@@ -414,7 +414,7 @@
 			background-color: transparent;
 			border-radius: 0;
 			border: 0;
-			color: inherit;
+			color: var(--wc-form-color-text, #000);
 			cursor: pointer;
 			font-size: inherit;
 			line-height: inherit;

--- a/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
@@ -423,17 +423,18 @@
 			position: absolute;
 			right: 0.7em;
 			text-decoration: none;
-			top: 0.7em;
+			top: 50%;
+			transform: translateY( -50% );
 			-moz-osx-font-smoothing: inherit;
 			-webkit-appearance: none;
 			-webkit-font-smoothing: inherit;
 		}
 
 		.show-password-input::after {
-
 			@include iconafter( "\e010" ); 	// Icon styles and glyph
-
 			margin-left: 0; /* reset the left margin from iconafter mixin */
+			margin-top: -2px; /* Manual vertical alignment adjustment */
+			vertical-align: middle;
 		}
 
 		.show-password-input.display-password::after {

--- a/plugins/woocommerce/client/legacy/js/frontend/password-strength-meter.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/password-strength-meter.js
@@ -1,39 +1,45 @@
 /* global wp, pwsL10n, wc_password_strength_meter_params */
-jQuery( function( $ ) {
-    'use strict';
+jQuery( function ( $ ) {
+	'use strict';
 	/**
 	 * Password Strength Meter class.
 	 */
 	var wc_password_strength_meter = {
-
 		/**
 		 * Initialize strength meter actions.
 		 */
-		init: function() {
-			$( document.body )
-				.on(
-					'keyup change',
-					'form.register #reg_password, form.checkout #account_password, ' +
+		init: function () {
+			$( document.body ).on(
+				'keyup change',
+				'form.register #reg_password, form.checkout #account_password, ' +
 					'form.edit-account #password_1, form.lost_reset_password #password_1',
-					this.strengthMeter
-				);
+				this.strengthMeter
+			);
 			$( 'form.checkout #createaccount' ).trigger( 'change' );
 		},
 
 		/**
 		 * Strength Meter.
 		 */
-		strengthMeter: function() {
-			var wrapper       = $( 'form.register, form.checkout, form.edit-account, form.lost_reset_password' ),
-				submit        = $( 'button[type="submit"]', wrapper ),
-				field         = $( '#reg_password, #account_password, #password_1', wrapper ),
-				strength      = 1,
-				fieldValue    = field.val(),
+		strengthMeter: function () {
+			var wrapper = $(
+					'form.register, form.checkout, form.edit-account, form.lost_reset_password'
+				),
+				submit = $( 'button[type="submit"]', wrapper ),
+				field = $(
+					'#reg_password, #account_password, #password_1',
+					wrapper
+				),
+				strength = 1,
+				fieldValue = field.val(),
 				stop_checkout = ! wrapper.is( 'form.checkout' ); // By default is disabled on checkout.
 
 			wc_password_strength_meter.includeMeter( wrapper, field );
 
-			strength = wc_password_strength_meter.checkPasswordStrength( wrapper, field );
+			strength = wc_password_strength_meter.checkPasswordStrength(
+				wrapper,
+				field
+			);
 
 			// Allow password strength meter stop checkout.
 			if ( wc_password_strength_meter_params.stop_checkout ) {
@@ -42,7 +48,8 @@ jQuery( function( $ ) {
 
 			if (
 				fieldValue.length > 0 &&
-				strength < wc_password_strength_meter_params.min_password_strength &&
+				strength <
+					wc_password_strength_meter_params.min_password_strength &&
 				-1 !== strength &&
 				stop_checkout
 			) {
@@ -58,7 +65,7 @@ jQuery( function( $ ) {
 		 * @param {Object} wrapper
 		 * @param {Object} field
 		 */
-		includeMeter: function( wrapper, field ) {
+		includeMeter: function ( wrapper, field ) {
 			var meter = wrapper.find( '.woocommerce-password-strength' );
 
 			if ( '' === field.val() ) {
@@ -66,7 +73,15 @@ jQuery( function( $ ) {
 				$( document.body ).trigger( 'wc-password-strength-hide' );
 				field.removeAttr( 'aria-describedby' );
 			} else if ( 0 === meter.length ) {
-				field.after( '<div id="password_strength" class="woocommerce-password-strength" role="alert"></div>' );
+				var meter =
+					'<div id="password_strength" class="woocommerce-password-strength" role="alert"></div>';
+				var wrapper = field.parent();
+				// If the field is inside a password-input, inject the meter after the password-input.
+				if ( wrapper.is( '.password-input' ) ) {
+					wrapper.after( meter );
+				} else {
+					field.after( meter );
+				}
 				field.attr( 'aria-describedby', 'password_strength' );
 				$( document.body ).trigger( 'wc-password-strength-added' );
 			} else {
@@ -82,12 +97,18 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Int}
 		 */
-		checkPasswordStrength: function( wrapper, field ) {
-			var meter     = wrapper.find( '.woocommerce-password-strength' ),
-				hint      = wrapper.find( '.woocommerce-password-hint' ),
-				hint_html = '<small class="woocommerce-password-hint">' + wc_password_strength_meter_params.i18n_password_hint + '</small>',
-				strength  = wp.passwordStrength.meter( field.val(), wp.passwordStrength.userInputDisallowedList() ),
-				error     = '';
+		checkPasswordStrength: function ( wrapper, field ) {
+			var meter = wrapper.find( '.woocommerce-password-strength' ),
+				hint = wrapper.find( '.woocommerce-password-hint' ),
+				hint_html =
+					'<small class="woocommerce-password-hint">' +
+					wc_password_strength_meter_params.i18n_password_hint +
+					'</small>',
+				strength = wp.passwordStrength.meter(
+					field.val(),
+					wp.passwordStrength.userInputDisallowedList()
+				),
+				error = '';
 
 			// Reset.
 			meter.removeClass( 'short bad good strong' );
@@ -98,36 +119,43 @@ jQuery( function( $ ) {
 			}
 
 			// Error to append
-			if ( strength < wc_password_strength_meter_params.min_password_strength ) {
-				error = ' - ' + wc_password_strength_meter_params.i18n_password_error;
+			if (
+				strength <
+				wc_password_strength_meter_params.min_password_strength
+			) {
+				error =
+					' - ' +
+					wc_password_strength_meter_params.i18n_password_error;
 			}
 
 			switch ( strength ) {
-				case 0 :
-					meter.addClass( 'short' ).html( pwsL10n['short'] + error );
+				case 0:
+					meter
+						.addClass( 'short' )
+						.html( pwsL10n[ 'short' ] + error );
 					meter.after( hint_html );
 					break;
-				case 1 :
+				case 1:
 					meter.addClass( 'bad' ).html( pwsL10n.bad + error );
 					meter.after( hint_html );
 					break;
-				case 2 :
+				case 2:
 					meter.addClass( 'bad' ).html( pwsL10n.bad + error );
 					meter.after( hint_html );
 					break;
-				case 3 :
+				case 3:
 					meter.addClass( 'good' ).html( pwsL10n.good + error );
 					break;
-				case 4 :
+				case 4:
 					meter.addClass( 'strong' ).html( pwsL10n.strong + error );
 					break;
-				case 5 :
+				case 5:
 					meter.addClass( 'short' ).html( pwsL10n.mismatch );
 					break;
 			}
 
 			return strength;
-		}
+		},
 	};
 
 	wc_password_strength_meter.init();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#53521 made some CSS selectors more specific to target `woocommerce-input-wrapper`. This class is not used on the account and login forms. This causes a style regression.

This PR fixes the regression as well as 'show password toggle' alignment and some theme specific issues found while testing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. See instructions in #53521.
2. In addition, check the "login" form and the "edit account details" forms. 
3. Check the password toggles are functional.
4. Check the password strength meter on the registration form shows when you type into the password field.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
