### PR TITLE
[dev] CI: clarify used actions version in setup-woocommerce-monorepo/action.yml

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -103,7 +103,7 @@ runs:
         - name: 'Cache Build Output'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
-          uses: 'google/wireit@4aad131006ea85c1e42af927534ebb13426dd730'
+          uses: 'google/wireit@setup-github-cache/v2'
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -52,28 +52,28 @@ runs:
               echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
         - name: 'Cache: pnpm downloads'
           if: ${{ inputs.pull-package-deps != 'false' }}
-          uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
+          uses: 'actions/cache@v4'
           with:
               path: "${{ env.PNPM_STORE_PATH }}"
               key: "${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
               restore-keys: '${{ runner.os }}-pnpm-${{ inputs.pull-package-deps }}-build:${{ inputs.build-type }}-'
         - name: 'Cache: node cache'
           if: ${{ inputs.pull-package-deps != 'false' }}
-          uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
+          uses: 'actions/cache@v4'
           with:
               path: './node_modules/.cache'
               key: "${{ runner.os }}-node-cache-${{ inputs.pull-package-deps }}-${{ hashFiles( 'pnpm-lock.yaml' ) }}"
               restore-keys: '${{ runner.os }}-node-cache-${{ inputs.pull-package-deps }}-'
         - name: 'Cache Composer Dependencies'
           if: ${{ inputs.pull-package-deps != 'false' || inputs.pull-package-composer-deps != 'false' }}
-          uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
+          uses: 'actions/cache@v4'
           with:
               path: '~/.cache/composer/files'
               key: "${{ runner.os }}-composer-${{ ( inputs.pull-package-deps != 'false' && inputs.pull-package-deps ) || inputs.pull-package-composer-deps }}-${{ hashFiles( 'packages/*/*/composer.lock', 'plugins/*/composer.lock' ) }}"
               restore-keys: "${{ runner.os }}-composer-${{ ( inputs.pull-package-deps != 'false' && inputs.pull-package-deps ) || inputs.pull-package-composer-deps }}-"
         - name: 'Cache: playwright downloads'
           if: ${{ inputs.pull-playwright-cache != 'false' }}
-          uses: 'actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319'
+          uses: 'actions/cache@v4'
           with:
               path: '~/.cache/ms-playwright/'
               key: "${{ runner.os }}-playwright-${{ hashFiles( 'pnpm-lock.yaml' ) }}"

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -103,7 +103,7 @@ runs:
         - name: 'Cache Build Output'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
-          uses: 'google/wireit@setup-github-cache/v2'
+          uses: 'google/wireit@v2'
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -26,7 +26,7 @@ runs:
     using: 'composite'
     steps:
         - name: 'Setup PNPM'
-          uses: 'pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d'
+          uses: 'pnpm/action-setup@v4'
         # Next step is rudimentary - fixes a know composite action bug during post-actions:
         # Error: Index was out of range. Must be non-negative and less than the size of the collection.
         - name: 'Read PNPM version'
@@ -34,14 +34,14 @@ runs:
           shell: 'bash'
           run: 'echo "version=$(pnpm --version)" >> $GITHUB_OUTPUT'
         - name: 'Setup Node'
-          uses: 'actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65'
+          uses: 'actions/setup-node@v4'
           with:
               node-version-file: '.nvmrc'
               # The built-in caching is not fit to per-package caching we are aiming.
               cache: ''
         - name: 'Setup PHP'
           if: ${{ inputs.php-version != 'false' }}
-          uses: 'shivammathur/setup-php@a36e1e52ff4a1c9e9c9be31551ee4712a6cb6bd0'
+          uses: 'shivammathur/setup-php@v2'
           with:
               php-version: '${{ inputs.php-version }}'
               coverage: 'none'

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -103,7 +103,7 @@ runs:
         - name: 'Cache Build Output'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
-          uses: 'google/wireit@v2'
+          uses: 'google/wireit@setup-github-actions-caching/v2'
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader class.
+ * Autoloader clazz.
  *
  * @since 3.7.0
  */

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader clazz.
+ * Autoloader class.
  *
  * @since 3.7.0
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1738689047181089-slack-C03CPM3UXDJ

Update workflows to specify 'v4' instead of hash for easier audits and support requests.

### How to test the changes in this Pull Request:

- CI-checks shall pass
- Example [run](https://github.com/woocommerce/woocommerce/actions/runs/13156458832/job/36714605280?pr=55125)