### PR TITLE
Unskip on WPCOM: `shopper/wordpress-post.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-unskip-wpcom-wordpress-post
+++ b/plugins/woocommerce/changelog/dev-e2e-unskip-wpcom-wordpress-post
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Make the E2E test `shopper/wordpress-post.spec.js` runnable on WPCOM by adding setup steps to disable Jetpack Comments.

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/fixtures.js
@@ -31,6 +31,12 @@ exports.test = base.test.extend( {
 		await use( wcAdminApi );
 	},
 
+	/**
+	 * Fixture for interacting with the [WordPress REST API](https://developer.wordpress.org/rest-api/reference/) endpoints.
+	 *
+	 * @param {{baseURL: string}} fixtures
+	 * @param {(fixture: base.APIRequestContext)} use
+	 */
 	wpApi: async ( { baseURL }, use ) => {
 		const wpApi = await base.request.newContext( {
 			baseURL,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of project task https://github.com/woocommerce/woocommerce/issues/54664.

This PR updates the e2e test `shopper/wordpress-post.spec.js` to be compatible with WPCOM.

Cause of previous failure in WPCOM: WPCOM sites have Jetpack Comments enabled, which replaces the built-in comment form in WordPress posts, resulting to locator incompatibility.

This is how the comment form looks like in WPCOM:
![Screenshot from 2025-01-21 11-29-53](https://github.com/user-attachments/assets/9eda7578-0d4d-493c-87b3-47f43a1b13db)

This is how it looks like on wp-env or Pressable (when Jetpack comments is disabled there too):
![Screenshot from 2025-01-21 11-29-37](https://github.com/user-attachments/assets/ee97468c-0b0e-4c50-9a98-66a3dcfc611e)

To fix this, this PR adds a beforeAll hook to see if Jetpack is installed and then disable Jetpack Comments (d823406c0d68cce359292a188ae55de14b510598)

I also added some JSDOC to the `wpApi` fixture to help with autocompletion in IDE (0c7c19aa2b767df20bfed47bb0cdadcee9bfb3a9).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Log in to the WPCOM and Pressable site and enable Jetpack Comments there via Jetpack > Settings > Discussion.
    <img width="1232" alt="Screenshot 2025-01-22 at 5 58 41 PM" src="https://github.com/user-attachments/assets/381fa82e-e13a-416f-86ba-9c7856d5374c" />
2. Run the test on WPCOM and Pressable, since Pressable has Jetpack installed too.
    ```sh
    export E2E_ENV_KEY=<...>
    pnpm test:e2e:with-env default-wpcom shopper/wordpress-post.spec.js
    pnpm test:e2e:with-env default-pressable shopper/wordpress-post.spec.js
    ```
3. Run the test in each environment one more time. This simulates the scenario where the test begins with Jetpack Comments is disabled at the start of the run. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
