### PR TITLE
Unskip on Pressable: `merchant/settings-woo-com.spec.js > WooCommerce woo.com Settings`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-unskip-on-pressable-settings-woocom
+++ b/plugins/woocommerce/changelog/dev-e2e-unskip-on-pressable-settings-woocom
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Make the E2E test `merchant/settings-woo-com.spec.js` runnable on Pressable.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-woo-com.spec.js
@@ -5,7 +5,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 test.describe(
 	'WooCommerce woo.com Settings',
 	{
-		tag: [ tags.SERVICES, tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ],
+		tag: [ tags.SERVICES, tags.SKIP_ON_WPCOM ],
 	},
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
@@ -18,7 +18,7 @@ test.describe(
 				consumerSecret: process.env.CONSUMER_SECRET,
 				version: 'wc/v3',
 			} );
-			await api.put( 'settings/advanced/woocommerce_analytics_enabled', {
+			await api.put( 'settings/advanced/woocommerce_allow_tracking', {
 				value: 'no',
 			} );
 			await api.put(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of project task https://github.com/woocommerce/woocommerce/issues/54664.

This PR unskips the E2E test `merchant/settings-woo-com.spec.js > WooCommerce woo.com Settings` on Pressable by correcting the API endpoint called in the test.

Cause of test failure in Pressable: The tests in `WooCommerce woo.com Settings` needs usage tracking to be disabled as a test setup. The beforeAll hook was calling the `settings/advanced/woocommerce_analytics_enabled` endpoint to accomplish this. However this endpoint affects analytics, not usage tracking. In wp-env this wouldn't cause a problem because wp-env launches with usage tracking disabled by default, so the test always passes on wp-env. On Pressable though, when usage tracking was left enabled manually or by a previous run of this test, future re-runs would always fail because the beforeAll hook was calling the wrong endpoint to disable it.

<img width="1074" alt="Screenshot 2025-01-22 at 4 33 18 PM" src="https://github.com/user-attachments/assets/52e54406-5e55-4ded-b2cc-3e75fd2725cc" />

This PR fixes this by using the correct endpoint: `settings/advanced/woocommerce_allow_tracking`.

Note that I left the `SKIP_ON_WPCOM` tag because WPCOM doesn't have a WooCommerce.com settings tab.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure that the tests in `merchant/settings-woo-com.spec.js > WooCommerce woo.com Settings` pass in CI.
2. Run the touched test at least twice in Pressable, and make sure it always passes:
    ```sh
    # Run the test at least twice in Pressable
    E2E_ENV_KEY=<...> pnpm test:e2e:with-env default-pressable  merchant/settings-woo-com.spec.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
