### PR TITLE
[Checkout] Increase padding for fields in block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-blocktheme-form-styles
+++ b/plugins/woocommerce/changelog/fix-blocktheme-form-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Updating styles for block themes.
+
+

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -453,7 +453,8 @@ a.added_to_cart {
 	// For block themes we increase the padding of the input fields across classic checkout and my account pages.
 	form .form-row {
 		select,
-		.input-text {
+		textarea.input-text,
+		input.input-text {
 			// Ensure inputs are well spaced.
 			font-size: var(--wp--preset--font-size--small);
 			padding: 0.9rem 1.1rem;

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -450,17 +450,44 @@ a.added_to_cart {
 * My account - Login form
 */
 .woocommerce-page {
-	.woocommerce-form-login,
-	.woocommerce-form-register {
-		 .woocommerce-form-row {
-			.input-text {
-				// Ensure inputs are well spaced.
-				font-size: var(--wp--preset--font-size--medium);
-			}
+	// For block themes we increase the padding of the input fields across classic checkout and my account pages.
+	form .form-row {
+		select,
+		.input-text {
+			// Ensure inputs are well spaced.
+			font-size: var(--wp--preset--font-size--small);
+			padding: 0.9rem 1.1rem;
+		}
 
-			label {
-				margin-bottom: 0.7em;
+		select {
+			background-position: calc(100% - 1.1rem) 50%;
+		}
+
+		label {
+			margin-bottom: 0.7em;
+		}
+
+		// Ensure dropdowns are visually consistent with other form fields.
+		.select2-container {
+			.select2-selection--single .select2-selection__rendered {
+				padding: 0.9rem 1.1rem;
 			}
+			.select2-selection--single .select2-selection__arrow {
+				right: 1.1em;
+			}
+		}
+	}
+
+	.select2-container {
+		.select2-search--dropdown {
+			padding: 0 1.1rem 0.5rem;
+		}
+		.select2-search--dropdown .select2-search__field {
+			padding: 0.5rem;
+			font-size: var(--wp--preset--font-size--small);
+		}
+		.select2-results__option {
+			padding:  0.5rem 1.1rem;
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some padding styles were removed in https://github.com/woocommerce/woocommerce/pull/53521 which decreased the height of inputs in block themes. These styles were consolidated into the main forms stylesheet but I didn't notice block themes were intentionally increasing padding.

This PR puts the extra padding back.

### How to test the changes in this Pull Request:

Testing a block theme such as 2025, check fields look correct under:

1. Classic checkout
2. Edit account
3. Edit address
4. Login

![Screenshot 2025-01-20 at 11 45 32](https://github.com/user-attachments/assets/3aa8da8d-034f-4241-a181-3ed92e70026d)

Note on classic checkout, padding of the coupon input should be roughly the same height as the button:

![Screenshot 2025-01-20 at 11 46 13](https://github.com/user-attachments/assets/64de80b9-d331-47e4-b237-397061e2d514)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
