### PR TITLE
Manual merge to trunk: CFE for 9.7 - Fix global popover CSS styling bug (#54744)

### DIFF
--- a/packages/js/onboarding/changelog/54744-fix-popover-styling
+++ b/packages/js/onboarding/changelog/54744-fix-popover-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix global popover CSS styling bug

--- a/plugins/woocommerce/changelog/54744-fix-popover-styling
+++ b/plugins/woocommerce/changelog/54744-fix-popover-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix global popover CSS styling bug

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
@@ -146,12 +146,13 @@ export const PaymentGateways = ( {
 							{ isPopoverVisible && (
 								<Popover
 									position="top left"
+									className="settings-payment-gateways__header-select-container--indicator-popover"
 									noArrow={ true }
 									onClose={ () =>
 										setIsPopoverVisible( false )
 									}
 								>
-									<div className="settings-payment-gateways__header-select-container--indicator-popover">
+									<div className="settings-payment-gateways__header-select-container--indicator-popover-content">
 										{ interpolateComponents( {
 											mixedString: __(
 												'Your business location does not match your store location. {{link}}Edit store location.{{/link}}',

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -300,7 +300,28 @@
 }
 
 .settings-payment-gateways__header-select-container--indicator-popover {
-	width: 236px;
-	font-size: 13px;
-	line-height: 20px;
+	.components-popover__content {
+		background: $white;
+		border: 1px solid $gray-100;
+		border-radius: 3px;
+		max-width: 255px;
+		padding: $gap-smaller;
+		box-shadow: none;
+		margin-bottom: $gap-smaller;
+
+		a {
+			outline: none;
+			text-decoration: none;
+
+			&:focus {
+				box-shadow: none;
+			}
+		}
+	}
+
+	&-content {
+		width: 236px;
+		font-size: 13px;
+		line-height: 20px;
+	}
 }


### PR DESCRIPTION
This is a manual merge to trunk for the CFE https://github.com/woocommerce/woocommerce/pull/54744 already merged to the release branch.