### PR TITLE
Allow changing the Add to Cart Button alignment in all cases

### DIFF
--- a/plugins/woocommerce-blocks/assets/css/style.scss
+++ b/plugins/woocommerce-blocks/assets/css/style.scss
@@ -57,8 +57,6 @@ body.wc-block-product-gallery-modal-open {
 	.wp-block-button__link {
 		word-break: break-word;
 		white-space: normal;
-		margin-right: auto !important;
-		margin-left: auto !important;
 		display: inline-flex;
 		justify-content: center;
 		text-align: center;

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -82,14 +82,12 @@ const Edit = ( {
 	return (
 		<>
 			<BlockControls>
-				{ isDescendentOfQueryLoop && (
-					<AlignmentToolbar
-						value={ attributes.textAlign }
-						onChange={ ( newAlign ) => {
-							setAttributes( { textAlign: newAlign || '' } );
-						} }
-					/>
-				) }
+				<AlignmentToolbar
+					value={ attributes.textAlign }
+					onChange={ ( newAlign ) => {
+						setAttributes( { textAlign: newAlign || '' } );
+					} }
+				/>
 			</BlockControls>
 			<InspectorControls>
 				<WidthPanel

--- a/plugins/woocommerce/changelog/add-product-button-alignment
+++ b/plugins/woocommerce/changelog/add-product-button-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow changing the Add to Cart Button alignment when used inside the All Products and Single Product blocks


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In order to fix https://github.com/woocommerce/woocommerce/issues/54204, we need the _Add to Cart Button_ block to allow left, center and right alignment. In fact, the block already allows that, but only when it is a descendant of the _Product Collection_ block. This PR enables alignment options in all contexts.

### How to test the changes in this Pull Request:

1. Add the _Product Collection_ and _All Products_ blocks. For the all products block, you can copy and paste this code (paste it with <kbd>Ctrl</kbd>+<kbd>V</kbd> so it gets converted to a block):
```HTML
<!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image",{"imageSizing":"cropped"}],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
<div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;,{&quot;imageSizing&quot;:&quot;cropped&quot;}],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"></div>
<!-- /wp:woocommerce/all-products -->
```
2. Edit both blocks and make sure you can align the button to the left, center and right and it looks good in the frontend.

Experimental testing (don't test as part of the release):

1. Install and activate the WooCommerce Beta Tester plugin
2. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Now, go to Appearance > Editor > Templates > Single Product.
4. Add the Single Product block.
5. Update the two instances of Add to Cart with Options with the blockified version.
6. In both cases, verify you can align the Add to Cart Button block to the left, center and right, and it looks good on the frontend.