### PR TITLE
[e2e tests] Improve create-shipping-spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-improve-create-shipping-zones-spec
+++ b/plugins/woocommerce/changelog/e2e-improve-create-shipping-zones-spec
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: improve create-shipping-zones spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -320,8 +320,6 @@ test.describe(
 						.getByLabel( 'Close Tour' )
 						.click( { timeout: 5000 } ); // close the tour if visible
 				} catch ( e ) {}
-
-				await page.reload(); // Playwright runs so fast, the location shows up as "Everywhere" at first
 			}
 			await expect( page.locator( '.wc-shipping-zones' ) ).toHaveText(
 				/USA Zone.*/

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -115,7 +115,6 @@ test.describe(
 				await page.goto(
 					'wp-admin/admin.php?page=wc-settings&tab=shipping'
 				);
-				await page.reload(); // Playwright runs so fast, the location shows up as "Everywhere" at first
 			}
 
 			await expect( page.locator( '.wc-shipping-zones' ) ).toHaveText(
@@ -187,7 +186,6 @@ test.describe(
 				await page.goto(
 					'wp-admin/admin.php?page=wc-settings&tab=shipping'
 				);
-				await page.reload(); // Playwright runs so fast, the location shows up as "Everywhere" at first
 			}
 			await expect( page.locator( '.wc-shipping-zones' ) ).toHaveText(
 				/BC with Free shipping.*/
@@ -264,7 +262,6 @@ test.describe(
 				await page.goto(
 					'wp-admin/admin.php?page=wc-settings&tab=shipping'
 				);
-				await page.reload(); // Playwright runs so fast, the location shows up as "Everywhere" at first
 			}
 			await expect( page.locator( '.wc-shipping-zones' ) ).toHaveText(
 				/Canada with Flat rate*/

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -314,12 +314,6 @@ test.describe(
 				await page.goto(
 					'wp-admin/admin.php?page=wc-settings&tab=shipping'
 				);
-
-				try {
-					await page
-						.getByLabel( 'Close Tour' )
-						.click( { timeout: 5000 } ); // close the tour if visible
-				} catch ( e ) {}
 			}
 			await expect( page.locator( '.wc-shipping-zones' ) ).toHaveText(
 				/USA Zone.*/

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -1,6 +1,4 @@
-const { test, expect } = require( '@playwright/test' );
-const { tags } = require( '../../fixtures/fixtures' );
-const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { test, expect, tags } = require( '../../fixtures/fixtures' );
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
 const maynePostal = 'V0N 2J0';
 const shippingZoneNameUSRegion = 'USA Zone';
@@ -8,32 +6,31 @@ const shippingZoneNameFlatRate = 'Canada with Flat rate';
 const shippingZoneNameFreeShip = 'BC with Free shipping';
 const shippingZoneNameLocalPickup = 'Mayne Island with Local pickup';
 
+test.beforeAll( async ( { api } ) => {
+	await api.put( 'settings/general/woocommerce_allowed_countries', {
+		value: 'all',
+	} );
+	await api.put( 'settings/general/woocommerce_currency', {
+		value: 'USD',
+	} );
+	await api.put( 'settings/general/woocommerce_price_thousand_sep', {
+		value: ',',
+	} );
+	await api.put( 'settings/general/woocommerce_price_decimal_sep', {
+		value: '.',
+	} );
+	await api.put( 'settings/general/woocommerce_price_num_decimals', {
+		value: '2',
+	} );
+} );
+
 test.describe(
 	'WooCommerce Shipping Settings - Add new shipping zone',
 	{ tag: [ tags.SERVICES ] },
 	() => {
 		test.use( { storageState: ADMIN_STATE_PATH } );
 
-		test.beforeAll( async ( { baseURL } ) => {
-			// Set selling location to all countries.
-			const api = new wcApi( {
-				url: baseURL,
-				consumerKey: process.env.CONSUMER_KEY,
-				consumerSecret: process.env.CONSUMER_SECRET,
-				version: 'wc/v3',
-			} );
-			await api.put( 'settings/general/woocommerce_allowed_countries', {
-				value: 'all',
-			} );
-		} );
-
-		test.afterAll( async ( { baseURL } ) => {
-			const api = new wcApi( {
-				url: baseURL,
-				consumerKey: process.env.CONSUMER_KEY,
-				consumerSecret: process.env.CONSUMER_SECRET,
-				version: 'wc/v3',
-			} );
+		test.afterAll( async ( { api } ) => {
 			await api.get( 'shipping/zones' ).then( ( response ) => {
 				for ( let i = 0; i < response.data.length; i++ ) {
 					if (
@@ -61,6 +58,7 @@ test.describe(
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
 			);
+			//todo this conditional invalidates the whole test, as it is not testing the creation of the shipping zone. We should remove it and ensure the shipping zone doesn't exist in a fixture.
 			if (
 				await page
 					.locator( `text=${ shippingZoneNameLocalPickup }` )
@@ -137,6 +135,7 @@ test.describe(
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
 			);
+			//todo this conditional invalidates the whole test, as it is not testing the creation of the shipping zone. We should remove it and ensure the shipping zone doesn't exist in a fixture.
 			if (
 				await page
 					.locator( `text=${ shippingZoneNameFreeShip }` )
@@ -207,6 +206,7 @@ test.describe(
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
 			);
+			//todo this conditional invalidates the whole test, as it is not testing the creation of the shipping zone. We should remove it and ensure the shipping zone doesn't exist in a fixture.
 			if (
 				await page
 					.locator( `text=${ shippingZoneNameFlatRate }` )
@@ -250,8 +250,9 @@ test.describe(
 				).toBeVisible();
 
 				await page
+					.getByText( 'Flat rate' )
 					.locator(
-						'td:has-text("Flat rate") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
+						'~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
 					)
 					.click();
 				await page.getByLabel( 'Cost', { exact: true } ).fill( '10' );
@@ -335,8 +336,9 @@ test.describe(
 			);
 
 			await page
+				.getByText( 'USA Zone' )
 				.locator(
-					'td:has-text("USA Zone") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
+					'~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
 				)
 				.click();
 
@@ -404,8 +406,9 @@ test.describe(
 				).toBeVisible();
 
 				await page
+					.getByText( 'Flat rate' )
 					.locator(
-						'td:has-text("Flat rate") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
+						'~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
 					)
 					.click();
 				await page
@@ -441,14 +444,8 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 	// note: tests are being run in an unauthenticated state (not as admin)
 	let productId, shippingFreeId, shippingFlatId, shippingLocalId;
 
-	test.beforeAll( async ( { baseURL } ) => {
+	test.beforeAll( async ( { api } ) => {
 		// need to add a product to the store so that we can order it and check shipping options
-		const api = new wcApi( {
-			url: baseURL,
-			consumerKey: process.env.CONSUMER_KEY,
-			consumerSecret: process.env.CONSUMER_SECRET,
-			version: 'wc/v3',
-		} );
 		await api
 			.post( 'products', {
 				name: 'Shipping options are the best',
@@ -520,13 +517,7 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 		await page.goto( `shop/?add-to-cart=${ productId }` );
 	} );
 
-	test.afterAll( async ( { baseURL } ) => {
-		const api = new wcApi( {
-			url: baseURL,
-			consumerKey: process.env.CONSUMER_KEY,
-			consumerSecret: process.env.CONSUMER_SECRET,
-			version: 'wc/v3',
-		} );
+	test.afterAll( async ( { api } ) => {
 		await api.delete( `products/${ productId }`, { force: true } );
 		await api.delete( `shipping/zones/${ shippingFlatId }`, {
 			force: true,
@@ -558,9 +549,7 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 				page.locator( '.shipping ul#shipping_method > li > label' )
 			).toContainText( 'Local pickup' );
 			await expect(
-				page.locator(
-					'td[data-title="Total"] > strong > .amount > bdi'
-				)
+				page.locator( 'td[data-title="Total"]' )
 			).toContainText( '25.99' );
 		}
 	);
@@ -584,9 +573,7 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 				page.locator( '.shipping ul#shipping_method > li > label' )
 			).toContainText( 'Free shipping' );
 			await expect(
-				page.locator(
-					'td[data-title="Total"] > strong > .amount > bdi'
-				)
+				page.locator( 'td[data-title="Total"]' )
 			).toContainText( '25.99' );
 		}
 	);
@@ -614,9 +601,7 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 				page.locator( '.shipping ul#shipping_method > li > label' )
 			).toContainText( '10.00' );
 			await expect(
-				page.locator(
-					'td[data-title="Total"] > strong > .amount > bdi'
-				)
+				page.locator( 'td[data-title="Total"]' )
 			).toContainText( '35.99' );
 		}
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some tweaks in `create-shipping-zones.spec.js` that make a faster and more robust spec.

- ensure some general settings are as expected by the tests (e.g. decimal settings)
- relaxed some locators in assertions. We don't need to check for strong and other css classes - it was failing in some environments
- added some todo comments to follow-up on the validity of the tests using conditionals
- use the api instance from fixtures instead of creating a new one each times throughout the spec
- updated some locators to make my IDE happy, it was showing errors for invalid selectors
- removed some extra page reloads. If the is an issue there with the content not being updated in time we need to fix it in other ways, not by forcing a page reload
- removed a code block waiting for a tour. this added an extra 5s execution time in an unexpected place inside the spec. If such a tour will cause issues in the future we'll solve it by using Playwright's [addLocatorHandler](https://playwright.dev/docs/api/class-page#page-add-locator-handler) instead (which doesn't wait unnecessarily)

### How to test the changes in this Pull Request:

Ran the spec many times on repeat - they passed every time. Tested on local wp-env and JN multisite.

```
pnpm test:e2e create-shipping-zones.spec.js
```
