### PR TITLE
[e2e tests] Remove left over Playwright project from main config file

### DIFF
--- a/plugins/woocommerce/changelog/e2e-clean-up-hpos-disabled-pw-project
+++ b/plugins/woocommerce/changelog/e2e-clean-up-hpos-disabled-pw-project
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: clean up left over HPOS disabled project in main config file

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -2,10 +2,6 @@
  * External dependencies
  */
 import { defineConfig, devices } from '@playwright/test';
-/**
- * Internal dependencies
- */
-import { tags } from './fixtures/fixtures';
 
 require( 'dotenv' ).config( { path: __dirname + '/.env' } );
 
@@ -137,10 +133,6 @@ export default defineConfig( {
 			name: 'api',
 			testMatch: '**/api-tests/**',
 			dependencies: [ 'site setup' ],
-		},
-		{
-			name: 'e2e-hpos-disabled',
-			grep: new RegExp( tags.HPOS ),
 		},
 	],
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove the HPOS disabled Playwright project from the main config file. It was supposed to be removed by https://github.com/woocommerce/woocommerce/pull/54934 but it was missed.

### How to test the changes in this Pull Request:

Not much to test, if CI is green we should be good.