### PR TITLE
Add workflow to merge release branch into trunk for 9.8 CFEs

### DIFF
--- a/.github/workflows/cfe-update-trunk-with-release.yml
+++ b/.github/workflows/cfe-update-trunk-with-release.yml
@@ -1,0 +1,118 @@
+# Applies only to the 9.8 cycle.
+# This workflow is used to merge the release branch into trunk when a CFE is merged.
+# We're explicitly excluding 'release/9.8' from new-cfe-cherry-pick.yml throughout the duration of this experiment.
+name: Update trunk from release branch after a CFE
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'release/9.8'
+  workflow_dispatch:
+    inputs:
+      silent:
+        description: 'Run silently. Do not trigger Slack pings.'
+        type: boolean
+        required: false
+        default: false
+      source_pr:
+        description: 'PR number that originated the event.'
+        type: number
+        required: true
+
+permissions: {}
+
+jobs:
+  open-pr-after-cfe-merge:
+    name: 'Open PR merging release branch into trunk after CFE merge'
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'cherry pick to trunk'))
+    runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
+    steps:
+      - name: 'Fetch CFE PR details'
+        id: cfe-details
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const cfePR = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: 'workflow_dispatch' === context.eventName ? context.payload.inputs.source_pr : context.payload.pull_request.number
+            });
+
+            if ( ! cfePR.data.merged || cfePR.data.state != 'closed' || cfePR.data.base.ref != 'release/9.8' ) {
+              core.setFailed( 'Triggered with invalid PR' );
+              process.exit( 1 );
+            }
+
+            core.setOutput( 'prNumber', cfePR.data.number );
+            core.setOutput( 'prTitle', cfePR.data.title );
+            core.setOutput( 'prURL', cfePR.data.html_url );
+      - name: 'Open or fetch merge PR' # Temporarily disabled.
+        id: fetch-pr
+        if: false
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let prNumber, prURL;
+
+            // PR already exists?
+            const existingPRs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'trunk',
+              head: 'release/9.8'
+            });
+
+            if ( existingPRs.data.length > 0 ) {
+              prNumber = existingPRs.data[0].number;
+              prURL = existingPRs.data[0].html_url;
+            } else {
+              // Create a new PR targeting trunk.
+              const newPR = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: 'trunk',
+                head: 'release/9.8',
+                title: '[9.8 cycle] Sync `trunk` with latest `release/9.8`',
+                body: 'This PR brings over changes from `release/9.8` to `trunk` after the merge of the following PR(s). Confirm that the changes in this PR are correct **and merge it by creating a merge commit**. Do not rebase or squash.'
+              });
+
+              prNumber = newPR.data.number;
+              prURL = newPR.data.html_url;
+            }
+
+            // Add comment with CFE PR details.
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: 'Includes: ${{ steps.cfe-details.outputs.prURL }}'
+            });
+
+            return prURL;
+          result-encoding: string
+        continue-on-error: true
+      - name: 'Notify via Slack (success)'
+        uses: archive/github-actions-slack@v2.0.0
+        if: ${{ success() && inputs.silent != true }}
+        continue-on-error: true
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+          slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
+          slack-optional-unfurl_links: false
+          slack-optional-unfurl_media: false
+          slack-text: |
+            :pull-request-merged: *[9.8 cycle]* CFE PR _<${{ steps.cfe-details.outputs.prURL }}|${{ steps.cfe-details.outputs.prNumber }} - ${{ steps.cfe-details.outputs.prTitle }}>_ was merged into the release branch. Confirm it's included in the next `release/9.8` → `trunk` <${{ steps.fetch-pr.outputs.result || format( 'https://github.com/{0}/compare/trunk...release/9.8?expand=1', github.repository ) }}|sync>.
+      - name: 'Notify via Slack (failure)'
+        uses: archive/github-actions-slack@v2.0.0
+        if: failure() && inputs.silent != true
+        continue-on-error: true
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+          slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
+          slack-optional-unfurl_links: false
+          slack-optional-unfurl_media: false
+          slack-text: |
+            :warning: *[9.8 cycle]* An error occurred while running the release branch → `trunk` sync workflow after a CFE was merged. Please visit this link to debug: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.

--- a/.github/workflows/new-cfe-cherry-pick.yml
+++ b/.github/workflows/new-cfe-cherry-pick.yml
@@ -1,8 +1,10 @@
-# This workflow is used to cherry pick PRs from release branche into trunk.
+# This workflow is used to cherry pick PRs from release branch into trunk.
 name: New CFE workflow - Cherry pick
 on:
     pull_request:
         types: [closed]
+        branches-ignore:
+          - 'release/9.8'
     workflow_dispatch:
         inputs:
             skipSlackPing:
@@ -50,7 +52,7 @@ jobs:
                   core.setOutput('base_ref', prDetails.data.base.ref);
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
             - name: check
               id: check
               uses: actions/github-script@v7
@@ -98,7 +100,7 @@ jobs:
                       console.log( 'releaseBranch:', releaseBranch )
                       console.log( 'version:', version )
                       console.log( 'pr:', pr )
-    
+
                       core.setOutput( 'pr', pr )
                       core.setOutput( 'version', version )
                       core.setOutput( 'release', releaseBranch )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a workflow that effectively replaces the ["cherry pick to trunk" workflow](https://github.com/woocommerce/woocommerce/blob/1130b93f62d7b063f6c092a90e1f5d2444681897/.github/workflows/new-cfe-cherry-pick.yml) specifically for PRs targeting `release/9.8`. That is, any PR targeting `release/9.8` that is labeled with `cherry pick to trunk` will be skipped by the cherry pick workflow and will be handled by this new workflow instead, which will notify via Slack and suggest a PR merging the release branch into `trunk` is opened.

To minimize disruptions, all other workflows remain unchanged, including those associated to PRs labeled `cherry pick to frozen release` or targeting release branches other than 9.8.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### 0. Set up a clone of the WC repo.
1. Fork the WC repo and make sure to include at least branches `trunk` and `release/9.7`.
1. Go to **Issues > Labels** in your fork and add the label `cherry pick to trunk` if it doesn't exist.
1. Go to **Settings > Secrets and variables > Actions** and add the following 2 secrets:
   - `CODE_FREEZE_BOT_TOKEN` set to the token of a Slack app you control. 
   - `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`  set to the name of a Slack channel where the app above is included.

   See p1739985355068039/1739985147.476089-slack-C0E1AV8T0 for reasonable values for these secrets.
1. Let's configure your fork correctly to "simulate" a repo in which this PR has already been merged and the 9.8 release branch exists. You can do this from your local copy of the WC repo by running these commands (replace variables as needed):

   ```shell
   # i. Add your fork as a remote in your local repo.
   git remote add woo_fork YOUR_FORK_REMOTE_URL

   # ii. Fetch this PR's branch and push it as trunk to your fork.
   git push woo_fork experiment/cfe-meging-release-9-7:trunk --force
   
   # iii. Also push this branch as release/9.8 for testing purposes.
   git push woo_fork experiment/cfe-meging-release-9-7:release/9.8 --force
   ```

   ⚠️ Please ignore the typo in this PR's branch name. Also, make sure to run the commands as indicated (changing only `woo_fork` and `YOUR_FORK_REMOTE_URL` as necessary), so that you don't affect the main repo. Alternatively, clone your fork in a different location.


### 1. Happy path.

#### Confirm that the workflow doesn't affect PRs _not_ labeled `cherry pick to trunk`:
1. Use the GitHub UI **in your fork** to create PRs based off both `release/9.8` and `trunk` with any changes you'd like and no particular labels.
1. Merge the PRs.
1. Confirm in the **Actions** tab that workflow _Update trunk from release branch after a CFE_ has not been triggered.

#### Confirm that the workflow doesn't impact CFE's targeting other branches:
1. Again, use the GitHub UI **in your fork** to create a PR that targets `release/9.7` with any changes and label it as `cherry pick to trunk`.
1. Merge the PR.
1. Confirm in **Actions** that the workflow _Update trunk from release branch after a CFE_ is **not** triggered and that, instead, _New CFE workflow - Cherry pick_ was triggered as usual, creating a PR with a cherry pick to trunk.

#### Confirm that CFEs for 9.8 trigger the new workflow:
1. Use the GitHub UI to create a PR based off `release/9.8` with any changes you'd like.
1. Label this PR with `cherry pick to trunk`.
1. Merge the PR.
1. Go to the **Actions** tab and confirm that the _Update trunk from release branch after a CFE_ workflow was triggered. Wait until it completes.
<!--
1. Go to the **Pull Requests** tab and confirm that a new PR has been created, which targets `trunk` and has `release/9.8` as head:
   <img width="500" alt="Screenshot 2025-02-19 at 16 14 36" src="https://github.com/user-attachments/assets/b6184343-6b28-4330-83f5-8cbfc919af2f" />

   This PR should also have a comment referencing the PR that initiated the workflow:

   <img width="500" alt="Screenshot 2025-02-19 at 16 14 43" src="https://github.com/user-attachments/assets/183d4f03-1417-47f9-9f67-f09ff2b6f6a5" />
-->
1. You should have also received a notification in Slack:
   <img width="1059" alt="Screenshot 2025-02-19 at 16 17 00" src="https://github.com/user-attachments/assets/0dd3df66-4201-40a4-aa7f-e98b98076940" />
<!--
1. Repeat steps 1-3 and confirm that this time instead of a new PR (step 5) the existing one just gets a new comment. The Slack notification should also be received.
-->

### 2. Test failures:
In order to test failures, which could happen if parts of the script trigger an error or exception, we're going to manually dispatch the workflow using invalid values:

1. Create or re-use any PR that doesn't target `release/9.8`.
1. Go to **Actions > _Update trunk from release branch after a CFE_** and click **Run workflow**.
1. Enter the PR number from step (1) in the textfield and run the workflow.
1. Confirm that you've received a notification in Slack about the failure.
1. Repeat the above with a PR number that doesn't exist and confirm that the results are the same.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>