### PR TITLE
Fix text alignment setting

### DIFF
--- a/plugins/woocommerce/changelog/fix-55012
+++ b/plugins/woocommerce/changelog/fix-55012
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Text Align: handle manual attributes (legacy approach) and global styles setting

--- a/plugins/woocommerce/src/Blocks/Utils/StyleAttributesUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/StyleAttributesUtils.php
@@ -604,9 +604,12 @@ class StyleAttributesUtils {
 	 * @return array
 	 */
 	public static function get_text_align_class_and_style( $attributes ) {
-		if ( isset( $attributes['textAlign'] ) ) {
+		// Check if the text align is set in the attributes manually (legacy) or in the global styles.
+		$text_align = $attributes['textAlign'] ?? $attributes['style']['typography']['textAlign'] ?? null;
+
+		if ( $text_align ) {
 			return array(
-				'class' => 'has-text-align-' . $attributes['textAlign'],
+				'class' => 'has-text-align-' . $text_align,
 				'style' => null,
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/Utils/StyleAttributesUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/StyleAttributesUtils.php
@@ -604,13 +604,12 @@ class StyleAttributesUtils {
 	 * @return array
 	 */
 	public static function get_text_align_class_and_style( $attributes ) {
-		if ( isset( $attributes['style']['typography']['textAlign'] ) ) {
+		if ( isset( $attributes['textAlign'] ) ) {
 			return array(
-				'class' => 'has-text-align-' . $attributes['style']['typography']['textAlign'],
+				'class' => 'has-text-align-' . $attributes['textAlign'],
 				'style' => null,
 			);
 		}
-
 		return self::EMPTY_STYLE;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/54570 I accidentally introduced the bug that affected other blocks than Product Gallery, specifically [in here](https://github.com/woocommerce/woocommerce/pull/54570/files#diff-096d39036a524a529e5740d95c1c41474ca6e0770fa8234417d3cd4b3b9d2776):

I changed the mapping from `attributes` to CSS class for text alignment assuming we should account for global styles and that there was a bug. However, there are blocks like Product Price (and others) that uses "manual" legacy approach by using direct attribute.

This PR fixes it by taking into account:
- legacy approach `$attributes['textAlign']`
- global styles settings `$attributes['style']['typography']['textAlign']`

Closes https://github.com/woocommerce/woocommerce/issues/55012

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### "Legacy" attribute

1. Go to /shop, make sure Product Price is centred
2. Go to Editor > Product Catalog
3. Change the alignment of Product Price block
4. Save and go to frontend
5. **Expected:** Make sure it's respected 

#### Global Styles

1. Go to the Editor > Single Product template.
2. Replace the Product Image Gallery block with the Product Gallery (beta) block.
3. Set “Stretch Items” justification on the “Large Image and Navigation” block

![image](https://github.com/user-attachments/assets/a64ffd15-68ad-4a95-b7b3-7646a0964956)

5. Change alignment option of Pager block

<img width="935" alt="image" src="https://github.com/user-attachments/assets/27dd51e1-62a2-4236-90da-318598895fb7" />

7. **Expected:** Make sure it's respected 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
