### PR TITLE
[NOX] Add new tracking events for the new Payment settings page

### DIFF
--- a/packages/js/data/changelog/add-54673-tracks-events-new-payment-settings
+++ b/packages/js/data/changelog/add-54673-tracks-events-new-payment-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Export the PluginData type.

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -45,6 +45,7 @@ export {
 	EnableGatewayResponse,
 	PaymentGatewayLink,
 	RecommendedPaymentMethod,
+	PluginData,
 } from './payment-settings/types';
 export { ShippingMethod } from './shipping-methods/types';
 

--- a/plugins/woocommerce/changelog/add-54673-tracks-events-new-payment-settings
+++ b/plugins/woocommerce/changelog/add-54673-tracks-events-new-payment-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add new tracking events for the new Payment settings page.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/complete-setup-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/complete-setup-button.tsx
@@ -9,6 +9,7 @@ import {
 	PaymentProviderOnboardingState,
 } from '@woocommerce/data';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -71,6 +72,12 @@ export const CompleteSetupButton = ( {
 	const onboardingCompleted = onboardingState.completed;
 
 	const completeSetup = () => {
+		// Record the click of this button.
+		recordEvent( 'settings_payments_provider_complete_setup_click', {
+			provider_id: gatewayId,
+			onboarding_state: onboardingState,
+		} );
+
 		setIsUpdating( true );
 
 		if ( ! accountConnected || ! onboardingStarted ) {

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -12,6 +12,7 @@ import {
 	PaymentProviderState,
 } from '@woocommerce/data';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 interface EnableGatewayButtonProps {
 	/**
@@ -95,10 +96,16 @@ export const EnableGatewayButton = ( {
 
 	const enableGateway = ( e: React.MouseEvent ) => {
 		e.preventDefault();
+
 		// Since this logic can toggle the gateway state on and off, we make sure we don't accidentally disable the gateway.
 		if ( gatewayState.enabled ) {
 			return;
 		}
+
+		// Record the event when user clicks on a gateway's enable button.
+		recordEvent( 'settings_payments_provider_enable_click', {
+			provider_id: gatewayId,
+		} );
 
 		const gatewayToggleNonce =
 			window.woocommerce_admin.nonces?.gateway_toggle || '';
@@ -124,6 +131,12 @@ export const EnableGatewayButton = ( {
 				if ( response.data === 'needs_setup' ) {
 					// We only need to perform additional logic/redirects if no account connected.
 					if ( ! gatewayState.account_connected ) {
+						// Record the event when user successfully enables a gateway.
+						recordEvent( 'settings_payments_provider_enable', {
+							provider_id: gatewayId,
+						} );
+
+						// Redirect to the recommended payment methods page if available, or the onboarding URL.
 						if ( gatewayHasRecommendedPaymentMethods ) {
 							const history = getHistory();
 							history.push(

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -48,7 +48,7 @@ interface EnableGatewayButtonProps {
 	/**
 	 * ID of the plugin that is being installed.
 	 */
-	installingPlugin: string | null;
+	installingPlugin?: string | null;
 	/**
 	 * The text of the button.
 	 */

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/settings-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/settings-button.tsx
@@ -3,12 +3,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
 
 interface SettingsButtonProps {
+	/**
+	 * ID of the associated gateway.
+	 */
+	gatewayId: string;
+
 	/**
 	 * The settings URL to navigate to when the enable gateway button is clicked.
 	 */
@@ -18,9 +24,9 @@ interface SettingsButtonProps {
 	 */
 	buttonText?: string;
 	/**
-	 * ID of the plugin that is being installed.
+	 * Whether the associated provider plugin is being installed.
 	 */
-	installingPlugin: string | null;
+	isInstallingPlugin?: boolean;
 }
 
 /**
@@ -28,15 +34,23 @@ interface SettingsButtonProps {
  * Used for managing settings for a payment gateway.
  */
 export const SettingsButton = ( {
+	gatewayId,
 	settingsHref,
-	installingPlugin,
+	isInstallingPlugin,
 	buttonText = __( 'Manage', 'woocommerce' ),
 }: SettingsButtonProps ) => {
+	const recordButtonClickEvent = () => {
+		recordEvent( 'settings_payments_provider_manage_click', {
+			provider_id: gatewayId,
+		} );
+	};
+
 	return (
 		<Button
 			variant={ 'secondary' }
 			href={ settingsHref }
-			disabled={ !! installingPlugin }
+			disabled={ isInstallingPlugin }
+			onClick={ recordButtonClickEvent }
 		>
 			{ buttonText }
 		</Button>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/complete-setup-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/complete-setup-button.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render, fireEvent } from '@testing-library/react';
+import {
+	PaymentProviderState,
+	PaymentProviderOnboardingState,
+} from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { CompleteSetupButton } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'CompleteSetupButton', () => {
+	it( 'should record settings_payments_provider_complete_setup_click event on click of the button', () => {
+		const { getByRole } = render(
+			<CompleteSetupButton
+				gatewayId="test-gateway"
+				gatewayState={
+					{
+						enabled: true,
+						account_connected: false,
+						needs_setup: true,
+						test_mode: false,
+						dev_mode: false,
+					} as PaymentProviderState
+				}
+				onboardingState={
+					{
+						started: true,
+						completed: false,
+						test_mode: false,
+					} as PaymentProviderOnboardingState
+				}
+				settingsHref="/settings"
+				onboardingHref={ '' }
+				gatewayHasRecommendedPaymentMethods={ false }
+				installingPlugin={ null }
+			/>
+		);
+
+		fireEvent.click( getByRole( 'button' ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_provider_complete_setup_click',
+			{
+				provider_id: 'test-gateway',
+				onboarding_state: {
+					started: true,
+					completed: false,
+					test_mode: false,
+				},
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/settings-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/settings-button.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsButton } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'SettingsButton', () => {
+	it( 'should record settings_payments_provider_manage_click event on click of the button', () => {
+		const { getByRole } = render(
+			<SettingsButton gatewayId={ 'test-gateway' } settingsHref={ '' } />
+		);
+		fireEvent.click( getByRole( 'link', { name: 'Manage' } ) );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_provider_manage_click',
+			{
+				provider_id: 'test-gateway',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
@@ -11,6 +11,7 @@ import {
 } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -120,6 +121,11 @@ export const EllipsisMenuContent = ( {
 	 * Disables the payment gateway from payment processing.
 	 */
 	const disableGateway = () => {
+		// Record the event when user clicks on a gateway's disable button.
+		recordEvent( 'settings_payments_provider_disable_click', {
+			provider_id: providerId,
+		} );
+
 		const gatewayToggleNonce =
 			window.woocommerce_admin.nonces?.gateway_toggle || '';
 
@@ -136,6 +142,11 @@ export const EllipsisMenuContent = ( {
 			gatewayToggleNonce
 		)
 			.then( () => {
+				// Record the event when user successfully disables a gateway.
+				recordEvent( 'settings_payments_provider_disable', {
+					provider_id: providerId,
+				} );
+
 				invalidateResolutionForStoreSelector( 'getPaymentProviders' );
 				setIsDisabling( false );
 				onToggle();

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/incentive-banner.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/incentive-banner.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button, Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 import { PaymentIncentive, PaymentProvider } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -75,11 +76,28 @@ export const IncentiveBanner = ( {
 
 	const context = 'wc_settings_payments__banner';
 
+	useEffect( () => {
+		// Record the event when the incentive is shown.
+		recordEvent( 'settings_payments_incentive_show', {
+			incentive_id: incentive.promo_id,
+			provider_id: provider.id,
+			display_context: context,
+		} );
+	} );
+
 	/**
 	 * Handles accepting the incentive.
 	 * Triggers the onAccept callback, dismisses the banner, and triggers plugin setup.
 	 */
 	const handleAccept = () => {
+		// Record the event when the user accepts the incentive.
+		recordEvent( 'settings_payments_incentive_accept', {
+			incentive_id: incentive.promo_id,
+			provider_id: provider.id,
+			display_context: context,
+		} );
+
+		// Accept the incentive and setup the plugin.
 		setIsBusy( true );
 		onAccept( incentive.promo_id );
 		onDismiss( incentive._links.dismiss.href, context ); // We also dismiss the incentive when it is accepted.
@@ -93,6 +111,14 @@ export const IncentiveBanner = ( {
 	 * Triggers the onDismiss callback and hides the banner.
 	 */
 	const handleDismiss = () => {
+		// Record the event when the user dismisses the incentive.
+		recordEvent( 'settings_payments_incentive_dismiss', {
+			incentive_id: incentive.promo_id,
+			provider_id: provider.id,
+			display_context: context,
+		} );
+
+		// Dimiss the incentive.
 		setIsBusy( true );
 		onDismiss( incentive._links.dismiss.href, context );
 		setIsBusy( false );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/incentive-banner.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/incentive-banner.tsx
@@ -83,7 +83,7 @@ export const IncentiveBanner = ( {
 			provider_id: provider.id,
 			display_context: context,
 		} );
-	} );
+	}, [ incentive.promo_id, provider.id ] );
 
 	/**
 	 * Handles accepting the incentive.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/test/incentive-banner.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/test/incentive-banner.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render, fireEvent } from '@testing-library/react';
+import {
+	PaymentIncentive,
+	PaymentProvider,
+	PaymentProviderType,
+	PluginData,
+} from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { IncentiveBanner } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const testIncentive: PaymentIncentive = {
+	id: 'test-incentive',
+	description: 'Test Incentive',
+	promo_id: 'test-promo-id',
+	title: 'Test Title',
+	short_description: 'Test Short Description',
+	cta_label: 'Test CTA Label',
+	tc_url: 'https://example.com',
+	badge: 'test-badge',
+	_dismissals: [],
+	_links: {
+		dismiss: {
+			href: 'https://example.com',
+		},
+	},
+};
+
+const testProvider: PaymentProvider = {
+	id: 'test-provider',
+	_order: 1,
+	_type: PaymentProviderType.Gateway, // or any valid PaymentProviderType
+	title: 'Test Title',
+	description: 'Test Description',
+	icon: 'test-icon',
+	plugin: {
+		id: 'test-plugin',
+		name: 'Test Plugin',
+		description: 'Test Plugin Description',
+		pluginUrl: 'https://example.com',
+		slug: 'test-plugin-slug',
+		file: 'test-plugin-file',
+		status: 'active',
+	} as PluginData,
+};
+
+describe( 'IncentiveBanner', () => {
+	it( 'should record settings_payments_incentive_show event when the incentive is shown', () => {
+		render(
+			<IncentiveBanner
+				incentive={ testIncentive }
+				provider={ testProvider }
+				onboardingUrl="https://example.com"
+				onAccept={ jest.fn() }
+				onDismiss={ jest.fn() }
+				setupPlugin={ jest.fn() }
+			/>
+		);
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_incentive_show',
+			{
+				display_context: 'wc_settings_payments__banner',
+				incentive_id: 'test-promo-id',
+				provider_id: 'test-provider',
+			}
+		);
+	} );
+
+	it( 'should record settings_payments_incentive_accept event when the accept button is clicked', () => {
+		const onAccept = jest.fn();
+		const { getByRole } = render(
+			<IncentiveBanner
+				incentive={ testIncentive }
+				provider={ testProvider }
+				onboardingUrl="https://example.com"
+				onAccept={ onAccept }
+				onDismiss={ jest.fn() }
+				setupPlugin={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByRole( 'button', { name: 'Test CTA Label' } ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_incentive_accept',
+			{
+				display_context: 'wc_settings_payments__banner',
+				incentive_id: 'test-promo-id',
+				provider_id: 'test-provider',
+			}
+		);
+	} );
+
+	it( 'should record settings_payments_incentive_dismiss event when the close button is clicked', () => {
+		const onAccept = jest.fn();
+		const { getByRole } = render(
+			<IncentiveBanner
+				incentive={ testIncentive }
+				provider={ testProvider }
+				onboardingUrl="https://example.com"
+				onAccept={ onAccept }
+				onDismiss={ jest.fn() }
+				setupPlugin={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByRole( 'button', { name: 'Dismiss' } ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_incentive_dismiss',
+			{
+				display_context: 'wc_settings_payments__banner',
+				incentive_id: 'test-promo-id',
+				provider_id: 'test-provider',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-modal/incentive-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-modal/incentive-modal.tsx
@@ -93,7 +93,7 @@ export const IncentiveModal = ( {
 			provider_id: provider.id,
 			display_context: context,
 		} );
-	} );
+	}, [ incentive.promo_id, provider.id ] );
 
 	/**
 	 * Closes the modal.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-modal/test/incentive-modal.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-modal/test/incentive-modal.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render, fireEvent } from '@testing-library/react';
+import {
+	PaymentIncentive,
+	PaymentProvider,
+	PaymentProviderType,
+	PluginData,
+} from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { IncentiveModal } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const testIncentive: PaymentIncentive = {
+	id: 'test-incentive',
+	description: 'Test Incentive',
+	promo_id: 'test-promo-id',
+	title: 'Test Title',
+	short_description: 'Test Short Description',
+	cta_label: 'Test CTA Label',
+	tc_url: 'https://example.com',
+	badge: 'test-badge',
+	_dismissals: [],
+	_links: {
+		dismiss: {
+			href: 'https://example.com',
+		},
+	},
+};
+
+const testProvider: PaymentProvider = {
+	id: 'test-provider',
+	_order: 1,
+	_type: PaymentProviderType.Gateway, // or any valid PaymentProviderType
+	title: 'Test Title',
+	description: 'Test Description',
+	icon: 'test-icon',
+	plugin: {
+		id: 'test-plugin',
+		name: 'Test Plugin',
+		description: 'Test Plugin Description',
+		pluginUrl: 'https://example.com',
+		slug: 'test-plugin-slug',
+		file: 'test-plugin-file',
+		status: 'active',
+	} as PluginData,
+};
+
+describe( 'IncentiveModal', () => {
+	it( 'should record settings_payments_incentive_show event when the incentive is shown', () => {
+		render(
+			<IncentiveModal
+				incentive={ testIncentive }
+				provider={ testProvider }
+				onboardingUrl="https://example.com"
+				onAccept={ jest.fn() }
+				onDismiss={ jest.fn() }
+				setupPlugin={ jest.fn() }
+			/>
+		);
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_incentive_show',
+			{
+				display_context: 'wc_settings_payments__modal',
+				incentive_id: 'test-promo-id',
+				provider_id: 'test-provider',
+			}
+		);
+	} );
+
+	it( 'should record settings_payments_incentive_accept event when the accept button is clicked', () => {
+		const onAccept = jest.fn();
+		const { getByRole } = render(
+			<IncentiveModal
+				incentive={ testIncentive }
+				provider={ testProvider }
+				onboardingUrl="https://example.com"
+				onAccept={ onAccept }
+				onDismiss={ jest.fn() }
+				setupPlugin={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByRole( 'button', { name: 'Test CTA Label' } ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_incentive_accept',
+			{
+				display_context: 'wc_settings_payments__modal',
+				incentive_id: 'test-promo-id',
+				provider_id: 'test-provider',
+			}
+		);
+	} );
+
+	it( 'should record settings_payments_incentive_dismiss event when the close button is clicked', () => {
+		const onAccept = jest.fn();
+		const { getByRole } = render(
+			<IncentiveModal
+				incentive={ testIncentive }
+				provider={ testProvider }
+				onboardingUrl="https://example.com"
+				onAccept={ onAccept }
+				onDismiss={ jest.fn() }
+				setupPlugin={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByRole( 'button', { name: 'Close' } ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_incentive_dismiss',
+			{
+				display_context: 'wc_settings_payments__modal',
+				incentive_id: 'test-promo-id',
+				provider_id: 'test-provider',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/test/woo-payments-post-sandbox-account-setup-modal.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/test/woo-payments-post-sandbox-account-setup-modal.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { WooPaymentsPostSandboxAccountSetupModal } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'WooPaymentsPostSandboxAccountSetupModal', () => {
+	it( 'should record settings_payments_switch_to_live_account_click event when Activate Payments button is clicked', () => {
+		const { getByRole } = render(
+			<WooPaymentsPostSandboxAccountSetupModal
+				isOpen={ true }
+				devMode={ false }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		const activatePaymentsButton = getByRole( 'button', {
+			name: 'Activate payments',
+		} );
+		fireEvent.click( activatePaymentsButton );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_switch_to_live_account_click',
+			{
+				provider_id: 'woocommerce_payments',
+			}
+		);
+	} );
+
+	it( 'should record settings_payments_continue_store_setup_click event when Continue Store Setup button is clicked', async () => {
+		const { getByRole } = render(
+			<WooPaymentsPostSandboxAccountSetupModal
+				isOpen={ true }
+				devMode={ false }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		const continueStoreSetupButton = getByRole( 'button', {
+			name: 'Continue store setup',
+		} );
+		fireEvent.click( continueStoreSetupButton );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_continue_store_setup_click',
+			{
+				provider_id: 'woocommerce_payments',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
@@ -8,6 +8,7 @@ import { Link } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useState } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -50,6 +51,11 @@ export const WooPaymentsPostSandboxAccountSetupModal = ( {
 	 * Redirects the user to the WooPayments setup live account link.
 	 */
 	const handleActivatePayments = () => {
+		// Record the event when the user clicks on the "Activate Payments" button.
+		recordEvent( 'settings_payments_switch_to_live_account_click', {
+			provider_id: 'woocommerce_payments',
+		} );
+
 		setIsActivatingPayments( true );
 
 		window.location.href = getWooPaymentsSetupLiveAccountLink();
@@ -60,6 +66,11 @@ export const WooPaymentsPostSandboxAccountSetupModal = ( {
 	 * Redirects the user to the WooCommerce admin store setup page.
 	 */
 	const handleContinueStoreSetup = () => {
+		// Record the event when the user clicks on the "Continue Store Setup" button.
+		recordEvent( 'settings_payments_continue_store_setup_click', {
+			provider_id: 'woocommerce_payments',
+		} );
+
 		setIsContinuingStoreSetup( true );
 
 		window.location.href = getAdminLink( 'admin.php?page=wc-admin' );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/offline-gateway-list-item/offline-payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/offline-gateway-list-item/offline-payment-gateway-list-item.tsx
@@ -83,6 +83,7 @@ export const OfflinePaymentGatewayListItem = ( {
 							/>
 						) : (
 							<SettingsButton
+								gatewayId={ gateway.id }
 								settingsHref={
 									gateway.management._links.settings.href
 								}

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
@@ -7,6 +7,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { WooPaymentsMethodsLogos } from '@woocommerce/onboarding';
 import { PaymentExtensionSuggestionProvider } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -123,6 +124,16 @@ export const PaymentExtensionSuggestionListItem = ( {
 						<Button
 							variant="primary"
 							onClick={ () => {
+								if ( pluginInstalled ) {
+									// Record the event when user clicks on a gateway's enable button.
+									recordEvent(
+										'settings_payments_provider_enable_click',
+										{
+											provider_id: extension.id,
+										}
+									);
+								}
+
 								if ( incentive ) {
 									acceptIncentive( incentive.promo_id );
 								}

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/test/payment-extension-suggestion-list-item.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/test/payment-extension-suggestion-list-item.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render, fireEvent } from '@testing-library/react';
+import {
+	PaymentExtensionSuggestionProvider,
+	PluginData,
+} from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { PaymentExtensionSuggestionListItem } from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'PaymentExtensionSuggestionListItem', () => {
+	it( 'should record settings_payments_provider_enable_click event on click of the Enable button', () => {
+		const { getByRole } = render(
+			<PaymentExtensionSuggestionListItem
+				extension={
+					{
+						id: 'test-gateway',
+						title: 'Test Gateway',
+						description: 'Test Gateway Description',
+						icon: 'test-gateway-icon',
+						image: 'test-gateway-image',
+						short_description: 'Test Gateway Short Description',
+						tags: [],
+						plugin: {
+							slug: 'test-gateway-plugin',
+							file: 'test-gateway-file',
+							status: 'installed',
+						} as PluginData,
+						_order: 1,
+						_type: 'test-type',
+					} as unknown as PaymentExtensionSuggestionProvider
+				}
+				installingPlugin={ null }
+				setupPlugin={ () => {} }
+				pluginInstalled={ true }
+				acceptIncentive={ () => {} }
+			/>
+		);
+
+		fireEvent.click( getByRole( 'button', { name: 'Enable' } ) );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_provider_enable_click',
+			{
+				provider_id: 'test-gateway',
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list-item/payment-gateway-list-item.tsx
@@ -169,10 +169,11 @@ export const PaymentGatewayListItem = ( {
 
 						{ ! gatewayNeedsOnboarding && (
 							<SettingsButton
+								gatewayId={ gateway.id }
 								settingsHref={
 									gateway.management._links.settings.href
 								}
-								installingPlugin={ installingPlugin }
+								isInstallingPlugin={ !! installingPlugin }
 							/>
 						) }
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
@@ -17,6 +17,7 @@ import { Link } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
 import InfoOutline from 'gridicons/dist/info-outline';
 import interpolateComponents from '@automattic/interpolate-components';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -113,6 +114,19 @@ export const PaymentGateways = ( {
 								method: 'POST',
 								data: { location: value },
 							} ).then( () => {
+								// Record the event when the country is changed.
+								const previouslySelectedCountry =
+									businessRegistrationCountry;
+								const currentSelectedCountry = value;
+								recordEvent(
+									'settings_payments_business_location_update',
+									{
+										old_location: previouslySelectedCountry,
+										new_location: currentSelectedCountry,
+									}
+								);
+
+								// Update UI.
 								setBusinessRegistrationCountry( value );
 								invalidateResolution( 'getPaymentProviders', [
 									value,

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -101,8 +101,6 @@ const SettingsPaymentsMain = () => {
 	useEffect( () => {
 		if ( location.pathname === '' ) {
 			hideWooCommerceNavTab( 'block' );
-			// Record the page view event
-			recordEvent( 'settings_payments_pageview' );
 		}
 	}, [ location ] );
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -101,6 +101,8 @@ const SettingsPaymentsMain = () => {
 	useEffect( () => {
 		if ( location.pathname === '' ) {
 			hideWooCommerceNavTab( 'block' );
+			// Record the page view event
+			recordEvent( 'settings_payments_pageview' );
 		}
 	}, [ location ] );
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -64,8 +64,11 @@ export const SettingsPaymentsMain = () => {
 			?.business_country_code || null
 	);
 
-	// Effect for handling URL parameters and displaying messages or modals.
 	useEffect( () => {
+		// Record the page view event
+		recordEvent( 'settings_payments_pageview' );
+
+		// Handle URL parameters and display messages or modals.
 		const urlParams = new URLSearchParams( window.location.search );
 		const isAccountTestDriveError =
 			urlParams.get( 'test_drive_error' ) === 'true';

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -14,6 +14,7 @@ import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -63,10 +64,9 @@ export const SettingsPaymentsMain = () => {
 			?.business_country_code || null
 	);
 
-	const urlParams = new URLSearchParams( window.location.search );
-
 	// Effect for handling URL parameters and displaying messages or modals.
 	useEffect( () => {
+		const urlParams = new URLSearchParams( window.location.search );
 		const isAccountTestDriveError =
 			urlParams.get( 'test_drive_error' ) === 'true';
 		if ( isAccountTestDriveError ) {
@@ -236,6 +236,11 @@ export const SettingsPaymentsMain = () => {
 					invalidateResolutionForStoreSelector(
 						'getPaymentProviders'
 					);
+
+					// Record the plugin installation event.
+					recordEvent( 'settings_payments_provider_installed', {
+						provider_id: id,
+					} );
 
 					// Wait for the state update and fetch the latest providers.
 					const updatedProviders = await resolveSelect(

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -258,6 +258,11 @@ export const SettingsPaymentsMain = () => {
 							provider.plugin.slug === slug // Last resort to find the provider.
 					);
 
+					// Record the event when user successfully enables a gateway.
+					recordEvent( 'settings_payments_provider_enable', {
+						provider_id: id,
+					} );
+
 					// If the installed and/or activated extension has recommended payment methods,
 					// redirect to the payment methods page.
 					if (

--- a/plugins/woocommerce/client/admin/client/settings-payments/test/settings-payments-main.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/test/settings-payments-main.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { recordEvent } from '@woocommerce/tracks';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsPaymentsMain } from '../settings-payments-main';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'SettingsPaymentsMain', () => {
+	it( 'should record settings_payments_pageview event on load', () => {
+		render( <SettingsPaymentsMain /> );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'settings_payments_pageview'
+		);
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54673.

Add tracking events for the new (Reactified) Payment settings page to capture key moments in the user journey related to providers, incentives, live payments, and business location. See the above issue for a comprehensive list of events.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

##### Local

1. Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );` on your site browser console. And look for verbose logs.
2. Enable the new Payment settings page by going to WP Admin > Tools > WCA Test Helper > Features and turning on the `reactify-classic-payments-settings` flag. (requires the WC Beta Tester plugin).
3. Go to WP Admin > WooCommerce > Settings > Payments. Verify that the `wcadmin_settings_payments_pageview event is recorded.
4. Use instructions in https://github.com/woocommerce/woocommerce/pull/53432 to trigger the action incentive for WooPayments. Check the troubleshooting section if you cannot see the incentive. Refreshing the Payment settings page should record `wcadmin_settings_payments_incentive_show` in addition to the pageview event. Accepting the incentive (clicking the "save 10%" button) should record `wcadmin_settings_payments_incentive_accept`. And dismissing (clicking the "no thanks" button) should record `wcadmin_settings_payments_incentive_dismiss`.
5. Click the Enable button for PayPal provider and verify `wcadmin_settings_payments_provider_installed` is recorded after installation of its plugin.
6. Click the Complete Setup button for PayPal and verify `wcadmin_settings_payments_provider_complete_setup_click` is recorded.
7. With WooPayments disabled and deactivated, click its Enable button. You should be redirected to the payment method selection screen. Go back without modifying selection or pressing the Continue button. If you previously did not create a test account, you will see the Complete Setup button. (If you previously created a test account, you will see Enable and Manage buttons. Choose the reset account option from the ellipses menu to delete the test account and show the Complete Setup button). Click it to create a test account (also verify `wcadmin_settings_payments_provider_complete_setup_click` is recorded). Once finished, you will be redirected back to the Payment settings page and shown a "ready to test payments" modal. Click the Continue Store Setup button and verify `wcadmin_settings_payments_continue_store_setup_click` is recorded.
8. Go back to the Payment settings page. You should see the Manage button for WooPayments. Click it and verify that `wcadmin_settings_payments_provider_manage_click` is recorded.
9. Go back to the Payment settings page. From WooPayments' ellipses menu, choose the disable option and verify that `wcadmin_settings_payments_provider_disable_click` and `wcadmin_settings_payments_provider_disable` are recorded.
10. Once WooPayments is disabled, you will see Enable and Manage buttons. This time click WooPayments' Enable button and verify that `wcadmin_settings_payments_provider_enable_click` is recorded.
11. Change the business location from the default United States to something else, say Ukraine. Verify that `wcadmin_settings_payments_business_location_update` is recorded.

<img width="1900" alt="image" src="https://github.com/user-attachments/assets/0cac4bec-a8f2-4cea-a2a0-c748e2a0f9ce" />

##### JurassicNinja

1. Create a new JN site with WooCommerce on this PR's live branch and the WooCommerce Beta Tester plugin (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=add/54673-tracks-events-new-payment-settings))
2. Go to WP Admin > WooCommerce menu item. You will be taken to the WooCommerce profiler. Click "Skip guided setup" and choose `US` as the store's base location country.
3. Go to WooCommerce > Settings > Advanced > WooCommerce.com and turn the `Enable tracking` flag on.
4. Install [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) browser extension and use its log of events.
13. Follow the steps in the Local section above. Instead of browser console, verify that correct events are recorded in Tracks Vigilante.

Note about testing incentive events:

Triggering action incentive is tricky on JN. Follow these steps to trigger switch incentive:

* The Switch incentive has the following eligibility criteria that we need to mimic:
  * store is in a WooPayments-eligibile country
  * store is 90+ days old → use the WC Beta Tester plugin and from Tools > WCA Test Helper > Tools use the “Update WC installation timestamp” option to set a store timestamp more than 90 days in the past
  * store has a PSP enabled (other than WooPayments) → enable an offline payment method
  * store has orders → create a test order (previously import the dummy products)
  * store doesn’t have WooPayments → do not have WooPayments installed.
* Switch the WooCommerce base location to a different country to force a re-fetch.
* To import the dummy products, use the “Import your products” WC onboarding task page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
