### PR TITLE
Fix email preview iframe overflow in Safari

### DIFF
--- a/plugins/woocommerce/changelog/54837-safari-email-preview-overflow
+++ b/plugins/woocommerce/changelog/54837-safari-email-preview-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email preview iframe overflow in Safari

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -72,10 +72,12 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 	}, [ nonce, setIsLoading, settingsIds, setCounter ] );
 
 	return (
-		<iframe
-			src={ `${ src }&hash=${ counter }` }
-			title={ __( 'Email preview frame', 'woocommerce' ) }
-			onLoad={ () => setIsLoading( false ) }
-		/>
+		<div>
+			<iframe
+				src={ `${ src }&hash=${ counter }` }
+				title={ __( 'Email preview frame', 'woocommerce' ) }
+				onLoad={ () => setIsLoading( false ) }
+			/>
+		</div>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

| <img width="877" alt="Screenshot 2025-01-24 at 14 13 32" src="https://github.com/user-attachments/assets/fb6ddf49-03a9-49f3-9776-3909651e5ee4" /> | <img width="875" alt="Screenshot 2025-01-24 at 14 13 38" src="https://github.com/user-attachments/assets/8f3f5787-5a13-4361-a52d-ebf51dcb112a" /> |
| ------- | ----- |
| Before | After |



[Playground URL](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/admin.php?page=wc-settings&tab=email%22,%22steps%22:%5B%7B%22step%22:%22login%22%7D,%7B%22step%22:%22runPHP%22,%22code%22:%22%3C?php%20require%20'/wordpress/wp-load.php';%20update_option(%20'woocommerce_onboarding_profile',%20%5B%20'completed'%20=%3E%20true%20%5D%20);%20update_option(%20'woocommerce_feature_email_improvements_enabled',%20'yes'%20);%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/wordpress/wp-content/mu-plugins/%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/wordpress/wp-content/mu-plugins/no-more-wizards.php%22,%22data%22:%22%3C?php%20require%20'/wordpress/wp-load.php';%20add_filter(%20'woocommerce_prevent_automatic_wizard_redirect',%20'__return_true'%20);%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip%22%7D%7D%5D%7D) to replicate the issue in Safari browser.

Closes #54837.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open Safari browser.
2. Enable `Email improvements` in **WooCommerce > Settings > Advanced > Features**.
3. Go to **WooCommerce > Settings > Emails**.
4. Check that the email preview is not overflowing its container (outlined by a border and padding).

<!-- End testing instructions -->

