### PR TITLE
Do not close the popover in the incentive's info button

### DIFF
--- a/plugins/woocommerce/changelog/54735-fix-popover-with-info-button
+++ b/plugins/woocommerce/changelog/54735-fix-popover-with-info-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the popover implementation in the incentive component consistent with the on in the logo's component.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.scss
@@ -39,7 +39,7 @@
 
 		a {
 			outline: none;
-			text-decoration: none;
+			text-decoration: underline;
 
 			&:focus {
 				box-shadow: none;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
@@ -123,23 +123,23 @@ export const StatusBadge = ( {
 						size={ 14 }
 						icon={ info }
 					/>
+					{ isPopoverVisible && (
+						<Popover
+							className="woocommerce-status-badge-popover"
+							position="top right"
+							noArrow={ true }
+							onClose={ () => setPopoverVisible( false ) }
+						>
+							<div
+								className={
+									'settings-payment-gateways__popover-container'
+								}
+							>
+								{ popoverContent }
+							</div>
+						</Popover>
+					) }
 				</span>
-			) }
-			{ isPopoverVisible && (
-				<Popover
-					className={ 'woocommerce-status-badge-popover' }
-					position="top right"
-					noArrow={ true }
-					onClose={ () => setPopoverVisible( false ) }
-				>
-					<div
-						className={
-							'settings-payment-gateways__popover-container'
-						}
-					>
-						{ popoverContent }
-					</div>
-				</Popover>
 			) }
 		</Pill>
 	);

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/status-badge/status-badge.tsx
@@ -107,19 +107,21 @@ export const StatusBadge = ( {
 		<Pill className={ `woocommerce-status-badge ${ getStatusClass() }` }>
 			{ message || getStatusMessage() }
 			{ popoverContent && (
-				<span className="woocommerce-status-badge__icon-container">
-					<Icon
-						onClick={ () => {
+				<span
+					className="woocommerce-status-badge__icon-container"
+					onClick={ () => setPopoverVisible( ! isPopoverVisible ) }
+					onMouseEnter={ () => setPopoverVisible( true ) }
+					onMouseLeave={ () => setPopoverVisible( false ) }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' || event.key === ' ' ) {
 							setPopoverVisible( ! isPopoverVisible );
-						} }
-						onKeyDown={ ( event ) => {
-							if ( event.key === 'Enter' || event.key === ' ' ) {
-								setPopoverVisible( ! isPopoverVisible );
-							}
-						} }
-						tabIndex={ 0 }
-						role="button"
-						className={ 'woocommerce-status-badge-icon' }
+						}
+					} }
+					tabIndex={ 0 }
+					role="button"
+				>
+					<Icon
+						className="woocommerce-status-badge-icon"
 						size={ 14 }
 						icon={ info }
 					/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes a consistent behavior in our Popover usage by not closing it when hovering inside it.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Payments
2. Force an incentive in `payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx` using:

```
<IncentiveStatusBadge
	incentive={
		incentive || {
			badge: 'test test',
			title: 'test test',
			description: 'test test',
			tc_url: 'https://www.google.com',
		}
	}
/>
```
4. Double-check that it works on hover and doesn't close if you move inside the popover


https://github.com/user-attachments/assets/54d85f7c-865b-4d74-8775-0481ea402451

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Make the popover implementation in the incentive component consistent with the on in the logo's component.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
