### PR TITLE
[Experimental] Fix /wp-json/wc/store/v1/products/{productId} API to return the grouped products ids when the product type is grouped

### DIFF
--- a/plugins/woocommerce/changelog/add-54784
+++ b/plugins/woocommerce/changelog/add-54784
@@ -1,0 +1,3 @@
+Significance: patch
+Type: add
+Comment: Add to the /wc/store/v1/products/{productId} API a feature that returns the grouped product ids when the product type is grouped

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -148,6 +148,32 @@ class WC_Product_Grouped extends WC_Product {
 		return $this->get_prop( 'children', $context );
 	}
 
+	/**
+	 * Return the product's children - visible only.
+	 *
+	 * @since 9.8.0
+	 * @return array Child products
+	 */
+	public function get_visible_children() {
+		$grouped_products = array_map( 'wc_get_product', $this->get_children() );
+		return array_filter( $grouped_products, 'wc_products_array_filter_visible_grouped' );
+	}
+
+	/**
+	 * Return the product's child ids - visible only.
+	 *
+	 * @since 9.8.0
+	 * @return array Child ids
+	 */
+	public function get_visible_child_ids() {
+		return array_map(
+			function ( $grouped_product ) {
+				return $grouped_product->get_id();
+			},
+			$this->get_visible_children(),
+		);
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Setters

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -159,21 +159,6 @@ class WC_Product_Grouped extends WC_Product {
 		return array_filter( $grouped_products, 'wc_products_array_filter_visible_grouped' );
 	}
 
-	/**
-	 * Return the product's child ids - visible only.
-	 *
-	 * @since 9.8.0
-	 * @return array Child ids
-	 */
-	public function get_visible_child_ids() {
-		return array_map(
-			function ( $grouped_product ) {
-				return $grouped_product->get_id();
-			},
-			$this->get_visible_children(),
-		);
-	}
-
 	/*
 	|--------------------------------------------------------------------------
 	| Setters

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -362,6 +362,17 @@ class ProductSchema extends AbstractSchema {
 					],
 				],
 			],
+			'grouped_products'    => [
+				'description' => __( 'List of grouped product IDs, if applicable.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'description' => __( 'List of grouped product ids.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+			],
 			'has_options'         => [
 				'description' => __( 'Does the product have additional options before it can be added to the cart?', 'woocommerce' ),
 				'type'        => 'boolean',
@@ -496,6 +507,7 @@ class ProductSchema extends AbstractSchema {
 			'tags'                => $this->get_term_list( $product, 'product_tag' ),
 			'attributes'          => $this->get_attributes( $product ),
 			'variations'          => $this->get_variations( $product ),
+			'grouped_products'    => $this->get_grouped_products( $product ),
 			'has_options'         => $product->has_options(),
 			'is_purchasable'      => $product->is_purchasable(),
 			'is_in_stock'         => $product->is_in_stock(),
@@ -689,6 +701,16 @@ class ProductSchema extends AbstractSchema {
 	}
 
 	/**
+	 * Get grouped product IDs.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return array
+	 */
+	protected function get_grouped_products( \WC_Product $product ) {
+		return $product->is_type( ProductType::GROUPED ) ? $product->get_visible_child_ids() : [];
+	}
+
+	/**
 	 * Get list of product attributes and attribute terms.
 	 *
 	 * @param \WC_Product $product Product instance.
@@ -826,7 +848,7 @@ class ProductSchema extends AbstractSchema {
 		}
 
 		if ( $product->is_type( ProductType::GROUPED ) ) {
-			$children       = array_filter( array_map( 'wc_get_product', $product->get_children() ), 'wc_products_array_filter_visible_grouped' );
+			$children       = $product->get_visible_children();
 			$price_function = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 
 			foreach ( $children as $child ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -707,7 +707,15 @@ class ProductSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_grouped_products( \WC_Product $product ) {
-		return $product->is_type( ProductType::GROUPED ) ? $product->get_visible_child_ids() : [];
+		if ( $product->is_type( ProductType::GROUPED ) ) {
+			return array_map(
+				function ( $child ) {
+					return $child->get_id();
+				},
+				$product->get_visible_children(),
+			);
+		}
+		return [];
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
@@ -89,26 +89,26 @@ class FixtureData {
 			)
 		);
 
-		$children = [];
+		$children   = array();
 		$children[] = $this->get_simple_product(
 			array(
-				'name'              => 'Child Product 1',
-				'stock_status'      => 'instock',
-				'regular_price'     => 10,
+				'name'          => 'Child Product 1',
+				'stock_status'  => 'instock',
+				'regular_price' => 10,
 			)
 		)->get_id();
 		$children[] = $this->get_simple_product(
 			array(
-				'name'              => 'Child Product 2',
-				'stock_status'      => 'instock',
-				'regular_price'     => 9,
+				'name'          => 'Child Product 2',
+				'stock_status'  => 'instock',
+				'regular_price' => 9,
 			)
 		)->get_id();
 		$children[] = $this->get_simple_product(
 			array(
-				'name'              => 'Child Product 3',
-				'stock_status'      => 'instock',
-				'regular_price'     => 10,
+				'name'          => 'Child Product 3',
+				'stock_status'  => 'instock',
+				'regular_price' => 10,
 			)
 		)->get_id();
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
@@ -73,6 +73,52 @@ class FixtureData {
 	}
 
 	/**
+	 * Create a grouped product and return the result.
+	 *
+	 * @param array $props Product props.
+	 * @return \WC_Product
+	 */
+	public function get_grouped_product( $props ) {
+		$product = new \WC_Product_Grouped();
+		$product->set_props(
+			wp_parse_args(
+				$props,
+				array(
+					'name' => 'Grouped Product',
+				)
+			)
+		);
+
+		$children = [];
+		$children[] = $this->get_simple_product(
+			array(
+				'name'              => 'Child Product 1',
+				'stock_status'      => 'instock',
+				'regular_price'     => 10,
+			)
+		)->get_id();
+		$children[] = $this->get_simple_product(
+			array(
+				'name'              => 'Child Product 2',
+				'stock_status'      => 'instock',
+				'regular_price'     => 9,
+			)
+		)->get_id();
+		$children[] = $this->get_simple_product(
+			array(
+				'name'              => 'Child Product 3',
+				'stock_status'      => 'instock',
+				'regular_price'     => 10,
+			)
+		)->get_id();
+
+		$product->set_children( $children );
+		$product->save();
+
+		return wc_get_product( $product->get_id() );
+	}
+
+	/**
 	 * Create and return a variation of a product.
 	 *
 	 * @param integer $parent_id Parent product ID.

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -41,6 +41,7 @@ class Products extends ControllerTestCase {
 					'image_id'      => $fixtures->sideload_image(),
 				)
 			),
+			$fixtures->get_grouped_product( array() ),
 		);
 	}
 
@@ -66,10 +67,29 @@ class Products extends ControllerTestCase {
 		$this->assertEquals( $this->products[0]->add_to_cart_text(), $data['add_to_cart']->text );
 		$this->assertEquals( $this->products[0]->add_to_cart_description(), $data['add_to_cart']->description );
 		$this->assertEquals( $this->products[0]->is_on_sale(), $data['on_sale'] );
+		$this->assertCount( 0, $data['grouped_products'] );
 
 		$this->assertCount( 1, $data['images'] );
 		$this->assertIsObject( $data['images'][0] );
 		$this->assertEquals( $this->products[0]->get_image_id(), $data['images'][0]->id );
+	}
+
+	/**
+	 * Test get grouped product.
+	 */
+	public function test_grouped_product() {
+		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->products[2]->get_id() ) );
+		$data     = $response->get_data();
+
+		$grouped_product_ids = $this->products[2]->get_visible_child_ids();
+		$total_ids = count( $grouped_product_ids );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( $total_ids, $data['grouped_products'] );
+
+		for ( $index = 0; $index < $total_ids; $index++ ) {
+			$this->assertEquals( $grouped_product_ids[ $index ], $data['grouped_products'][ $index ] );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -82,7 +82,7 @@ class Products extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$grouped_product_ids = $this->products[2]->get_visible_child_ids();
-		$total_ids = count( $grouped_product_ids );
+		$total_ids           = count( $grouped_product_ids );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( $total_ids, $data['grouped_products'] );
@@ -100,7 +100,7 @@ class Products extends ControllerTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( 6, count( $data ) );
 		$this->assertArrayHasKey( 'id', $data[0] );
 		$this->assertArrayHasKey( 'name', $data[0] );
 		$this->assertArrayHasKey( 'variation', $data[0] );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -81,7 +81,12 @@ class Products extends ControllerTestCase {
 		$response = rest_get_server()->dispatch( new \WP_REST_Request( 'GET', '/wc/store/v1/products/' . $this->products[2]->get_id() ) );
 		$data     = $response->get_data();
 
-		$grouped_product_ids = $this->products[2]->get_visible_child_ids();
+		$grouped_product_ids = array_map(
+			function ( $child ) {
+				return $child->get_id();
+			},
+			$this->products[2]->get_visible_children(),
+		);
 		$total_ids           = count( $grouped_product_ids );
 
 		$this->assertEquals( 200, $response->get_status() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #54784

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Go to WooCommerce Admin Test Helper > Features and enable experimental-blocks and blockified-add-to-cart.
3. Go to Appearance > Editor > Templates > Single Product, select the Add to Cart with Options block and update it to the blockified one.
4. Select the Add to Cart block and choose the Grouped product type from the product type selector.
5. Since in this template the add to cart block sets a mock product then the grouped products listed in the form are the first 3 returned by the products endpoint.
6. Then create a new post
7. Add the single product block
8. Select a grouped product
9. Make sure the grouped products listed in the form are the right ones associated with the parent product.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
