### PR TITLE
[Experimental]: Find a way to identify when a block is descendant of the SingleProduct block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -4,12 +4,7 @@
 	"title": "Add to Cart with Options (Experimental)",
 	"description": "Create an \"Add To Cart\" composition by using blocks",
 	"category": "woocommerce-product-elements",
-	"attributes": {
-		"isDescendentOfSingleProductBlock": {
-			"type": "boolean",
-			"default": false
-		}
-	},
+	"attributes": {},
 	"usesContext": [ "postId" ],
 	"textdomain": "woocommerce",
 	"supports": {

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -16,7 +16,6 @@ import {
 /**
  * Internal dependencies
  */
-import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import ToolbarProductTypeGroup from '../components/toolbar-type-product-selector-group';
 import { DowngradeNotice } from '../components/downgrade-notice';
 import useProductTypeSelector from '../hooks/use-product-type-selector';
@@ -33,15 +32,10 @@ export type FeaturesProps = {
 export type UpdateFeaturesType = ( key: FeaturesKeys, value: boolean ) => void;
 
 const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
-	const { setAttributes } = props;
 	const { product } = useProductDataContext();
 
 	const blockProps = useBlockProps();
 	const blockClientId = blockProps?.id;
-	const { isDescendentOfSingleProductBlock } =
-		useIsDescendentOfSingleProductBlock( {
-			blockClientId,
-		} );
 
 	const {
 		current: currentProductType,
@@ -50,20 +44,11 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 	} = useProductTypeSelector();
 
 	useEffect( () => {
-		setAttributes( {
-			isDescendentOfSingleProductBlock,
-		} );
 		registerListener( blockClientId );
 		return () => {
 			unregisterListener( blockClientId );
 		};
-	}, [
-		setAttributes,
-		isDescendentOfSingleProductBlock,
-		blockClientId,
-		registerListener,
-		unregisterListener,
-	] );
+	}, [ blockClientId, registerListener, unregisterListener ] );
 
 	const productType =
 		product.id === 0 ? currentProductType?.slug : product.type;

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -7,5 +7,4 @@ export type QuantitySelectorStyleProps = 'input' | 'stepper';
 
 export interface Attributes {
 	className?: string;
-	isDescendentOfSingleProductBlock: boolean;
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -32,7 +32,10 @@ const AddToCartWithOptionsVariationSelectorEdit = (
 		className,
 	} );
 
-	if ( currentProductType?.slug !== 'variable' ) {
+	const productType =
+		product.id === 0 ? currentProductType?.slug : product.type;
+
+	if ( productType !== 'variable' ) {
 		return null;
 	}
 

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
@@ -5,10 +5,6 @@
 	"description": "Display a button so the customer can add a product to their cart. Options will also be displayed depending on product type. e.g. quantity, variation.",
 	"category": "woocommerce-product-elements",
 	"attributes": {
-		"isDescendentOfSingleProductBlock": {
-			"type": "boolean",
-			"default": false
-		},
 		"quantitySelectorStyle": {
 			"type": "string",
 			"enum": [ "input", "stepper" ],

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Skeleton } from '@woocommerce/base-components/skeleton';
@@ -16,7 +15,6 @@ import { isBoolean } from '@woocommerce/types';
  * Internal dependencies
  */
 import './editor.scss';
-import { useIsDescendentOfSingleProductBlock } from '../../../atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block';
 import { QuantitySelectorStyle, AddToCartFormSettings } from './settings';
 import { shouldBlockifiedAddToCartWithOptionsBeRegistered } from '../../add-to-cart-with-options/utils';
 import { UpgradeNotice } from './components/upgrade-notice';
@@ -42,16 +40,6 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 	const blockProps = useBlockProps( {
 		className: `wc-block-add-to-cart-form ${ quantitySelectorStyleClass }`,
 	} );
-	const { isDescendentOfSingleProductBlock } =
-		useIsDescendentOfSingleProductBlock( {
-			blockClientId: blockProps?.id,
-		} );
-
-	useEffect( () => {
-		setAttributes( {
-			isDescendentOfSingleProductBlock,
-		} );
-	}, [ setAttributes, isDescendentOfSingleProductBlock ] );
 
 	const isSiteEditor = useSelect(
 		( select ) => isSiteEditorPage( select( 'core/edit-site' ) ),

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
@@ -17,7 +17,6 @@ import '../../../base/components/quantity-selector/style.scss';
 
 export interface Attributes {
 	className?: string;
-	isDescendentOfSingleProductBlock: boolean;
 	quantitySelectorStyle: QuantitySelectorStyle;
 }
 

--- a/plugins/woocommerce/changelog/add-53284
+++ b/plugins/woocommerce/changelog/add-53284
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Remove isDescendentOfSingleProductBlock attribute from the AddToCartWithOptions block
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -31,7 +31,7 @@ class AddToCartForm extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 		// Scope the excecution of this hook to be only when the add to cart form is submitted.
-		if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 			add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -30,8 +30,10 @@ class AddToCartForm extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
-		add_filter( 'wc_add_to_cart_message_html', array( $this, 'add_to_cart_message_html_filter' ), 10, 2 );
-		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
+		// Scope the excecution of this hook to be only when the add to cart form is submitted.
+		if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+			add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
+		}
 	}
 
 	/**
@@ -174,11 +176,7 @@ class AddToCartForm extends AbstractBlock {
 		$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
 
 		$parsed_attributes                     = $this->parse_attributes( $attributes );
-		$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
-
-		if ( ! $is_external_product_with_url ) {
-			$product_html = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product_html, $is_descendent_of_single_product_block );
-		}
+		$is_descendent_of_single_product_block = is_null( $previous_product ) || $post_id !== $previous_product->get_id();
 
 		$product_html       = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
@@ -222,62 +220,16 @@ class AddToCartForm extends AbstractBlock {
 	}
 
 	/**
-	 * Add a hidden input to the Add to Cart form to indicate that it is a descendent of a Single Product block.
-	 *
-	 * @param string $product_html The Add to Cart Form HTML.
-	 * @param string $is_descendent_of_single_product_block Indicates if block is descendent of Single Product block.
-	 *
-	 * @return string The Add to Cart Form HTML with the hidden input.
-	 */
-	protected function add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product_html, $is_descendent_of_single_product_block ) {
-		$hidden_is_descendent_of_single_product_block_input = sprintf(
-			'<input type="hidden" name="is-descendent-of-single-product-block" value="%1$s">',
-			$is_descendent_of_single_product_block ? 'true' : 'false'
-		);
-		$regex_pattern                                      = '/<button\s+type="submit"[^>]*>.*?<\/button>/i';
-
-		preg_match( $regex_pattern, $product_html, $input_matches );
-
-		if ( ! empty( $input_matches ) ) {
-			$product_html = preg_replace( $regex_pattern, $hidden_is_descendent_of_single_product_block_input . $input_matches[0], $product_html );
-		}
-
-		return $product_html;
-	}
-
-	/**
-	 * Filter the add to cart message to prevent the Notice from being displayed when the Add to Cart form is a descendent of a Single Product block
-	 * and the Add to Cart button is clicked.
-	 *
-	 * @param string $message Message to be displayed when product is added to the cart.
-	 */
-	public function add_to_cart_message_html_filter( $message ) {
-		// phpcs:ignore
-		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' === $_POST['is-descendent-of-single-product-block'] ) {
-			return false;
-		}
-		return $message;
-	}
-
-	/**
-	 * Hooks into the `woocommerce_add_to_cart_redirect` filter to prevent redirecting
-	 * to another page when the block is inside the Single Product block and the Add to Cart button
-	 * is clicked.
+	 * Hooks into the `woocommerce_add_to_cart_redirect` filter to redirect to
+	 * the request referer when the add to cart return to url is not set.
 	 *
 	 * @param string $url The URL to redirect to after the product is added to the cart.
 	 * @return string The filtered redirect URL.
 	 */
 	public function add_to_cart_redirect_filter( $url ) {
-		// phpcs:ignore
-		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ) {
-
-			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
-				return wc_get_cart_url();
-			}
-
-			return wp_validate_redirect( wp_get_referer(), $url );
+		if ( $url ) {
+			return $url;
 		}
-
-		return $url;
+		return wp_validate_redirect( wp_get_referer(), $url );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -226,7 +226,7 @@ class AddToCartForm extends AbstractBlock {
 	 * @return string The filtered redirect URL.
 	 */
 	public function add_to_cart_redirect_filter( $url ) {
-		if ( $url ) {
+		if ( $url || 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 			return $url;
 		}
 		return wp_validate_redirect( wp_get_referer(), $url );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -45,8 +45,7 @@ class AddToCartForm extends AbstractBlock {
 	private function parse_attributes( $attributes ) {
 		// These should match what's set in JS `registerBlockType`.
 		$defaults = array(
-			'isDescendentOfSingleProductBlock' => false,
-			'quantitySelectorStyle'            => 'input',
+			'quantitySelectorStyle' => 'input',
 		);
 
 		return wp_parse_args( $attributes, $defaults );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -42,7 +42,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 *
 	 * @return string | void Rendered block output.
 	 */
-	protected function render( $attributes, $content, $block ) {	
+	protected function render( $attributes, $content, $block ) {
 		global $product;
 
 		$post_id = $block->context['postId'];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -21,38 +21,6 @@ class AddToCartWithOptions extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options';
 
 	/**
-	 * Initializes the AddToCartWithOptions block and hooks into the `wc_add_to_cart_message_html` filter
-	 * to prevent displaying the Cart Notice when the block is inside the Single Product block
-	 * and the Add to Cart button is clicked.
-	 *
-	 * It also hooks into the `woocommerce_add_to_cart_redirect` filter to prevent redirecting
-	 * to another page when the block is inside the Single Product block and the Add to Cart button
-	 * is clicked.
-	 *
-	 * @return void
-	 */
-	protected function initialize() {
-		parent::initialize();
-		add_filter( 'wc_add_to_cart_message_html', array( $this, 'add_to_cart_message_html_filter' ), 10, 2 );
-		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
-	}
-
-	/**
-	 * Get the block's attributes.
-	 *
-	 * @param array $attributes Block attributes. Default empty array.
-	 * @return array  Block attributes merged with defaults.
-	 */
-	private function parse_attributes( $attributes ) {
-		// These should match what's set in JS `registerBlockType`.
-		$defaults = array(
-			'isDescendentOfSingleProductBlock' => false,
-		);
-
-		return wp_parse_args( $attributes, $defaults );
-	}
-
-	/**
 	 * Extra data passed through from server to client for block.
 	 *
 	 * @param array $attributes  Any attributes that currently are available from the block.
@@ -74,7 +42,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 *
 	 * @return string | void Rendered block output.
 	 */
-	protected function render( $attributes, $content, $block ) {
+	protected function render( $attributes, $content, $block ) {	
 		global $product;
 
 		$post_id = $block->context['postId'];
@@ -155,65 +123,5 @@ class AddToCartWithOptions extends AbstractBlock {
 		}
 
 		return $form_html;
-	}
-
-	/**
-	 * Add a hidden input to the Add to Cart form to indicate that it is a descendent of a Single Product block.
-	 *
-	 * @param string $product_html The Add to Cart Form HTML.
-	 * @param string $is_descendent_of_single_product_block Indicates if block is descendent of Single Product block.
-	 *
-	 * @return string The Add to Cart Form HTML with the hidden input.
-	 */
-	protected function add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product_html, $is_descendent_of_single_product_block ) {
-		$hidden_is_descendent_of_single_product_block_input = sprintf(
-			'<input type="hidden" name="is-descendent-of-single-product-block" value="%1$s">',
-			$is_descendent_of_single_product_block ? 'true' : 'false'
-		);
-		$regex_pattern                                      = '/<button\s+type="submit"[^>]*>.*?<\/button>/i';
-
-		preg_match( $regex_pattern, $product_html, $input_matches );
-
-		if ( ! empty( $input_matches ) ) {
-			$product_html = preg_replace( $regex_pattern, $hidden_is_descendent_of_single_product_block_input . $input_matches[0], $product_html );
-		}
-
-		return $product_html;
-	}
-
-	/**
-	 * Filter the add to cart message to prevent the Notice from being displayed when the Add to Cart form is a descendent of a Single Product block
-	 * and the Add to Cart button is clicked.
-	 *
-	 * @param string $message Message to be displayed when product is added to the cart.
-	 */
-	public function add_to_cart_message_html_filter( $message ) {
-		// phpcs:ignore
-		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' === $_POST['is-descendent-of-single-product-block'] ) {
-			return false;
-		}
-		return $message;
-	}
-
-	/**
-	 * Hooks into the `woocommerce_add_to_cart_redirect` filter to prevent redirecting
-	 * to another page when the block is inside the Single Product block and the Add to Cart button
-	 * is clicked.
-	 *
-	 * @param string $url The URL to redirect to after the product is added to the cart.
-	 * @return string The filtered redirect URL.
-	 */
-	public function add_to_cart_redirect_filter( $url ) {
-		// phpcs:ignore
-		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ) {
-
-			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
-				return wc_get_cart_url();
-			}
-
-			return wp_validate_redirect( wp_get_referer(), $url );
-		}
-
-		return $url;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
@@ -28,7 +28,7 @@ class AddToCartWithOptionsGroupedProductSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( ! $product instanceof \WC_Product || ! $product->is_type( 'grouped' ) ) {
+		if ( ! $product->is_type( 'grouped' ) ) {
 			return '';
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
@@ -26,7 +26,9 @@ class AddToCartWithOptionsGroupedProductSelector extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ): string {
-		if ( ! isset( $block->context['postId'] ) ) {
+		global $product;
+
+		if ( ! $product instanceof \WC_Product || ! $product->is_type( 'grouped' ) ) {
 			return '';
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
@@ -28,10 +28,10 @@ class AddToCartWithOptionsGroupedProductSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( ! $product->is_type( 'grouped' ) ) {
-			return '';
+		if ( $product instanceof \WC_Product && $product->is_type( 'grouped' ) ) {
+			return $content;
 		}
 
-		return $content;
+		return '';
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelectorItemTemplate.php
@@ -65,15 +65,7 @@ class AddToCartWithOptionsGroupedProductSelectorItemTemplate extends AbstractBlo
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ): string {
-		if ( ! isset( $block->context['postId'] ) ) {
-			return '';
-		}
-
-		$product = wc_get_product( $block->context['postId'] );
-
-		if ( ! $product instanceof \WC_Product || ! $product->is_type( 'grouped' ) ) {
-			return '';
-		}
+		global $product;
 
 		$content = '';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -308,16 +308,9 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ): string {
-		if ( ! isset( $block->context['postId'] ) ) {
-			return '';
-		}
-
 		global $product;
-		$previous_product = $product;
-		$product          = wc_get_product( $block->context['postId'] );
 
-		if ( ! $product instanceof \WC_Product || ! $product->is_type( 'variable' ) ) {
-			$product = $previous_product;
+		if ( ! $product->is_type( 'variable' ) ) {
 			return '';
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -310,10 +310,10 @@ class AddToCartWithOptionsVariationSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( ! $product->is_type( 'variable' ) ) {
-			return '';
+		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
+			return $this->render_variation_form( $product, $attributes );
 		}
 
-		return $this->render_variation_form( $product, $attributes );
+		return '';
 	}
 }

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -1,5 +1,31 @@
-<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector /-->
-<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector /-->
+<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
+<div
+	class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector"
+	role="list"
+>
+	<!-- wp:woocommerce/add-to-cart-with-options-grouped-product-selector-item -->
+	<div
+		class="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector-item"
+		role="listitem"
+	>
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}},"layout":{"type":"flex","orientation":"horizontal","flexWrap":"nowrap"}} -->
+		<div
+			class="wp-block-group"
+			style="margin-top: 1rem; margin-bottom: 1rem"
+		>
+			<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector /-->
+
+			<!-- wp:post-title {"isLink":true,"style":{"layout":{"selfStretch":"fill"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":400}},"fontSize":"medium"} /-->
+
+			<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"fontSize":"medium","style":{"typography":{"fontWeight":400}}} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector-item -->
+</div>
+<!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
 <!-- wp:woocommerce/product-button {"textAlign":"center","fontSize":"small"} -->
-<div class="wp-block-woocommerce-product-button is-loading has-small-font-size"></div>
+<div
+	class="wp-block-woocommerce-product-button is-loading has-small-font-size"
+></div>
 <!-- /wp:woocommerce/product-button -->


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53284
Closes #53283

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Go to WooCommerce Admin Test Helper > Features and enable experimental-blocks and blockified-add-to-cart.
3. Go to Appearance > Editor > Templates > Single Product, select the Add to Cart with Options block and update it to the blockified one.
4. Create a new post
5. Add the single product block
6. Select a simple product and save the post
7. Go to view the post created
8. The simple product should be shown in the frontend
9. When adding the product to the cart no notice should be shown
10. Go to edit the single product template
11. Change the add to cart with options block to the blockified one
12. Save the template and go to the view a simple product from the store
13. When click on add to cart the simple product the notice should be shown.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
