### PR TITLE
[dev] Update Core e2e with HPOS disabled job config

### DIFF
--- a/plugins/woocommerce/changelog/dev-update-e2e-hpos-job-config
+++ b/plugins/woocommerce/changelog/dev-update-e2e-hpos-job-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update e2e CI job configuration

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -344,16 +344,13 @@
 					"name": "Core e2e tests - HPOS disabled",
 					"testType": "e2e",
 					"command": "test:e2e:with-env default-hpos-disabled --project=ui",
-					"shardingArguments": [
-						"tests/e2e-pw/**"
-					],
+					"shardingArguments": [],
+					"changes": [],
 					"events": [
-						"pull_request",
 						"daily-checks",
 						"release-checks",
 						"core-e2e-hpos-disabled"
 					],
-					"changes": [],
 					"testEnv": {
 						"start": "env:test",
 						"config": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -343,7 +343,7 @@
 				{
 					"name": "Core e2e tests - HPOS disabled",
 					"testType": "e2e",
-					"command": "test:e2e:with-env default-hpos-disabled --project=ui",
+					"command": "test:e2e:with-env default-hpos-disabled --project=e2e-hpos-disabled",
 					"shardingArguments": [],
 					"changes": [],
 					"events": [

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-hpos-disabled/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-hpos-disabled/playwright.config.js
@@ -1,21 +1,10 @@
 let config = require( '../../playwright.config.js' );
-const { tags } = require( '../../fixtures/fixtures' );
 
 process.env.USE_WP_ENV = 'true';
 process.env.DISABLE_HPOS = '1';
 
 config = {
 	...config,
-	projects: [
-		{
-			name: 'ui',
-			grep: new RegExp( tags.HPOS ),
-		},
-		{
-			name: 'api',
-			testMatch: '**/api-tests/**',
-		},
-	],
 };
 
 module.exports = config;

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { defineConfig, devices } from '@playwright/test';
+/**
+ * Internal dependencies
+ */
+import { tags } from './fixtures/fixtures';
 
 require( 'dotenv' ).config( { path: __dirname + '/.env' } );
 
@@ -134,6 +138,10 @@ export default defineConfig( {
 			name: 'api',
 			testMatch: '**/api-tests/**',
 			dependencies: [ 'site setup' ],
+		},
+		{
+			name: 'e2e-hpos-disabled',
+			grep: new RegExp( tags.HPOS ),
 		},
 	],
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: p1738072709191129-slack-C03CPM3UXDJ

Fixes some configuration issues with the Core e2e HPOS disabled job:
- removes the pull_request trigger
- fixes a Playwright project conflict making the job run all tests instead of only the 106 ones that are tagged with `@hpos`

### How to test the changes in this Pull Request:

- Check CI, the `Core e2e tests - HPOS disabled` should not run for this PR
- Check locally by running the list command. It should list 106 tests.
```
pnpm test:e2e:with-env default-hpos-disabled --project=e2e-hpos-disabled --list
```