### PR TITLE
[WC Payments NOX] Additional provider buttons for WooPayments

### DIFF
--- a/plugins/woocommerce/changelog/update-54306-additional-button-states-for-woopayments-provider
+++ b/plugins/woocommerce/changelog/update-54306-additional-button-states-for-woopayments-provider
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Update WooPayments provider buttons to include reactivate payments button.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -148,7 +148,7 @@ export const EnableGatewayButton = ( {
 						);
 					}
 				}
-				// If no redirect occured, the data needs to be refreshed.
+				// If no redirect occurred, the data needs to be refreshed.
 				invalidateResolutionForStoreSelector(
 					isOffline
 						? 'getOfflinePaymentGateways'

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/reactivate-live-payments-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/reactivate-live-payments-button.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { dispatch, useDispatch } from '@wordpress/data';
+import { PAYMENT_SETTINGS_STORE_NAME } from '@woocommerce/data';
+import apiFetch from '@wordpress/api-fetch';
+
+interface ReactivateLivePaymentsButtonProps {
+	/**
+	 * The text of the button.
+	 */
+	buttonText?: string;
+	/**
+	 * The settings URL to navigate to when the enable gateway button is clicked.
+	 */
+	settingsHref: string;
+}
+
+/**
+ * A button component that allows users to disable test mode payments (only for WooPayments at the moment).
+ */
+export const ReactivateLivePaymentsButton = ( {
+	buttonText = __( 'Reactivate payments', 'woocommerce' ),
+	settingsHref,
+}: ReactivateLivePaymentsButtonProps ) => {
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const { createSuccessNotice, createErrorNotice } =
+		dispatch( 'core/notices' );
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		PAYMENT_SETTINGS_STORE_NAME
+	);
+
+	const disableTestModePayments = ( e: React.MouseEvent ) => {
+		e.preventDefault();
+		setIsUpdating( true );
+
+		apiFetch( {
+			path: '/wc/v3/payments/settings',
+			method: 'POST',
+			data: {
+				is_test_mode_enabled: false,
+			},
+		} )
+			.then( () => {
+				createSuccessNotice(
+					sprintf(
+						/* translators: %s: WooPayments */
+						__(
+							'%s is now processing live payments (real payment methods and charges).',
+							'woocommerce'
+						),
+						'WooPayments'
+					),
+					{
+						type: 'snackbar',
+						explicitDismiss: false,
+					}
+				);
+
+				// Force the providers to be refreshed.
+				invalidateResolutionForStoreSelector( 'getPaymentProviders' );
+
+				setIsUpdating( false );
+			} )
+			.catch( () => {
+				// In case of errors, redirect to the gateway settings page.
+				setIsUpdating( false );
+
+				createErrorNotice(
+					sprintf(
+						/* translators: %s: WooPayments */
+						__(
+							'An error occurred. You will be redirected to the %s settings page to manage payments processing mode from there.',
+							'woocommerce'
+						),
+						'WooPayments'
+					),
+					{
+						type: 'snackbar',
+						explicitDismiss: true,
+					}
+				);
+
+				window.location.href = settingsHref;
+			} );
+	};
+
+	return (
+		<Button
+			variant={ 'primary' }
+			isBusy={ isUpdating }
+			disabled={ isUpdating }
+			onClick={ disableTestModePayments }
+			href={ settingsHref }
+		>
+			{ buttonText }
+		</Button>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -26,6 +26,7 @@ import {
 	EnableGatewayButton,
 	SettingsButton,
 } from '~/settings-payments/components/buttons';
+import { ReactivateLivePaymentsButton } from '~/settings-payments/components/buttons/reactivate-live-payments-button';
 
 type PaymentGatewayItemProps = {
 	gateway: PaymentGatewayProvider;
@@ -199,6 +200,20 @@ export const PaymentGatewayListItem = ( {
 								<ActivatePaymentsButton
 									acceptIncentive={ acceptIncentive }
 									incentive={ incentive }
+								/>
+							) }
+
+						{ isWooPayments( gateway.id ) &&
+							// There are no live payments in dev mode or test accounts, so no point in reactivating them.
+							! gateway.state.dev_mode &&
+							gateway.state.account_connected &&
+							gateway.onboarding.state.completed &&
+							! gateway.onboarding.state.test_mode &&
+							gateway.state.test_mode && (
+								<ReactivateLivePaymentsButton
+									settingsHref={
+										gateway.management._links.settings.href
+									}
 								/>
 							) }
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -45,7 +45,7 @@ export const PaymentGatewayListItem = ( {
 	const gatewayHasRecommendedPaymentMethods =
 		( gateway.onboarding.recommended_payment_methods ?? [] ).length > 0;
 
-	// If the account is not connected or the onboarding is not started, or not completed then the gateway needs setup.
+	// If the account is not connected or the onboarding is not started, or not completed then the gateway needs onboarding.
 	const gatewayNeedsOnboarding =
 		! gateway.state.account_connected ||
 		( gateway.state.account_connected &&

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -59,6 +59,11 @@ export const PaymentGatewayListItem = ( {
 			return 'needs_setup';
 		}
 		if ( gateway.state.enabled ) {
+			// A test account also implies test mode.
+			if ( gateway.onboarding.state.test_mode ) {
+				return 'test_account';
+			}
+
 			if ( gateway.state.test_mode ) {
 				return 'test_mode';
 			}

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
@@ -20,6 +20,7 @@ interface StatusBadgeProps {
 		| 'inactive'
 		| 'needs_setup'
 		| 'test_mode'
+		| 'test_account'
 		| 'recommended'
 		| 'has_incentive';
 	/**
@@ -51,6 +52,7 @@ export const StatusBadge = ( { status, message }: StatusBadgeProps ) => {
 				return 'woocommerce-status-badge--success';
 			case 'needs_setup':
 			case 'test_mode':
+			case 'test_account':
 				return 'woocommerce-status-badge--warning';
 			case 'recommended':
 			case 'inactive':
@@ -73,6 +75,8 @@ export const StatusBadge = ( { status, message }: StatusBadgeProps ) => {
 				return __( 'Action needed', 'woocommerce' );
 			case 'test_mode':
 				return __( 'Test mode', 'woocommerce' );
+			case 'test_account':
+				return __( 'Test account', 'woocommerce' );
 			case 'recommended':
 				return __( 'Recommended', 'woocommerce' );
 			default:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54306  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja site with WooCommerce on this PR's live branch, WooCommerce Beta Tester, and WooPayments Dev Tools (here is [a direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce-payments-dev-tools&woocommerce&branches.woocommerce=update/54306-additional-button-states-for-woopayments-provider))
1. Go to the newly created site WP admin dashboard.
1. Go to Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature.
1. Go to Jetpack > Beta Tester and make sure WooCommerce is on this PR's branch:
![Screenshot 2025-01-17 at 16 21 15](https://github.com/user-attachments/assets/3cad10b2-4189-4b1c-8df1-87c948cb8214)
1. Go through the WooCommerce profiler (click on the "WooCommerce" menu item if it doesn't start automatically), click on "Skip guided setup", and choose **United States** as your store's location.
1. Click on the "WCPay Dev" main menu item and make sure dev mode is enabled:
![Screenshot 2025-01-17 at 16 22 37](https://github.com/user-attachments/assets/ac9d78cb-1dcd-4f48-a358-6d8bd6a02a7f)
1. Click on the "Payments" main menu item and then click on "Install" for WooPayments:
![Screenshot 2025-01-17 at 16 20 33](https://github.com/user-attachments/assets/43a50bfb-f062-450d-abac-0f46ad2d1bdd)
1. Click on "Continue" on the next step, connect your JN store to your WPCOM account (set up the Jetpack connection), and wait for the onboarding to finish. Close the modal:
![Screenshot 2025-01-17 at 16 26 34](https://github.com/user-attachments/assets/8d296ee9-83ff-45bc-85e7-adc34bde0c52)
1. Notice that WooPayments has a "Test account" badge, but no "Activate payments" button, only a "Manage" one:
![Screenshot 2025-01-17 at 16 27 02](https://github.com/user-attachments/assets/93d2631f-0dfd-47e8-acf3-78789cf7b34a)
1. Click on the "WCPay Dev" main menu item and disable dev mode.
1. Go to WooCommerce > Settings > Payments and notice that WooPayments now has a "Activate payments" button and a "Manage" one:
![Screenshot 2025-01-17 at 16 28 39](https://github.com/user-attachments/assets/ec521c8e-6662-44a9-8f24-09f1956af115)
1. Click on "Activate payments" and you will be taken to the WooPayments onboarding wizard (MOX):
![Screenshot 2025-01-17 at 16 32 01](https://github.com/user-attachments/assets/63f1a90f-877e-4ba1-8f95-a86522a8b105)

#### Testing reactivating live payments

1. On your local WooPayments installation, use WooCommerce with this PR's code.
1. Make sure WooPayments is on `develop` and it is built with `npm run build:client`.
1. WooPayments should be talking with your local server installation (make sure that is on the latest `trunk`, for good measure).
1. Remove any account you have, disable dev mode, and onboard a "live" account (through the WooPayments Connect page, live flow).
1. Go to the WooPayments settings, and enable test mode payments processing.
1. Go to WooCommerce > Settings > Payments, and you should see for WooPayments a "Test mode" badge  and a "Reactivate payments" button:
![Screenshot 2025-01-17 at 16 51 50](https://github.com/user-attachments/assets/e11173d2-356a-4ca1-b921-6f664e207e75)
1. Click on "Reactivate payments", the provider list should refresh, a snackbar notice should appear, and WooPayments should be "Active" with no "Reactivate payments" button:
![Screenshot 2025-01-17 at 16 54 20](https://github.com/user-attachments/assets/f10985bb-569a-4860-8c86-3bedad2fccdc)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
