### PR TITLE
Improve error message for core profiler plugin installation failures

### DIFF
--- a/plugins/woocommerce/changelog/enhance-improve-plugin-installation-failures
+++ b/plugins/woocommerce/changelog/enhance-improve-plugin-installation-failures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Refactor plugin selection handling in Core Profiler

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -65,7 +65,7 @@ import { getCountryStateOptions } from './services/country';
 import { CoreProfilerLoader } from './components/loader/Loader';
 import { Plugins } from './pages/Plugins/Plugins';
 import { NoPermissionsError } from './pages/Plugins/NoPermissions';
-import { getPluginSlug, useFullScreen } from '~/utils';
+import { useFullScreen } from '~/utils';
 import './style.scss';
 import {
 	InstalledPlugin,
@@ -114,7 +114,7 @@ export type CoreProfilerStateMachineContext = {
 	} & Partial< ProfileItems >;
 	pluginsAvailable: ExtensionList[ 'plugins' ] | [];
 	pluginsTruncated: string[];
-	pluginsSelected: string[]; // extension slugs
+	pluginsSelected: ExtensionList[ 'plugins' ][ number ][ 'key' ][];
 	pluginsInstallationErrors: PluginInstallError[];
 	geolocatedLocation: GeolocationResponse | undefined;
 	businessInfo: {
@@ -682,7 +682,7 @@ const assignPluginsSelected = assign( {
 	}: {
 		event: PluginsInstallationRequestedEvent;
 	} ) => {
-		return event.payload.pluginsSelected.map( getPluginSlug );
+		return event.payload.pluginsSelected;
 	},
 } );
 

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
@@ -167,7 +167,7 @@ export const Plugins = ( {
 			}, {} as Record< string, string > ),
 		[ context.pluginsAvailable ]
 	);
-	console.log( context );
+
 	return (
 		<div
 			className="woocommerce-profiler-plugins"

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/Plugins.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Extension, ExtensionList } from '@woocommerce/data';
-import { useState } from 'react';
+import { useState, useMemo } from '@wordpress/element';
 import clsx from 'clsx';
 
 /**
@@ -159,6 +159,15 @@ export const Plugins = ( {
 		context.pluginsAvailable.length / 2
 	);
 
+	const pluginsSlugToName = useMemo(
+		() =>
+			context.pluginsAvailable.reduce( ( acc, plugin ) => {
+				acc[ plugin.key ] = plugin.name;
+				return acc;
+			}, {} as Record< string, string > ),
+		[ context.pluginsAvailable ]
+	);
+	console.log( context );
 	return (
 		<div
 			className="woocommerce-profiler-plugins"
@@ -185,6 +194,7 @@ export const Plugins = ( {
 						pluginsInstallationErrors={
 							context.pluginsInstallationErrors
 						}
+						pluginsSlugToName={ pluginsSlugToName }
 						onClick={ submitInstallationRequest }
 					/>
 				) }

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
@@ -14,12 +14,12 @@ import { joinWithAnd, composeListFormatParts } from '../../Plugins';
 export const PluginErrorBanner = ( {
 	pluginsInstallationPermissionsFailure,
 	pluginsInstallationErrors,
-	pluginsSlugToName,
+	pluginsSlugToName = {},
 	onClick,
 }: {
 	pluginsInstallationPermissionsFailure?: boolean;
 	pluginsInstallationErrors?: PluginInstallError[];
-	pluginsSlugToName: Record< string, string >;
+	pluginsSlugToName?: Record< string, string >;
 	onClick?: () => void;
 } ) => {
 	let installationErrorMessage;

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
@@ -43,7 +43,7 @@ export const PluginErrorBanner = ( {
 				);
 			break;
 	}
-	console.log( pluginsSlugToName );
+
 	const failedPluginNames = [
 		...new Set(
 			( pluginsInstallationErrors || [] ).map(

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
+import { Extension } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -14,10 +15,12 @@ import { joinWithAnd, composeListFormatParts } from '../../Plugins';
 export const PluginErrorBanner = ( {
 	pluginsInstallationPermissionsFailure,
 	pluginsInstallationErrors,
+	pluginsSlugToName,
 	onClick,
 }: {
 	pluginsInstallationPermissionsFailure?: boolean;
 	pluginsInstallationErrors?: PluginInstallError[];
+	pluginsSlugToName: Record< string, string >;
 	onClick?: () => void;
 } ) => {
 	let installationErrorMessage;
@@ -40,16 +43,22 @@ export const PluginErrorBanner = ( {
 				);
 			break;
 	}
+	console.log( pluginsSlugToName );
+	const failedPluginNames = [
+		...new Set(
+			( pluginsInstallationErrors || [] ).map(
+				// Use the plugin name if available, otherwise use the plugin slug
+				( error ) => pluginsSlugToName[ error.plugin ] || error.plugin
+			)
+		),
+	];
+
 	return (
 		<p className="plugin-error">
 			{ interpolateComponents( {
 				mixedString: sprintf(
 					installationErrorMessage,
-					joinWithAnd(
-						( pluginsInstallationErrors || [] ).map(
-							( error ) => error.plugin
-						)
-					)
+					joinWithAnd( failedPluginNames )
 						.map( composeListFormatParts )
 						.join( '' )
 				),

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/PluginErrorBanner.tsx
@@ -4,7 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Extension } from '@woocommerce/data';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/test/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/components/plugin-error-banner/test/index.tsx
@@ -31,13 +31,20 @@ describe( 'PluginErrorBanner', () => {
 				error: 'An error occurred during installation',
 			},
 		];
-		render( <PluginErrorBanner pluginsInstallationErrors={ errors } /> );
+		render(
+			<PluginErrorBanner
+				pluginsInstallationErrors={ errors }
+				pluginsSlugToName={ {
+					'test-plugin': 'Test Plugin',
+				} }
+			/>
+		);
 		expect(
 			screen.getByText(
 				/Oops! We encountered a problem while installing/i
 			)
 		).toBeInTheDocument();
-		expect( screen.getByText( 'test-plugin' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Test Plugin' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render the correct strings if multiple plugins fail to install', () => {
@@ -57,14 +64,22 @@ describe( 'PluginErrorBanner', () => {
 				error: 'An error occurred during installation',
 			},
 		];
-		render( <PluginErrorBanner pluginsInstallationErrors={ errors } /> );
+		render(
+			<PluginErrorBanner
+				pluginsInstallationErrors={ errors }
+				pluginsSlugToName={ {
+					'test-plugin-1': 'Test Plugin 1',
+					'test-plugin-2': 'Test Plugin 2',
+				} }
+			/>
+		);
 		expect(
 			screen.getByText(
 				/Oops! We encountered a problem while installing/i
 			)
 		).toBeInTheDocument();
-		expect( screen.getByText( 'test-plugin-1' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'test-plugin-2' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Test Plugin 1' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Test Plugin 2' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render permissions failure message when pluginsInstallationErrors contains a 403 error', () => {
@@ -80,7 +95,14 @@ describe( 'PluginErrorBanner', () => {
 				error: 'An error occurred during installation',
 			},
 		];
-		render( <PluginErrorBanner pluginsInstallationErrors={ errors } /> );
+		render(
+			<PluginErrorBanner
+				pluginsSlugToName={ {
+					'test-plugin': 'Test Plugin',
+				} }
+				pluginsInstallationErrors={ errors }
+			/>
+		);
 		expect(
 			screen.getByText(
 				/You do not have permissions to install plugins/i
@@ -101,6 +123,9 @@ describe( 'PluginErrorBanner', () => {
 		];
 		render(
 			<PluginErrorBanner
+				pluginsSlugToName={ {
+					'test-plugin': 'Test Plugin',
+				} }
 				pluginsInstallationErrors={ errors }
 				onClick={ mockOnClick }
 			/>

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/Plugins.test.tsx
@@ -206,7 +206,8 @@ describe( 'Plugins Component', () => {
 			?.querySelector( 'input[type="checkbox"]' );
 		expect( checkbox3 ).not.toBeChecked();
 		const checkbox4 = screen
-			.getByText( 'Plugin 4' )
+			// use role because error message also contains the plugin name
+			.getByRole( 'heading', { level: 3, name: 'Plugin 4' } )
 			.closest( '.woocommerce-profiler-plugins-plugin-card' )
 			?.querySelector( 'input[type="checkbox"]' );
 		expect( checkbox4 ).toBeChecked();

--- a/plugins/woocommerce/client/admin/client/core-profiler/services/installAndActivatePlugins.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/services/installAndActivatePlugins.ts
@@ -25,6 +25,7 @@ import {
 	PluginsInstallationCompletedEvent,
 	PluginsInstallationCompletedWithErrorsEvent,
 } from '../events';
+import { getPluginSlug } from '~/utils/plugins';
 
 export type InstalledPlugin = {
 	plugin: string;
@@ -37,6 +38,7 @@ export type InstallationCompletedResult = {
 };
 
 export type PluginInstallError = {
+	/** Slug of the plugin that failed to install */
 	plugin: string;
 	error: string;
 	errorDetails: Pick< InstallAndActivateErrorResponse, 'data' >;
@@ -116,16 +118,15 @@ export const pluginInstallerMachine = createMachine(
 			>;
 		} ) => {
 			return {
-				selectedPlugins:
-					input?.selectedPlugins || ( [] as PluginNames[] ),
+				selectedPlugins: input?.selectedPlugins || [],
 				pluginsAvailable:
 					input?.pluginsAvailable ||
 					( [] as ExtensionList[ 'plugins' ] | [] ),
-				pluginsInstallationQueue: [] as PluginNames[],
-				installedPlugins: [] as InstalledPlugin[],
+				pluginsInstallationQueue: [],
+				installedPlugins: [],
 				startTime: 0,
 				installationDuration: 0,
-				errors: [] as PluginInstallError[],
+				errors: [],
 			} as PluginInstallerMachineContext;
 		},
 		states: {
@@ -213,7 +214,7 @@ export const pluginInstallerMachine = createMachine(
 				pluginsInstallationQueue: ( { context } ) => {
 					// Sort the plugins by install_priority so that the smaller plugins are installed first
 					// install_priority is set by plugin's size
-					// Lower install_prioirty means the plugin is smaller
+					// Lower install_priority means the plugin is smaller
 					return context.selectedPlugins.slice().sort( ( a, b ) => {
 						const aIndex = context.pluginsAvailable.find(
 							( plugin ) => plugin.key === a
@@ -318,7 +319,7 @@ export const pluginInstallerMachine = createMachine(
 					return dispatch(
 						PLUGINS_STORE_NAME
 					).installAndActivatePlugins( [
-						pluginsInstallationQueue[ 0 ],
+						getPluginSlug( pluginsInstallationQueue[ 0 ] ),
 					] );
 				}
 			),
@@ -331,7 +332,9 @@ export const pluginInstallerMachine = createMachine(
 					return dispatch(
 						ONBOARDING_STORE_NAME
 					).installAndActivatePluginsAsync(
-						pluginsInstallationQueue
+						pluginsInstallationQueue.map(
+							getPluginSlug
+						) as PluginNames[]
 					);
 				}
 			),

--- a/plugins/woocommerce/client/admin/client/core-profiler/services/installAndActivatePlugins.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/services/installAndActivatePlugins.ts
@@ -38,7 +38,6 @@ export type InstallationCompletedResult = {
 };
 
 export type PluginInstallError = {
-	/** Slug of the plugin that failed to install */
 	plugin: string;
 	error: string;
 	errorDetails: Pick< InstallAndActivateErrorResponse, 'data' >;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/53983

This PR enhances the clarity of error messages displayed when plugin installations fail during the Core Profiler setup. The updates ensure that error messages are concise, avoid redundancy, and display plugin names instead of slugs for better user understanding.

There is also a bug that the shipping and tax plugins are not re-selected when error occurs. This is because we assign the pluginsSelected to the plugin slug instead of the plugin key and we compare the plugin slug with the plugin key. This PR fixes the bug.

Changes:

- Updated the type of `pluginsSelected` to use the plugin key directly.
- Enhanced `PluginErrorBanner` to utilize the new `pluginsSlugToName` for displaying error messages.

Before:
<img width="1147" alt="Screenshot 2025-01-22 at 16 57 36" src="https://github.com/user-attachments/assets/a31c3203-e2ca-4937-ac38-49b8afe59e83" />

After:
<img width="1147" alt="Screenshot 2025-01-22 at 16 57 11" src="https://github.com/user-attachments/assets/d373e0a8-ae3c-4fc5-8fa2-78ceeeeb6e89" />

Also match the original design:
Y5pUYSJPsGEud1vknUZhi8-fi-739_53444


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site with Code Snippet plugin installed and activated
2. Add a new snippet with the following code:

```php

add_filter( 'plugins_api', function( $result, $action, $args ) {
	return new WP_Error(
		'plugins_api_error',
		__( 'This is a simulated error for the plugins_api call.', 'woocommerce' )
	);
}, 10, 3 );
```

3. Go to Core Profiler
4. Select the United States as the country
5. Continue to plugin installation step
6. Select all plugins and continue
7. Confirm the error message is displayed with the plugin name instead of the slug and no duplicate plugin names are displayed
8. Confirm all plugins are selected
9. Turn off the code snippet
10. Go back to plugin installation step and continue
11. Confirm the plugin installation is successful

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>