### PR TITLE
WC_Product_Variable_Data_Store_CPT: Validate data before we set it in a transient

### DIFF
--- a/plugins/woocommerce/changelog/update-validate-variable-product-transient-data-before-setting-it
+++ b/plugins/woocommerce/changelog/update-validate-variable-product-transient-data-before-setting-it
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Validate transient data before setting it

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -163,7 +163,10 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			$children['visible'] = get_posts( apply_filters( 'woocommerce_variable_children_args', $visible_only_args, $product, true ) );
 			$children['version'] = $transient_version;
 
-			set_transient( $children_transient_name, $children, DAY_IN_SECONDS * 30 );
+			// Validate the children data before storing it in the transient.
+			if ( $this->validate_children_data( $children, $transient_version ) ) {
+				set_transient( $children_transient_name, $children, DAY_IN_SECONDS * 30 );
+			}
 		}
 
 		$children['all']     = wp_parse_id_list( (array) $children['all'] );
@@ -388,7 +391,10 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					$transient_cached_prices_array[ $price_hash ][ $key ] = $values;
 				}
 
-				set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
+				// Validate the prices data before storing it in the transient.
+				if ( $this->validate_prices_data( $transient_cached_prices_array, $transient_version ) ) {
+					set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
+				}
 			}
 
 			/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Previously, we only validated transient data when reading it, if validation failed we queried the product data directly and updated the transient. This PR adds validation before setting any transient data, ensuring only valid data gets stored in the first place.

Closes https://github.com/woocommerce/woocommerce/issues/50855
Closes https://github.com/woocommerce/woocommerce/issues/46260

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Regression test variable products continue to work as expected. Make various updates to the product data and check they continue to work on the frontend.
2. You can install the Transient Manager plugin and check that the transient data being set for your products is correct. For example, on [this PR](https://github.com/woocommerce/woocommerce/pull/53724) you can see examples of corrupted data which should not be present in your transients.
3. Update your product variant prices, and check the transient `wc_var_prices_{product_id}` has correctly updated
4. Ensure unit test cases are valid and that they pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
