### PR TITLE
Add font family fallback in emails

### DIFF
--- a/plugins/woocommerce/changelog/54625-email-font-family
+++ b/plugins/woocommerce/changelog/54625-email-font-family
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix rendering font family in emails

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -741,7 +741,8 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 */
 	public function email_font_family( $value ) {
 		$option_value = $value['value'];
-		$custom_fonts = $this->get_custom_fonts();
+		// This is a temporary fix to prevent using custom fonts without fallback
+		$custom_fonts = null; // $this->get_custom_fonts();
 
 		?>
 		<tr class="<?php echo esc_attr( $value['row_class'] ); ?>">

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\BrandingController;
+use Automattic\WooCommerce\Internal\Email\EmailFont;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -20,24 +21,6 @@ if ( class_exists( 'WC_Settings_Emails', false ) ) {
  * WC_Settings_Emails.
  */
 class WC_Settings_Emails extends WC_Settings_Page {
-
-	/**
-	 * Array of font families supported in email templates
-	 *
-	 * @var string[]
-	 */
-	public static $font = array(
-		'Arial'           => "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-		'Comic Sans MS'   => "'Comic Sans MS', 'Marker Felt-Thin', Arial, sans-serif",
-		'Courier New'     => "'Courier New', Courier, 'Lucida Sans Typewriter', 'Lucida Typewriter', monospace",
-		'Georgia'         => "Georgia, Times, 'Times New Roman', serif",
-		'Helvetica'       => "'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif",
-		'Lucida'          => "'Lucida Sans Unicode', 'Lucida Grande', sans-serif",
-		'Tahoma'          => 'Tahoma, Verdana, Segoe, sans-serif',
-		'Times New Roman' => "'Times New Roman', Times, Baskerville, Georgia, serif",
-		'Trebuchet MS'    => "'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif",
-		'Verdana'         => 'Verdana, Geneva, sans-serif',
-	);
 
 	/**
 	 * Constructor.
@@ -791,7 +774,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					>
 					<optgroup label="<?php echo esc_attr__( 'Standard fonts', 'woocommerce' ); ?>">
 						<?php
-						foreach ( self::$font as $key => $font_family ) {
+						foreach ( EmailFont::$font as $key => $font_family ) {
 							?>
 							<option
 								value="<?php echo esc_attr( $key ); ?>"

--- a/plugins/woocommerce/src/Internal/Email/EmailFont.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailFont.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * EmailFont class file
+ */
+
+namespace Automattic\WooCommerce\Internal\Email;
+
+/**
+ * Helper class for getting fonts for emails.
+ *
+ * @internal Just for internal use.
+ */
+class EmailFont {
+
+	/**
+	 * Array of font families supported in email templates
+	 *
+	 * @var string[]
+	 */
+	public static $font = array(
+		'Arial'           => "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+		'Comic Sans MS'   => "'Comic Sans MS', 'Marker Felt-Thin', Arial, sans-serif",
+		'Courier New'     => "'Courier New', Courier, 'Lucida Sans Typewriter', 'Lucida Typewriter', monospace",
+		'Georgia'         => "Georgia, Times, 'Times New Roman', serif",
+		'Helvetica'       => "'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif",
+		'Lucida'          => "'Lucida Sans Unicode', 'Lucida Grande', sans-serif",
+		'Tahoma'          => 'Tahoma, Verdana, Segoe, sans-serif',
+		'Times New Roman' => "'Times New Roman', Times, Baskerville, Georgia, serif",
+		'Trebuchet MS'    => "'Trebuchet MS', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Tahoma, sans-serif",
+		'Verdana'         => 'Verdana, Geneva, sans-serif',
+	);
+
+}

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -15,6 +15,7 @@
  * @version 9.7.0
  */
 
+use Automattic\WooCommerce\Internal\Email\EmailFont;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -30,7 +31,7 @@ $base             = get_option( 'woocommerce_email_base_color' );
 $text             = get_option( 'woocommerce_email_text_color' );
 $footer_text      = get_option( 'woocommerce_email_footer_text_color' );
 $header_alignment = get_option( 'woocommerce_email_header_alignment', $email_improvements_enabled ? 'left' : false );
-$default_font     = '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif';
+$default_font     = 'Helvetica';
 $font_family      = $email_improvements_enabled ? get_option( 'woocommerce_email_font_family', $default_font ) : $default_font;
 
 /**
@@ -58,6 +59,9 @@ if ( $is_email_preview ) {
 	$header_alignment = $header_alignment_transient ? $header_alignment_transient : $header_alignment;
 	$font_family      = $font_family_transient ? $font_family_transient : $font_family;
 }
+
+// Only use safe fonts. They won't be escaped to preserve single quotes.
+$safe_font_family = EmailFont::$font[ $font_family ] ?? EmailFont::$font[ $default_font ];
 
 $base_text = wc_light_or_dark( $base, '#202020', '#ffffff' );
 
@@ -118,7 +122,7 @@ body {
 	font-weight: bold;
 	line-height: 100%;
 	vertical-align: middle;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 }
 
 #template_header h1,
@@ -143,7 +147,7 @@ body {
 
 .email-logo-text {
 	color: <?php echo esc_attr( $link_color ); ?>;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: 18px;
 }
 
@@ -179,7 +183,7 @@ body {
 		border-top: 1px solid rgba(0, 0, 0, .2);
 	<?php endif; ?>
 	color: <?php echo esc_attr( $footer_text ); ?>;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: 12px;
 	line-height: <?php echo $email_improvements_enabled ? '140%' : '150%'; ?>;
 	text-align: center;
@@ -304,7 +308,7 @@ body {
 
 #body_content_inner {
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: <?php echo $email_improvements_enabled ? '16px' : '14px'; ?>;
 	line-height: 150%;
 	text-align: <?php echo is_rtl() ? 'right' : 'left'; ?>;
@@ -340,7 +344,7 @@ body {
 
 .text {
 	color: <?php echo esc_attr( $text ); ?>;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 }
 
 .link {
@@ -365,7 +369,7 @@ body {
 
 h1 {
 	color: <?php echo esc_attr( $email_improvements_enabled ? $text : $base ); ?>;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: <?php echo $email_improvements_enabled ? '32px' : '30px'; ?>;
 	font-weight: <?php echo $email_improvements_enabled ? 700 : 300; ?>;
 	<?php if ( $email_improvements_enabled ) : ?>
@@ -382,7 +386,7 @@ h1 {
 h2 {
 	color: <?php echo esc_attr( $email_improvements_enabled ? $text : $base ); ?>;
 	display: block;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: <?php echo $email_improvements_enabled ? '20px' : '18px'; ?>;
 	font-weight: bold;
 	line-height: <?php echo $email_improvements_enabled ? '160%' : '130%'; ?>;
@@ -393,7 +397,7 @@ h2 {
 h3 {
 	color: <?php echo esc_attr( $email_improvements_enabled ? $text : $base ); ?>;
 	display: block;
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	font-size: 16px;
 	font-weight: bold;
 	line-height: <?php echo $email_improvements_enabled ? '160%' : '130%'; ?>;
@@ -429,7 +433,7 @@ h2.email-order-detail-heading span {
 }
 
 .font-family {
-	font-family: <?php echo esc_attr( $font_family ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 }
 
 .text-align-left {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-email.spec.js
@@ -476,7 +476,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 			await fontFamilyElement.selectOption( 'Times New Roman' );
 
 			// Test theme font selection
-			await fontFamilyElement.selectOption( 'Inter' );
+			// await fontFamilyElement.selectOption( 'Inter' );
 		}
 	);
 

--- a/plugins/woocommerce/tests/legacy/data/sample-email.html
+++ b/plugins/woocommerce/tests/legacy/data/sample-email.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <html>
 <head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
-<body style="background-color: #f7f7f7; padding: 0; text-align: center;" bgcolor="#f7f7f7"><p class="text" style="color: #3c3c3c;">Hello World!</p></body>
+<body style="background-color: #f7f7f7; padding: 0; text-align: center;" bgcolor="#f7f7f7"><p class="text" style='color: #3c3c3c; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif;'>Hello World!</p></body>
 </html>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54625.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Emal improvements` flag in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. Observe that by default `Helvetica` is chosen and is also correctly used in email preview.
4. Change font family and observe, that it's used in email preview.

<!-- End testing instructions -->