### PR TITLE
[Experimental] Add compatibility layer to blockified Add to Cart with Options block

### DIFF
--- a/plugins/woocommerce-blocks/tests/e2e/plugins/single-product-template-compatibility-layer.php
+++ b/plugins/woocommerce-blocks/tests/e2e/plugins/single-product-template-compatibility-layer.php
@@ -8,111 +8,35 @@
  * @package woocommerce-blocks-test-single-product-template-compatibility-layer
  */
 
-add_action(
+$hooks = array(
 	'woocommerce_before_main_content',
-	function () {
-		echo '<p data-testid="woocommerce_before_main_content">
-			Hook: woocommerce_before_main_content
-		</p>';
-	}
-);
-
-add_action(
 	'woocommerce_sidebar',
-	function () {
-		echo '<p data-testid="woocommerce_sidebar">
-			Hook: woocommerce_sidebar
-		</p>';
-	}
-);
-
-add_action(
-	'woocommerce_before_single_product',
-	function () {
-		echo '<p data-testid="woocommerce_before_single_product">
-			Hook: woocommerce_before_single_product
-		</p>';
-	}
-);
-
-add_action(
-	'woocommerce_before_single_product_summary',
-	function () {
-		echo '<p data-testid="woocommerce_before_single_product_summary">
-			Hook: woocommerce_before_single_product_summary
-		</p>';
-	}
-);
-
-add_action(
-	'woocommerce_single_product_summary',
-	function () {
-		echo '<p data-testid="woocommerce_single_product_summary">
-			Hook: woocommerce_single_product_summary
-		</p>';
-	}
-);
-
-add_action(
 	'woocommerce_before_add_to_cart_button',
-	function () {
-		echo '<p data-testid="woocommerce_before_add_to_cart_button">
-			Hook: woocommerce_before_add_to_cart_button
-		</p>';
-	}
-);
-
-
-add_action(
+	'woocommerce_before_single_product',
+	'woocommerce_before_single_product_summary',
+	'woocommerce_single_product_summary',
 	'woocommerce_product_meta_start',
-	function () {
-		echo '<p data-testid="woocommerce_product_meta_start">
-			Hook: woocommerce_product_meta_start
-		</p>';
-	}
-);
-
-add_action(
 	'woocommerce_product_meta_end',
-	function () {
-		echo '<p data-testid="woocommerce_product_meta_end">
-			Hook: woocommerce_product_meta_end
-		</p>';
-	}
-);
-
-add_action(
 	'woocommerce_share',
-	function () {
-		echo '<p data-testid="woocommerce_share">
-			Hook: woocommerce_share
-		</p>';
-	}
-);
-
-add_action(
 	'woocommerce_after_single_product_summary',
-	function () {
-		echo '<p data-testid="woocommerce_after_single_product_summary">
-			Hook: woocommerce_after_single_product_summary
-		</p>';
-	}
-);
-
-add_action(
 	'woocommerce_after_single_product',
-	function () {
-		echo '<p data-testid="woocommerce_after_single_product">
-			Hook: woocommerce_after_single_product
-		</p>';
-	}
+	'woocommerce_after_main_content',
+	'woocommerce_before_add_to_cart_form',
+	'woocommerce_after_add_to_cart_form',
+	'woocommerce_before_add_to_cart_quantity',
+	'woocommerce_after_add_to_cart_quantity',
+	'woocommerce_after_add_to_cart_button',
+	'woocommerce_before_variations_form',
+	'woocommerce_after_variations_form'
 );
 
-add_action(
-	'woocommerce_after_main_content',
-	function () {
-		echo '<p data-testid="woocommerce_after_main_content">
-			Hook: woocommerce_after_main_content
+foreach ( $hooks as $hook ) {
+	add_action(
+		$hook,
+		function () use ( $hook ) {
+			echo '<p data-testid="' . esc_attr( $hook ) . '">
+			Hook: ' . esc_html( $hook ) . '
 		</p>';
-	}
-);
+		}
+	);
+}

--- a/plugins/woocommerce-blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -83,6 +83,57 @@ const singleOccurrenceScenarios: Scenario[] = [
 	},
 ];
 
+const singleOccurrenceScenariosWithAddToCartWithOptionsBlock: Scenario[] = [
+	{
+		title: 'Before Add To Cart Form',
+		dataTestId: 'woocommerce_before_add_to_cart_form',
+		content: 'Hook: woocommerce_before_add_to_cart_form',
+		amount: 1,
+	},
+	{
+		title: 'After Add To Cart Form',
+		dataTestId: 'woocommerce_after_add_to_cart_form',
+		content: 'Hook: woocommerce_after_add_to_cart_form',
+		amount: 1,
+	},
+	{
+		title: 'Before Add To Cart Quantity',
+		dataTestId: 'woocommerce_before_add_to_cart_quantity',
+		content: 'Hook: woocommerce_before_add_to_cart_quantity',
+		amount: 1,
+	},
+	{
+		title: 'After Add To Cart Quantity',
+		dataTestId: 'woocommerce_after_add_to_cart_quantity',
+		content: 'Hook: woocommerce_after_add_to_cart_quantity',
+		amount: 1,
+	},
+	{
+		title: 'Before Add To Cart Button',
+		dataTestId: 'woocommerce_before_add_to_cart_button',
+		content: 'Hook: woocommerce_before_add_to_cart_button',
+		amount: 1,
+	},
+	{
+		title: 'After Add To Cart Button',
+		dataTestId: 'woocommerce_after_add_to_cart_button',
+		content: 'Hook: woocommerce_after_add_to_cart_button',
+		amount: 1,
+	},
+	{
+		title: 'Before Variations Form',
+		dataTestId: 'woocommerce_before_variations_form',
+		content: 'Hook: woocommerce_before_variations_form',
+		amount: 1,
+	},
+	{
+		title: 'After Variations Form',
+		dataTestId: 'woocommerce_after_variations_form',
+		content: 'Hook: woocommerce_after_variations_form',
+		amount: 1,
+	},
+];
+
 test.describe( 'Compatibility Layer in Single Product template', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.activatePlugin(
@@ -90,15 +141,68 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 		);
 	} );
 
-	for ( const scenario of singleOccurrenceScenarios ) {
-		test( `${ scenario.title } is attached to the page`, async ( {
-			page,
-		} ) => {
-			await page.goto( '/product/hoodie/' );
+	test( 'hooks are attached to the page', async ( { page } ) => {
+		await page.goto( '/product/hoodie/' );
+
+		for ( const scenario of singleOccurrenceScenarios ) {
 			const hooks = page.getByTestId( scenario.dataTestId );
 
-			await expect( hooks ).toHaveCount( scenario.amount );
-			await expect( hooks ).toHaveText( scenario.content );
+			await expect(
+				hooks,
+				`Expected ${ scenario.dataTestId } hook to appear ${ scenario.amount } time(s)`
+			).toHaveCount( scenario.amount );
+			await expect(
+				hooks,
+				`Expected ${ scenario.dataTestId } hook to have text "${ scenario.content }"`
+			).toHaveText( scenario.content );
+		}
+	} );
+
+	test( 'hooks are attached to the page when using the Add to Cart with Options block', async ( {
+		page,
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		/* Switch to the blockified Add to Cart with Options block to be able to test all hooks */
+		await requestUtils.setFeatureFlag( 'experimental-blocks', true );
+		await requestUtils.setFeatureFlag( 'blockified-add-to-cart', true );
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//single-product',
+			postType: 'wp_template',
+			canvas: 'edit',
 		} );
-	}
+		const addToCartFormBlock = await editor.getBlockByName(
+			'woocommerce/add-to-cart-form'
+		);
+		await editor.selectBlocks( addToCartFormBlock );
+
+		await page
+			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.click();
+
+		await expect(
+			editor.canvas.getByLabel(
+				'Block: Quantity Selector (Experimental)'
+			)
+		).toBeVisible();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/hoodie/' );
+
+		for ( const scenario of singleOccurrenceScenariosWithAddToCartWithOptionsBlock ) {
+			const hooks = page.getByTestId( scenario.dataTestId );
+
+			await expect(
+				hooks,
+				`Expected ${ scenario.dataTestId } hook to appear ${ scenario.amount } time(s)`
+			).toHaveCount( scenario.amount );
+			await expect(
+				hooks,
+				`Expected ${ scenario.dataTestId } hook to have text "${ scenario.content }"`
+			).toHaveText( scenario.content );
+		}
+	} );
 } );

--- a/plugins/woocommerce/changelog/fix-54847-add-to-cart-with-options-php-hooks-compatibility-layer
+++ b/plugins/woocommerce/changelog/fix-54847-add-to-cart-with-options-php-hooks-compatibility-layer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Add compatibility layer to blockified Add to Cart with Options block
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -133,11 +133,36 @@ class AddToCartWithOptions extends AbstractBlock {
 				)
 			);
 
+			$hooks_before = '';
+			$hooks_after  = '';
+
+			/**
+			* Filter to disable the compatibility layer for the blockified templates.
+			*
+			* This hook allows to disable the compatibility layer for the blockified.
+			*
+			* @since 7.6.0
+			* @param boolean.
+			*/
+			$is_disabled_compatibility_layer       = apply_filters( 'woocommerce_disable_compatibility_layer', false );
+			$is_descendent_of_single_product_block = is_null( $previous_product ) || $post_id !== $previous_product->get_id();
+
+			if ( ! $is_disabled_compatibility_layer && ! $is_descendent_of_single_product_block && ProductType::VARIABLE === $product_type ) {
+				ob_start();
+				do_action( 'woocommerce_before_variations_form' );
+				$hooks_before = ob_get_clean();
+
+				ob_start();
+				do_action( 'woocommerce_after_variations_form' );
+				$hooks_after = ob_get_clean();
+			}
+
 			$form_html = sprintf(
-				'<form %1$s %2$s>%3$s</form>',
+				'<form %1$s>%2$s%3$s%4$s</form>',
 				$wrapper_attributes,
-				'',
-				$template_part_contents
+				$hooks_before,
+				$template_part_contents,
+				$hooks_after,
 			);
 
 			$product = $previous_product;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -149,10 +149,24 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			if ( ! $is_disabled_compatibility_layer && ! $is_descendent_of_single_product_block && ProductType::VARIABLE === $product_type ) {
 				ob_start();
+				/**
+				 * Hook: woocommerce_before_variations_form.
+				 *
+				 * Fires inside the Add to Cart form of variable products.
+				 *
+				 * @since 2.4.0
+				 */
 				do_action( 'woocommerce_before_variations_form' );
 				$hooks_before = ob_get_clean();
 
 				ob_start();
+				/**
+				 * Hook: woocommerce_after_variations_form.
+				 *
+				 * Fires after the variations form in variable products.
+				 *
+				 * @since 2.4.0
+				 */
 				do_action( 'woocommerce_after_variations_form' );
 				$hooks_after = ob_get_clean();
 			}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
@@ -128,15 +128,6 @@ class AddToCartWithOptionsQuantitySelector extends AbstractBlock {
 
 		ob_start();
 
-		/**
-		 * Hook: woocommerce_before_add_to_cart_quantity.
-		 *
-		 * Action that fires before the quantity input field is rendered.
-		 *
-		 * @since 2.7.0
-		 */
-		do_action( 'woocommerce_before_add_to_cart_quantity' );
-
 		woocommerce_quantity_input(
 			array(
 				/**
@@ -158,15 +149,6 @@ class AddToCartWithOptionsQuantitySelector extends AbstractBlock {
 				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			)
 		);
-
-		/**
-		 * Hook: woocommerce_after_add_to_cart_quantity.
-		 *
-		 * Action that fires after the quantity input field is rendered.
-		 *
-		 * @since 2.7.0
-		 */
-		do_action( 'woocommerce_after_add_to_cart_quantity' );
 
 		$product_html = ob_get_clean();
 

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -104,6 +104,7 @@ abstract class AbstractTemplateCompatibility {
 	 *       <function-name> => <priority>,
 	 *        ...
 	 *     ],
+	 *     conditional => <function-name>,
 	 *  ],
 	 * ]
 	 * Where:
@@ -113,9 +114,33 @@ abstract class AbstractTemplateCompatibility {
 	 * - hooked is an array of functions hooked to the hook that will be
 	 *   replaced. The key is the function name and the value is the
 	 *   priority.
+	 * - conditional is a function that will be used to determine if the hook
+	 *   should be injected. The function should return a boolean.
 	 */
 	abstract protected function set_hook_data();
 
+	/**
+	 * Get the hooks for a given block.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block Block.
+	 *
+	 * @return array
+	 */
+	protected function get_block_hooks( $block_content, $block ) {
+		$block_name = $block['blockName'];
+
+		return array_filter(
+			$this->hook_data,
+			function ( $hook ) use ( $block_name, $block_content, $block ) {
+				if ( ! in_array( $block_name, $hook['block_names'], true ) ) {
+					return false;
+				}
+
+				return ! isset( $hook['conditional'] ) || $hook['conditional']( $block_content, $block );
+			}
+		);
+	}
 
 	/**
 	 * Remove the default callback added by WooCommerce. We replaced these

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplateCompatibility.php
@@ -122,14 +122,13 @@ abstract class AbstractTemplateCompatibility {
 	/**
 	 * Get the hooks for a given block.
 	 *
+	 * @param string $block_name Block name.
 	 * @param string $block_content Block content.
 	 * @param array  $block Block.
 	 *
 	 * @return array
 	 */
-	protected function get_block_hooks( $block_content, $block ) {
-		$block_name = $block['blockName'];
-
+	protected function get_block_hooks( $block_name, $block_content, $block ) {
 		return array_filter(
 			$this->hook_data,
 			function ( $hook ) use ( $block_name, $block_content, $block ) {

--- a/plugins/woocommerce/src/Blocks/Templates/ArchiveProductTemplatesCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ArchiveProductTemplatesCompatibility.php
@@ -76,7 +76,7 @@ class ArchiveProductTemplatesCompatibility extends AbstractTemplateCompatibility
 			$block_name = self::LOOP_ITEM_ID;
 		}
 
-		$block_hooks = $this->get_block_hooks( $block_content, $block );
+		$block_hooks = $this->get_block_hooks( $block_name, $block_content, $block );
 
 		// We want to inject hooks to the core/post-template or product template block only when the products exist:
 		// https://github.com/woocommerce/woocommerce-blocks/issues/9463.

--- a/plugins/woocommerce/src/Blocks/Templates/ArchiveProductTemplatesCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ArchiveProductTemplatesCompatibility.php
@@ -76,12 +76,7 @@ class ArchiveProductTemplatesCompatibility extends AbstractTemplateCompatibility
 			$block_name = self::LOOP_ITEM_ID;
 		}
 
-		$block_hooks = array_filter(
-			$this->hook_data,
-			function ( $hook ) use ( $block_name ) {
-				return in_array( $block_name, $hook['block_names'], true );
-			}
-		);
+		$block_hooks = $this->get_block_hooks( $block_content, $block );
 
 		// We want to inject hooks to the core/post-template or product template block only when the products exist:
 		// https://github.com/woocommerce/woocommerce-blocks/issues/9463.

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -32,7 +32,9 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 
 		$this->remove_default_hooks();
 
-		$block_hooks = $this->get_block_hooks( $block_content, $block );
+		$block_name = $block['blockName'];
+
+		$block_hooks = $this->get_block_hooks( $block_name, $block_content, $block );
 
 		$first_or_last_block_content = $this->inject_hook_to_first_and_last_blocks( $block_content, $block, $block_hooks );
 

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Blocks\Templates;
 
+use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -19,6 +22,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 *
 	 * @param mixed $block_content The rendered block content.
 	 * @param mixed $block         The parsed block data.
+	 *
 	 * @return string
 	 */
 	public function inject_hooks( $block_content, $block ) {
@@ -28,14 +32,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 
 		$this->remove_default_hooks();
 
-		$block_name = $block['blockName'];
-
-		$block_hooks = array_filter(
-			$this->hook_data,
-			function ( $hook ) use ( $block_name ) {
-				return in_array( $block_name, $hook['block_names'], true );
-			}
-		);
+		$block_hooks = $this->get_block_hooks( $block_content, $block );
 
 		$first_or_last_block_content = $this->inject_hook_to_first_and_last_blocks( $block_content, $block, $block_hooks );
 
@@ -64,6 +61,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * @param mixed $block_content The rendered block content.
 	 * @param mixed $block         The parsed block data.
 	 * @param array $block_hooks   The hooks that should be injected to the block.
+	 *
 	 * @return string
 	 */
 	private function inject_hook_to_first_and_last_blocks( $block_content, $block, $block_hooks ) {
@@ -248,7 +246,92 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 					'woocommerce_output_related_products'  => 20,
 				),
 			),
+			'woocommerce_before_add_to_cart_form'       => array(
+				'block_names' => array( 'woocommerce/add-to-cart-with-options' ),
+				'position'    => 'before',
+				'hooked'      => array(),
+				'conditional' => array( $this, 'is_template_descendent' ),
+			),
+			'woocommerce_after_add_to_cart_form'        => array(
+				'block_names' => array( 'woocommerce/add-to-cart-with-options' ),
+				'position'    => 'after',
+				'hooked'      => array(),
+				'conditional' => array( $this, 'is_template_descendent' ),
+			),
+			'woocommerce_before_add_to_cart_quantity'   => array(
+				'block_names' => array( 'woocommerce/add-to-cart-with-options-quantity-selector' ),
+				'position'    => 'before',
+				'hooked'      => array(),
+				'conditional' => array( $this, 'is_template_descendent' ),
+			),
+			'woocommerce_after_add_to_cart_quantity'    => array(
+				'block_names' => array( 'woocommerce/add-to-cart-with-options-quantity-selector' ),
+				'position'    => 'after',
+				'hooked'      => array(),
+				'conditional' => array( $this, 'is_template_descendent' ),
+			),
+			'woocommerce_before_add_to_cart_button'     => array(
+				'block_names' => array( 'woocommerce/add-to-cart-with-options-quantity-selector', 'woocommerce/product-button' ),
+				'position'    => 'before',
+				'hooked'      => array(),
+				'conditional' => array( $this, 'woocommerce_before_add_to_cart_button_conditional' ),
+			),
+			'woocommerce_after_add_to_cart_button'      => array(
+				'block_names' => array( 'woocommerce/product-button' ),
+				'position'    => 'after',
+				'hooked'      => array(),
+				'conditional' => array( $this, 'is_template_descendent' ),
+			),
 		);
+	}
+
+	/**
+	 * Check if the block is a descendent of the Single Product template instead of the Query Loop or the Single Product block.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block         Block.
+	 * @return bool
+	 */
+	protected static function is_template_descendent( $block_content, $block ) {
+		global $product;
+
+		if ( ! $product instanceof \WC_Product ) {
+			return false;
+		}
+
+		// Avoid running the compatibility layer for blocks which are not directly descendants of the Single Product template.
+		if (
+			( isset( $block['attrs']['isDescendentOfQueryLoop'] ) && $block['attrs']['isDescendentOfQueryLoop'] ) ||
+			( isset( $block['attrs']['isDescendentOfSingleProductBlock'] ) && $block['attrs']['isDescendentOfSingleProductBlock'] )
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Run the hook conditionally before the Add to Cart Button block or the Quantity Selector block depending on the product type.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block         Block.
+	 * @return bool
+	 */
+	protected static function woocommerce_before_add_to_cart_button_conditional( $block_content, $block ) {
+		if ( ! self::is_template_descendent( $block_content, $block ) ) {
+			return false;
+		}
+
+		global $product;
+
+		if ( 'woocommerce/product-button' === $block['blockName'] && ProductType::SIMPLE !== $product->get_type() ) {
+			return true;
+		}
+		if ( 'woocommerce/add-to-cart-with-options-quantity-selector' === $block['blockName'] && ProductType::SIMPLE === $product->get_type() ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -388,7 +471,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * @return bool True if the template has a single product template block, false otherwise.
 	 */
 	private static function has_single_product_template_blocks( $parsed_blocks ) {
-		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
+		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/add-to-cart-with-options', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
 
 		return BlockTemplateUtils::has_block_including_patterns( $single_product_template_blocks, $parsed_blocks );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/54847.

This PR adds a compatibility layer to the blockified _Add to Cart with Options_ block and its inner blocks.

The hooks which are supported in this PR:

* `woocommerce_before_add_to_cart_form`
* `woocommerce_after_add_to_cart_form`
* `woocommerce_before_add_to_cart_quantity`
* `woocommerce_after_add_to_cart_quantity`
* `woocommerce_before_add_to_cart_button`
* `woocommerce_after_add_to_cart_button`
* `woocommerce_before_variations_form`
* `woocommerce_after_variations_form`

Hooks which are not supported:

* `woocommerce_after_variations_table`: this one is still in `AddToCartWithOptionsVariationSelector.php`, we can evaluate adding it to the compatibility layer once we blockify the Variation Selector block.
* `woocommerce_add_to_cart_form_action`: not sure if we will want to support this one, as the migration to the iAPI will change how the form behaves. In any case, we can evaluate later.
* `woocommerce_before_single_variation`, `woocommerce_single_variation` and `woocommerce_after_single_variation`: they refer to the Variation Selector description, price, etc. We hadn't blockified that yet, we can evaluate it later (see pfrEX1-HI-p2#comment-813 for more context).
* `woocommerce_grouped_product_list_before`, `woocommerce_grouped_product_list_after`, `woocommerce_grouped_product_list_before_<column_id>` and `woocommerce_grouped_product_list_column_<column_id>`: they allow modifying the Grouped Product Selector table. However, in the blockified approach, they are `<div>`'s instead of a `<table>`, so for now I leaned towards the conservative approach and didn't support them to avoid breakages.
* `woocommerce_grouped_product_list_link`: I didn't add support for this one as it would involve modifying the core `post-title` block and wanted to lean on the conservative side. We can always re-evaluate this decision in the future if we see the need. As the block already offers some options (removing the link, changing styles, etc.) it might not be needed.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Add this code snippet somewhere in your site. For exemple, by using the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin:

```PHP
    $hooks = [
        'woocommerce_before_add_to_cart_form',
        'woocommerce_after_add_to_cart_form',
        'woocommerce_before_add_to_cart_quantity',
        'woocommerce_after_add_to_cart_quantity',
        'woocommerce_before_add_to_cart_button',
        'woocommerce_after_add_to_cart_button',
        'woocommerce_before_variations_form',
        'woocommerce_after_variations_form'
    ];
    
    foreach ($hooks as $hook) {
        add_action($hook, function() use ($hook) {
            echo '<p style="color: red; font-weight: bold;">' . esc_html($hook) . ' successfully run</p>';
        });
    }
```

2. Visit the frontend of a Single Product page.
3. Verify the hooks are displayed correctly and only once. Keep in mind you will need to test a variable product for `woocommerce_before_variations_form` and `woocommerce_after_variations_form` to show up.
4. Optional: feel free to install plugins that use those hooks and make sure they display the correct input forms (note: it's expected the form elements don't work yet with the iAPI). Ie, Product Add-Ons or Name Your Price.
![imatge](https://github.com/user-attachments/assets/384b40e9-4017-46d7-8252-83897c20e90b)
