### PR TITLE
[e2e tests] Stricter locators for multisite setup comatibility

### DIFF
--- a/plugins/woocommerce/changelog/e2e-tests-tweaks-for-multisite-compatibility
+++ b/plugins/woocommerce/changelog/e2e-tests-tweaks-for-multisite-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: small tweaks for multisite setup compatibility

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -180,7 +180,7 @@ test.describe(
 				logoPickerPageObject.getEmptyLogoPickerLocator( assembler );
 			await expect( emptyLogoLocator ).toBeHidden();
 			await assembler.getByLabel( 'Options', { exact: true } ).click();
-			await assembler.getByText( 'Delete' ).click();
+			await assembler.getByRole( 'menuitem', { name: 'Delete' } ).click();
 			await expect( emptyLogoLocator ).toBeVisible();
 		} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-product-brand.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-product-brand.spec.js
@@ -130,7 +130,7 @@ test( 'Merchant can add brands', async ( { page } ) => {
 		} );
 
 		// Click on the "Delete" button.
-		await page.getByRole( 'link', { name: 'Delete' } ).click();
+		await page.getByRole( 'link', { name: 'Delete', exact: true } ).click();
 
 		// We should now be in the Brands page.
 		// Confirm that the brand has been deleted and is no longer in the Brands table.

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-block.spec.js
@@ -816,13 +816,7 @@ test.describe(
 
 			// click to log in and make sure you are on the same page after logging in
 			await page.locator( 'text=Log in' ).click();
-			await page
-				.locator( 'input[name="username"]' )
-				.fill( customer.username );
-			await page
-				.locator( 'input[name="password"]' )
-				.fill( customer.password );
-			await page.locator( 'text=Log in' ).click();
+			await logIn( page, customer.username, customer.password, false );
 			await expect(
 				page.getByRole( 'heading', { name: testPage.title } )
 			).toBeVisible();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates some locators that were failing in multisite setups. The 'Delete site' button is creating a strict mode violation.

Unrelated improvement: replaced login code with a call to login function.

### How to test the changes in this Pull Request:


Run the affected tests:

```
pnpm test:e2e logo-picker/logo-picker.spec.js create-product-brand.spec.js checkout-block.spec.js
```