### PR TITLE
Fixed - Cart Block shows dummy data for local pickup options in block editor

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -12,7 +12,10 @@ import { API_SITE_CURRENCY, displayForMinorUnit } from './utils';
 
 // Get local pickup locations from the settings and format into some preview shipping rates for the response.
 const localPickupEnabled = getSetting< boolean >( 'localPickupEnabled', false );
-const localPickupTitle = getSetting< string >( 'localPickupText', __( 'Local pickup', 'woocommerce' ) );
+const localPickupTitle = getSetting< string >(
+	'localPickupText',
+	__( 'Local pickup', 'woocommerce' )
+);
 const localPickupCost = getSetting< string >( 'localPickupCost', '' );
 const localPickupLocations = localPickupEnabled
 	? getSetting<

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -12,6 +12,7 @@ import { API_SITE_CURRENCY, displayForMinorUnit } from './utils';
 
 // Get local pickup locations from the settings and format into some preview shipping rates for the response.
 const localPickupEnabled = getSetting< boolean >( 'localPickupEnabled', false );
+const localPickupTitle = getSetting< string >( 'localPickupText', '' );
 const localPickupCost = getSetting< string >( 'localPickupCost', '' );
 const localPickupLocations = localPickupEnabled
 	? getSetting<
@@ -28,7 +29,7 @@ const localPickupRates = localPickupLocations
 	? Object.values( localPickupLocations ).map(
 			( location, index: number ) => ( {
 				...API_SITE_CURRENCY,
-				name: __( 'Local pickup #1', 'woocommerce' ),
+				name: localPickupTitle + ' (' + location.name + ')',
 				description: '',
 				delivery_time: '',
 				price: displayForMinorUnit( localPickupCost, 0 ) || '0',

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -29,7 +29,7 @@ const localPickupRates = localPickupLocations
 	? Object.values( localPickupLocations ).map(
 			( location, index: number ) => ( {
 				...API_SITE_CURRENCY,
-				name: localPickupTitle + ' (' + location.name + ')',
+				name: `${ localPickupTitle } (${ location.name })`,
 				description: '',
 				delivery_time: '',
 				price: displayForMinorUnit( localPickupCost, 0 ) || '0',

--- a/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
+++ b/plugins/woocommerce-blocks/assets/js/previews/shipping-rates.ts
@@ -12,7 +12,7 @@ import { API_SITE_CURRENCY, displayForMinorUnit } from './utils';
 
 // Get local pickup locations from the settings and format into some preview shipping rates for the response.
 const localPickupEnabled = getSetting< boolean >( 'localPickupEnabled', false );
-const localPickupTitle = getSetting< string >( 'localPickupText', '' );
+const localPickupTitle = getSetting< string >( 'localPickupText', __( 'Local pickup', 'woocommerce' ) );
 const localPickupCost = getSetting< string >( 'localPickupCost', '' );
 const localPickupLocations = localPickupEnabled
 	? getSetting<

--- a/plugins/woocommerce/changelog/fix-Cart-Block-shows-dummy-data-for-local-pickup-options-in-block-editor
+++ b/plugins/woocommerce/changelog/fix-Cart-Block-shows-dummy-data-for-local-pickup-options-in-block-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Now the cart block shows dynamic data for local pickup options in block editor.


### PR DESCRIPTION
Now the cart block shows dynamic data for local pickup options in block editor.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55068 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to /wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location.
2. Enable local pickup and add a pickup location
3. Go to the Editor, in cart block, the local pickup options are now dynamic as saved earlier.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Now the cart block shows dynamic data for local pickup options in block editor.
</details>
