### PR TITLE
[dev] Docs: add note about Ubuntu crashes case

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ pnpm install
 pnpm build
 ```
 
+Note: If you're working on an Ubuntu machine and observing freezes/crashes while running build and watch commands, the issue might be related to the swap configuration.
+<details>
+    <summary>Details:</summary>
+  
+    We have confirmed cases similar to https://askubuntu.com/questions/1194943/computer-often-freezes-because-of-webpack with systems having up to 32GB RAM.
+    Please follow the conversation for more context, troubleshooting, and possible mitigation options.
+  
+    As for the root cause, our `build` and `watch:build` commands (defined in `package.json` files under `scripts` section)
+    are heavily using the parallelization feature of pnpm  (`--workspace-concurrency=Infinity`), which, in combination with
+    running code editors / IDEs can, at peak usage, exhaust the RAM and swap.
+</details>
+
 ## Repository Structure
 
 Each plugin, package, and tool has its own `package.json` file containing project-specific dependencies and scripts. Most projects also contain a `README.md` file with any project-specific setup instructions and documentation.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Document some pointers for troubleshooting Ubuntu-specific crashes caused by build/watch commands.

### How to test the changes in this Pull Request:

n/a
