### PR TITLE
Product Gallery: fix E2E flaky test

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -334,68 +334,6 @@ test.describe( `${ blockData.name }`, () => {
 				} );
 
 			expect( popUpSelectedImageId ).toBe( nextImageId );
-		} );
-
-		test( 'if available, should display the same image when pop-up is closed', async ( {
-			page,
-			editor,
-			pageObject,
-		} ) => {
-			await pageObject.addProductGalleryBlock( { cleanContent: true } );
-
-			await editor.saveSiteEditorEntities( {
-				isOnlyCurrentEntityDirty: true,
-			} );
-
-			await page.goto( blockData.productPage );
-
-			const largeImageBlock = await pageObject.getMainImageBlock( {
-				page: 'frontend',
-			} );
-			const initialVisibleLargeImageId = await getVisibleLargeImageId(
-				largeImageBlock
-			);
-
-			const secondImageThumbnailId = await getThumbnailImageIdByNth(
-				1,
-				await pageObject.getThumbnailsBlock( {
-					page: 'frontend',
-				} )
-			);
-
-			expect( initialVisibleLargeImageId ).not.toBe(
-				secondImageThumbnailId
-			);
-
-			const nextButton = page
-				.locator(
-					'.wc-block-product-gallery-large-image-next-previous--button'
-				)
-				.nth( 1 );
-			await nextButton.click();
-
-			const imageAfterClickingNextButton = await getVisibleLargeImageId(
-				largeImageBlock
-			);
-
-			expect( imageAfterClickingNextButton ).toBe(
-				secondImageThumbnailId
-			);
-
-			await largeImageBlock.click();
-
-			const popUpInitialSelectedImageId =
-				await pageObject.getActiveElementImageId( {
-					page,
-				} );
-
-			await page.keyboard.press( 'Tab' );
-
-			const popUpNextImageId = await pageObject.getActiveElementImageId( {
-				page,
-			} );
-
-			expect( popUpInitialSelectedImageId ).not.toBe( popUpNextImageId );
 
 			const closePopUpButton = page.locator(
 				'.wc-block-product-gallery-dialog__close-button'
@@ -406,7 +344,7 @@ test.describe( `${ blockData.name }`, () => {
 				largeImageBlock
 			);
 
-			expect( singleProductImageId ).toBe( popUpNextImageId );
+			expect( singleProductImageId ).toBe( nextImageId );
 		} );
 	} );
 

--- a/plugins/woocommerce/changelog/fix-product-gallery-e2e-flaky-test
+++ b/plugins/woocommerce/changelog/fix-product-gallery-e2e-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix E2E flaky test, not worth mentioning in changelog
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/54803 the feature to keep the "full page" and "small" galleries in sync was removed. Hence the "small" gallery shows the same image no matter the interactions in "full page" gallery.

Flaky test was testing this feature that was removed and it's been passing accidentally. I removed the test and extended existing one with additional check that tests closing the dialog.

<img width="1562" alt="image" src="https://github.com/user-attachments/assets/133d20be-c0cf-41cc-a5a6-96e34ca49139" />

Closes https://github.com/woocommerce/woocommerce/issues/54933

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI should pass with no flaky test in `CI / Blocks e2e tests 8/10`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
