### PR TITLE
E2E: Optimize resetting of home task list in `task-list.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-optimize-task-list-spec
+++ b/plugins/woocommerce/changelog/dev-e2e-optimize-task-list-spec
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Optimize `task-list.spec.js` by using the REST API to reset the home task list.

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
@@ -1,5 +1,4 @@
-const { test, expect } = require( '@playwright/test' );
-const { tags } = require( '../../fixtures/fixtures' );
+const { tags, test, expect } = require( '../../fixtures/fixtures' );
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
 
 test.describe( 'WC Home Task List >', () => {
@@ -42,20 +41,16 @@ test.describe( 'WC Home Task List >', () => {
 		}
 	);
 
-	test.afterAll( async ( { browser } ) => {
+	test.afterAll( async ( { wcAdminApi } ) => {
 		await test.step( 'Re-enable task list', async () => {
-			const context = await browser.newContext();
-			const page = await context.newPage();
-
-			await page.goto(
-				'wp-admin/admin.php?page=wc-admin&reset_task_list=1'
+			const { statusText, data } = await wcAdminApi.post(
+				'onboarding/tasks/setup/unhide'
 			);
-			await expect(
-				page.getByText( 'Customize your store' )
-			).toBeVisible();
+			const { isHidden, isVisible } = data;
 
-			await page.close();
-			await context.close();
+			expect( statusText ).toEqual( 'OK' );
+			expect( isHidden ).toEqual( false );
+			expect( isVisible ).toEqual( true );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/task-list.spec.js
@@ -1,18 +1,61 @@
 const { tags, test, expect } = require( '../../fixtures/fixtures' );
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
 
+const get_task_list_state = async ( wcAdminApi ) => {
+	const {
+		statusText,
+		data: { woocommerce_task_list_hidden },
+	} = await wcAdminApi.get( 'options?options=woocommerce_task_list_hidden' );
+
+	expect( statusText ).toEqual( 'OK' );
+
+	return woocommerce_task_list_hidden;
+};
+
+const update_task_list_state = async ( wcAdminApi, new_state ) => {
+	// Send request to update task list.
+	const data = { woocommerce_task_list_hidden: new_state };
+	const { statusText } = await wcAdminApi.put( 'options', data );
+	expect( statusText ).toEqual( 'OK' );
+
+	// Verify task list was updated correctly.
+	const actual_state = await get_task_list_state( wcAdminApi );
+	expect( actual_state ).toEqual( new_state );
+};
+
+let init_task_list_state;
+
+// TODO (E2E Audit): This test should be combined with other WC Homepage setup tests like the tests in activate-and-setup/stats-overview.spec.js into a single spec.
 test.describe( 'WC Home Task List >', () => {
 	test.use( { storageState: ADMIN_STATE_PATH } );
 
-	// TODO (E2E Audit): This test should be combined with other WC Homepage setup tests like the tests in activate-and-setup/stats-overview.spec.js into a single spec.
+	test.beforeAll( async ( { wcAdminApi } ) => {
+		await test.step( 'Remember initial state of task list.', async () => {
+			init_task_list_state = await get_task_list_state( wcAdminApi );
+		} );
+
+		await test.step( 'Show the home task list', async () => {
+			// Skip this step if task list is already visible.
+			if ( init_task_list_state === 'no' ) {
+				return;
+			}
+
+			await update_task_list_state( wcAdminApi, 'no' );
+		} );
+	} );
+
+	test.afterAll( async ( { wcAdminApi } ) => {
+		await test.step( 'Revert task list state', async () => {
+			await update_task_list_state( wcAdminApi, init_task_list_state );
+		} );
+	} );
+
 	test(
 		'Can hide the task list',
 		{ tag: [ tags.NOT_E2E ] },
 		async ( { page } ) => {
-			await test.step( 'Load the WC Admin page with the task list enabled', async () => {
-				await page.goto(
-					'wp-admin/admin.php?page=wc-admin&reset_task_list=1'
-				);
+			await test.step( 'Load the WC Admin page.', async () => {
+				await page.goto( 'wp-admin/admin.php?page=wc-admin' );
 				await expect(
 					page.getByText( 'Customize your store' )
 				).toBeVisible();
@@ -40,17 +83,4 @@ test.describe( 'WC Home Task List >', () => {
 			} );
 		}
 	);
-
-	test.afterAll( async ( { wcAdminApi } ) => {
-		await test.step( 'Re-enable task list', async () => {
-			const { statusText, data } = await wcAdminApi.post(
-				'onboarding/tasks/setup/unhide'
-			);
-			const { isHidden, isVisible } = data;
-
-			expect( statusText ).toEqual( 'OK' );
-			expect( isHidden ).toEqual( false );
-			expect( isVisible ).toEqual( true );
-		} );
-	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As a follow-up to the review in https://github.com/woocommerce/woocommerce/pull/54902#issuecomment-2618199745 this PR replaces the UI page navigation in the `afterAll`  hook of `task-list.spec.js` with the `wcAdminApi` fixture to show the WC home task list using the REST API.

Before executing the test, `task-list.spec.js` would now check for the initial for state of the task list (whether it's currently hidden or shown) and then enable (show) it in the beforeAll hook. The afterAll hook will then revert the task list to its initial state.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure all e2e tests pass in CI.
2. To test locally, run the Core Profiler e2e tests first before running the test that this PR updated. Inspect the HTML report to make sure that calls in the beforeAll and afterAll hooks were correctly executed.
    ```bash
    pnpm test:e2e core-profiler.spec.js task-list.spec.js
    ```
4. Also test this on WPCOM and Pressable. Inspect their respective trace logs as well.
    ```bash
    export E2E_ENV_KEY="..."
    pnpm test:e2e:with-env default-wpcom task-list.spec.js
    pnpm test:e2e:with-env default-pressable task-list.spec.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
