### PR TITLE
Update default product id in k6 perf test config

### DIFF
--- a/plugins/woocommerce/changelog/54789-update-k6-http-perf-config-product-id
+++ b/plugins/woocommerce/changelog/54789-update-k6-http-perf-config-product-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Perf Test Config Change
+

--- a/plugins/woocommerce/tests/performance/config.js
+++ b/plugins/woocommerce/tests/performance/config.js
@@ -50,7 +50,7 @@ export const payment_method = 'cod';
 
 export const product_sku = __ENV.P_SKU || 'woo-beanie';
 export const product_url = __ENV.P_URL || 'beanie';
-export const product_id = __ENV.P_ID || '13';
+export const product_id = __ENV.P_ID || '25';
 export const product_search_term = __ENV.P_TERM || 'beanie';
 export const product_category = __ENV.P_CAT || 'Accessories';
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Test runs for the k6 http performance tests against trunk have been failing since https://github.com/woocommerce/woocommerce/pull/51583 was merged to trunk.

The test change in this PR will fix the failing tests _if_ we don't need to revert/patch https://github.com/woocommerce/woocommerce/pull/51583

I traced the failing tests back to this test request
```
Request:
POST /?wc-ajax=add_to_cart HTTP/1.1

product_id=13&product_sku=woo-beanie&quantity=1
```

we create products on our test env by running
`wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml` which uses [sample_products.xml](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/sample-data/sample_products.xml)

this has always (over thousands of test runs in the last [4 years](https://github.com/woocommerce/woocommerce/blame/2e16176464b20f46a0e93074b245209d596965b8/plugins/woocommerce/tests/performance/config.js#L53)) imported the `woo-beanie` product with a `product_id` of `13`

after the change in https://github.com/woocommerce/woocommerce/pull/51583  it is now getting a `product_id` of `25`

I'm not sure if this is an expected outcome of https://github.com/woocommerce/woocommerce/pull/51583 @wavvves or if it will have any other consequences.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See passing run of tests against this branch here https://github.com/woocommerce/woocommerce/actions/runs/12918560963/job/36027337791
If you want to run yourself
Use [On demand](https://github.com/woocommerce/woocommerce/actions/workflows/tests-on-demand.yml) workflow, Select this branch
`custom` as the `Event name`
`core-k6` as `Custom event name`
2. Alternatively if you want to run yourself locally, checkout this branch
Run `pnpm test:perf:ci-setup`
Run `k6 run gh-action-pr-requests.js `
Check test run passes
3. (After merge to trunk) Check `Core Performance tests (K6) - @woocommerce/plugin-woocommerce [performance] (optional)` [job in CI](https://github.com/woocommerce/woocommerce/actions/workflows/ci.yml?query=branch%3Atrunk) passes

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->Perf Test Config Change

</details>
