### PR TITLE
[dev] CI: when building CI-jobs matrix, properly inject PR source repository.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
       - name: Setup - checkout
         uses: 'actions/checkout@v4'
         with:
-          fetch-depth: ${{ steps.checkout_depth.outputs.value }}
+          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo ) || '' }}
           ref: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.ref ) || '' }}
+          fetch-depth: ${{ steps.checkout_depth.outputs.value }}
+          
       - name: Setup - calculate base sha
         id: checkout_base_sha
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           fetch-depth: ${{ steps.checkout_depth.outputs.value }}
           ref: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.ref ) || '' }}
-          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.name ) || '' }}
+          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ) || '' }}
       - name: Setup - calculate base sha
         id: checkout_base_sha
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           fetch-depth: ${{ steps.checkout_depth.outputs.value }}
           ref: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.ref ) || '' }}
-          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo ) || '' }}
+          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.name ) || '' }}
       - name: Setup - calculate base sha
         id: checkout_base_sha
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,9 @@ jobs:
       - name: Setup - checkout
         uses: 'actions/checkout@v4'
         with:
-          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo ) || '' }}
-          ref: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.ref ) || '' }}
           fetch-depth: ${{ steps.checkout_depth.outputs.value }}
-          
+          ref: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.ref ) || '' }}
+          repository: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.repo ) || '' }}
       - name: Setup - calculate base sha
         id: checkout_base_sha
         shell: bash


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Contest: p1737763821095679-slack-C03CPM3UXDJ

Update checkout step to dispatch PR's source repository (currently defaults to our repository)

### How to test the changes in this Pull Request:

- CI-checks shall pass
- Test run for a PR from a fork [here](https://github.com/woocommerce/woocommerce/actions/runs/12984279666/job/36206901184?pr=54871)