### PR TITLE
[Experimental] Product Filters: Fix removable chips X icon color not styling with global settings

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/style.scss
@@ -52,7 +52,7 @@
 			margin: 0;
 			display: flex;
 			align-items: center;
-			color: currentColor;
+			color: var(--wc-product-filter-removable-chips-text, currentColor);
 
 			.wc-block-product-filter-removable-chips__remove-icon {
 				fill: currentColor;

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/removable-chips/style.scss
@@ -52,7 +52,11 @@
 			margin: 0;
 			display: flex;
 			align-items: center;
-			fill: var(--wc-product-filter-removable-chips-text, currentColor);
+			color: currentColor;
+
+			.wc-block-product-filter-removable-chips__remove-icon {
+				fill: currentColor;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/changelog/54965-product-filters-fix-removable-chip-color
+++ b/plugins/woocommerce/changelog/54965-product-filters-fix-removable-chip-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: [Experimental] Product Filters: Fix removable chips colors not applying global styles
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/54943

This PR fixes the issue with global styles not applying to the X icon in the Active filter removable chips block.

| Before | After |
|--------|--------|
|![407533195-265de489-ae4c-4c2c-8a92-4ef9738e3b29](https://github.com/user-attachments/assets/b97c2fcb-f7d5-4f41-9f8e-5426eb0f9623) |![Google Chrome - Product Catalog ‹ Template ‹ woo-blocks-dev ‹ Editor — WordPress 2025-01-29 at 6 08 07 AM](https://github.com/user-attachments/assets/c3e9b47b-b7da-455f-978b-f5ece2794d57)| 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Edit the template.
3. With the block inserter, add Product Filters (Experimental) block to the template.
4. Go to the Global Styles->Colors->Text in the inspector controls.
5. Change the text color and ensure you see changes in the Active Filter Chips including the icon.
6. Save and go to the frontend and ensure the colors persisted. (You will need to click on a filter to get the Active filter to show).
7. Back in the editor, now select the Active Filter Chips block.
8. Go to the Styles panel in the inspector controls.
9. Change the Chip text color and ensure you see changes in the Active Filter Chips including the Icon.
10. Save and go to the frontend and ensure the colors persisted. (You will need to click on a filter to get the Active filter to show).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
[Experimental] Product Filters: Fix removable chips colors not applying global styles
</details>
