### PR TITLE
Bump action scheduler version to 3.9.2

### DIFF
--- a/plugins/woocommerce/changelog/update-action-scheduler-3.9.1
+++ b/plugins/woocommerce/changelog/update-action-scheduler-3.9.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Bump Action Scheduler to 3.9.1

--- a/plugins/woocommerce/changelog/update-action-scheduler-3.9.1
+++ b/plugins/woocommerce/changelog/update-action-scheduler-3.9.1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Bump Action Scheduler to 3.9.1
+Bump Action Scheduler to 3.9.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -38,7 +38,7 @@
 		"maxmind-db/reader": "^1.11",
 		"opis/json-schema": "*",
 		"pelago/emogrifier": "^6.0",
-		"woocommerce/action-scheduler": "3.9.0",
+		"woocommerce/action-scheduler": "3.9.1",
 		"woocommerce/blueprint": "*"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -38,7 +38,7 @@
 		"maxmind-db/reader": "^1.11",
 		"opis/json-schema": "*",
 		"pelago/emogrifier": "^6.0",
-		"woocommerce/action-scheduler": "3.9.1",
+		"woocommerce/action-scheduler": "3.9.2",
 		"woocommerce/blueprint": "*"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1b3c101fc2eaec1cbaf85b89e499ee5",
+    "content-hash": "2e9b3768cceeab3382975cfedc9336a6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -1300,16 +1300,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.9.0",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771"
+                "reference": "d73b5f83cd42832fa137e03687bad3e312298d29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/90b98e6fe97d455679b1d288f050cad8f6f79771",
-                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/d73b5f83cd42832fa137e03687bad3e312298d29",
+                "reference": "d73b5f83cd42832fa137e03687bad3e312298d29",
                 "shasum": ""
             },
             "require": {
@@ -1337,9 +1337,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.0"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.1"
             },
-            "time": "2024-11-15T00:11:39+00:00"
+            "time": "2025-01-21T11:39:08+00:00"
         },
         {
             "name": "woocommerce/blueprint",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -1300,16 +1300,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.9.1",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "d73b5f83cd42832fa137e03687bad3e312298d29"
+                "reference": "efbb7953f72a433086335b249292f280dd43ddfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/d73b5f83cd42832fa137e03687bad3e312298d29",
-                "reference": "d73b5f83cd42832fa137e03687bad3e312298d29",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/efbb7953f72a433086335b249292f280dd43ddfe",
+                "reference": "efbb7953f72a433086335b249292f280dd43ddfe",
                 "shasum": ""
             },
             "require": {
@@ -1337,9 +1337,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.1"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.2"
             },
-            "time": "2025-01-21T11:39:08+00:00"
+            "time": "2025-02-03T09:09:30+00:00"
         },
         {
             "name": "woocommerce/blueprint",


### PR DESCRIPTION
- Bump AS version to 3.9.2

## Testing

Perform a smoke test with AS installed, and check if it is working well.