### PR TITLE
Remove variant assignment check from remote logging

### DIFF
--- a/plugins/woocommerce/changelog/update-remote-logging-full-rollout
+++ b/plugins/woocommerce/changelog/update-remote-logging-full-rollout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove variant assignment check from remote logging

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -152,10 +152,6 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 
-		if ( ! $this->is_variant_assignment_allowed() ) {
-			return false;
-		}
-
 		if ( ! $this->should_current_version_be_logged() ) {
 			return false;
 		}
@@ -266,16 +262,6 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 		return true;
-	}
-
-	/**
-	 * Check if the store is allowed to log based on the variant assignment percentage.
-	 *
-	 * @return bool
-	 */
-	private function is_variant_assignment_allowed() {
-		$assignment = SafeGlobalFunctionProxy::get_option( 'woocommerce_remote_variant_assignment', 0 ) ?? 0;
-		return ( $assignment <= 12 ); // Considering 10% of the 0-120 range.
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -57,7 +57,6 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 				'option_woocommerce_admin_remote_feature_enabled',
 				'option_woocommerce_allow_tracking',
 				'option_woocommerce_version',
-				'option_woocommerce_remote_variant_assignment',
 				'plugins_api',
 				'pre_http_request',
 				'woocommerce_remote_logger_formatted_log_data',
@@ -97,19 +96,15 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 		 */
 		public function remote_logging_disallowed_provider() {
 			return array(
-				'feature flag disabled'   => array(
+				'feature flag disabled' => array(
 					'condition' => 'feature flag disabled',
 					'setup'     => fn() => update_option( 'woocommerce_feature_remote_logging_enabled', 'no' ),
 				),
-				'tracking opted out'      => array(
+				'tracking opted out'    => array(
 					'condition' => 'tracking opted out',
 					'setup'     => fn() => add_filter( 'option_woocommerce_allow_tracking', fn() => 'no' ),
 				),
-				'high variant assignment' => array(
-					'condition' => 'high variant assignment',
-					'setup'     => fn() => add_filter( 'option_woocommerce_remote_variant_assignment', fn() => 15 ),
-				),
-				'outdated version'        => array(
+				'outdated version'      => array(
 					'condition' => 'outdated version',
 					'setup'     => function () {
 						$version = WC()->version;
@@ -696,7 +691,6 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 		private function setup_remote_logging_conditions( $enabled = true ) {
 			update_option( 'woocommerce_feature_remote_logging_enabled', $enabled ? 'yes' : 'no' );
 			add_filter( 'option_woocommerce_allow_tracking', fn() => 'yes' );
-			add_filter( 'option_woocommerce_remote_variant_assignment', fn() => 5 );
 			$this->setup_mock_plugin_updates( $enabled ? WC()->version : '9.0.0' );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The remote logging feature has been released since WooCommerce 9.4 for a few months. We used a variant assignment check to only enable the feature for 10% of the stores. Since it's stable now and users can opt-out via UI, this PR allows for the feature for all stores so that we can capture more logs.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Reviewing the changes should be sufficient.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
