### PR TITLE
Unskip on WPCOM: `merchant/products/add-variable-product/create-variations.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-unskip-wpcom-create-variations
+++ b/plugins/woocommerce/changelog/dev-e2e-unskip-wpcom-create-variations
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Make the 'create-variations' E2E test runnable in WPCOM by using more accurate locator.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-variations.spec.js
@@ -70,7 +70,9 @@ test.describe( 'Add variations', { tag: tags.GUTENBERG }, () => {
 			await test.step( `Expect the variation "${ variation.join(
 				', '
 			) }" to be generated.`, async () => {
-				let variationRow = page.locator( '.woocommerce_variation h3' );
+				let variationRow = page.getByRole( 'heading', {
+					name: /#\d+/,
+				} );
 
 				for ( const attributeValue of variation ) {
 					variationRow = variationRow.filter( {
@@ -85,117 +87,105 @@ test.describe( 'Add variations', { tag: tags.GUTENBERG }, () => {
 		}
 	} );
 
-	test(
-		'can manually add a variation',
-		{ tag: tags.SKIP_ON_WPCOM },
-		async ( { page } ) => {
-			await test.step( `Open "Edit product" page of product id ${ productId_addManually }`, async () => {
-				await page.goto(
-					`wp-admin/post.php?post=${ productId_addManually }&action=edit`
-				);
+	test( 'can manually add a variation', async ( { page } ) => {
+		await test.step( `Open "Edit product" page of product id ${ productId_addManually }`, async () => {
+			await page.goto(
+				`wp-admin/post.php?post=${ productId_addManually }&action=edit`
+			);
+		} );
+
+		// hook up the woocommerce_variations_added jQuery trigger so we can check if it's fired
+		await test.step( 'Hook up the woocommerce_variations_added jQuery trigger', async () => {
+			await page.evaluate( () => {
+				window.woocommerceVariationsAddedFunctionCalls = [];
+
+				window
+					.jQuery( '#variable_product_options' )
+					.on( 'woocommerce_variations_added', ( event, data ) => {
+						window.woocommerceVariationsAddedFunctionCalls.push( [
+							event,
+							data,
+						] );
+					} );
 			} );
+		} );
 
-			// hook up the woocommerce_variations_added jQuery trigger so we can check if it's fired
-			await test.step( 'Hook up the woocommerce_variations_added jQuery trigger', async () => {
-				await page.evaluate( () => {
-					window.woocommerceVariationsAddedFunctionCalls = [];
+		await test.step( 'Click on the "Variations" tab.', async () => {
+			await page.locator( '.variations_tab' ).click();
+		} );
 
-					window
-						.jQuery( '#variable_product_options' )
-						.on(
-							'woocommerce_variations_added',
-							( event, data ) => {
-								window.woocommerceVariationsAddedFunctionCalls.push(
-									[ event, data ]
-								);
-							}
-						);
-				} );
-			} );
+		await test.step( `Manually add ${ variationsToManuallyCreate.length } variations`, async () => {
+			const variationRows = page.getByRole( 'heading', { name: /#\d+/ } );
+			let variationRowsCount = await variationRows.count();
+			const originalVariationRowsCount = variationRowsCount;
 
-			await test.step( 'Click on the "Variations" tab.', async () => {
-				await page.locator( '.variations_tab' ).click();
-			} );
-
-			await test.step( `Manually add ${ variationsToManuallyCreate.length } variations`, async () => {
-				const variationRows = page.locator(
-					'.woocommerce_variation h3'
-				);
-				let variationRowsCount = await variationRows.count();
-				const originalVariationRowsCount = variationRowsCount;
-
-				for ( const variationToCreate of variationsToManuallyCreate ) {
-					await test.step( 'Click "Add manually"', async () => {
-						const addManuallyButton = page.getByRole( 'button', {
-							name: 'Add manually',
-						} );
-
-						await addManuallyButton.click();
-
-						await expect( variationRows ).toHaveCount(
-							++variationRowsCount
-						);
-
-						// verify that the woocommerce_variations_added jQuery trigger was fired
-						const woocommerceVariationsAddedFunctionCalls =
-							await page.evaluate(
-								() =>
-									window.woocommerceVariationsAddedFunctionCalls
-							);
-						expect(
-							woocommerceVariationsAddedFunctionCalls.length
-						).toEqual(
-							variationRowsCount - originalVariationRowsCount
-						);
+			for ( const variationToCreate of variationsToManuallyCreate ) {
+				await test.step( 'Click "Add manually"', async () => {
+					const addManuallyButton = page.getByRole( 'button', {
+						name: 'Add manually',
 					} );
 
-					for ( const attributeValue of variationToCreate ) {
-						const attributeName = productAttributes.find(
-							( { options } ) =>
-								options.includes( attributeValue )
-						).name;
-						const addAttributeMenu = variationRows
-							.nth( 0 )
-							.locator( 'select', {
-								has: page.locator( 'option', {
-									hasText: attributeValue,
-								} ),
-							} );
+					await addManuallyButton.click();
 
-						await test.step( `Select "${ attributeValue }" from the "${ attributeName }" attribute menu`, async () => {
-							await addAttributeMenu.selectOption(
-								attributeValue
-							);
+					await expect( variationRows ).toHaveCount(
+						++variationRowsCount
+					);
+
+					// verify that the woocommerce_variations_added jQuery trigger was fired
+					const woocommerceVariationsAddedFunctionCalls =
+						await page.evaluate(
+							() => window.woocommerceVariationsAddedFunctionCalls
+						);
+					expect(
+						woocommerceVariationsAddedFunctionCalls.length
+					).toEqual(
+						variationRowsCount - originalVariationRowsCount
+					);
+				} );
+
+				for ( const attributeValue of variationToCreate ) {
+					const attributeName = productAttributes.find(
+						( { options } ) => options.includes( attributeValue )
+					).name;
+					const addAttributeMenu = variationRows
+						.nth( 0 )
+						.locator( 'select', {
+							has: page.locator( 'option', {
+								hasText: attributeValue,
+							} ),
+						} );
+
+					await test.step( `Select "${ attributeValue }" from the "${ attributeName }" attribute menu`, async () => {
+						await addAttributeMenu.selectOption( attributeValue );
+					} );
+				}
+
+				await test.step( 'Click "Save changes"', async () => {
+					await page
+						.getByRole( 'button', {
+							name: 'Save changes',
+						} )
+						.click();
+				} );
+
+				await test.step( `Expect the variation ${ variationToCreate.join(
+					', '
+				) } to be successfully saved.`, async () => {
+					let newlyAddedVariationRow;
+
+					for ( const attributeValue of variationToCreate ) {
+						newlyAddedVariationRow = (
+							newlyAddedVariationRow || variationRows
+						).filter( {
+							has: page.locator( 'option[selected]', {
+								hasText: attributeValue,
+							} ),
 						} );
 					}
 
-					await test.step( 'Click "Save changes"', async () => {
-						await page
-							.getByRole( 'button', {
-								name: 'Save changes',
-							} )
-							.click();
-					} );
-
-					await test.step( `Expect the variation ${ variationToCreate.join(
-						', '
-					) } to be successfully saved.`, async () => {
-						let newlyAddedVariationRow;
-
-						for ( const attributeValue of variationToCreate ) {
-							newlyAddedVariationRow = (
-								newlyAddedVariationRow || variationRows
-							).filter( {
-								has: page.locator( 'option[selected]', {
-									hasText: attributeValue,
-								} ),
-							} );
-						}
-
-						await expect( newlyAddedVariationRow ).toBeVisible();
-					} );
-				}
-			} );
-		}
-	);
+					await expect( newlyAddedVariationRow ).toBeVisible();
+				} );
+			}
+		} );
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of project task https://github.com/woocommerce/woocommerce/issues/54664.

This PR makes the E2E test `merchant/products/add-variable-product/create-variations.spec.js` compatible with WPCOM sites.

Cause of previous incompatibility with WPCOM: The test had been using the locator `.woocommerce_variation h3` for each variation generated in the Variations tab in the Product Editor. This locator works well on non-WPCOM sites, but on WPCOM it matches several more (in fact, hidden) elements from other extensions, causing a strict locator violation. See below.

![Screenshot from 2025-01-21 08-48-16](https://github.com/user-attachments/assets/d33b2c6d-c339-4eec-b2c0-7b112711faf7)


To fix this, this PR uses a more specific locator that uses a regex pattern to match the variation id created in the test.

The other significant change is the removal of the `SKIP_ON_WPCOM` tag. The other line changes you'd see on the diff are only spacing adjustments resulting from the removal of this tag.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the touched test multiple times in WPCOM to make sure it's stable:
    ```sh
    E2E_ENV_KEY=<...> pnpm test:e2e:with-env default-wpcom merchant/products/add-variable-product/create-variations.spec.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
