### PR TITLE
[dev] Monorepo: patch wpenv to stabilize test containers startup in CI.

### DIFF
--- a/bin/patches/@wordpress__env@10.14.0.patch
+++ b/bin/patches/@wordpress__env@10.14.0.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/build-docker-compose-config.js b/lib/build-docker-compose-config.js
+index a1a4f68256b688efecd0da79282bc7e9f1ed1f1c..28cdeeb724f9e681f5eae4c7939a080c658d24fc 100644
+--- a/lib/build-docker-compose-config.js
++++ b/lib/build-docker-compose-config.js
+@@ -225,6 +225,7 @@ module.exports = function buildDockerComposeConfig( config ) {
+ 			},
+ 			'tests-wordpress': {
+ 				depends_on: [ 'tests-mysql' ],
++				restart: 'on-failure:5',
+ 				build: {
+ 					context: '.',
+ 					dockerfile: 'Tests-WordPress.Dockerfile',

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
 			"react-resize-aware": "3.1.1"
 		},
 		"patchedDependencies": {
-			"@wordpress/edit-site@5.15.0": "bin/patches/@wordpress__edit-site@5.15.0.patch"
+			"@wordpress/edit-site@5.15.0": "bin/patches/@wordpress__edit-site@5.15.0.patch",
+			"@wordpress/env@10.14.0": "bin/patches/@wordpress__env@10.14.0.patch"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ patchedDependencies:
   '@wordpress/edit-site@5.15.0':
     hash: u2xn4lpm453vgqpkdgbivlveaa
     path: bin/patches/@wordpress__edit-site@5.15.0.patch
+  '@wordpress/env@10.14.0':
+    hash: nycgcwcabap5g2lmhb3gkbhvhq
+    path: bin/patches/@wordpress__env@10.14.0.patch
 
 importers:
 
@@ -3286,7 +3289,7 @@ importers:
         version: 10.0.2(react@18.3.1)
       '@wordpress/env':
         specifier: 10.14.0
-        version: 10.14.0
+        version: 10.14.0(patch_hash=nycgcwcabap5g2lmhb3gkbhvhq)
       '@wordpress/prettier-config':
         specifier: 2.17.0
         version: 2.17.0(wp-prettier@2.8.5)
@@ -3380,7 +3383,7 @@ importers:
         version: 1.0.1(@playwright/test@1.49.1)(encoding@0.1.13)(typescript@5.7.2)
       '@wordpress/env':
         specifier: 10.14.0
-        version: 10.14.0
+        version: 10.14.0(patch_hash=nycgcwcabap5g2lmhb3gkbhvhq)
       '@wordpress/stylelint-config':
         specifier: ^21.36.0
         version: 21.36.0(postcss@8.4.32)(stylelint@14.16.1)
@@ -3555,7 +3558,7 @@ importers:
         version: link:../../packages/js/eslint-plugin
       '@wordpress/env':
         specifier: 10.14.0
-        version: 10.14.0
+        version: 10.14.0(patch_hash=nycgcwcabap5g2lmhb3gkbhvhq)
       '@wordpress/prettier-config':
         specifier: 2.17.0
         version: 2.17.0(wp-prettier@2.8.5)
@@ -3944,7 +3947,7 @@ importers:
         version: 5.22.0
       '@wordpress/env':
         specifier: 10.14.0
-        version: 10.14.0
+        version: 10.14.0(patch_hash=nycgcwcabap5g2lmhb3gkbhvhq)
       '@wordpress/hooks':
         specifier: wp-6.6
         version: 4.0.1
@@ -4925,7 +4928,7 @@ importers:
         version: 20.17.8
       '@wordpress/env':
         specifier: 10.14.0
-        version: 10.14.0
+        version: 10.14.0(patch_hash=nycgcwcabap5g2lmhb3gkbhvhq)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -44005,7 +44008,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@wordpress/env@10.14.0':
+  '@wordpress/env@10.14.0(patch_hash=nycgcwcabap5g2lmhb3gkbhvhq)':
     dependencies:
       chalk: 4.1.2
       copy-dir: 1.3.0


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes #54831

Patch the dependency so docker-compose attempts to restart the failing test container up to 5 times during startup (let's see if it'll be enough for the MySQL to spinoff).

### How to test the changes in this Pull Request:

- CI-checks shall pass
