### PR TITLE
[dev] CI: skip changelog-auto-add.yml jobs if PR description doesn't request it.

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
     add-changelog:
         name: 'Add changelog to PR'
-        if: ${{ github.event.pull_request.user.login != 'github-actions[bot]' }}
+        if: ${{ github.event.pull_request.user.login != 'github-actions[bot]' && ( github.event_name != 'pull_request_target' || contains( github.event.pull_request.body, '[x] Automatically create a changelog' ) ) }}
         runs-on: ubuntu-20.04
         permissions:
             contents: write


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure the workflow is skipped if the corresponding checkbox is missing or not made in the PR description.

### How to test the changes in this Pull Request:

- Test runs: [unchecked](https://github.com/woocommerce/woocommerce/actions/runs/13054253686/job/36421324559?pr=55018), [checked](https://github.com/woocommerce/woocommerce/actions/runs/13054276434/job/36421398908?pr=55018), [missing](https://github.com/woocommerce/woocommerce/actions/runs/13054300053/job/36421477622?pr=55018)
