### PR TITLE
[Experimental] Product Filters: Add 100% width in editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/editor.scss
@@ -24,3 +24,7 @@ $blue: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 		}
 	}
 }
+
+.wc-block-product-filters__overlay {
+	width: 100%;
+}

--- a/plugins/woocommerce/changelog/55025-product-filters-fix-width-in-editor
+++ b/plugins/woocommerce/changelog/55025-product-filters-fix-width-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix the width of product filters in the editor
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a width issue in the editor where it is not using 100% of the width when it should.

| Before | After |
|--------|--------|
|![Google Chrome - Product Catalog ‹ Template ‹ woo-blocks-dev ‹ Editor — WordPress 2025-01-30 at 12 26 34 PM](https://github.com/user-attachments/assets/ab80c4fb-584d-439e-8f5f-44d52bdaa399)|![Google Chrome - Product Catalog ‹ Template ‹ woo-blocks-dev ‹ Editor — WordPress 2025-01-30 at 12 28 15 PM](https://github.com/user-attachments/assets/402f29e3-0b87-42fe-9b2d-3c1cd4b98b78)|
 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Edit the template.
3. With the block inserter, add Product Filters (Experimental) block to the template on top of the product collection block.
4. Select the Product Filters (Experimental) block and set it to Wide Width alignment.
5. Add a row block inside the Product Filters (Experimental) block after the Active (Experimental) block.
6. Drag the filters Price, Rating, Attribute and Status into the row block you create above.
7. Select the row block and set the justification to "Space between items".
8. Ensure you see that the individual filter blocks are correctly space out to the "wide width" limits.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
[Experimental] Product Filters: Fix width not 100% in the editor.
</details>
