### PR TITLE
Revert "Fix variable prod can be added to cart without variations

### DIFF
--- a/plugins/woocommerce/changelog/51583-fix-44868
+++ b/plugins/woocommerce/changelog/51583-fix-44868
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Added verification for variable product without a specified variation when programmatically calling add_to_cart()

--- a/plugins/woocommerce/changelog/54804-test-revert_51583
+++ b/plugins/woocommerce/changelog/54804-test-revert_51583
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Reverting #51583
+

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1045,12 +1045,6 @@ class WC_Cart extends WC_Legacy_Cart {
 				return false;
 			}
 
-			// Variable product cannot be added to cart without a specified variation.
-			if ( ! $variation_id && $product_data->is_type( ProductType::VARIABLE ) ) {
-				/* translators: 1: product link, 2: product name */
-				throw new Exception( sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( $product_data->get_permalink() ), esc_html( $product_data->get_name() ) ) );
-			}
-
 			if ( $product_data->is_type( ProductType::VARIATION ) ) {
 				$missing_attributes = array();
 				$parent_data        = wc_get_product( $product_data->get_parent_id() );

--- a/plugins/woocommerce/tests/performance/requests/shopper/cart.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/cart.js
@@ -37,6 +37,18 @@ export function cart() {
 			commonNonStandardHeaders
 		);
 
+		const product = http.get(
+			`${ base_url }/wp-json/wc/store/v1/products/${ product_id }`,
+			{
+				headers: requestheaders,
+				tags: { name: 'Shopper - Verify product' },
+			}
+		);
+
+		check( product, {
+			'is the infamous Beanie': ( r ) => r.sku === 'woo-beanie',
+		} );
+
 		const response = http.post(
 			`${ base_url }/?wc-ajax=add_to_cart`,
 			{

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -97,39 +97,6 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox variable product should not be added to the cart if variation_id=0.
-	 */
-	public function test_add_variation_to_the_cart_zero_variation_id() {
-		WC()->cart->empty_cart();
-		WC()->session->set( 'wc_notices', null );
-
-		$variable_product = WC_Helper_Product::create_variation_product();
-
-		// Add variable and variation_id=0.
-		WC()->cart->add_to_cart(
-			$variable_product->get_id(),
-			1,
-			0
-		);
-		$notices = WC()->session->get( 'wc_notices', array() );
-
-		// Check for cart contents.
-		$this->assertCount( 0, WC()->cart->get_cart_contents() );
-		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
-
-		// Check that the notices contain an error message about the product option is not selected.
-		$this->assertArrayHasKey( 'error', $notices );
-		$this->assertCount( 1, $notices['error'] );
-		$expected = sprintf( sprintf( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', esc_url( $variable_product->get_permalink() ), esc_html( $variable_product->get_name() ) ) );
-		$this->assertEquals( $expected, $notices['error'][0]['notice'] );
-
-		// Reset cart.
-		WC()->cart->empty_cart();
-		WC()->customer->set_is_vat_exempt( false );
-		$variable_product->delete( true );
-	}
-
-	/**
 	 * Test cloning cart holds no references in session
 	 */
 	public function test_cloning_cart_session() {


### PR DESCRIPTION
This reverts commit a9600503d8b85ca7b6596b3439996446c4a6241d.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

For testing purposes, see https://github.com/woocommerce/woocommerce/pull/54789

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Reverting #51583
</details>
