### PR TITLE
[Experimental] Product Filters: Refactor clear button to use core/button only

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,37 +16,33 @@ const Edit = ( props: EditProps ) => {
 		text = __( 'Clear all', 'woocommerce' );
 	}
 
-	return (
-		<InnerBlocks
-			template={ [
-				[
-					'core/buttons',
-					{ layout: { type: 'flex' } },
-					[
-						[
-							'core/button',
-							{
-								text,
-								className:
-									'wc-block-product-filter-clear-button is-style-outline',
-								style: {
-									border: {
-										width: '0px',
-										style: 'none',
-									},
-									typography: {
-										textDecoration: 'underline',
-									},
-									outline: 'none',
-									fontSize: 'medium',
-								},
-							},
-						],
-					],
-				],
-			] }
-		/>
-	);
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/button' ],
+		template: [
+			[
+				'core/button',
+				{
+					text,
+					className:
+						'wc-block-product-filter-clear-button is-style-outline',
+					style: {
+						border: {
+							width: '0px',
+							style: 'none',
+						},
+						typography: {
+							textDecoration: 'underline',
+						},
+						outline: 'none',
+						fontSize: 'medium',
+					},
+				},
+			],
+		],
+	} );
+
+	return <div { ...innerBlocksProps } />;
 };
 
 export default Edit;

--- a/plugins/woocommerce/changelog/55078-product-filters-clear-button
+++ b/plugins/woocommerce/changelog/55078-product-filters-clear-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: [Experimental] Product filters refactor clear button


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR does the following things:
- Remove the outer `core/buttons` block and retain using only `core/button` to simply usage.
- Make the `core/button` block insertable within the Clear Button block container.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Edit the template.
3. With the block inserter, add Product Filters (Experimental) block to the template.
4. In the list view ensure you see the `Button` block listed under the Clear (Experimental) block of each relevant filters.
5. Ensure you can delete the `core/button` block and insert it again within the same location.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
[Experimental] Product filters: refactor the clear button block.
</details>
