### PR TITLE
Update product editor naming to match documentation

### DIFF
--- a/packages/js/product-editor/changelog/update-product_editor_naming
+++ b/packages/js/product-editor/changelog/update-product_editor_naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update copy from 'form' to 'editor' to match documentation.

--- a/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
+++ b/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
@@ -52,7 +52,7 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 				action: PRODUCT_EDITOR_FEEDBACK_CES_ACTION,
 				showDescription: false,
 				title: __(
-					'What do you think of the new product form?',
+					'What do you think of the new product editor?',
 					'woocommerce'
 				),
 				firstQuestion: __(
@@ -60,7 +60,7 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 					'woocommerce'
 				),
 				secondQuestion: __(
-					'Product form is easy to use',
+					'Product editor is easy to use',
 					'woocommerce'
 				),
 				onsubmitLabel: __(
@@ -203,7 +203,7 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 					<div className="woocommerce-product-mvp-ces-footer__message">
 						{ createInterpolateElement(
 							__(
-								'How is your experience with the new product form? <span><shareButton>Share feedback</shareButton> or <turnOffButton>turn it off</turnOffButton></span>',
+								'How is your experience with the new product editor? <span><shareButton>Share feedback</shareButton> or <turnOffButton>turn it off</turnOffButton></span>',
 								'woocommerce'
 							),
 							{

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -104,7 +104,7 @@ function ProductMVPFeedbackModal( {
 	return (
 		<FeedbackModal
 			title={ __(
-				'Thanks for trying out the new product form!',
+				'Thanks for trying out the new product editor!',
 				'woocommerce'
 			) }
 			onSubmit={ onSendFeedback }
@@ -126,7 +126,7 @@ function ProductMVPFeedbackModal( {
 				<fieldset className="woocommerce-product-mvp-feedback-modal__reason">
 					<legend>
 						{ __(
-							'What made you turn off the new product form?',
+							'What made you turn off the new product editor?',
 							'woocommerce'
 						) }
 					</legend>

--- a/plugins/woocommerce/changelog/update-product_editor_naming
+++ b/plugins/woocommerce/changelog/update-product_editor_naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update copy from 'form' to 'editor' to match documentation.

--- a/plugins/woocommerce/changelog/update-product_editor_naming
+++ b/plugins/woocommerce/changelog/update-product_editor_naming
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Update copy from 'form' to 'editor' to match documentation.
+Product Editor: Update copy from 'form' to 'editor' to match documentation.

--- a/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
+++ b/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
@@ -75,7 +75,7 @@ export const ClassicEditorMenuItem = ( {
 				'woocommerce'
 			) }
 		>
-			{ __( 'Turn off the new product form', 'woocommerce' ) }
+			{ __( 'Turn off the new product editor', 'woocommerce' ) }
 		</MenuItem>
 	);
 };

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/disable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/block-editor/disable-block-product-editor.spec.js
@@ -79,7 +79,7 @@ test.describe.serial(
 			await page.locator( 'button[aria-label="Options"]' ).click();
 			await page
 				.getByRole( 'menuitem', {
-					name: 'Turn off the new product form',
+					name: 'Turn off the new product editor',
 				} )
 				.click();
 			await dismissFeedbackModalIfShown( page );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We recently updated the [public documentation](https://woocommerce.com/document/new-product-editor-beta/) of the product editor to use "editor" instead of "form". There was still a couple cases of this in our UI. This PR updates it. 

Reference: p1734617165441459-slack-C02NVV8LQLW

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Turn on the new product editor under **WooCommerce > Settings > Advanced > Features** also enable tracking under the **Advanced > woocommerce.com** tab.
2. Go to **Products > Add new product** 
3. Click the 3-dot menu in the top right
4. It should say **Turn off the new product editor**
5. Click this, it should show a modal asking for feedback. This should also use **product editor** instead of **product form**.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>