### PR TITLE
Rename "Collection" to "Pickup" in cart and checkout blocks

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx
@@ -54,7 +54,7 @@ const Block = ( { className }: { className: string } ): JSX.Element | null => {
 				<TotalsShipping
 					label={
 						hasSelectedCollectionOnly
-							? __( 'Collection', 'woocommerce' )
+							? __( 'Pickup', 'woocommerce' )
 							: __( 'Delivery', 'woocommerce' )
 					}
 					placeholder={

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx
@@ -47,7 +47,7 @@ const Block = ( {
 			<TotalsShipping
 				label={
 					hasSelectedCollectionOnly
-						? __( 'Collection', 'woocommerce' )
+						? __( 'Pickup', 'woocommerce' )
 						: __( 'Delivery', 'woocommerce' )
 				}
 				placeholder={

--- a/plugins/woocommerce/changelog/54746-issues-#54726-rename-collection-to-pickup
+++ b/plugins/woocommerce/changelog/54746-issues-#54726-rename-collection-to-pickup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Rename "Collection" to "Pickup" in cart and checkout blocks


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54726
Closes #53927

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add item to cart.
2. Go to the cart page using the Cart block.
3. Toggle between shipping and local pickup.
4. Verify that the label for local pickup says "Pickup" instead of "Collection".
5. Go to the checkout page using the Checkout block.
6. Toggle between shipping and local pickup.
7. Verify that the label for local pickup says "Pickup" instead of "Collection".

#### Cart block

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="415" alt="Screenshot 2025-01-24 at 13 39 52" src="https://github.com/user-attachments/assets/3f731e9c-37bf-4195-8c25-87ea57577d7e" />
</td>
<td valign="top">After:
<br><br>
<img width="437" alt="Screenshot 2025-01-24 at 13 34 46" src="https://github.com/user-attachments/assets/f33b8377-afa7-488a-8c28-c146b62d30c2" />
</td>
</tr>
</table>

#### Checkout block

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="402" alt="Screenshot 2025-01-24 at 13 39 39" src="https://github.com/user-attachments/assets/f06826ff-f7cc-477a-b49e-c6a665ceb413" />
</td>
<td valign="top">After:
<br><br>
<img width="405" alt="Screenshot 2025-01-24 at 13 35 06" src="https://github.com/user-attachments/assets/e177f4b3-c202-4c6c-a8f3-4b49ef07e9da" />
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Rename "Collection" to "Pickup" in cart and checkout blocks
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
