### PR TITLE
[Experimental] Pass in selected value to checkbox list

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -115,7 +115,7 @@ const Edit = ( props: EditProps ) => {
 							? `${ term.name } (${ term.count })`
 							: term.name,
 						value: term.id.toString(),
-						selected: index === 1,
+						selected: index === 0,
 						rawData: term,
 					} ) )
 			);

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -103,8 +103,7 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 												type="checkbox"
 												className="wc-block-product-filter-checkbox-list__input"
 												defaultChecked={
-													!! item.selected ||
-													index === 1
+													!! item.selected
 												}
 											/>
 											<Icon

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -134,7 +134,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 			? collectionFilters.rating_counts
 					.sort( ( a, b ) => b.rating - a.rating )
 					.filter( ( { rating } ) => rating >= minimumRating )
-					.map( ( { rating, count } ) => ( {
+					.map( ( { rating, count }, index ) => ( {
 						label: (
 							<Rating
 								key={ rating }
@@ -143,6 +143,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 							/>
 						),
 						value: rating?.toString(),
+						selected: index === 0,
 					} ) )
 			: [];
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -72,7 +72,7 @@ const Edit = ( props: EditProps ) => {
 
 	const items = useMemo( () => {
 		return Object.entries( stockStatusOptions )
-			.map( ( [ key, value ] ) => {
+			.map( ( [ key, value ], index ) => {
 				const count =
 					filteredCounts?.stock_status_counts?.find(
 						( item ) => item.status === key
@@ -84,6 +84,7 @@ const Edit = ( props: EditProps ) => {
 						? `${ value } (${ count.toString() })`
 						: value,
 					count,
+					selected: index === 0,
 				};
 			} )
 			.filter( ( item ) => ! hideEmpty || item.count > 0 );

--- a/plugins/woocommerce/changelog/54653-product-filters-pass-selected-to-checkbox-list
+++ b/plugins/woocommerce/changelog/54653-product-filters-pass-selected-to-checkbox-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: [Experimental] Product filters - remove default selected state from checkbox list
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is a follow up to the comments made https://github.com/woocommerce/woocommerce/pull/54539#pullrequestreview-2559295137

It removes the default selected/checked state from the checkbox list block and gets the props from the parent block instead.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Edit the template.
3. With the block inserter, add Product Filters (Experimental) block to the template.
4. Ensure you see first item of each checkbox list is checked for Rating, Attributes and Status Filter blocks.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
[Experimental] Product filters - remove default selected state from checkbox list
</details>
