### PR TITLE
[dev] Monorepo: fix failing pmpm install on clean repository.

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -68,7 +68,7 @@ function updateConfig( packageName, packagePath, declaredDependencies, resolvedD
 			context.log( `[wireit][${ packageName }]    Inspecting workspace dependency: ${ key } (${ normalizedPath })` );
 
 			// Actualize output storage with the identified entries.
-			const dependencyFile = loadPackageFile( path.join( packagePath, 'node_modules', key ) );
+			const dependencyFile = loadPackageFile( normalizedPath );
 			if ( dependencyFile.files ) {
 				for ( const entry in dependencyFile.files ) {
 					const entryValue = dependencyFile.files[entry];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@wordpress/data': wp-6.6
   react-resize-aware: 3.1.1
 
-pnpmfileChecksum: kxz5g5a3bfs6hxevxhantmz4wa
+pnpmfileChecksum: 7otryvkmutbypzotqew4atnafq
 
 patchedDependencies:
   '@wordpress/edit-site@5.15.0':


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1738764153080629-slack-C03CPM3UXDJ

Fixes failing pnpm install on clean repository introduced in #55095.

### How to test the changes in this Pull Request:

n/a