### PR TITLE
Enhancement: Remove yellow background from product category count in block themes

### DIFF
--- a/plugins/woocommerce/changelog/54963-fix-54009-mark-classcount-elements-use-user-agent-stylesheet-when-a-block-theme-is-active
+++ b/plugins/woocommerce/changelog/54963-fix-54009-mark-classcount-elements-use-user-agent-stylesheet-when-a-block-theme-is-active
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enhancement: Remove yellow background from product category count in block themes

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -510,3 +510,10 @@ p.demo_store,
 		color: var(--wp--preset--color--background, $primarytext);
 	}
 }
+
+/**
+* Product category count
+*/
+.woocommerce .product-category mark.count {
+	background-color: transparent;
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54009

This PR improve the appearance of product category counts specifically for block themes. It removes the default highlight background color applied to `<mark class="count">` elements inside `.woocommerce .product-category`. This ensures a more consistent and visually appealing display across block themes, especially those that do not define specific styles for the `<mark>` element. I tried to keep scope of the change as small as possible.

**Why this change?**

- Some block themes, like Twenty Twenty-Four and Twenty Twenty-Five, do not style the `<mark>` element, causing the product category count to appear with an unintended yellow background.
- Resetting the background color to `transparent` aligns the count styling with other text elements and prevents unexpected theme-based variations.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable a block theme like Twenty Twenty-Five.
2. Create a new post
3. Add shortcode `[product_categories]`
4. Publish the post and verify on Frontend that the product category count is not highlighted with a yellow background.
5. Also, verify that this new CSS is not applied to non-block themes.
<img width="852" alt="image" src="https://github.com/user-attachments/assets/3c4560f4-038d-471a-9d3b-575a0610e884" />


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Enhancement: Remove yellow background from product category count in block themes
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
