### PR TITLE
[NOT REVIEW] Test `is_rest_api_request` function

### DIFF
--- a/plugins/woocommerce/tests/php/src/Internal/RestApiTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApiTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal;
+
+use Automattic\WooCommerce\Internal\RestApiParameterUtil;
+
+/**
+ * Tests for the RestApiParameterUtil class.
+ * @package Automattic\WooCommerce\Tests\Internal
+ */
+class RestApiTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' adjust the 'reason' parameter to null if it's somehow empty.
+	 *
+	 * @testWith ["", null]
+	 *           ["none", null]
+	 *           ["foo", "foo"]
+	 *
+	 * @param string $input_reason The value of 'reason' to test.
+	 * @param string $expected_output_reason The expected converted value of 'reason'.
+	 */
+	public function test_rest_api_returns_false( $input_reason, $expected_output_reason ) {
+
+		$this->assertEquals( WC()->is_rest_api_request(), false );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/RestApiTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/RestApiTest.php
@@ -2,26 +2,16 @@
 
 namespace Automattic\WooCommerce\Tests\Internal;
 
-use Automattic\WooCommerce\Internal\RestApiParameterUtil;
-
 /**
- * Tests for the RestApiParameterUtil class.
+ * Tests for the RestApiTest class.
  * @package Automattic\WooCommerce\Tests\Internal
  */
 class RestApiTest extends \WC_Unit_Test_Case {
 
 	/**
-	 * @testdox 'adjust_create_refund_request_parameters' adjust the 'reason' parameter to null if it's somehow empty.
-	 *
-	 * @testWith ["", null]
-	 *           ["none", null]
-	 *           ["foo", "foo"]
-	 *
-	 * @param string $input_reason The value of 'reason' to test.
-	 * @param string $expected_output_reason The expected converted value of 'reason'.
+	 * Test that the rest api returns false when it is not an rest api request.
 	 */
-	public function test_rest_api_returns_false( $input_reason, $expected_output_reason ) {
-
+	public function test_rest_api_returns_false() {
 		$this->assertEquals( WC()->is_rest_api_request(), false );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Summary
While working on unit tests for [PR #54787](https://github.com/woocommerce/woocommerce/pull/54787), I discovered inconsistent behavior in `is_rest_api_request`.  

- **Single Test**: Running the `RestApiTest` in isolation returns `false` (expected behavior).  
- **Full Suite**: Running the entire test suite causes `is_rest_api_request` to return `true` (incorrect behavior).  

### Steps to Reproduce  
1. Run the single test:
   ```sh
   pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env --filter='RestApiTest'

Working on unit test for https://github.com/woocommerce/woocommerce/pull/54787, I found a weird behavior with `is_rest_api_request`. 

✅  Test passes, is_rest_api_request returns false.

2. Run the full suite:

pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env

❌ Test fails, is_rest_api_request returns true. (You can check the unit test job of this PR too)


### Possible Cause


I think that there is a side effect in our unit test suite that changes the behavior of this function. 

I found [this issue](https://github.com/woocommerce/woocommerce/issues/29822), but I'm not sure how much it is related. At the same time, I'm wondering if we should migrate to [WordPress Core functions ](https://core.trac.wordpress.org/ticket/42061). There is even a todo in our codebase:


https://github.com/woocommerce/woocommerce/blob/2e65e46b8faa51d22ff5a86780758379cc647de5/plugins/woocommerce/includes/class-woocommerce.php#L504-L527



