### PR TITLE
Add sale price before regular price in structured data

### DIFF
--- a/plugins/woocommerce/changelog/fix-55043-sale-price-before-regular-price
+++ b/plugins/woocommerce/changelog/fix-55043-sale-price-before-regular-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add sale price before regular price in structured data to better SEO

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -336,12 +336,17 @@ class WC_Structured_Data {
 						$sale_price_valid_until = gmdate( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
 					}
 
-					$markup_offer['priceSpecification'][] = array(
-						'@type'                 => 'UnitPriceSpecification',
-						'price'                 => wc_format_decimal( $min_sale_price, wc_get_price_decimals() ),
-						'priceCurrency'         => $currency,
-						'valueAddedTaxIncluded' => wc_prices_include_tax(),
-						'validThrough'          => $sale_price_valid_until ?? $price_valid_until,
+					// We add the sale price to the top of the array so it's the first offer.
+					// See https://github.com/woocommerce/woocommerce/issues/55043.
+					array_unshift(
+						$markup_offer['priceSpecification'],
+						array(
+							'@type'                 => 'UnitPriceSpecification',
+							'price'                 => wc_format_decimal( $min_sale_price, wc_get_price_decimals() ),
+							'priceCurrency'         => $currency,
+							'valueAddedTaxIncluded' => wc_prices_include_tax(),
+							'validThrough'          => $sale_price_valid_until ?? $price_valid_until,
+						)
 					);
 				}
 			} else {
@@ -369,12 +374,17 @@ class WC_Structured_Data {
 						$sale_price_valid_until = gmdate( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
 					}
 
-					$markup_offer['priceSpecification'][] = array(
-						'@type'                 => 'UnitPriceSpecification',
-						'price'                 => wc_format_decimal( $product->get_sale_price(), wc_get_price_decimals() ),
-						'priceCurrency'         => $currency,
-						'valueAddedTaxIncluded' => wc_prices_include_tax(),
-						'validThrough'          => $sale_price_valid_until ?? $price_valid_until,
+					// We add the sale price to the top of the array so it's the first offer.
+					// See https://github.com/woocommerce/woocommerce/issues/55043.
+					array_unshift(
+						$markup_offer['priceSpecification'],
+						array(
+							'@type'                 => 'UnitPriceSpecification',
+							'price'                 => wc_format_decimal( $product->get_sale_price(), wc_get_price_decimals() ),
+							'priceCurrency'         => $currency,
+							'valueAddedTaxIncluded' => wc_prices_include_tax(),
+							'validThrough'          => $sale_price_valid_until ?? $price_valid_until,
+						)
 					);
 				}
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

See https://github.com/woocommerce/woocommerce/issues/55043 for more details. For some reason, it seems like Yandex didn't like the changes we introduced in https://github.com/woocommerce/woocommerce/pull/52105 and https://github.com/woocommerce/woocommerce/pull/52871. I suspect it might be because when there is a regular price and a sale price, we print the sale price as the second one.

Printing the sale price first, would also make us aligned with Google's example:

https://developers.google.com/search/docs/appearance/structured-data/merchant-listing#sale-pricing-example

Closes #55043.

### How to test the changes in this Pull Request:

1. Create a simple product with a sale. Go to the frontend and copy and paste the page source code.
2. Paste it in https://search.google.com/test/rich-results and verify the price info is correct (you need to click on Product Snippet to see the product data; you might see some errors due to missing reviews, shipping details, hasMerchantReturnPolicy or the image not being accessible by Google, but that's unrelated :slightly_smiling_face: ): 
![imatge](https://github.com/user-attachments/assets/b77f8c00-78e2-465d-b17a-89b2c1651ed0)
3. Paste it in https://validator.schema.org/ and verify the price info is also correct:
![imatge](https://github.com/user-attachments/assets/071c4874-6489-4891-92fb-6275d8b556ef)
4. Repeat steps 1-3 with a Grouped product on sale. Keep in mind that you will need the sale price of one of the products inside the grouped product to be the lowest. For example, if product A has price $18, product B (the one on sale) needs to be lower than $18 (ie ~$20~ $17).

![imatge](https://github.com/user-attachments/assets/341a7dba-62ee-474e-989f-3694b386000a)