### PR TITLE
[dev] Monorepo: disable update notification from pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,8 +2,9 @@
 auto-install-peers=true
 strict-peer-dependencies=false
 
-; See https://github.com/pnpm/pnpm/pull/8363 (we adding the setting now, to not miss when migrating to pnpm 9.7+)
+; quality of live tweaks for engineering teams
 manage-package-manager-versions=true
+update-notifier=false
 
 ; pnpm installation speed tweaks
 ; https://pnpm.io/npmrc#modules-cache-max-age, 20160 is for two weeks in minutes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1737428827353239-slack-C03CPM3UXDJ

Disable https://pnpm.io/npmrc#update-notifier as we pin pnpm to specific versions via `packageManager` property.


### How to test the changes in this Pull Request:

N/A