### PR TITLE
[dev] CI: disable wp-env debug mode for testing containers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             needs-markdown-validation:
               - '!(.github/**)/**/*.md'
             needs-syncpack-validation:
-              - '(.syncpackrc)|(**/package.json)'
+              - '(.syncpackrc)|(pnpm-lock.yaml)'
 
   project-jobs:
     # Since this is a monorepo, not every pull request or change is going to impact every project.

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -91,7 +91,7 @@
 		"test:e2e:jest:dev": "echo 'test:e2e:jest is no more. Use test:e2e instead.'",
 		"test:e2e:jest:dev-watch": "echo 'test:e2e:jest is no more. Use test:e2e instead.'",
 		"test:e2e:jest:update": "echo 'test:e2e:jest is no more. Use test:e2e instead.'",
-		"env:start": "pnpm --filter='@woocommerce/block-library' wp-env start --debug && ./tests/e2e/bin/test-env-setup.sh",
+		"env:start": "pnpm --filter='@woocommerce/block-library' wp-env start && ./tests/e2e/bin/test-env-setup.sh",
 		"env:restart": "pnpm run wp-env clean all && pnpm run wp-env start && ./tests/e2e/bin/test-env-setup.sh",
 		"env:stop": "pnpm run wp-env stop",
 		"test:help": "wp-scripts test-unit-js --help",

--- a/plugins/woocommerce/changelog/dev-disable-wpenv-debug-for-testing-containers
+++ b/plugins/woocommerce/changelog/dev-disable-wpenv-debug-for-testing-containers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: disable wp-env debug mode for test containers.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -29,7 +29,7 @@
 		"env:start": "pnpm wp-env start",
 		"env:start:blocks": "pnpm --filter='@woocommerce/block-library' env:start && pnpm playwright install chromium --with-deps",
 		"env:stop": "pnpm wp-env stop",
-		"env:test": "pnpm env:dev --debug",
+		"env:test": "pnpm env:dev",
 		"env:perf": "pnpm env:dev && pnpm env:performance-init",
 		"preinstall": "npx only-allow pnpm",
 		"postinstall": "rimraf -g vendor/woocommerce && XDEBUG_MODE=off composer install --quiet",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since we have [the necessary clues](https://github.com/woocommerce/woocommerce/issues/54831#issuecomment-2620879936) for #54831, we are revering debug mode introduced in #54903 and #54926.


### How to test the changes in this Pull Request:

- CI-checks shall pass
