### PR TITLE
[dev] CI: add wp-env debug output when starting testing containers.

### DIFF
--- a/plugins/woocommerce/changelog/dev-enable-wpenv-debug-for-testing-containers
+++ b/plugins/woocommerce/changelog/dev-enable-wpenv-debug-for-testing-containers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: enable wp-env debug mode to get more details on occasional test containers startup failures.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -29,7 +29,7 @@
 		"env:start": "pnpm wp-env start",
 		"env:start:blocks": "pnpm --filter='@woocommerce/block-library' env:start && pnpm playwright install chromium --with-deps",
 		"env:stop": "pnpm wp-env stop",
-		"env:test": "pnpm env:dev",
+		"env:test": "pnpm env:dev --debug",
 		"env:perf": "pnpm env:dev && pnpm env:performance-init",
 		"preinstall": "npx only-allow pnpm",
 		"postinstall": "rimraf -g vendor/woocommerce && XDEBUG_MODE=off composer install --quiet",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: pinpoint exact place occasionally causing `Error: Error establishing a database connection.` error when starting test containers.

After merging #54839, the error is still occurring, and we need some debug output to evaluate why the patch is not preventing the error.

### How to test the changes in this Pull Request:

- CI-checks shall pass
