### PR TITLE
[settings] Enhance edits components with dynamic label and help text handling

### DIFF
--- a/packages/js/settings-editor/changelog/update-settings-edits
+++ b/packages/js/settings-editor/changelog/update-settings-edits
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Enhance edits components with dynamic label and help text handling
+
+

--- a/packages/js/settings-editor/src/components/checkbox-edit/index.tsx
+++ b/packages/js/settings-editor/src/components/checkbox-edit/index.tsx
@@ -10,25 +10,23 @@ import type { DataFormControlProps } from '@wordpress/dataviews';
  */
 import type { DataFormItem } from '../../types';
 
-export const CheckboxEdit = ( {
-	field,
-	onChange,
-	data,
-}: DataFormControlProps< DataFormItem > ) => {
-	const { id, getValue, label } = field;
-	const value = getValue( { item: data } );
-
-	return (
-		<CheckboxControl
-			__nextHasNoMarginBottom={ true }
-			id={ id }
-			label={ label }
-			checked={ value === 'yes' }
-			onChange={ ( checked ) => {
-				onChange( {
-					[ id ]: checked ? 'yes' : 'no',
-				} );
-			} }
-		/>
-	);
-};
+export const getCheckboxEdit =
+	( help?: React.ReactNode ) =>
+	( { field, onChange, data }: DataFormControlProps< DataFormItem > ) => {
+		const { id, getValue, label } = field;
+		const value = getValue( { item: data } );
+		return (
+			<CheckboxControl
+				__nextHasNoMarginBottom={ true }
+				id={ id }
+				label={ label }
+				help={ help }
+				checked={ value === 'yes' }
+				onChange={ ( checked ) => {
+					onChange( {
+						[ id ]: checked ? 'yes' : 'no',
+					} );
+				} }
+			/>
+		);
+	};

--- a/packages/js/settings-editor/src/components/checkbox-edit/index.tsx
+++ b/packages/js/settings-editor/src/components/checkbox-edit/index.tsx
@@ -13,7 +13,12 @@ import type { DataFormItem } from '../../types';
 export const getCheckboxEdit =
 	( help?: React.ReactNode ) =>
 	( { field, onChange, data }: DataFormControlProps< DataFormItem > ) => {
-		const { id, getValue, label } = field;
+		const { id, getValue } = field;
+
+		// DataForm will automatically use the id as the label if no label is provided so we conditionally set the label to undefined if it matches the id to avoid displaying it.
+		// We should contribute upstream to allow label to be optional.
+		const label = field.label === id ? undefined : field.label;
+
 		const value = getValue( { item: data } );
 		return (
 			<CheckboxControl

--- a/packages/js/settings-editor/src/components/inputEdit/index.tsx
+++ b/packages/js/settings-editor/src/components/inputEdit/index.tsx
@@ -11,10 +11,14 @@ import { __experimentalInputControl as InputControl } from '@wordpress/component
 import type { DataFormItem } from '../../types';
 
 export const getInputEdit =
-	( type: BaseSettingsField[ 'type' ] ) =>
+	( type: React.HTMLInputTypeAttribute, help?: React.ReactNode ) =>
 	( { field, onChange, data }: DataFormControlProps< DataFormItem > ) => {
-		const { id, getValue, label } = field;
+		const { id, getValue, placeholder } = field;
 		const value = getValue( { item: data } );
+
+		// DataForm will automatically use the id as the label if no label is provided so we conditionally set the label to undefined if it matches the id to avoid displaying it.
+		// We should contribute upstream to allow label to be optional.
+		const label = field.label === id ? undefined : field.label;
 
 		return (
 			<InputControl
@@ -22,6 +26,8 @@ export const getInputEdit =
 				label={ label }
 				type={ type }
 				value={ value }
+				help={ help }
+				placeholder={ placeholder }
 				onChange={ ( newValue ) => {
 					onChange( {
 						[ id ]: newValue,

--- a/packages/js/settings-editor/src/components/selectEdit/index.tsx
+++ b/packages/js/settings-editor/src/components/selectEdit/index.tsx
@@ -19,7 +19,12 @@ export const getSelectEdit =
 		onChange,
 		hideLabelFromVision,
 	}: DataFormControlProps< DataFormItem > ) => {
-		const { id, label } = field;
+		const { id } = field;
+
+		// DataForm will automatically use the id as the label if no label is provided so we conditionally set the label to undefined if it matches the id to avoid displaying it.
+		// We should contribute upstream to allow label to be optional.
+		const label = field.label === id ? undefined : field.label;
+
 		const value = field.getValue( { item: data } ) ?? '';
 		const onChangeControl = useCallback(
 			( newValue: string ) =>

--- a/packages/js/settings-editor/src/components/selectEdit/index.tsx
+++ b/packages/js/settings-editor/src/components/selectEdit/index.tsx
@@ -11,44 +11,47 @@ import type { DataFormControlProps } from '@wordpress/dataviews';
  */
 import type { DataFormItem } from '../../types';
 
-export const SelectEdit = ( {
-	data,
-	field,
-	onChange,
-	hideLabelFromVision,
-}: DataFormControlProps< DataFormItem > ) => {
-	const { id, label } = field;
-	const value = field.getValue( { item: data } ) ?? '';
-	const onChangeControl = useCallback(
-		( newValue: string ) =>
-			onChange( {
-				[ id ]: newValue,
-			} ),
-		[ id, onChange ]
-	);
+export const getSelectEdit =
+	( help?: React.ReactNode ) =>
+	( {
+		data,
+		field,
+		onChange,
+		hideLabelFromVision,
+	}: DataFormControlProps< DataFormItem > ) => {
+		const { id, label } = field;
+		const value = field.getValue( { item: data } ) ?? '';
+		const onChangeControl = useCallback(
+			( newValue: string ) =>
+				onChange( {
+					[ id ]: newValue,
+				} ),
+			[ id, onChange ]
+		);
 
-	const elements = [
-		/*
-		 * Value can be undefined when:
-		 *
-		 * - the field is not required
-		 * - in bulk editing
-		 *
-		 */
-		{ label: __( 'Select item', 'woocommerce' ), value: '' },
-		...( field?.elements ?? [] ),
-	];
+		const elements = [
+			/*
+			 * Value can be undefined when:
+			 *
+			 * - the field is not required
+			 * - in bulk editing
+			 *
+			 */
+			{ label: __( 'Select item', 'woocommerce' ), value: '' },
+			...( field?.elements ?? [] ),
+		];
 
-	return (
-		<SelectControl
-			id={ id }
-			label={ label }
-			value={ value }
-			options={ elements }
-			onChange={ onChangeControl }
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			hideLabelFromVision={ hideLabelFromVision }
-		/>
-	);
-};
+		return (
+			<SelectControl
+				id={ id }
+				label={ label }
+				value={ value }
+				help={ help }
+				options={ elements }
+				onChange={ onChangeControl }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				hideLabelFromVision={ hideLabelFromVision }
+			/>
+		);
+	};

--- a/packages/js/settings-editor/src/hooks/utils/tests/transformers.test.tsx
+++ b/packages/js/settings-editor/src/hooks/utils/tests/transformers.test.tsx
@@ -10,6 +10,7 @@ import {
 	transformToInitialData,
 	transformToField,
 	transformToFormField,
+	getLabelAndHelp,
 } from '../transformers';
 
 describe( 'dataforms-transformers', () => {
@@ -256,6 +257,100 @@ describe( 'dataforms-transformers', () => {
 			expect( transformToFormField( custom ) ).toBe( 'custom1' );
 			expect( transformToFormField( group ) ).toBe( 'group1' );
 			expect( transformToFormField( slotfill ) ).toBe( 'slot1' );
+		} );
+	} );
+
+	describe( 'getLabelAndHelp', () => {
+		it( 'should set help text to desc when desc_tip is true', () => {
+			const setting: BaseSettingsField = {
+				id: 'test',
+				type: 'text',
+				desc: 'Test description',
+				desc_tip: true,
+				value: 'test',
+			};
+
+			const result = getLabelAndHelp( setting );
+			expect( result ).toEqual( {
+				label: '',
+				help: 'Test description',
+			} );
+		} );
+
+		it( 'should set label and help text when both desc and desc_tip are provided', () => {
+			const setting: BaseSettingsField = {
+				id: 'test',
+				type: 'text',
+				desc: 'Main description',
+				desc_tip: 'Helpful tip',
+				value: 'test',
+			};
+
+			const result = getLabelAndHelp( setting );
+			expect( result ).toEqual( {
+				label: 'Main description',
+				help: 'Helpful tip',
+			} );
+		} );
+
+		it( 'should set empty help text when desc_tip is false', () => {
+			const setting: BaseSettingsField = {
+				id: 'test',
+				type: 'text',
+				desc: 'Test description',
+				desc_tip: false,
+				value: 'test',
+			};
+
+			const result = getLabelAndHelp( setting );
+			expect( result ).toEqual( {
+				label: 'Test description',
+				help: '',
+			} );
+		} );
+
+		it( 'should handle desc_tip undefined', () => {
+			const setting: BaseSettingsField = {
+				id: 'test',
+				type: 'text',
+				desc: 'Test description',
+				value: 'test',
+			};
+
+			const result = getLabelAndHelp( setting );
+			expect( result ).toEqual( {
+				label: 'Test description',
+				help: '',
+			} );
+		} );
+
+		it( 'should use description if desc is not provided', () => {
+			const setting: BaseSettingsField = {
+				id: 'test',
+				type: 'text',
+				description: 'Test description',
+				value: 'test',
+			};
+
+			const result = getLabelAndHelp( setting );
+			expect( result ).toEqual( {
+				label: 'Test description',
+				help: '',
+			} );
+		} );
+
+		it( 'should handle empty descriptions', () => {
+			const setting: BaseSettingsField = {
+				id: 'test',
+				type: 'text',
+				value: 'test',
+			};
+
+			const result = getLabelAndHelp( setting );
+			expect( result ).toEqual( {
+				label: '',
+				help: '',
+			} );
 		} );
 	} );
 } );

--- a/packages/js/settings-editor/src/hooks/utils/tests/transformers.test.tsx
+++ b/packages/js/settings-editor/src/hooks/utils/tests/transformers.test.tsx
@@ -11,8 +11,6 @@ import {
 	transformToField,
 	transformToFormField,
 } from '../transformers';
-import { CheckboxEdit } from '../../../components/checkbox-edit';
-import { SelectEdit } from '../../../components/selectEdit';
 
 describe( 'dataforms-transformers', () => {
 	describe( 'transformToInitialData', () => {
@@ -86,7 +84,7 @@ describe( 'dataforms-transformers', () => {
 				id: 'check1',
 				type: 'text',
 				label: 'Checkbox Input',
-				Edit: CheckboxEdit,
+				Edit: expect.any( Function ),
 			} );
 		} );
 
@@ -106,12 +104,12 @@ describe( 'dataforms-transformers', () => {
 			expect( result ).toEqual( {
 				id: 'select1',
 				type: 'text',
-				label: 'Select Input (TO BE IMPLEMENTED)',
+				label: 'Select Input',
 				elements: [
 					{ label: 'Option 1', value: 'value1' },
 					{ label: 'Option 2', value: 'value2' },
 				],
-				Edit: SelectEdit,
+				Edit: expect.any( Function ),
 			} );
 		} );
 
@@ -173,13 +171,13 @@ describe( 'dataforms-transformers', () => {
 					id: 'check1',
 					type: 'text',
 					label: 'Check 1',
-					Edit: CheckboxEdit,
+					Edit: expect.any( Function ),
 				},
 				{
 					id: 'check2',
 					type: 'text',
 					label: 'Check 2',
-					Edit: CheckboxEdit,
+					Edit: expect.any( Function ),
 				},
 			] );
 		} );

--- a/packages/js/settings-editor/src/hooks/utils/transformers.tsx
+++ b/packages/js/settings-editor/src/hooks/utils/transformers.tsx
@@ -24,6 +24,12 @@ export type DataItem = Record< string, BaseSettingsField[ 'value' ] >;
  *
  * @param setting The setting object containing description and tip information
  * @return Object with label and help text
+ *
+ * Cases:
+ * - desc_tip === true: description becomes help text, empty label
+ * - desc_tip is string: string becomes help text, description becomes label
+ * - desc_tip === false: empty help text, description becomes label
+ * - desc_tip undefined: empty help text, description becomes label
  */
 export const getLabelAndHelp = (
 	setting: BaseSettingsField | CheckboxSettingsField

--- a/packages/js/settings-editor/src/hooks/utils/transformers.tsx
+++ b/packages/js/settings-editor/src/hooks/utils/transformers.tsx
@@ -20,15 +20,26 @@ import { getSelectEdit } from '../../components/selectEdit';
 export type DataItem = Record< string, BaseSettingsField[ 'value' ] >;
 
 /**
- * Helper function to determine label and help text from setting
- * If desc_tip is true, we should display the desc as the help text.
+ * Helper function to determine label and help text from setting.
+ *
+ * @param setting The setting object containing description and tip information
+ * @return Object with label and help text
  */
-const getLabelAndHelp = (
+export const getLabelAndHelp = (
 	setting: BaseSettingsField | CheckboxSettingsField
 ) => {
+	const description = setting.desc || setting.description || '';
+
+	if ( setting.desc_tip === true ) {
+		return {
+			label: '',
+			help: description,
+		};
+	}
+
 	return {
-		label: setting.desc_tip === true ? '' : setting.desc,
-		help: setting.desc_tip === true ? setting.desc : setting.desc_tip,
+		label: description,
+		help: typeof setting.desc_tip === 'string' ? setting.desc_tip : '',
 	};
 };
 

--- a/packages/js/settings-editor/typings/global.d.ts
+++ b/packages/js/settings-editor/typings/global.d.ts
@@ -28,6 +28,7 @@ declare global {
 			| 'slotfill_placeholder';
 		id: string;
 		desc?: string;
+		description?: string;
 		desc_tip?: boolean | string;
 		default?: string | number | boolean | object;
 		value: string | number | boolean | object;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/54826

This PR improves the rendering of settings fields, addressing issues related to labels, placeholders, and descriptions. It ensures text fields without a desc property are handled appropriately, respects the placeholder property, and shows the help text.

In classic settings, we render the help text as a tooltip. It's possible to do the same thing by modifying the edit components. However, since we want to reuse the upstream components in the future, at this moment, I don't want to customize the edit components too much. So I just pass the help text to the `help` prop to `*Control` components`. If we get the design requirement to render the help text as a tooltip, we can customize the edit components then but should also request the upstream components to support that.

Changes:

- Refactor checkbox, input, and select edit components to support optional help text
- Add utility function to determine label and help text based on setting configuration
- Update transformers to handle label and help text for various setting types

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add/Enable Gutenberg 19.8 or earlier
2. Turn on `settings` feature flag
3. `WooCommerce > Settings`
4. See that text inputs, checkboxes, and select inputs have labels and help text
5. Go to `Emails > Email sender options`
6. See `"From" name` and `"From" address` input fields don't have unexpected id labels 
7. See `Header image` input has placeholder text `N\A`

![Screenshot 2025-01-27 at 17 13 21](https://github.com/user-attachments/assets/6d2a1466-9b9e-4af4-bec0-5d8ea2e8f2fe)

![Screenshot 2025-01-27 at 17 12 50](https://github.com/user-attachments/assets/166e9703-e58e-42d8-aa20-f5288e4753ab)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
