### PR TITLE
Fix PHP warning 'Undefined array key "cost" [...]'

### DIFF
--- a/plugins/woocommerce/changelog/55004-fix-prevent-undefined-key-cost
+++ b/plugins/woocommerce/changelog/55004-fix-prevent-undefined-key-cost
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure the `cost` key is always present in `get_local_pickup_settings` to prevent PHP warnings in the Checkout block.

--- a/plugins/woocommerce/src/StoreApi/Utilities/LocalPickupUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/LocalPickupUtils.php
@@ -31,6 +31,10 @@ class LocalPickupUtils {
 			$pickup_location_settings['enabled'] = 'no';
 		}
 
+		if ( ! isset( $pickup_location_settings['cost'] ) ) {
+			$pickup_location_settings['cost'] = '';
+		}
+
 		// Return settings as is if we're editing them.
 		if ( 'edit' === $context ) {
 			return $pickup_location_settings;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In p1738172568380129-slack-C8X6Q7XQU, @gigitux reported the following PHP warning (when using `PHP 8.2.23`):

```
[29-Jan-2025 17:39:07 UTC] PHP Warning:  Undefined array key "cost" in /Users/gigitux/work/woocommerce/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php on line 438
```

This issue occurs when enabling Local Pickups via `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location`. The `get_local_pickup_settings` option should store a value similar to:

```js
{s:7:"enabled";s:3:"yes";s:5:"title";s:6:"Pickup";s:10:"tax_status";s:7:"taxable";s:4:"cost";s:0:"";}
```

However, in @gigitux’s case, the `cost` key was missing:

```js
a:2:{s:7:"enabled";s:2:"no";s:5:"title";s:0:"";}
```

This PR adds a safeguard to ensure that the `cost` key is always present in `get_local_pickup_settings`. If the key is missing, it is automatically added with an empty string as its default value, preventing PHP warnings.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Local Pickups.
2. Open the database table `{prefix}_options`.
3. Locate the option `get_local_pickup_settings` and manually remove the `cost` key from its serialized value. 
4. Open the page that contains the Checkout block.
5. Toggle between `Ship` and `Pickup`.
7. Check the debug logs in `wp-content/debug.log`. 
8. Verify that the following PHP warning no longer appears:

```
Undefined array key "cost" in /Users/gigitux/work/woocommerce/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php on line 438
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure the `cost` key is always present in `get_local_pickup_settings` to prevent PHP warnings in the Checkout block.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>