### PR TITLE
Correctly render plain text emails in email preview

### DIFF
--- a/plugins/woocommerce/changelog/53950-preview-plain-text-emails
+++ b/plugins/woocommerce/changelog/53950-preview-plain-text-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix generating email preview of plain text emails

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -634,7 +634,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * Creates the React mount point for the email preview.
 	 */
 	public function email_preview() {
-		$this->delete_transient_email_settings( null );
+		$this->delete_transient_email_settings();
 		$emails      = WC()->mailer()->get_emails();
 		$email_types = array();
 		foreach ( $emails as $type => $email ) {
@@ -659,7 +659,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * @param object $email The email object to run the method on.
 	 */
 	public function email_preview_single( $email ) {
-		$this->delete_transient_email_settings( $email->id );
+		$this->delete_transient_email_settings();
 		// Email types array should have a single entry for current email.
 		$email_types = array(
 			array(
@@ -687,14 +687,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	/**
 	 * Deletes transient with email settings used for live preview. This is to
 	 * prevent conflicts where the preview would show values from previous session.
-	 *
-	 * @param string|null $email_id Email ID.
 	 */
-	private function delete_transient_email_settings( ?string $email_id ) {
-		$setting_ids = array_merge(
-			EmailPreview::get_email_style_settings_ids(),
-			EmailPreview::get_email_content_settings_ids( $email_id ),
-		);
+	private function delete_transient_email_settings() {
+		$setting_ids = EmailPreview::get_all_email_settings_ids();
 		foreach ( $setting_ids as $id ) {
 			delete_transient( $id );
 		}

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -502,7 +502,19 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_email_type() {
-		$email_type = $this->get_transient_or_value( 'email_type', $this->email_type );
+		$email_type = $this->email_type;
+		/**
+		 * This filter is documented in templates/emails/email-styles.php
+		 *
+		 * @since 9.6.0
+		 * @param bool $is_email_preview Whether the email is being previewed.
+		 */
+		$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
+		// Transient is used for live email preview without saving the settings.
+		if ( $is_email_preview ) {
+			$transient  = get_transient( "woocommerce_{$this->id}_email_type" );
+			$email_type = $transient ? $transient : $email_type;
+		}
 		return $email_type && class_exists( 'DOMDocument' ) ? $email_type : 'plain';
 	}
 
@@ -1245,29 +1257,5 @@ class WC_Email extends WC_Settings_API {
 		}
 
 		return $option;
-	}
-
-	/**
-	 * Return transient or provided value for email preview.
-	 *
-	 * @param string $key Option key.
-	 * @param mixed  $value Value to return when transient is not set.
-	 */
-	private function get_transient_or_value( string $key, $value ) {
-		/**
-		 * This filter is documented in templates/emails/email-styles.php
-		 *
-		 * @since 9.6.0
-		 * @param bool $is_email_preview Whether the email is being previewed.
-		 */
-		$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
-		if ( $is_email_preview ) {
-			$email_id  = $this->id;
-			$transient = get_transient( "woocommerce_{$email_id}_{$key}" );
-			if ( false !== $transient ) {
-				return $transient ? $transient : $value;
-			}
-		}
-		return $value;
 	}
 }

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -502,7 +502,8 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_email_type() {
-		return $this->email_type && class_exists( 'DOMDocument' ) ? $this->email_type : 'plain';
+		$email_type = $this->get_transient_or_value( 'email_type', $this->email_type );
+		return $email_type && class_exists( 'DOMDocument' ) ? $email_type : 'plain';
 	}
 
 	/**
@@ -1244,5 +1245,29 @@ class WC_Email extends WC_Settings_API {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * Return transient or provided value for email preview.
+	 *
+	 * @param string $key Option key.
+	 * @param mixed  $value Value to return when transient is not set.
+	 */
+	private function get_transient_or_value( string $key, $value ) {
+		/**
+		 * This filter is documented in templates/emails/email-styles.php
+		 *
+		 * @since 9.6.0
+		 * @param bool $is_email_preview Whether the email is being previewed.
+		 */
+		$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
+		if ( $is_email_preview ) {
+			$email_id  = $this->id;
+			$transient = get_transient( "woocommerce_{$email_id}_{$key}" );
+			if ( false !== $transient ) {
+				return $transient ? $transient : $value;
+			}
+		}
+		return $value;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -284,7 +284,13 @@ class EmailPreview {
 			$this->set_email_type( self::DEFAULT_EMAIL_TYPE );
 		}
 
-		$content = $this->email->get_content_html();
+		if ( 'plain' === $this->email->get_email_type() ) {
+			$content  = '<pre style="word-wrap: break-word; white-space: pre-wrap;">';
+			$content .= $this->email->get_content_plain();
+			$content .= '</pre>';
+		} else {
+			$content = $this->email->get_content_html();
+		}
 		$inlined = $this->email->style_inline( $content );
 
 		$this->clean_up_filters();

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -135,6 +135,7 @@ class EmailPreview {
 			"woocommerce_{$email_id}_subject",
 			"woocommerce_{$email_id}_heading",
 			"woocommerce_{$email_id}_additional_content",
+			"woocommerce_{$email_id}_email_type",
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -23,6 +23,13 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	const SITE_TITLE = 'Test Blog';
 
 	/**
+	 * Email type option key for default preview email.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_EMAIL_TYPE_KEY = 'woocommerce_' . EmailPreview::DEFAULT_EMAIL_ID . '_email_type';
+
+	/**
 	 * "System Under Test", an instance of the class to be tested.
 	 *
 	 * @var EmailPreview
@@ -70,6 +77,28 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( $order_title, $message );
 		$this->assertStringContainsString( $order_content, $message );
 		$this->assertStringContainsString( $order_product, $message );
+	}
+
+	/**
+	 * Tests that it renders HTML email.
+	 */
+	public function test_it_renders_html_email() {
+		set_transient( self::DEFAULT_EMAIL_TYPE_KEY, 'html', HOUR_IN_SECONDS );
+		$message = $this->sut->render();
+		$this->assertStringContainsString( '<html', $message );
+		$this->assertStringContainsString( '<table', $message );
+		delete_transient( self::DEFAULT_EMAIL_TYPE_KEY );
+	}
+
+	/**
+	 * Tests that it renders HTML email.
+	 */
+	public function test_it_renders_plain_text_email() {
+		set_transient( self::DEFAULT_EMAIL_TYPE_KEY, 'plain', HOUR_IN_SECONDS );
+		$message = $this->sut->render();
+		$this->assertStringNotContainsString( '<html', $message );
+		$this->assertStringNotContainsString( '<table', $message );
+		delete_transient( self::DEFAULT_EMAIL_TYPE_KEY );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53950.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Email improvements` feature in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. Click on `Manage` any email. 
4. Change the Email type to `Plain text`.
5. Verify that the email preview correctly rendered a plain text version of the email. 

<!-- End testing instructions -->

