### PR TITLE
[e2e tests] Remove DEFAULT_TIMEOUT_OVERRIDE support

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-timeout-override-env-variable
+++ b/plugins/woocommerce/changelog/e2e-remove-timeout-override-env-variable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: remove support for DEFAULT_TIMEOUT_OVERRIDE environment variable

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -54,14 +54,7 @@ Other ways of running tests (make sure you are in the `plugins/woocommerce` fold
 - `pnpm test:e2e --debug` (runs tests in debug mode)
 - `pnpm test:e2e basic.spec.js` (runs a single test file - `basic.spec.js` in this case)
 - `pnpm test:e2e ./tests/e2e-pw/tests/merchant` (runs all tests that are found in the `merchant` folder)
-- `pnpm test:e2e --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode)). You may need
-  to increase the [test timeout](https://playwright.dev/docs/api/class-testconfig#test-config-timeout) by setting
-  the `DEFAULT_TIMEOUT_OVERRIDE` environment variable like so:
-
-    ```bash
-    # Increase test timeout to 3 minutes
-    export DEFAULT_TIMEOUT_OVERRIDE=180000 pnpm test:e2e --ui
-    ```
+- `pnpm test:e2e --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode)).
 
 To see all the Playwright options, make sure you are in the `plugins/woocommerce` folder and
 run `pnpm playwright test --help`

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -10,14 +10,8 @@ if ( ! process.env.BASE_URL ) {
 	process.env.BASE_URL = 'http://localhost:8086';
 }
 
-const {
-	ALLURE_RESULTS_DIR,
-	BASE_URL,
-	CI,
-	DEFAULT_TIMEOUT_OVERRIDE,
-	E2E_MAX_FAILURES,
-	REPEAT_EACH,
-} = process.env;
+const { ALLURE_RESULTS_DIR, BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } =
+	process.env;
 
 export const TESTS_ROOT_PATH = __dirname;
 export const TESTS_RESULTS_PATH = `${ TESTS_ROOT_PATH }/test-results`;
@@ -94,9 +88,7 @@ export const setupProjects = [
 ];
 
 export default defineConfig( {
-	timeout: DEFAULT_TIMEOUT_OVERRIDE
-		? Number( DEFAULT_TIMEOUT_OVERRIDE )
-		: 120 * 1000,
+	timeout: 120 * 1000,
 	expect: { timeout: 20 * 1000 },
 	outputDir: TESTS_RESULTS_PATH,
 	testDir: `${ TESTS_ROOT_PATH }/tests`,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/55057

Remove the support for `DEFAULT_TIMEOUT_OVERRIDE` environment variable in Playwright main config.

### How to test the changes in this Pull Request:

CI green.
