### PR TITLE
E2E: Make sure WC Home task list is enabled at the end of `task-list.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-enable-task-list-at-teardown
+++ b/plugins/woocommerce/changelog/dev-e2e-enable-task-list-at-teardown
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Make sure WC Home task list is enabled at the end of the `task-list.spec.js` E2E test.

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
@@ -38,12 +38,23 @@ test.describe( 'WC Home Task List >', () => {
 					page.getByText( 'Store management' )
 				).toBeVisible();
 			} );
-
-			await test.step( 'Re-enable task list', async () => {
-				await page.goto(
-					'wp-admin/admin.php?page=wc-admin&reset_task_list=1'
-				);
-			} );
 		}
 	);
+
+	test.afterAll( async ( { browser } ) => {
+		await test.step( 'Re-enable task list', async () => {
+			const context = await browser.newContext();
+			const page = await context.newPage();
+
+			await page.goto(
+				'wp-admin/admin.php?page=wc-admin&reset_task_list=1'
+			);
+			await expect(
+				page.getByText( 'Customize your store' )
+			).toBeVisible();
+
+			await page.close();
+			await context.close();
+		} );
+	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, there's an issue in `trunk` where there are [35 failing tests](https://github.com/woocommerce/woocommerce/actions/runs/13004614890/job/36269247510#step:9:2398).

This is because the E2E test `task-list.spec.js` doesn't seem to properly re-enable the WC Home task list at the end of its run, and these failing tests happen to depend on the task list being enabled.

I suspect that [this page navigation](https://github.com/woocommerce/woocommerce/blob/bfd7e881f1248ccfe1f08f6c74c09c1158ec045f/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js#L42-L46) that's supposed to reset the task list doesn't complete loading when the test ends.

To fix this, this PR adds an `afterAll` hook that makes sure the home task list is enabled.
 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure all e2e tests in the pipeline pass, especially these [35 tests](https://github.com/woocommerce/woocommerce/actions/runs/13004614890/job/36269247510#step:9:2398) failing in `Core e2e tests 1/6` in trunk.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
