### PR TITLE
Update remote logging feature UI to depend on usage tracking status

### DIFF
--- a/plugins/woocommerce/changelog/enhance-remote-logging-feature
+++ b/plugins/woocommerce/changelog/enhance-remote-logging-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update remote logging feature UI to depend on usage tracking status

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -296,7 +296,7 @@ class FeaturesController {
 						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">',
 						'</a>'
 					),
-					'enabled_by_default' => $tracking_enabled,
+					'enabled_by_default' => true,
 					'disable_ui'         => false,
 
 					/*

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\Features;
 
+use WC_Site_Tracking;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
@@ -163,7 +164,9 @@ class FeaturesController {
 	private function get_feature_definitions() {
 		if ( empty( $this->features ) ) {
 			$alpha_feature_testing_is_enabled = Constants::is_true( 'WOOCOMMERCE_ENABLE_ALPHA_FEATURE_TESTING' );
-			$legacy_features                  = array(
+			$tracking_enabled                 = WC_Site_Tracking::is_tracking_enabled();
+
+			$legacy_features = array(
 				'analytics'              => array(
 					'name'               => __( 'Analytics', 'woocommerce' ),
 					'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
@@ -287,11 +290,13 @@ class FeaturesController {
 				),
 				'remote_logging'         => array(
 					'name'               => __( 'Remote Logging', 'woocommerce' ),
-					'description'        => __(
-						'Enable this feature to log errors and related data to Automattic servers for debugging purposes and to improve WooCommerce',
-						'woocommerce'
+					'description'        => sprintf(
+						/* translators: %1$s: opening link tag, %2$s: closing link tag */
+						__( 'Allow WooCommerce to send error logs and non-sensitive diagnostic data to help improve WooCommerce. This feature requires %1$susage tracking%2$s to be enabled.', 'woocommerce' ),
+						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">',
+						'</a>'
 					),
-					'enabled_by_default' => true,
+					'enabled_by_default' => WC_Site_Tracking::is_tracking_enabled(),
 					'disable_ui'         => false,
 
 					/*
@@ -304,6 +309,17 @@ class FeaturesController {
 					 */
 					'is_legacy'          => true,
 					'is_experimental'    => false,
+					'setting'            => array(
+						'disabled' => function () use ( $tracking_enabled ) {
+							return ! $tracking_enabled;
+						},
+						'desc_tip' => function () use ( $tracking_enabled ) {
+							if ( ! $tracking_enabled ) {
+								return __( '⚠ Usage tracking must be enabled to use remote logging.', 'woocommerce' );
+							}
+							return '';
+						},
+					),
 				),
 				'email_improvements'     => array(
 					'name'        => __( 'Email improvements', 'woocommerce' ),
@@ -313,6 +329,11 @@ class FeaturesController {
 					),
 				),
 			);
+
+			if ( ! $tracking_enabled ) {
+				// Uncheck the remote logging feature when usage tracking is disabled.
+				$legacy_features['remote_logging']['setting']['value'] = 'no';
+			}
 
 			foreach ( $legacy_features as $slug => $definition ) {
 				$this->add_feature_definition( $slug, $definition['name'], $definition );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -296,7 +296,7 @@ class FeaturesController {
 						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) . '">',
 						'</a>'
 					),
-					'enabled_by_default' => WC_Site_Tracking::is_tracking_enabled(),
+					'enabled_by_default' => $tracking_enabled,
 					'disable_ui'         => false,
 
 					/*


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/54824

Improve remote logging feature UI:

1. Adjust the wording to clarify that:
- Remote Logging is only active when tracking is enabled.
- Include clearer messaging for the remote logging feature.

2. Grey Out Setting:
Uncheck and disable (grey out) the Remote Logging setting when tracking is unchecked.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Case1: Opt-out of usage tracking**
1. Create a fresh site with this branch
2. Go to Core Profiler
3. Opt-out of usage tracking and skip core profiler
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
5. Verify that the remote logging feature is unchecked and disabled. The description should mention that usage tracking must be enabled to use remote logging. 
6. Click the link to the usage tracking settings page.
7. Verify that the usage tracking settings page is displayed.
8. Opt-in to usage tracking and go back to the features page.
9. Verify that remote logging is checked.
10. Disable remote logging
11. Disable and re-enable the usage tracking
12. Verify that remote logging is still unchecked.

**Case2: Opt-in of usage tracking**
1. Create a fresh site with this branch
2. Go to Core Profiler
3. Opt-in of usage tracking and skip core profiler
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
5. Verify that the remote logging feature is checked

<img width="923" alt="Screenshot 2025-02-05 at 16 37 42" src="https://github.com/user-attachments/assets/9b37b5aa-2ead-4978-8d1b-7de0156ddda3" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
