### PR TITLE
Improve order details in plain text emails

### DIFF
--- a/plugins/woocommerce/changelog/54465-plain-text-emails
+++ b/plugins/woocommerce/changelog/54465-plain-text-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve plain text order details under Email Improvements feature

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -12,15 +12,25 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 3.7.0
+ * @version 9.8.0
  */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
 
-/* translators: %1$s: Order ID. %2$s: Order date */
-echo wp_kses_post( wc_strtoupper( sprintf( esc_html__( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
+if ( $email_improvements_enabled ) {
+	/* translators: %1$s: Order ID. %2$s: Order date */
+	echo wp_kses_post( sprintf( esc_html__( 'Order #%1$s (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) . "\n";
+	echo "\n==========\n";
+} else {
+	/* translators: %1$s: Order ID. %2$s: Order date */
+	echo wp_kses_post( wc_strtoupper( sprintf( esc_html__( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
+}
 echo "\n" . wc_get_email_order_items( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	$order,
 	array(

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -53,7 +53,7 @@ if ( $item_totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+	echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
 }
 
 if ( $sent_to_admin ) {

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -21,6 +21,10 @@ defined( 'ABSPATH' ) || exit;
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
+if ( $email_improvements_enabled ) {
+	add_filter( 'woocommerce_order_shipping_to_display_shipped_via', '__return_false' );
+}
+
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
 
 if ( $email_improvements_enabled ) {
@@ -48,7 +52,17 @@ $item_totals = $order->get_order_item_totals();
 
 if ( $item_totals ) {
 	foreach ( $item_totals as $total ) {
-		echo wp_kses_post( $total['label'] . "\t " . $total['value'] ) . "\n";
+		if ( $email_improvements_enabled ) {
+			$label = $total['label'];
+			if ( isset( $total['meta'] ) ) {
+				$label .= ' ' . $total['meta'];
+			}
+			echo wp_kses_post( str_pad( wp_kses_post( $label ), 40 ) );
+			echo ' ';
+			echo esc_html( str_pad( wp_kses( $total['value'], array() ), 20, ' ', STR_PAD_LEFT ) ) . "\n";
+		} else {
+			echo wp_kses_post( $total['label'] . "\t " . $total['value'] ) . "\n";
+		}
 	}
 }
 

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -67,7 +67,11 @@ if ( $item_totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+	if ( $email_improvements_enabled ) {
+		echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+	} else {
+		echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+	}
 }
 
 if ( $sent_to_admin ) {

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -12,12 +12,16 @@
  *
  * @see         https://woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates\Emails\Plain
- * @version     5.2.0
+ * @version     9.8.0
  */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
 foreach ( $items as $item_id => $item ) :
 	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
@@ -30,14 +34,25 @@ foreach ( $items as $item_id => $item ) :
 			$purchase_note = $product->get_purchase_note();
 		}
 
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
-		if ( $show_sku && $sku ) {
-			echo ' (#' . $sku . ')';
+		if ( $email_improvements_enabled ) {
+			$product_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
+			$product_name .= ' × ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
+			echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );
+			echo ' ';
+			echo esc_html( str_pad( wp_kses( $order->get_formatted_line_subtotal( $item ), array() ), 20, ' ', STR_PAD_LEFT ) ) . "\n";
+			if ( $sku ) {
+				echo esc_html( '(#' . $sku . ")\n" );
+			}
+		} else {
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+			if ( $show_sku && $sku ) {
+				echo ' (#' . $sku . ')';
+			}
+			echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
+			echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
+			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-		echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
-		echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
-		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -35,7 +35,23 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		if ( $email_improvements_enabled ) {
+			/**
+			 * Email Order Item Name hook.
+			 *
+			 * @since 2.1.0
+			 * @since 2.4.0 Added $is_visible parameter.
+			 * @param string        $product_name Product name.
+			 * @param WC_Order_Item $item Order item object.
+			 * @param bool          $is_visible Is item visible.
+			 */
 			$product_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
+			/**
+			 * Email Order Item Quantity hook.
+			 *
+			 * @since 2.4.0
+			 * @param int           $quantity Item quantity.
+			 * @param WC_Order_Item $item     Item object.
+			 */
 			$product_name .= ' × ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
 			echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );
 			echo ' ';
@@ -45,10 +61,26 @@ foreach ( $items as $item_id => $item ) :
 			}
 		} else {
 			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			/**
+			 * Email Order Item Name hook.
+			 *
+			 * @since 2.1.0
+			 * @since 2.4.0 Added $is_visible parameter.
+			 * @param string        $product_name Product name.
+			 * @param WC_Order_Item $item Order item object.
+			 * @param bool          $is_visible Is item visible.
+			 */
 			echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
 			if ( $show_sku && $sku ) {
 				echo ' (#' . $sku . ')';
 			}
+			/**
+			 * Email Order Item Quantity hook.
+			 *
+			 * @since 2.4.0
+			 * @param int           $quantity Item quantity.
+			 * @param WC_Order_Item $item     Item object.
+			 */
 			echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
 			echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
 			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/templates/emails/plain/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-items.php
@@ -56,7 +56,7 @@ foreach ( $items as $item_id => $item ) :
 			echo wp_kses_post( str_pad( wp_kses_post( $product_name ), 40 ) );
 			echo ' ';
 			echo esc_html( str_pad( wp_kses( $order->get_formatted_line_subtotal( $item ), array() ), 20, ' ', STR_PAD_LEFT ) ) . "\n";
-			if ( $sku ) {
+			if ( $show_sku && $sku ) {
 				echo esc_html( '(#' . $sku . ")\n" );
 			}
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<img width="634" alt="Screenshot 2025-01-29 at 11 09 42" src="https://github.com/user-attachments/assets/628108ae-b002-4c9e-99a7-1a1894e4c921" />

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Improve order details in plain text emails:
- Unify with the HTML version how the order number and date are rendered.
- Add string padding to align product prices and total prices.
    - Note that while prices are aligned within products and totals, they might not be aligned together. This is because we use [`str_pad()`](https://www.php.net/manual/en/function.str-pad.php) instead of [`mb_str_pad()`](https://www.php.net/manual/en/function.mb-str-pad.php) which was added only in PHP 8.3, and would handle multi-byte strings correctly. I don't think it's worth writing a polyfill in this case. 
- Replace `X` with `×` in item quantity.

Closes #54465.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Email improvements` feature in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. Manage any order-related email.
4. Change the email type to `Plain text`.
5. Observe changes in the email preview.

<!-- End testing instructions -->
