### PR TITLE
Fix `wc_customer_bought_product` by using default tables

### DIFF
--- a/plugins/woocommerce/changelog/fix-customer-bought-function-correctness
+++ b/plugins/woocommerce/changelog/fix-customer-bought-function-correctness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a correctness over performance issue with wc_customer_bought_product (regression)

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -414,7 +414,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 	/**
 	 * Whether to use lookup tables - it can optimize performance, but correctness depends on the frequency of the AS job.
 	 *
-	 * @since 9.6.2
+	 * @since 9.7.0
 	 *
 	 * @param bool $enabled
 	 * @param string $customer_email Customer email to check.

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -460,7 +460,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id, $lo
 				$user_id_clause = 'OR o.customer_id = ' . absint( $user_id );
 			}
 			if ( $lookup_tables ) {
-				$sql    = "
+				$sql = "
 SELECT DISTINCT product_or_variation_id FROM (
 SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
 FROM {$wpdb->prefix}wc_order_product_lookup lookup
@@ -471,7 +471,7 @@ AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_c
 WHERE product_or_variation_id != 0
 ";
 			} else {
-				$sql    = "
+				$sql = "
 SELECT DISTINCT im.meta_value FROM $order_table AS o
 INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON o.id = i.order_id
 INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
@@ -482,10 +482,9 @@ AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_c
 ";
 			}
 			$result = $wpdb->get_col( $sql );
-		} else {
-			if ( $lookup_tables ) {
-				$result = $wpdb->get_col(
-					"
+		} elseif ( $lookup_tables ) {
+			$result = $wpdb->get_col(
+				"
 SELECT DISTINCT product_or_variation_id FROM (
 SELECT CASE WHEN lookup.product_id != 0 THEN lookup.product_id ELSE lookup.variation_id END AS product_or_variation_id
 FROM {$wpdb->prefix}wc_order_product_lookup AS lookup
@@ -496,11 +495,12 @@ AND pm.meta_key IN ( '_billing_email', '_customer_user' )
 AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )
 ) AS subquery
 WHERE product_or_variation_id != 0
-			"
-				); // WPCS: unprepared SQL ok.
-			} else {
-				$result = $wpdb->get_col(
-					"
+		"
+			); // WPCS: unprepared SQL ok.
+		} else {
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			$result = $wpdb->get_col(
+				"
 SELECT DISTINCT im.meta_value FROM {$wpdb->posts} AS p
 INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
 INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON p.ID = i.order_id
@@ -510,9 +510,9 @@ AND pm.meta_key IN ( '_billing_email', '_customer_user' )
 AND im.meta_key IN ( '_product_id', '_variation_id' )
 AND im.meta_value != 0
 AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )
-			"
-				); // WPCS: unprepared SQL ok.
-			}
+		"
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		}
 		$result = array_map( 'absint', $result );
 

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -472,6 +472,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 				$user_id_clause = 'OR o.customer_id = ' . absint( $user_id );
 			}
 			if ( $use_lookup_tables ) {
+				// HPOS: yes, Lookup table: yes.
 				$sql = "
 SELECT DISTINCT product_or_variation_id FROM (
 SELECT CASE WHEN product_id != 0 THEN product_id ELSE variation_id END AS product_or_variation_id
@@ -483,6 +484,7 @@ AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_c
 WHERE product_or_variation_id != 0
 ";
 			} else {
+				// HPOS: yes, Lookup table: no.
 				$sql = "
 SELECT DISTINCT im.meta_value FROM $order_table AS o
 INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON o.id = i.order_id
@@ -495,6 +497,7 @@ AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_c
 			}
 			$result = $wpdb->get_col( $sql );
 		} elseif ( $use_lookup_tables ) {
+			// HPOS: no, Lookup table: yes.
 			$result = $wpdb->get_col(
 				"
 SELECT DISTINCT product_or_variation_id FROM (
@@ -510,6 +513,7 @@ WHERE product_or_variation_id != 0
 		"
 			); // WPCS: unprepared SQL ok.
 		} else {
+			// HPOS: no, Lookup table: no.
 			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 			$result = $wpdb->get_col(
 				"

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
@@ -286,7 +286,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		foreach ( [ true, false ] as $lookup_tables ) {
+		foreach ( array( true, false ) as $lookup_tables ) {
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1, $lookup_tables ) );
 			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1, $lookup_tables ) );
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1, $lookup_tables ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
@@ -286,11 +286,13 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
-		$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
-		$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
-		$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
-		$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+		foreach ( [ true, false ] as $lookup_tables ) {
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1, $lookup_tables ) );
+			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1, $lookup_tables ) );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1, $lookup_tables ) );
+			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2, $lookup_tables ) );
+			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1, $lookup_tables ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/functions.php
@@ -286,12 +286,14 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		foreach ( array( true, false ) as $lookup_tables ) {
-			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1, $lookup_tables ) );
-			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1, $lookup_tables ) );
-			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1, $lookup_tables ) );
-			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2, $lookup_tables ) );
-			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1, $lookup_tables ) );
+		foreach ( array( '__return_true', '__return_false' ) as $lookup_tables ) {
+			add_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
+			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
+			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
+			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -61,11 +61,13 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
-		$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
-		$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
-		$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
-		$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+		foreach ( [ true, false ] as $lookup_tables ) {
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1, $lookup_tables ) );
+			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1, $lookup_tables ) );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1, $lookup_tables ) );
+			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2, $lookup_tables ) );
+			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1, $lookup_tables ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -61,7 +61,7 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		foreach ( [ true, false ] as $lookup_tables ) {
+		foreach ( array( true, false ) as $lookup_tables ) {
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1, $lookup_tables ) );
 			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1, $lookup_tables ) );
 			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1, $lookup_tables ) );

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -61,12 +61,14 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 		// Manually trigger the product lookup tables update, since it may take a few moments for it to happen automatically.
 		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 
-		foreach ( array( true, false ) as $lookup_tables ) {
-			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1, $lookup_tables ) );
-			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1, $lookup_tables ) );
-			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1, $lookup_tables ) );
-			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2, $lookup_tables ) );
-			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1, $lookup_tables ) );
+		foreach ( array( '__return_true', '__return_false' ) as $lookup_tables ) {
+			add_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
+			$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
+			$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
+			$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
+			$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+			remove_filter( 'woocommerce_customer_bought_product_use_lookup_tables', $lookup_tables );
 		}
 	}
 


### PR DESCRIPTION
Adds a parameter to use lookup tables, which may be performant in some cases, but correctness depends on when the AS job was ran.

Ideally there would be no delay for populating the lookup table but that might be trickier, and the this PR could serve as a good quick fix.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55052, #54853, #54898. Introduced by #52919.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Buy a product and run the following code to ensure that the function detects the purchase:

```
$customer_email = 'test@example.com'; // Replace with actual email used in purchase
$product_id = 123; // Replace with actual product ID
$bought = wc_customer_bought_product( $customer_email, get_current_user_id(), $product_id );

var_dump( $bought ); // Expected: true
```

Now, add this code snippet to your test site:

```php
add_filter( 'woocommerce_customer_bought_product_use_lookup_tables', '__return_true' );
```

Then buy another product, go to Tools > Scheduled Actions and run the pending action to sync the order product lookup table, and run the code again. You should get the same result.

Disable HPOS (go to WooCommerce > Settings > Advanced > Features and switch "Order data storage" to "WordPress posts), and try the testing steps again, making sure you still get the same results.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
