### PR TITLE
WC_Order: Ensure status is a string in the setter

### DIFF
--- a/plugins/woocommerce/changelog/fix-54855-update-status-not-string
+++ b/plugins/woocommerce/changelog/fix-54855-update-status-not-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid a fatal error when trying to set an order status and the given status is not a valid type

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -650,19 +650,31 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function set_status( $new_status ) {
 		$old_status = $this->get_status();
-		$new_status = OrderUtil::remove_status_prefix( $new_status );
+		$new_status = OrderUtil::remove_status_prefix( (string) $new_status );
 
 		$status_exceptions = array( OrderStatus::AUTO_DRAFT, OrderStatus::TRASH );
 
 		// If setting the status, ensure it's set to a valid status.
 		if ( true === $this->object_read ) {
 			// Only allow valid new status.
-			if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses(), true ) && ! in_array( $new_status, $status_exceptions, true ) ) {
+			if (
+				! in_array( 'wc-' . $new_status, $this->get_valid_statuses(), true )
+				&& ! in_array( $new_status, $status_exceptions, true )
+			) {
 				$new_status = OrderStatus::PENDING;
 			}
 
 			// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-			if ( $old_status && ( OrderStatus::AUTO_DRAFT === $old_status || ( ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && ! in_array( $old_status, $status_exceptions, true ) ) ) ) {
+			if (
+				$old_status
+				&& (
+					OrderStatus::AUTO_DRAFT === $old_status
+					|| (
+						! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true )
+						&& ! in_array( $old_status, $status_exceptions, true )
+					)
+				)
+			) {
 				$old_status = OrderStatus::PENDING;
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This simply ensures type safety when setting an order status, before using the `OrderUtil::remove_status_prefix`, which requires a string for its input. Necessary when using more modern code within older parts of the codebase that were written before type hinting was widely available in PHP.

This also updates the linebreaks and whitespace in two complex conditionals within the same method, for better readability.

Fixes #54855

### How to test the changes in this Pull Request:

1. You can replicate the reported issue using `wp shell` before checking out this branch:
    ```
    wp shell
    $o = wc_create_order()
    $o->update_status( array( 'asdf' ) )
    ```
2. This should give you a fatal error:
    `Uncaught TypeError: Automattic\WooCommerce\Utilities\OrderUtil::remove_status_prefix()`
4. Now check out this branch and repeat the commands. This time, you should get a PHP warning instead:
    `Warning: Array to string conversion in /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php on line 653`

I debated whether to allow the PHP warning, and decided it was ok so that extension developers still get some kind of feedback when their code is doing something wrong. I could be convinced otherwise, though.