### PR TITLE
Unskip "Marketing Overview page have relevant content" E2E test on WPCOM

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-make-marketing-test-runnable-on-wpcom
+++ b/plugins/woocommerce/changelog/dev-e2e-make-marketing-test-runnable-on-wpcom
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Make the E2E test "Marketing Overview page have relevant content" runnable on WPCOM and Pressable sites.

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
@@ -1,6 +1,8 @@
 let config = require( '../../playwright.config.js' );
 const { tags } = require( '../../fixtures/fixtures' );
 
+process.env.IS_PRESSABLE = 'true';
+
 const grepInvert = new RegExp(
 	`${ tags.SKIP_ON_PRESSABLE }|${ tags.SKIP_ON_EXTERNAL_ENV }|${ tags.COULD_BE_LOWER_LEVEL_TEST }|${ tags.NON_CRITICAL }|${ tags.TO_BE_REMOVED }`
 );

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
@@ -1,6 +1,8 @@
 let config = require( '../../playwright.config.js' );
 const { tags } = require( '../../fixtures/fixtures' );
 
+process.env.IS_WPCOM = 'true';
+
 const grepInvert = new RegExp(
 	`${ tags.SKIP_ON_WPCOM }|${ tags.SKIP_ON_EXTERNAL_ENV }|${ tags.COULD_BE_LOWER_LEVEL_TEST }|${ tags.NON_CRITICAL }|${ tags.TO_BE_REMOVED }`
 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -10,9 +10,7 @@ test.describe( 'Marketing page', () => {
 		page,
 	} ) => {
 		// See if this is a WPCOM site.
-		const base_hostname = new URL( baseURL ).hostname;
-		const pattern_domain_name = /\.(?:wordpress\.com|wpcomstaging\.com)$/;
-		const is_wpcom_site = pattern_domain_name.test( base_hostname );
+		const is_wpcom_site = process.env.IS_WPCOM.toLowerCase() === 'true';
 
 		// Go to the Marketing page.
 		await page.goto( 'wp-admin/admin.php?page=wc-admin&path=%2Fmarketing' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -48,11 +48,10 @@ test.describe( 'Marketing page', () => {
 			await expect(
 				page.getByRole( 'tab', { name: 'CRM', exact: true } )
 			).toBeVisible();
+			await expect(
+				page.getByText( 'Learn about marketing a store' )
+			).toBeVisible();
 		}
-
-		await expect(
-			page.getByText( 'Learn about marketing a store' )
-		).toBeVisible();
 	} );
 
 	test(

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -6,7 +6,6 @@ test.describe( 'Marketing page', () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
 	test( 'Marketing Overview page have relevant content', async ( {
-		baseURL,
 		page,
 	} ) => {
 		// See if this is a WPCOM site.

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -9,7 +9,9 @@ test.describe( 'Marketing page', () => {
 		page,
 	} ) => {
 		// See if this is a WPCOM site.
-		const is_wpcom_site = process.env.IS_WPCOM.toLowerCase() === 'true';
+		const is_wpcom_site =
+			process.env.IS_WPCOM &&
+			process.env.IS_WPCOM.toLowerCase() === 'true';
 
 		// Go to the Marketing page.
 		await page.goto( 'wp-admin/admin.php?page=wc-admin&path=%2Fmarketing' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -31,7 +31,7 @@ test.describe( 'Marketing page', () => {
 			page.getByText( 'Channels', { exact: true } )
 		).toBeVisible();
 
-		// Check the 'Discover more marketing tools' card and its individual tabs only on non-WPCOM sites.
+		// Check the 'Discover more marketing tools' and 'Learn about marketing a store' cards only on non-WPCOM sites.
 		if ( ! is_wpcom_site ) {
 			await expect(
 				page.getByText( 'Discover more marketing tools' )

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-marketing/overview.spec.js
@@ -8,15 +8,11 @@ test.describe( 'Marketing page', () => {
 	test( 'Marketing Overview page have relevant content', async ( {
 		baseURL,
 		page,
-		request,
 	} ) => {
 		// See if this is a WPCOM site.
 		const base_hostname = new URL( baseURL ).hostname;
-		const is_wpcom_site = (
-			await request.get(
-				`https://public-api.wordpress.com/wp/v2/sites/${ base_hostname }`
-			)
-		 ).ok();
+		const pattern_domain_name = /\.(?:wordpress\.com|wpcomstaging\.com)$/;
+		const is_wpcom_site = pattern_domain_name.test( base_hostname );
 
 		// Go to the Marketing page.
 		await page.goto( 'wp-admin/admin.php?page=wc-admin&path=%2Fmarketing' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Partially closes project task https://github.com/woocommerce/woocommerce/issues/54664.

This PR makes the E2E test `admin-marketing/overview.spec.js > Marketing Overview page have relevant content` runnable on a WPCOM site where it was previously failing, and was thus skipped.

Cuase of failure on WPCOM: WPCOM sites don't have a `Discover more marketing tools` and `Learn about marketing a store` cards in their Marketing Overview page. 

<img width="718" alt="Screenshot 2025-01-22 at 11 35 15 AM" src="https://github.com/user-attachments/assets/553c41f3-5ebc-453e-aa5d-11a0e13c10c6" />

To address this, the checking of these 2 cards will now be done conditionally, depending on whether the site being tested is a WPCOM site or not.

The PR contains the following changes:
- Removes the `SKIP_ON_WPCOM` tag from the `Marketing Overview page have relevant content` test.
- Adds a step to check if the site being tested is hosted on WPCOM  by querying the WPCOM public api.
- Move the assertions for `Discover more marketing tools` and `Learn about marketing a store` cards into a conditional if-block that will only get executed when the site isn't hosted in WPCOM.


### How to test the changes in this Pull Request:

The steps below assumes you had already installed all PNPM dependencies and built the WooCommerce plugin.

#### Test on wp-env

1. Clone this branch and start up the local test env.
    ```sh
    pnpm env:test
    ```
3. Run this test and make sure it passes
    ```sh
    pnpm test:e2e admin-marketing -g "Marketing Overview page have relevant content"
    ```
1. Make sure no other e2e tests in the CI checks failed due to the changes in this PR.
 
#### Test on WPCOM and Pressable

1. Run the test on our WPCOM and Pressable sites and make sure `Marketing Overview page have relevant content` pass:
    ```sh
    export E2E_ENV_KEY=<...>
    pnpm test:e2e:with-env default-wpcom admin-marketing
    
    # Then do the same in Pressable
    pnpm test:e2e:with-env default-pressable admin-marketing
    ```
