### PR TITLE
Fix links to WooCommerce Beta Tester

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -1520,7 +1520,7 @@
           "post_title": "Beta Testing",
           "tags": "how-to",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/testing/beta-testing.md",
-          "hash": "09be54c71d8805df451263a1cddd12d744b2b1d81f669fb539bd2f14cfdefeeb",
+          "hash": "fefc443d305a81703e63e812fab3ec5ccc8521893dd96031b40f78f7449b269b",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/testing/beta-testing.md",
           "id": "01f266904647aad0d44b5687fb5f143560dabc67"
         }
@@ -1915,5 +1915,5 @@
       "categories": []
     }
   ],
-  "hash": "541fa48f03c824c6b66c26ea761ad690aba0eda3084e9e28b0a8a5d26f5ffbc7"
+  "hash": "123ddfa050df61ec619604dd059bf25271eeb424725df2a70cf5009059784b7a"
 }

--- a/docs/testing/beta-testing.md
+++ b/docs/testing/beta-testing.md
@@ -15,13 +15,13 @@ Please ensure you test responsibly, it is not a good idea to run beta versions o
 
 To get started, go to Plugins > Add New > Upload plugin, and install the beta tester plugin which you can download from:
 
-[WooCommerce Beta Tester](https://wordpress.org/plugins/woocommerce-beta-tester/)
+[WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/)
 
 This plugin will give you access to all of the WooCommerce versions uploaded to [WordPress.org]. This includes beta releases and release candidates.
 
 ## Giving Feedback
 
-During testing, if you come across a bug or want to propose or contribute an enhancement, [submit an issue on Github](https://github.com/woocommerce/woocommerce/issues/new?assignees=&labels=type%3A+enhancement%2Cstatus%3A+awaiting+triage&template=2-enhancement.yml&title=%5BEnhancement%5D%3A+). Ensure you read our guidelines on contributing and note which version you are using specifically. It is also possible to easily submit a new GitHub issue through the [beta tester plugin](https://wordpress.org/plugins/woocommerce-beta-tester/).
+During testing, if you come across a bug or want to propose or contribute an enhancement, [submit an issue on Github](https://github.com/woocommerce/woocommerce/issues/new?assignees=&labels=type%3A+enhancement%2Cstatus%3A+awaiting+triage&template=2-enhancement.yml&title=%5BEnhancement%5D%3A+). Ensure you read our guidelines on contributing and note which version you are using specifically. It is also possible to easily submit a new GitHub issue through the [beta tester plugin](https://woocommerce.com/products/woocommerce-beta-tester/).
 
 Sometimes we may also ask for feedback via other means, such as the surveys and calls for testing on the [developer blog](https://developer.woocommerce.com/blog/). We appreciate immediate feedback, comments, and responses to surveys as it helps us judge how well received our releases and betas are and will help us shape future versions.
 

--- a/plugins/woocommerce-beta-tester/README.md
+++ b/plugins/woocommerce-beta-tester/README.md
@@ -4,7 +4,7 @@ A plugin that makes it easy to test out pre-releases such as betas release candi
 
 ## Installation
 
-You can either install the latest version from [wp.org](https://wordpress.org/plugins/woocommerce-beta-tester/) or symlink this directory by running `ln -s ./ :path-to-your-wp-plugin-directory/woocommerce-beta-tester`
+You can either install the latest version from [woocommerce.com](https://woocommerce.com/products/woocommerce-beta-tester/) or symlink this directory by running `ln -s ./ :path-to-your-wp-plugin-directory/woocommerce-beta-tester`
 
 ## Development
 

--- a/plugins/woocommerce-beta-tester/changelog/beta-tester-link
+++ b/plugins/woocommerce-beta-tester/changelog/beta-tester-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update links to download WooCommerce Beta Tester

--- a/tools/release-posts/templates/beta-release.ejs
+++ b/tools/release-posts/templates/beta-release.ejs
@@ -119,7 +119,7 @@
 <!-- wp:paragraph -->
 <p>
 	If you'd like to dive in and help test this new release, our handy&nbsp;<a
-		href="https://wordpress.org/plugins/woocommerce-beta-tester/"
+		href="https://woocommerce.com/products/woocommerce-beta-tester/"
 		target="_blank"
 		>WooCommerce Beta Tester plugin</a
 	>&nbsp;allows you to switch between beta versions and release candidates.

--- a/tools/release-posts/templates/rc-release.ejs
+++ b/tools/release-posts/templates/rc-release.ejs
@@ -72,7 +72,7 @@
 
 <!-- wp:paragraph -->
 <p>If you'd like to dive in and help test this new release, our handy&nbsp;<a
-		href="https://wordpress.org/plugins/woocommerce-beta-tester/"
+		href="https://woocommerce.com/products/woocommerce-beta-tester/"
 		target="_blank"
 		>WooCommerce Beta Tester plugin</a
 	>&nbsp;allows you to switch between beta versions and release candidates.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The WooCommerce Beta Tester plugin was removed from .org repo in 2023, but we still refer to `https://wordpress.org/plugins/woocommerce-beta-tester/` in some places. This PR changes those URLs to `https://woocommerce.com/products/woocommerce-beta-tester/`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I don't know if this is actually testable other than checking the code diff.

<!-- End testing instructions -->

