### PR TITLE
Delete post associated data when a post is deleted

### DIFF
--- a/plugins/woocommerce/changelog/55097-51412-fix-orphaned-sku-lookup-data
+++ b/plugins/woocommerce/changelog/55097-51412-fix-orphaned-sku-lookup-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Delete all post-associated data when a post is deleted.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -305,6 +305,8 @@ class WC_Post_Data {
 	/**
 	 * Removes variations etc. belonging to a deleted post, and clears transients
 	 *
+	 * @internal Use the delete_post function instead.
+	 *
 	 * @param mixed $id ID of post being deleted.
 	 */
 	public static function delete_post_data( $id ) {

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -54,7 +54,7 @@ class WC_Post_Data {
 
 		// Status transitions.
 		add_action( 'transition_post_status', array( __CLASS__, 'transition_post_status' ), 10, 3 );
-		add_action( 'delete_post', array( __CLASS__, 'delete_post' ) );
+		add_action( 'delete_post', array( __CLASS__, 'delete_post_data' ) );
 		add_action( 'wp_trash_post', array( __CLASS__, 'trash_post' ) );
 		add_action( 'untrashed_post', array( __CLASS__, 'untrash_post' ) );
 		add_action( 'before_delete_post', array( __CLASS__, 'before_delete_order' ) );
@@ -303,15 +303,12 @@ class WC_Post_Data {
 	}
 
 	/**
-	 * Removes variations etc belonging to a deleted post, and clears transients.
+	 * Removes variations etc. belonging to a deleted post, and clears transients
 	 *
 	 * @param mixed $id ID of post being deleted.
 	 */
-	public static function delete_post( $id ) {
+	public static function delete_post_data( $id ) {
 		$container = wc_get_container();
-		if ( ! $container->get( LegacyProxy::class )->call_function( 'current_user_can', 'delete_posts' ) || ! $id ) {
-			return;
-		}
 
 		$post_type = self::get_post_type( $id );
 		switch ( $post_type ) {
@@ -347,6 +344,20 @@ class WC_Post_Data {
 				}
 				break;
 		}
+	}
+
+	/**
+	 * Removes variations etc. belonging to a deleted post, and clears transients, if the user has permission.
+	 *
+	 * @param mixed $id ID of post being deleted.
+	 */
+	public static function delete_post( $id ) {
+		$container = wc_get_container();
+		if ( ! $container->get( LegacyProxy::class )->call_function( 'current_user_can', 'delete_posts' ) || ! $id ) {
+			return;
+		}
+
+		self::delete_post_data( $id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -54,7 +54,7 @@ class WC_Post_Data {
 
 		// Status transitions.
 		add_action( 'transition_post_status', array( __CLASS__, 'transition_post_status' ), 10, 3 );
-		add_action( 'delete_post', array( __CLASS__, '_delete_post_data' ) );
+		add_action( 'delete_post', array( __CLASS__, 'delete_post_data' ) );
 		add_action( 'wp_trash_post', array( __CLASS__, 'trash_post' ) );
 		add_action( 'untrashed_post', array( __CLASS__, 'untrash_post' ) );
 		add_action( 'before_delete_post', array( __CLASS__, 'before_delete_order' ) );
@@ -310,7 +310,7 @@ class WC_Post_Data {
 	 *
 	 * @param mixed $id ID of post being deleted.
 	 */
-	public static function _delete_post_data( $id ) {
+	public static function delete_post_data( $id ) {
 		$container = wc_get_container();
 
 		$post_type = self::get_post_type( $id );
@@ -360,7 +360,7 @@ class WC_Post_Data {
 			return;
 		}
 
-		self::_delete_post_data( $id );
+		self::delete_post_data( $id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -54,7 +54,7 @@ class WC_Post_Data {
 
 		// Status transitions.
 		add_action( 'transition_post_status', array( __CLASS__, 'transition_post_status' ), 10, 3 );
-		add_action( 'delete_post', array( __CLASS__, 'delete_post_data' ) );
+		add_action( 'delete_post', array( __CLASS__, '_delete_post_data' ) );
 		add_action( 'wp_trash_post', array( __CLASS__, 'trash_post' ) );
 		add_action( 'untrashed_post', array( __CLASS__, 'untrash_post' ) );
 		add_action( 'before_delete_post', array( __CLASS__, 'before_delete_order' ) );
@@ -303,13 +303,14 @@ class WC_Post_Data {
 	}
 
 	/**
-	 * Removes variations etc. belonging to a deleted post, and clears transients
+	 * Removes variations etc. belonging to a deleted post, and clears transients.
 	 *
 	 * @internal Use the delete_post function instead.
+	 * @since 9.8.0
 	 *
 	 * @param mixed $id ID of post being deleted.
 	 */
-	public static function delete_post_data( $id ) {
+	public static function _delete_post_data( $id ) {
 		$container = wc_get_container();
 
 		$post_type = self::get_post_type( $id );
@@ -359,7 +360,7 @@ class WC_Post_Data {
 			return;
 		}
 
-		self::delete_post_data( $id );
+		self::_delete_post_data( $id );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the permissions check before the function deletes a deleted post's associated post data.
At that point, the post doesn't exist anymore, so the permission check does not make much sense. But, since the `delete_post` function is public, we are still keeping it with the permission check in place.

Closes #51412

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Test lookup table data is removed with `wp_scheduled_delete`:

1. Create a new product with SKU and move it to the trash.
2. In the DB, go to the `wp_wc_product_meta_lookup` table and check for metadata associated with the product ID from step 1.
3. In the DB, go to the `wp_postmeta` table and change the  `_wp_trash_meta_time` of the product to `1706955993` (this is to simulate that the product was moved to the trash more than 30 days ago).
4. Run the command: `wp cron event run wp_scheduled_delete`.
6. Go to the `wp_wc_product_meta_lookup` again and check all the metadata associated to the product ID is no longer there.

### Test `delete_post` checks user permissions

1. Create a new product with SKU and move it to the trash.
2. In the DB, go to the `wp_wc_product_meta_lookup` table and check for metadata associated with the product ID from step 1.
3. Run `wp shell --user=<USER_ID>`, with a user **without permissions** (for example, a customer).
4. In the shell, run `WC_Post_Data::delete_post(<PRODUCT_ID>);`.
5. Verify the product data still exists in `wp_wc_product_meta_lookup`.
6. Now Run `wp shell --user=<USER_ID>`, with a user **with permissions**.
7. In the shell, run `WC_Post_Data::delete_post(<PRODUCT_ID>)`;
8. Verify the product data is removed from `wp_wc_product_meta_lookup`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Delete all post-associated data when a post is deleted.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
