### PR TITLE
Fix global popover styling

### DIFF
--- a/packages/js/onboarding/changelog/54723-fix-global-popover-element
+++ b/packages/js/onboarding/changelog/54723-fix-global-popover-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix a bug introducing global popover styling

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/PaymentMethodsLogos.scss
@@ -54,29 +54,31 @@
 	}
 }
 
-.inside-popover {
-	display: grid;
-	grid-template-columns: repeat(4, 1fr);
-	grid-template-rows: repeat(3, 1fr);
-	gap: $gap-smaller;
-	padding: 0px;
-}
+.woocommerce-woopayments-payment-methods-logos-popover {
+	.components-popover__content {
+		background: $white;
+		border: 1px solid $gray-100;
+		border-radius: 3px;
+		max-width: 255px;
+		padding: $gap-smaller;
+		box-shadow: none;
+		margin-bottom: $gap-smaller;
 
-.components-popover__content {
-	background: $white;
-	border: 1px solid $gray-100;
-	border-radius: 3px;
-	max-width: 255px;
-	padding: $gap-smaller;
-	box-shadow: none;
-	margin-bottom: $gap-smaller;
+		a {
+			outline: none;
+			text-decoration: none;
 
-	a {
-		outline: none;
-		text-decoration: none;
-
-		&:focus {
-			box-shadow: none;
+			&:focus {
+				box-shadow: none;
+			}
 		}
+	}
+
+	.woocommerce-woopayments-payment-methods-logos {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		grid-template-rows: repeat(3, 1fr);
+		gap: $gap-smaller;
+		padding: 0px;
 	}
 }

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
@@ -237,7 +237,7 @@ export const WooPaymentsMethodsLogos: React.FC< {
 							noArrow={ true }
 							onClose={ () => setIsPopoverVisible( false ) }
 						>
-							<div className="woocommerce-woopayments-payment-methods-logos inside-popover">
+							<div className="woocommerce-woopayments-payment-methods-logos">
 								{ hiddenPaymentMethods.map(
 									( pm ) => pm.component
 								) }

--- a/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
+++ b/packages/js/onboarding/src/components/WooPaymentsMethodsLogos/index.tsx
@@ -233,6 +233,7 @@ export const WooPaymentsMethodsLogos: React.FC< {
 					{ isPopoverVisible && (
 						<Popover
 							position="top right"
+							className="woocommerce-woopayments-payment-methods-logos-popover"
 							noArrow={ true }
 							onClose={ () => setIsPopoverVisible( false ) }
 						>

--- a/plugins/woocommerce/changelog/54723-fix-global-popover-element
+++ b/plugins/woocommerce/changelog/54723-fix-global-popover-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix a bug introducing global popover styling

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-status-badge/incentive-status-badge.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-status-badge/incentive-status-badge.scss
@@ -1,5 +1,6 @@
 .woocommerce-incentive-popover {
 	&__title {
+		margin-top: 0;
 		font-size: 13px;
 		line-height: 20px;
 	}
@@ -7,5 +8,6 @@
 	&__terms {
 		font-size: 12px;
 		line-height: 18px;
+		margin-bottom: 0;
 	}
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -27,6 +27,7 @@ import {
 	SettingsButton,
 } from '~/settings-payments/components/buttons';
 import { ReactivateLivePaymentsButton } from '~/settings-payments/components/buttons/reactivate-live-payments-button';
+import { IncentiveStatusBadge } from '~/settings-payments/components/incentive-status-badge';
 
 type PaymentGatewayItemProps = {
 	gateway: PaymentGatewayProvider;
@@ -102,10 +103,7 @@ export const PaymentGatewayListItem = ( {
 					<span className="woocommerce-list__item-title">
 						{ gateway.title }
 						{ incentive ? (
-							<StatusBadge
-								status="has_incentive"
-								message={ incentive.badge }
-							/>
+							<IncentiveStatusBadge incentive={ incentive } />
 						) : (
 							<StatusBadge status={ determineGatewayStatus() } />
 						) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.scss
@@ -31,11 +31,19 @@
 // Popover styling
 .woocommerce-status-badge-popover {
 	.components-popover__content {
-		padding: 4px 12px;
+		background: $white;
+		padding: $gap-small;
+		border: 1px solid $gray-100;
+		box-shadow: none;
+		border-radius: 3px;
 
 		a {
-			text-decoration: underline;
-			outline: 0;
+			outline: none;
+			text-decoration: none;
+
+			&:focus {
+				box-shadow: none;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
@@ -114,7 +114,7 @@ export const StatusBadge = ( {
 						} }
 						onKeyDown={ ( event ) => {
 							if ( event.key === 'Enter' || event.key === ' ' ) {
-								setPopoverVisible( ! isPopoverVisible );
+								setPopoverVisible( ! setPopoverVisible );
 							}
 						} }
 						tabIndex={ 0 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This fixes a bug where styling was applied to all popovers. This will only apply the necessary changes to the Popover used in the respective page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Settings > Payments
2. Hover over WooPayments's +X and make sure it's showing as expected
<img width="335" alt="Screenshot 2025-01-21 at 13 04 14" src="https://github.com/user-attachments/assets/1271e17d-a659-476c-89a8-407d03544b41" />

3. Force an incentive in `payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx` by using:
```
<IncentiveStatusBadge
	incentive={
		incentive || {
			badge: 'test test',
			title: 'test test',
			description: 'test test',
			tc_url: 'https://www.google.com',
		}
	}
/>
```

Make sure the link is correctly displayed in the popover.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a bug introducing global popover styling

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
