### PR TITLE
Sync the @wordpress/data and interactivity API cart stores when there is a change in any of them

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/index.ts
@@ -6,6 +6,7 @@ import {
 	subscribe,
 	createReduxStore,
 	dispatch as wpDispatch,
+	select,
 } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 
@@ -62,6 +63,94 @@ window.addEventListener( 'load', () => {
 
 // Pushes changes whenever the store is updated.
 subscribe( pushChanges, store );
+
+// Todo: remove
+function diffObjects( obj1, obj2, path = [] ) {
+	if ( ! obj1 || ! obj2 ) return;
+	const allKeys = new Set( [
+		...Object.keys( obj1 ),
+		...Object.keys( obj2 ),
+	] );
+
+	for ( const key of allKeys ) {
+		const val1 = obj1[ key ];
+		const val2 = obj2[ key ];
+		const currentPath = [ ...path, key ];
+
+		if ( val1 === val2 ) continue; // Values are identical, nothing to log
+
+		if ( ! obj1.hasOwnProperty( key ) ) {
+			console.log(
+				`Added: ${ currentPath.join( '.' ) } - ${ JSON.stringify(
+					val2
+				) }`
+			);
+		} else if ( ! obj2.hasOwnProperty( key ) ) {
+			console.log(
+				`Deleted: ${ currentPath.join( '.' ) } - ${ JSON.stringify(
+					val1
+				) }`
+			);
+		} else if ( typeof val1 === 'object' && typeof val2 === 'object' ) {
+			diffObjects( val1, val2, currentPath ); // Recurse for nested objects
+		} else {
+			console.log(
+				`Modified: ${ currentPath.join(
+					'.'
+				) } - From ${ JSON.stringify( val1 ) } to ${ JSON.stringify(
+					val2
+				) }`
+			);
+		}
+	}
+}
+
+let previousCart = {};
+let id = 0;
+let ignoreUpdate = false;
+
+// Emmits event to sync iAPI store.
+subscribe( () => {
+	const cart = select( STORE_KEY ).getCartData();
+	if ( ! ignoreUpdate && previousCart !== cart ) {
+		console.groupCollapsed(
+			`Cart sync started on the @wordpress/data store: data-${ ++id }`
+		);
+		// Todo: check why there are multiple updates of the cart on page load.
+		diffObjects( previousCart, cart );
+		console.groupEnd();
+
+		window.dispatchEvent(
+			// Question: What are the usual names for WooCommerce events?
+			new CustomEvent( 'woocommerce-cart-sync-required', {
+				detail: { type: 'from_@wordpress/data', id },
+			} )
+		);
+
+		previousCart = cart;
+	}
+}, store );
+
+// Listens to cart sync events from the iAPI store.
+window.addEventListener(
+	'woocommerce-cart-sync-required',
+	async ( event: Event ) => {
+		const customEvent = event as CustomEvent< {
+			type: string;
+			id: number;
+		} >;
+		if ( customEvent.detail.type === 'from_iAPI' ) {
+			console.log(
+				`Cart sync received on the @wordpress/data store: iapi-${ customEvent.detail.id }`
+			);
+
+			// Todo: investigate how to avoid infinite loops without causing racing conditions.
+			ignoreUpdate = true;
+			await wpDispatch( store ).syncCartWithIAPIStore();
+			ignoreUpdate = false;
+		}
+	}
+);
 
 // This will skip the debounce and immediately push changes to the server when a field is blurred.
 document.body.addEventListener( 'focusout', ( event: FocusEvent ) => {

--- a/plugins/woocommerce-blocks/assets/js/data/cart/resolvers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/resolvers.ts
@@ -41,7 +41,7 @@ export const getCartData =
 					return;
 				}
 
-				receiveCart( cartData );
+				receiveCart( cartData, { sync: false } );
 			} )
 			.catch( () => {
 				const { receiveError } = dispatch;

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -136,6 +136,30 @@ export const applyExtensionCartUpdate =
 	};
 
 /**
+ * Syncs the cart with the iAPI store.
+ *
+ * @throws Will throw an error if there is an API problem.
+ */
+export const syncCartWithIAPIStore =
+	() =>
+	async ( { dispatch }: CartThunkArgs ) => {
+		try {
+			const { response } = await apiFetchWithHeaders< {
+				response: CartResponse;
+			} >( {
+				path: '/wc/store/v1/cart',
+				method: 'GET',
+				cache: 'no-store',
+			} );
+			dispatch.receiveCart( response );
+			return response;
+		} catch ( error ) {
+			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
+			return Promise.reject( error );
+		}
+	};
+
+/**
  * Applies a coupon code and either invalidates caches, or receives an error if
  * the coupon cannot be applied.
  *

--- a/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/thunks.ts
@@ -29,7 +29,11 @@ import { cartStore } from '@woocommerce/block-data';
 import { notifyQuantityChanges } from './notify-quantity-changes';
 import { updateCartErrorNotices } from './notify-errors';
 import { apiFetchWithHeaders } from '../shared-controls';
-import { getIsCustomerDataDirty, setIsCustomerDataDirty } from './utils';
+import {
+	getIsCustomerDataDirty,
+	setIsCustomerDataDirty,
+	setIgnoreSync,
+} from './utils';
 
 interface CartThunkArgs {
 	select: CurriedSelectorsOf< typeof cartStore >;
@@ -41,14 +45,16 @@ interface CartThunkArgs {
  * of any unexpected quantity changes occurred.
  */
 export const receiveCart =
-	( response: Partial< CartResponse > ) =>
+	( response: Partial< CartResponse >, options?: { sync?: boolean } ) =>
 	( { dispatch, select }: CartThunkArgs ) => {
 		const cartResponse = camelCaseKeys( response ) as unknown as Cart;
 		const oldCart = select.getCartData();
 		const oldCartErrors = [ ...oldCart.errors, ...select.getCartErrors() ];
 
 		// Set data from the response.
-		dispatch.setCartData( cartResponse );
+		if ( options?.sync === false ) setIgnoreSync( true );
+		dispatch.setCartData( cartResponse, options );
+		if ( options?.sync === false ) setIgnoreSync( false );
 
 		// Get the new cart data before showing updates.
 		const newCart = select.getCartData();
@@ -151,7 +157,7 @@ export const syncCartWithIAPIStore =
 				method: 'GET',
 				cache: 'no-store',
 			} );
-			dispatch.receiveCart( response );
+			dispatch.receiveCart( response, { sync: false } );
 			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );

--- a/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
@@ -140,3 +140,12 @@ export const setIsCustomerDataDirty = debounce(
 	},
 	300
 );
+
+/**
+ * Controls whether to ignore sync events.
+ */
+let ignoreSync = false;
+export const setIgnoreSync = ( value: boolean ) => {
+	ignoreSync = value;
+};
+export const getIgnoreSync = () => ignoreSync;

--- a/plugins/woocommerce-blocks/assets/js/interactivity/index.js
+++ b/plugins/woocommerce-blocks/assets/js/interactivity/index.js
@@ -11,6 +11,7 @@ export { directive, getContext, getElement } from './hooks';
 export { navigate, prefetch } from './router';
 export { h as createElement } from 'preact';
 export { useEffect, useContext, useMemo } from 'preact/hooks';
+export { effect } from '@preact/signals';
 export { deepSignal } from 'deepsignal';
 
 document.addEventListener( 'DOMContentLoaded', async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is still very preliminary.

The idea of this pull request is to synchronize the store created with the `@wordpress/data` package with the new store of the Interactivity API. So that when there are changes in one, the other store reconciles itself by making a new request to the Store API to update its internal state.

There are several ways to synchronize both stores:

1.  Observe the state to monitor when it changes and trigger the event.
3. Create a middleware that emits the event when an action is emitted from a specific list of actions that modify the state.
4.  Trigger the event within the actions that modify the state.

For now, I have tried to make it work by synchronizing any change in the state since, if we can make it work like that, it would be the most solid way.

It is also necessary to find a mechanism to prevent infinite loops to ensure that the synchronization of one of the stores does not trigger the synchronization event of the other store. Right now, I'm using a variable that ignores any change in the state while a synchronization is taking place. However, I'm not sure that it's the best solution because that could cause other changes that occur in between to be ignored.

Finally, it is necessary to investigate what happens when the page is loaded, since both stores make a request to the Store API to update their state and, in theory, it would be good to ignore these changes. This also means that it would be good to start thinking about how to better organize the store of the Interactivity API in this regard because right now this initial synchronization is being delegated to the blocks, and maybe it's something it should do on its own.

Closes #54501.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Basically, adding products to the cart with the Product Button block and checking that they are correctly updated in the Minicart block or vice versa. But I will update these instructions when I move forward with the implementation and the Pull Request is ready to review.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
