### PR TITLE
[dev] CI: add wp-env debug output when starting testing containers.

### DIFF
--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -91,7 +91,7 @@
 		"test:e2e:jest:dev": "echo 'test:e2e:jest is no more. Use test:e2e instead.'",
 		"test:e2e:jest:dev-watch": "echo 'test:e2e:jest is no more. Use test:e2e instead.'",
 		"test:e2e:jest:update": "echo 'test:e2e:jest is no more. Use test:e2e instead.'",
-		"env:start": "pnpm --filter='@woocommerce/block-library' wp-env start && ./tests/e2e/bin/test-env-setup.sh",
+		"env:start": "pnpm --filter='@woocommerce/block-library' wp-env start --debug && ./tests/e2e/bin/test-env-setup.sh",
 		"env:restart": "pnpm run wp-env clean all && pnpm run wp-env start && ./tests/e2e/bin/test-env-setup.sh",
 		"env:stop": "pnpm run wp-env stop",
 		"test:help": "wp-scripts test-unit-js --help",

--- a/plugins/woocommerce/changelog/dev-enable-wpenv-debug-for-testing-containers-1
+++ b/plugins/woocommerce/changelog/dev-enable-wpenv-debug-for-testing-containers-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: enable wp-env debug mode to get more details on occasional test containers startup failures.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: pinpoint exact place occasionally causing `Error: Error establishing a database connection.` error when starting test containers.

After merging #54839, the error is still occurring, and we need some debug output to evaluate why the patch is not preventing the error.

### How to test the changes in this Pull Request:

- CI-checks shall pass
