### PR TITLE
Avoid redirection loop in product canonical urls

### DIFF
--- a/plugins/woocommerce/changelog/fix-54737-multibyte-category-slug
+++ b/plugins/woocommerce/changelog/fix-54737-multibyte-category-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure that category slugs with non-latin characters do not cause a redirection loop

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -310,6 +310,7 @@ function wc_product_canonical_redirect(): void {
 	// What category slug did we expect? Normally this maps back to the first assigned product_cat
 	// term. However, this is filterable so we use the relevant helper function to figure this out.
 	$expected_category_slug = wc_product_post_type_link( '%product_cat%', get_post( get_the_ID() ) );
+	$expected_category_slug = urldecode( $expected_category_slug );
 
 	if ( $specified_category_slug === $expected_category_slug ) {
 		return;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #51637 we introduced `wc_product_canonical_redirect` to ensure that the category part of a product URL couldn't be any arbitrary string. However, in the string comparison that happens within that method, we didn't take into account that category slugs with multibyte characters (e.g. Cyrillic or Arabic) that we retrieve with
`wc_product_post_type_link` would be url-encoded, while the category slug from the query object would not. Thus we ended up with a situation where there could be an infinite redirect loop. This change simply ensures that both sides of the string comparison are decoded beforehand.

Fixes #54737
Might fix #54188

### How to test the changes in this Pull Request:

* On your test site, create a product category that has non-latin characters in the name. Something like `деликатес`.
* Go to Settings > Permalink Settings. Under the Product Permalinks section, choose "Custom base" and then set it to also use non-latin characters, along with the product category. Something like this: `/ресторант/%product_cat%/`.
* Now create a new product or edit a product. Add your new non-latin category as the only category on the product.
* Now view the product on the front end. With this changeset, the product page should load normally. Without this changeset, you should get an error about an infinite loop.