### PR TITLE
Add Cc and Bcc fields to store emails

### DIFF
--- a/plugins/woocommerce/changelog/54909-emails-cc-bcc
+++ b/plugins/woocommerce/changelog/54909-emails-cc-bcc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Cc and Bcc fields for store emails

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -587,9 +587,32 @@ class WC_Settings_Emails extends WC_Settings_Page {
 										</td>';
 										break;
 									case 'recipient':
-										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
-										' . esc_html( $email->is_customer_email() ? __( 'Customer', 'woocommerce' ) : $email->get_recipient() ) . '
-										</td>';
+										$to  = $email->is_customer_email() ? __( 'Customer', 'woocommerce' ) : $email->get_recipient();
+										$cc  = false;
+										$bcc = false;
+										if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+											$ccs  = $email->get_cc_recipient();
+											$bccs = $email->get_bcc_recipient();
+											// Translators: %s: comma separated email address to which the email is cc-ed.
+											$cc = $ccs ? sprintf( __( '<b>Cc</b>: %s', 'woocommerce' ), $ccs ) : false;
+											// Translators: %s: comma separated email address to which the email is bcc-ed.
+											$bcc = $bccs ? sprintf( __( '<b>Bcc</b>: %s', 'woocommerce' ), $bccs ) : false;
+											if ( $cc || $bcc ) {
+												// Translators: %s: comma separated email address to which the email is sent.
+												$to = sprintf( __( '<b>To</b>: %s', 'woocommerce' ), $to );
+											}
+										}
+										$allowed_tags = array( 'b' => array() );
+
+										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">';
+										echo wp_kses( $to, $allowed_tags );
+										if ( $cc ) {
+											echo '<br>' . wp_kses( $cc, $allowed_tags );
+										}
+										if ( $bcc ) {
+											echo '<br>' . wp_kses( $bcc, $allowed_tags );
+										}
+										echo '</td>';
 										break;
 									case 'status':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">';

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -584,12 +584,12 @@ class WC_Settings_Emails extends WC_Settings_Page {
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
 										<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=email&section=' . strtolower( $email_key ) ) ) . '">' . esc_html( $email->get_title() ) . '</a>
 										' . wc_help_tip( $email->get_description() ) . '
-									</td>';
+										</td>';
 										break;
 									case 'recipient':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
 										' . esc_html( $email->is_customer_email() ? __( 'Customer', 'woocommerce' ) : $email->get_recipient() ) . '
-									</td>';
+										</td>';
 										break;
 									case 'status':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">';
@@ -607,12 +607,12 @@ class WC_Settings_Emails extends WC_Settings_Page {
 									case 'email_type':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
 										' . esc_html( $email->get_content_type() ) . '
-									</td>';
+										</td>';
 										break;
 									case 'actions':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
 										<a class="button alignright" href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=email&section=' . strtolower( $email_key ) ) ) . '">' . esc_html__( 'Manage', 'woocommerce' ) . '</a>
-									</td>';
+										</td>';
 										break;
 									default:
 										do_action( 'woocommerce_email_setting_column_' . $key, $email );

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -593,7 +593,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 										if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
 											$ccs  = $email->get_cc_recipient();
 											$bccs = $email->get_bcc_recipient();
-											// Translators: %s: comma-separated email addressed to which the email is cc-ed.
+											// Translators: %s: comma-separated email addresses to which the email is cc-ed.
 											$cc = $ccs ? sprintf( __( '<b>Cc</b>: %s', 'woocommerce' ), $ccs ) : false;
 											// Translators: %s: comma-separated email addresses to which the email is bcc-ed.
 											$bcc = $bccs ? sprintf( __( '<b>Bcc</b>: %s', 'woocommerce' ), $bccs ) : false;

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -593,12 +593,12 @@ class WC_Settings_Emails extends WC_Settings_Page {
 										if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
 											$ccs  = $email->get_cc_recipient();
 											$bccs = $email->get_bcc_recipient();
-											// Translators: %s: comma separated email address to which the email is cc-ed.
+											// Translators: %s: comma-separated email addressed to which the email is cc-ed.
 											$cc = $ccs ? sprintf( __( '<b>Cc</b>: %s', 'woocommerce' ), $ccs ) : false;
-											// Translators: %s: comma separated email address to which the email is bcc-ed.
+											// Translators: %s: comma-separated email addresses to which the email is bcc-ed.
 											$bcc = $bccs ? sprintf( __( '<b>Bcc</b>: %s', 'woocommerce' ), $bccs ) : false;
 											if ( $cc || $bcc ) {
-												// Translators: %s: comma separated email address to which the email is sent.
+												// Translators: %s: comma-separated email addresses to which the email is sent.
 												$to = sprintf( __( '<b>To</b>: %s', 'woocommerce' ), $to );
 											}
 										}

--- a/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -201,6 +203,26 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 					'desc_tip'    => true,
 				),
 			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = array(
+					'title'       => __( 'Cc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+				$this->form_fields['bcc'] = array(
+					'title'       => __( 'Bcc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
@@ -204,24 +204,8 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 				),
 			);
 			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-				$this->form_fields['cc']  = array(
-					'title'       => __( 'Cc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
-				$this->form_fields['bcc'] = array(
-					'title'       => __( 'Bcc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 					'title'       => __( 'Cc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,
@@ -217,7 +217,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 					'title'       => __( 'Bcc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -234,6 +235,26 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 					'desc_tip'    => true,
 				),
 			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = array(
+					'title'       => __( 'Cc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+				$this->form_fields['bcc'] = array(
+					'title'       => __( 'Bcc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
@@ -236,24 +236,8 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 				),
 			);
 			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-				$this->form_fields['cc']  = array(
-					'title'       => __( 'Cc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
-				$this->form_fields['bcc'] = array(
-					'title'       => __( 'Bcc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
@@ -240,7 +240,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 					'title'       => __( 'Cc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 					'title'       => __( 'Bcc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -294,6 +296,26 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 					'desc_tip'    => true,
 				),
 			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = array(
+					'title'       => __( 'Cc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+				$this->form_fields['bcc'] = array(
+					'title'       => __( 'Bcc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
@@ -297,24 +297,8 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 				),
 			);
 			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-				$this->form_fields['cc']  = array(
-					'title'       => __( 'Cc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
-				$this->form_fields['bcc'] = array(
-					'title'       => __( 'Bcc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
@@ -301,7 +301,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 					'title'       => __( 'Cc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,
@@ -310,7 +310,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 					'title'       => __( 'Bcc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,

--- a/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -199,6 +201,26 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 					'desc_tip'    => true,
 				),
 			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = array(
+					'title'       => __( 'Cc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+				$this->form_fields['bcc'] = array(
+					'title'       => __( 'Bcc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 					'title'       => __( 'Cc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,
@@ -215,7 +215,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 					'title'       => __( 'Bcc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,

--- a/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php
@@ -202,24 +202,8 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 				),
 			);
 			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-				$this->form_fields['cc']  = array(
-					'title'       => __( 'Cc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
-				$this->form_fields['bcc'] = array(
-					'title'       => __( 'Bcc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -224,6 +226,26 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 					'desc_tip'    => true,
 				),
 			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = array(
+					'title'       => __( 'Cc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+				$this->form_fields['bcc'] = array(
+					'title'       => __( 'Bcc(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				);
+			}
 		}
 
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -227,24 +227,8 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 				),
 			);
 			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-				$this->form_fields['cc']  = array(
-					'title'       => __( 'Cc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
-				$this->form_fields['bcc'] = array(
-					'title'       => __( 'Bcc(s)', 'woocommerce' ),
-					'type'        => 'text',
-					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
-					'placeholder' => '',
-					'default'     => '',
-					'desc_tip'    => true,
-				);
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
 			}
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -231,7 +231,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 					'title'       => __( 'Cc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,
@@ -240,7 +240,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 					'title'       => __( 'Bcc(s)', 'woocommerce' ),
 					'type'        => 'text',
 					/* translators: %s: admin email */
-					'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+					'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 					'placeholder' => '',
 					'default'     => '',
 					'desc_tip'    => true,

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -463,6 +463,15 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_recipient() {
+		/**
+		 * Filter the recipient for the email.
+		 *
+		 * @since 2.0.0
+		 * @since 3.7.0 Added $email parameter.
+		 * @param string   $recipient Recipient.
+		 * @param object   $object    The object (ie, product or order) this email relates to, if any.
+		 * @param WC_Email $email     WC_Email instance managing the email.
+		 */
 		$recipient  = apply_filters( 'woocommerce_email_recipient_' . $this->id, $this->recipient, $this->object, $this );
 		$recipients = array_map( 'trim', explode( ',', $recipient ) );
 		$recipients = array_filter( $recipients, 'is_email' );

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -107,6 +107,20 @@ class WC_Email extends WC_Settings_API {
 	public $recipient;
 
 	/**
+	 * Cc recipients for the email.
+	 *
+	 * @var string
+	 */
+	public $cc;
+
+	/**
+	 * Bcc recipients for the email.
+	 *
+	 * @var string
+	 */
+	public $bcc;
+
+	/**
 	 * Object this email is for, for example a customer, product, or email.
 	 *
 	 * @var object|bool
@@ -262,6 +276,10 @@ class WC_Email extends WC_Settings_API {
 
 		$this->email_type = $this->get_option( 'email_type' );
 		$this->enabled    = $this->get_option( 'enabled' );
+		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+			$this->cc  = $this->get_option( 'cc' );
+			$this->bcc = $this->get_option( 'bcc' );
+		}
 
 		add_action( 'phpmailer_init', array( $this, 'handle_multipart' ) );
 		add_action( 'woocommerce_update_options_email_' . $this->id, array( $this, 'process_admin_options' ) );
@@ -484,7 +502,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_cc_recipient() {
-		$cc = $this->get_option( 'cc' );
+		$cc = $this->cc;
 		/**
 		 * Filter the Cc recipient for the email.
 		 *
@@ -505,7 +523,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_bcc_recipient() {
-		$bcc = $this->get_option( 'bcc' );
+		$bcc = $this->bcc;
 		/**
 		 * Filter the Bcc recipient for the email.
 		 *

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Pelago\Emogrifier\CssInliner;
 use Pelago\Emogrifier\HtmlProcessor\CssToAttributeConverter;
 use Pelago\Emogrifier\HtmlProcessor\HtmlPruner;
@@ -850,6 +851,26 @@ class WC_Email extends WC_Settings_API {
 				'desc_tip'    => true,
 			),
 		);
+		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+			$this->form_fields['cc']  = array(
+				'title'       => __( 'Cc(s)', 'woocommerce' ),
+				'type'        => 'text',
+				/* translators: %s: admin email */
+				'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+				'placeholder' => '',
+				'default'     => '',
+				'desc_tip'    => true,
+			);
+			$this->form_fields['bcc'] = array(
+				'title'       => __( 'Bcc(s)', 'woocommerce' ),
+				'type'        => 'text',
+				/* translators: %s: admin email */
+				'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+				'placeholder' => '',
+				'default'     => '',
+				'desc_tip'    => true,
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -479,6 +479,48 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
+	 * Get valid Cc recipients.
+	 *
+	 * @return string
+	 */
+	public function get_cc_recipient() {
+		$cc = $this->get_option( 'cc' );
+		/**
+		 * Filter the Cc recipient for the email.
+		 *
+		 * @since 9.8.0
+		 * @param string   $cc     Cc recipient.
+		 * @param object   $object The object (ie, product or order) this email relates to, if any.
+		 * @param WC_Email $email  WC_Email instance managing the email.
+		 */
+		$cc  = apply_filters( 'woocommerce_email_cc_recipient_' . $this->id, $cc, $this->object, $this );
+		$ccs = array_map( 'trim', explode( ',', $cc ) );
+		$ccs = array_filter( $ccs, 'is_email' );
+		return implode( ', ', $ccs );
+	}
+
+	/**
+	 * Get valid Bcc recipients.
+	 *
+	 * @return string
+	 */
+	public function get_bcc_recipient() {
+		$bcc = $this->get_option( 'bcc' );
+		/**
+		 * Filter the Bcc recipient for the email.
+		 *
+		 * @since 9.8.0
+		 * @param string   $bcc    CC recipient.
+		 * @param object   $object The object (ie, product or order) this email relates to, if any.
+		 * @param WC_Email $email  WC_Email instance managing the email.
+		 */
+		$bcc  = apply_filters( 'woocommerce_email_bcc_recipient_' . $this->id, $bcc, $this->object, $this );
+		$bccs = array_map( 'trim', explode( ',', $bcc ) );
+		$bccs = array_filter( $bccs, 'is_email' );
+		return implode( ', ', $bccs );
+	}
+
+	/**
 	 * Get email headers.
 	 *
 	 * @return string
@@ -492,6 +534,18 @@ class WC_Email extends WC_Settings_API {
 			}
 		} elseif ( $this->get_from_address() && $this->get_from_name() ) {
 			$header .= 'Reply-to: ' . $this->get_from_name() . ' <' . $this->get_from_address() . ">\r\n";
+		}
+
+		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+			$cc = $this->get_cc_recipient();
+			if ( ! empty( $cc ) ) {
+				$header .= 'Cc: ' . $cc . "\r\n";
+			}
+
+			$bcc = $this->get_bcc_recipient();
+			if ( ! empty( $bcc ) ) {
+				$header .= 'Bcc: ' . $bcc . "\r\n";
+			}
 		}
 
 		return apply_filters( 'woocommerce_email_headers', $header, $this->id, $this->object, $this );

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -514,6 +514,7 @@ class WC_Email extends WC_Settings_API {
 		$cc  = apply_filters( 'woocommerce_email_cc_recipient_' . $this->id, $cc, $this->object, $this );
 		$ccs = array_map( 'trim', explode( ',', $cc ) );
 		$ccs = array_filter( $ccs, 'is_email' );
+		$ccs = array_map( 'sanitize_email', $ccs );
 		return implode( ', ', $ccs );
 	}
 
@@ -535,6 +536,7 @@ class WC_Email extends WC_Settings_API {
 		$bcc  = apply_filters( 'woocommerce_email_bcc_recipient_' . $this->id, $bcc, $this->object, $this );
 		$bccs = array_map( 'trim', explode( ',', $bcc ) );
 		$bccs = array_filter( $bccs, 'is_email' );
+		$bccs = array_map( 'sanitize_email', $bccs );
 		return implode( ', ', $bccs );
 	}
 
@@ -557,12 +559,12 @@ class WC_Email extends WC_Settings_API {
 		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
 			$cc = $this->get_cc_recipient();
 			if ( ! empty( $cc ) ) {
-				$header .= 'Cc: ' . $cc . "\r\n";
+				$header .= 'Cc: ' . sanitize_text_field( $cc ) . "\r\n";
 			}
 
 			$bcc = $this->get_bcc_recipient();
 			if ( ! empty( $bcc ) ) {
-				$header .= 'Bcc: ' . $bcc . "\r\n";
+				$header .= 'Bcc: ' . sanitize_text_field( $bcc ) . "\r\n";
 			}
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -935,25 +935,43 @@ class WC_Email extends WC_Settings_API {
 			),
 		);
 		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-			$this->form_fields['cc']  = array(
-				'title'       => __( 'Cc(s)', 'woocommerce' ),
-				'type'        => 'text',
-				/* translators: %s: admin email */
-				'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
-				'placeholder' => '',
-				'default'     => '',
-				'desc_tip'    => true,
-			);
-			$this->form_fields['bcc'] = array(
-				'title'       => __( 'Bcc(s)', 'woocommerce' ),
-				'type'        => 'text',
-				/* translators: %s: admin email */
-				'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
-				'placeholder' => '',
-				'default'     => '',
-				'desc_tip'    => true,
-			);
+			$this->form_fields['cc']  = $this->get_cc_field();
+			$this->form_fields['bcc'] = $this->get_bcc_field();
 		}
+	}
+
+	/**
+	 * Get the cc field definition.
+	 *
+	 * @return array
+	 */
+	protected function get_cc_field() {
+		return array(
+			'title'       => __( 'Cc(s)', 'woocommerce' ),
+			'type'        => 'text',
+			/* translators: %s: admin email */
+			'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
+			'placeholder' => '',
+			'default'     => '',
+			'desc_tip'    => true,
+		);
+	}
+
+	/**
+	 * Get the bcc field definition.
+	 *
+	 * @return array
+	 */
+	protected function get_bcc_field() {
+		return array(
+			'title'       => __( 'Bcc(s)', 'woocommerce' ),
+			'type'        => 'text',
+			/* translators: %s: admin email */
+			'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
+			'placeholder' => '',
+			'default'     => '',
+			'desc_tip'    => true,
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -937,7 +937,7 @@ class WC_Email extends WC_Settings_API {
 				'title'       => __( 'Cc(s)', 'woocommerce' ),
 				'type'        => 'text',
 				/* translators: %s: admin email */
-				'description' => __( 'Enter Cc recipients (comma separated) for this email.', 'woocommerce' ),
+				'description' => __( 'Enter Cc recipients (comma-separated) for this email.', 'woocommerce' ),
 				'placeholder' => '',
 				'default'     => '',
 				'desc_tip'    => true,
@@ -946,7 +946,7 @@ class WC_Email extends WC_Settings_API {
 				'title'       => __( 'Bcc(s)', 'woocommerce' ),
 				'type'        => 'text',
 				/* translators: %s: admin email */
-				'description' => __( 'Enter Bcc recipients (comma separated) for this email.', 'woocommerce' ),
+				'description' => __( 'Enter Bcc recipients (comma-separated) for this email.', 'woocommerce' ),
 				'placeholder' => '',
 				'default'     => '',
 				'desc_tip'    => true,

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/api-tests-fixtures.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/api-tests-fixtures.js
@@ -13,3 +13,4 @@ exports.test = base.test.extend( {
 
 exports.expect = base.expect;
 exports.tags = tags;
+exports.request = base.request;

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -2097,6 +2097,8 @@ test.describe( 'Settings API tests: CRUD', () => {
 	);
 
 	test.describe( 'List all Email New Order settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email new order settings', async ( {
 			request,
 		} ) => {
@@ -2196,10 +2198,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Failed Order settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test(
 			'can retrieve all email failed order settings',
 			{ tag: tags.SKIP_ON_PRESSABLE },
@@ -2302,11 +2340,47 @@ test.describe( 'Settings API tests: CRUD', () => {
 						} ),
 					] )
 				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'cc',
+							label: 'Cc(s)',
+							description: expect.stringContaining(
+								'Enter Cc recipients (comma separated) for this email.'
+							),
+							type: 'text',
+							default: '',
+							tip: expect.stringContaining(
+								'Enter Cc recipients (comma separated) for this email.'
+							),
+							value: expect.any( String ),
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'bcc',
+							label: 'Bcc(s)',
+							description: expect.stringContaining(
+								'Enter Bcc recipients (comma separated) for this email.'
+							),
+							type: 'text',
+							default: '',
+							tip: expect.stringContaining(
+								'Enter Bcc recipients (comma separated) for this email.'
+							),
+							value: expect.any( String ),
+						} ),
+					] )
+				);
 			}
 		);
 	} );
 
 	test.describe( 'List all Email Customer On Hold Order settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer on hold order settings', async ( {
 			request,
 		} ) => {
@@ -2390,10 +2464,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer Processing Order settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer processing order settings', async ( {
 			request,
 		} ) => {
@@ -2476,10 +2586,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer Completed Order settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer completed order settings', async ( {
 			request,
 		} ) => {
@@ -2562,10 +2708,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer Refunded Order settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer refunded order settings', async ( {
 			request,
 		} ) => {
@@ -2678,10 +2860,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer Invoice settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer invoice settings', async ( {
 			request,
 		} ) => {
@@ -2767,10 +2985,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer Note settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer note settings', async ( {
 			request,
 		} ) => {
@@ -2853,10 +3107,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer Reset Password settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer reset password settings', async ( {
 			request,
 		} ) => {
@@ -2939,10 +3229,46 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
 		} );
 	} );
 
 	test.describe( 'List all Email Customer New Account settings', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
 		test( 'can retrieve all email customer new account settings', async ( {
 			request,
 		} ) => {
@@ -3022,6 +3348,40 @@ test.describe( 'Settings API tests: CRUD', () => {
 						},
 						tip: 'Choose which format of email to send.',
 						value: 'html',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'cc',
+						label: 'Cc(s)',
+						description: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Cc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'bcc',
+						label: 'Bcc(s)',
+						description: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						type: 'text',
+						default: '',
+						tip: expect.stringContaining(
+							'Enter Bcc recipients (comma separated) for this email.'
+						),
+						value: expect.any( String ),
 					} ),
 				] )
 			);

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1,8 +1,10 @@
 const {
 	test,
 	expect,
+	request: apiRequest,
 	tags,
 } = require( '../../../fixtures/api-tests-fixtures' );
+const { setOption } = require( '../../../utils/options' );
 
 const { BASE_URL } = process.env;
 const shouldSkip = ! BASE_URL.includes( 'localhost' );
@@ -12,6 +14,24 @@ const {
 	currencies,
 	stateOptions,
 } = require( '../../../data/settings' );
+
+const enableEmailImprovementsFeature = async () => {
+	await setOption(
+		apiRequest,
+		BASE_URL,
+		'woocommerce_feature_email_improvements_enabled',
+		'yes'
+	);
+};
+
+const disableEmailImprovementsFeature = async () => {
+	await setOption(
+		apiRequest,
+		BASE_URL,
+		'woocommerce_feature_email_improvements_enabled',
+		'no'
+	);
+};
 
 test.describe( 'Settings API tests: CRUD', () => {
 	test.describe( 'List all settings groups', () => {
@@ -1603,6 +1623,170 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#3c3c3c',
 						tip: 'The main body text color. Default <code>#3c3c3c</code>.',
+						value: '#3c3c3c',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_merchant_email_notifications',
+						label: 'Enable email insights',
+						description:
+							'Receive email notifications with additional guidance to complete the basic store setup and helpful insights',
+						type: 'checkbox',
+						default: 'no',
+						value: 'no',
+					} ),
+				] )
+			);
+		} );
+	} );
+
+	test.describe( 'List all Email settings options with Email Improvements feature enabled', () => {
+		test.beforeAll( enableEmailImprovementsFeature );
+		test.afterAll( disableEmailImprovementsFeature );
+		test( 'can retrieve all email settings with Email Improvements feature enabled', async ( {
+			request,
+		} ) => {
+			// call API to retrieve all settings options
+			const response = await request.get(
+				'./wp-json/wc/v3/settings/email'
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_from_name',
+						label: '"From" name',
+						description: expect.any( String ),
+						type: 'text',
+						default: expect.any( String ),
+						tip: expect.any( String ),
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_from_address',
+						label: '"From" address',
+						description: '',
+						type: 'email',
+						default: expect.any( String ),
+						tip: '',
+						value: expect.any( String ),
+					} ),
+				] )
+			);
+			// woocommerce_email_header_image is custom slotfill and not included in the response
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_header_image_width',
+						label: 'Logo width (px)',
+						type: 'number',
+						default: 120,
+						value: 120,
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_header_alignment',
+						label: 'Header alignment',
+						description: '',
+						type: 'select',
+						default: 'left',
+						value: 'left',
+					} ),
+				] )
+			);
+			// woocommerce_email_font_family is custom slotfill and not included in the response
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_footer_text',
+						label: 'Footer text',
+						description:
+							'This text will appear in the footer of all of your WooCommerce emails. Available placeholders: {site_title} {site_url} {store_address} {store_email}',
+						type: 'textarea',
+						default: '{site_title}<br />{store_address}',
+						tip: 'This text will appear in the footer of all of your WooCommerce emails. Available placeholders: {site_title} {site_url} {store_address} {store_email}',
+						value: '{site_title} &mdash; Built with {WooCommerce}',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_base_color',
+						label: 'Accent',
+						description:
+							'Customize the color of your buttons and links. Default <code>#000000</code>.',
+						type: 'color',
+						default: '#000000',
+						tip: 'Customize the color of your buttons and links. Default <code>#000000</code>.',
+						value: '#7f54b3',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_background_color',
+						label: 'Email background',
+						description:
+							'Select a color for the background of your emails. Default <code>#ffffff</code>.',
+						type: 'color',
+						default: '#ffffff',
+						tip: 'Select a color for the background of your emails. Default <code>#ffffff</code>.',
+						value: '#f7f7f7',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_body_background_color',
+						label: 'Content background',
+						description:
+							'Choose a background color for the content area of your emails. Default <code>#ffffff</code>.',
+						type: 'color',
+						default: '#ffffff',
+						tip: 'Choose a background color for the content area of your emails. Default <code>#ffffff</code>.',
+						value: '#ffffff',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_text_color',
+						label: 'Heading & text',
+						description:
+							'Set the color of your headings and text. Default <code>#000000</code>.',
+						type: 'color',
+						default: '#000000',
+						tip: 'Set the color of your headings and text. Default <code>#000000</code>.',
+						value: '#3c3c3c',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_email_footer_text_color',
+						label: 'Secondary text',
+						description:
+							'Choose a color for your secondary text, such as your footer content. Default <code>#787c82</code>.',
+						type: 'color',
+						default: '#787c82',
+						tip: 'Choose a color for your secondary text, such as your footer content. Default <code>#787c82</code>.',
 						value: '#3c3c3c',
 					} ),
 				] )

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -2204,12 +2204,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2221,12 +2221,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2346,12 +2346,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 							id: 'cc',
 							label: 'Cc(s)',
 							description: expect.stringContaining(
-								'Enter Cc recipients (comma separated) for this email.'
+								'Enter Cc recipients (comma-separated) for this email.'
 							),
 							type: 'text',
 							default: '',
 							tip: expect.stringContaining(
-								'Enter Cc recipients (comma separated) for this email.'
+								'Enter Cc recipients (comma-separated) for this email.'
 							),
 							value: expect.any( String ),
 						} ),
@@ -2363,12 +2363,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 							id: 'bcc',
 							label: 'Bcc(s)',
 							description: expect.stringContaining(
-								'Enter Bcc recipients (comma separated) for this email.'
+								'Enter Bcc recipients (comma-separated) for this email.'
 							),
 							type: 'text',
 							default: '',
 							tip: expect.stringContaining(
-								'Enter Bcc recipients (comma separated) for this email.'
+								'Enter Bcc recipients (comma-separated) for this email.'
 							),
 							value: expect.any( String ),
 						} ),
@@ -2470,12 +2470,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2487,12 +2487,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2592,12 +2592,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2609,12 +2609,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2714,12 +2714,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2731,12 +2731,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2866,12 +2866,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2883,12 +2883,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -2991,12 +2991,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3008,12 +3008,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3113,12 +3113,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3130,12 +3130,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3235,12 +3235,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3252,12 +3252,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3357,12 +3357,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'cc',
 						label: 'Cc(s)',
 						description: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Cc recipients (comma separated) for this email.'
+							'Enter Cc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),
@@ -3374,12 +3374,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'bcc',
 						label: 'Bcc(s)',
 						description: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						type: 'text',
 						default: '',
 						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma separated) for this email.'
+							'Enter Bcc recipients (comma-separated) for this email.'
 						),
 						value: expect.any( String ),
 					} ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
@@ -4,6 +4,8 @@
  * @package WooCommerce\Tests\Emails
  */
 
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+
 /**
  * WC_Tests_WC_Emails.
  *
@@ -61,6 +63,42 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 		$result = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
 		$this->assertTrue( false !== strpos( $result, $str_present ) );
 		$this->assertTrue( false === strpos( $result, $str_removed ) );
+	}
+
+	/**
+	 * Test that headers are properly generated.
+	 */
+	public function test_headers() {
+		$email             = new WC_Email();
+		$email->id         = 'headers_test';
+		$email->email_type = 'html';
+
+		$result = $email->get_headers();
+		$this->assertTrue( false !== strpos( $result, 'Content-Type: text/html' ) );
+		$this->assertTrue( false === strpos( $result, 'Cc:' ) );
+		$this->assertTrue( false === strpos( $result, 'Bcc:' ) );
+	}
+
+	/**
+	 * Test that headers are properly generated in email improvements.
+	 */
+	public function test_headers_with_enabled_email_improvements() {
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$original_value      = $features_controller->feature_is_enabled( 'email_improvements' );
+		$features_controller->change_feature_enable( 'email_improvements', true );
+
+		$email             = new WC_Email();
+		$email->id         = 'headers_test';
+		$email->email_type = 'plain';
+		$email->cc         = '   cc@example.com, invalid$&*^&%_email,      valid@email.com    ';
+		$email->bcc        = '     invalid value, header should be skipped     ';
+
+		$result = $email->get_headers();
+		$this->assertTrue( false !== strpos( $result, 'Content-Type: text/plain' ) );
+		$this->assertTrue( false !== strpos( $result, 'Cc: cc@example.com, valid@email.com' ) );
+		$this->assertTrue( false === strpos( $result, 'Bcc:' ) );
+
+		$features_controller->change_feature_enable( 'email_improvements', $original_value );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Tests\Settings
  */
 
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 
 require_once __DIR__ . '/class-wc-settings-unit-test-case.php';
@@ -88,6 +89,48 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );
+	}
+
+	/**
+	 * @testdox get_settings('') should return all the settings for the default section
+	 * when the email improvements feature is enabled.
+	 */
+	public function test_get_default_settings_returns_all_settings_with_email_improvements_feature() {
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$original_value      = $features_controller->feature_is_enabled( 'email_improvements' );
+		$features_controller->change_feature_enable( 'email_improvements', true );
+
+		$sut = new WC_Settings_Emails();
+
+		$settings               = $sut->get_settings_for_section( '' );
+		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+
+		$expected = array(
+			'email_notification_settings'              => array( 'title', 'sectionend' ),
+			''                                         => array( 'email_notification', 'email_preview' ),
+			'email_recipient_options'                  => 'sectionend',
+			'email_options'                            => array( 'title', 'sectionend' ),
+			'woocommerce_email_from_name'              => 'text',
+			'woocommerce_email_from_address'           => 'email',
+			'email_template_options'                   => array( 'title', 'sectionend', 'sectionend' ),
+			'woocommerce_email_header_image'           => 'email_image_url',
+			'woocommerce_email_header_image_width'     => 'number',
+			'woocommerce_email_header_alignment'       => 'select',
+			'woocommerce_email_font_family'            => 'email_font_family',
+			'woocommerce_email_footer_text'            => 'textarea',
+			'woocommerce_email_base_color'             => 'color',
+			'woocommerce_email_background_color'       => 'color',
+			'woocommerce_email_body_background_color'  => 'color',
+			'email_color_palette'                      => 'email_color_palette',
+			'woocommerce_email_text_color'             => 'color',
+			'woocommerce_email_footer_text_color'      => 'color',
+			'email_merchant_notes'                     => array( 'title', 'sectionend' ),
+			'woocommerce_merchant_email_notifications' => 'checkbox',
+		);
+
+		$this->assertEquals( $expected, $settings_ids_and_types );
+
+		$features_controller->change_feature_enable( 'email_improvements', $original_value );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
@@ -92,7 +92,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox get_settings('') should return all the settings for the default section
+	 * @testdox get_settings_for_section('') should return all the settings for the default section
 	 * when the email improvements feature is enabled.
 	 */
 	public function test_get_default_settings_returns_all_settings_with_email_improvements_feature() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Add `Cc` and `Bcc` fields to all WooCommerce emails. 

<img width="1099" alt="Screenshot 2025-02-03 at 17 19 33" src="https://github.com/user-attachments/assets/315127f7-c25d-40ac-afd9-2915afa93edd" />

Closes #54909.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Optional, install the [WP Mail Logging plugin](https://wordpress.org/plugins/wp-mail-logging/) for easier debugging. 
1. Enable `Email improvements` feature in **WooCommerce > Settings > Advanced > Features**. 
2. Go to **WooCommerce > Settings > Emails**.
3. Click to manage any of the emails.
    - I recommend `Order details` (`/wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_invoice`) because it's easily triggered in the order detail in **Order actions**.
4. Enter anything into `Cc(s)` and `Bcc(s)` and save the email to see that the values are saved.
5. Test with valid, invalid and mixed values (i.e., enter multiple comma-separated values where some are valid emails, some are random strings, e.g. `valid@email.com, fdsfkjh3254,     8967(*&^%^hf,    again@valid.com`).
6. Trigger the email (depending on which you are testing). 
7. If your website can send emails, check that you received an email from the Cc or Bcc fields. Alternatively, go to the **WP Mail Logging** plugin and check what headers were included in the email.

<!-- End testing instructions -->
