### PR TITLE
Prevent flaky Mini cart test by force-hiding widget welcome guide

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/utils/admin/index.ts
@@ -6,10 +6,16 @@ import { Admin as CoreAdmin } from '@wordpress/e2e-test-utils-playwright';
 export class Admin extends CoreAdmin {
 	async visitWidgetEditor() {
 		await this.page.goto( '/wp-admin/widgets.php' );
-		await this.page
-			.getByLabel( 'Welcome to block Widgets' )
-			.getByRole( 'button', { name: 'Close' } )
-			.click();
+		await this.page.waitForFunction( () => {
+			window.wp.data
+				.dispatch( window.wp.preferences.store )
+				.set( 'core/edit-widgets', 'welcomeGuide', false );
+			return (
+				window.wp.data
+					.select( window.wp.preferences.store )
+					.get( 'core/edit-widgets', 'welcomeGuide' ) === false
+			);
+		} );
 	}
 
 	async createNewPattern( name: string, synced = true ) {

--- a/plugins/woocommerce/changelog/fix-flaky-mini-cart-test
+++ b/plugins/woocommerce/changelog/fix-flaky-mini-cart-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This PR only adjusts E2E tests.
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the `visitWidgetEditor` function to forcibly close the welcome guide by using the data store directly when visiting the page, this welcome guide was a source of flakiness in the mini cart test.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #48186 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure E2E passes, and ensure the `Merchant -> Mini-cart -> In widget editor -> Can only be inserted once` test is not flaky and passes first time. 
2. Run the E2E test a few times locally to verify, destroy and rebuild your env each time.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
