### PR TITLE
ProductFilterRating: fix lint errors

### DIFF
--- a/plugins/woocommerce/changelog/54840-fix-filter-lint
+++ b/plugins/woocommerce/changelog/54840-fix-filter-lint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: ProductFilterRating: fix lint errors.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -102,18 +102,18 @@ final class ProductFilterRating extends AbstractBlock {
 			return '';
 		}
 
-		$min_rating             = $attributes['minRating'] ?? 0;
-		$rating_counts          = $this->get_rating_counts( $block );
+		$min_rating    = $attributes['minRating'] ?? 0;
+		$rating_counts = $this->get_rating_counts( $block );
 		// User selected minimum rating to display.
 		$rating_counts_with_min = array_filter(
 			$rating_counts,
-			function( $rating ) use ( $min_rating ) {
+			function ( $rating ) use ( $min_rating ) {
 				return $rating['rating'] >= $min_rating;
 			}
 		);
-		$filter_params   = $block->context['filterParams'] ?? array();
-		$rating_query    = $filter_params[ self::RATING_FILTER_QUERY_VAR ] ?? '';
-		$selected_rating = array_filter( explode( ',', $rating_query ) );
+		$filter_params          = $block->context['filterParams'] ?? array();
+		$rating_query           = $filter_params[ self::RATING_FILTER_QUERY_VAR ] ?? '';
+		$selected_rating        = array_filter( explode( ',', $rating_query ) );
 
 		$filter_options = array_map(
 			function ( $rating ) use ( $selected_rating, $attributes ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When I merged trunk into #54740, I started to get PHP linter errors:

<img width="708" alt="image" src="https://github.com/user-attachments/assets/dfc4dd34-236e-4579-bc12-598b22f55a9a" />


This PR resolves several errors that were previously missed due to a bug in the CI pipeline, which caused the lint job to skip the check in some cases.

The CI issue has already been addressed in https://github.com/woocommerce/woocommerce/pull/54785.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that CI jobs are green


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

ProductFilterRating: fix lint errors.

</details>
