### PR TITLE
[REST API] System Status endpoint should always return `shortcode` as a string within `pages`

### DIFF
--- a/plugins/woocommerce/changelog/fix-system-status-pages-api-return-type
+++ b/plugins/woocommerce/changelog/fix-system-status-pages-api-return-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix return type of the `pages` property in REST API so shortcode is a string

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -690,7 +690,42 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
-						'type' => 'string',
+						'type'       => 'object',
+						'properties' => array(
+							'page_name'          => array(
+								'type' => 'string',
+							),
+							'page_id'            => array(
+								'type' => 'string',
+							),
+							'page_set'           => array(
+								'type' => 'boolean',
+							),
+							'page_exists'        => array(
+								'type' => 'boolean',
+							),
+							'page_visible'       => array(
+								'type' => 'boolean',
+							),
+							'shortcode'          => array(
+								'type' => 'string',
+							),
+							'block'              => array(
+								'type' => 'string',
+							),
+							'shortcode_required' => array(
+								'type' => 'boolean',
+							),
+							'shortcode_present'  => array(
+								'type' => 'boolean',
+							),
+							'block_present'      => array(
+								'type' => 'boolean',
+							),
+							'block_required'     => array(
+								'type' => 'boolean',
+							),
+						),
 					),
 				),
 				'post_type_counts'   => array(
@@ -1455,7 +1490,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							return $shortcode;
 						}
 					}
-					return false;
+					return '';
 				},
 				'block_callback'     => function ( $page ) {
 					if ( $page ) {
@@ -1466,7 +1501,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							return 'woocommerce/classic-shortcode';
 						}
 					}
-					return false;
+					return '';
 				},
 			),
 			_x( 'Checkout', 'Page setting', 'woocommerce' ) => array(
@@ -1480,7 +1515,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							return $shortcode;
 						}
 					}
-					return false;
+					return '';
 				},
 				'block_callback'     => function ( $page ) {
 					if ( $page ) {
@@ -1491,7 +1526,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							return 'woocommerce/classic-shortcode';
 						}
 					}
-					return false;
+					return '';
 				},
 			),
 			_x( 'My account', 'Page setting', 'woocommerce' ) => array(
@@ -1513,9 +1548,9 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			$shortcode_required = false;
 			$block_present      = false;
 			$block_required     = false;
-			$block              = false;
-			$shortcode          = false;
 			$page               = false;
+			$block              = '';
+			$shortcode          = '';
 
 			// Page checks.
 			if ( $page_id ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a change in https://github.com/woocommerce/woocommerce/pull/54340/files which could make `shortcode` and `block` return as `false` if unused instead of a string. Now a string will always be returned.

There was no schema defined for this response, so to avoid future uncertainties I've included the correct object schema as well.

![Screenshot 2025-01-22 at 13 03 11](https://github.com/user-attachments/assets/817d53b0-d648-443c-869a-b7018da7f515)

This will be raised as a CFE for 9.7.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Status and confirm the `pages` section contains correct information about shortcodes and blocks
2. Developers: Request GET `store.local/wp-json/wc/v2/system_status`. Check `shortcode` and `block` are both strings in the response under `pages`.
3. Developers: Request OPTIOJNS `store.local/wp-json/wc/v2/system_status`. Check the pages schema shows what properties will be returned. Before this PR it would wrongly report pages as being an array of strings.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
