### PR TITLE
Blueprint - Only display active plugins and theme

### DIFF
--- a/plugins/woocommerce/changelog/55148-update-remove-inactive-theme-and-plugins
+++ b/plugins/woocommerce/changelog/55148-update-remove-inactive-theme-and-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Blueprint - only show active theme and plugins

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -125,53 +125,53 @@ class Init {
 	 * @return array
 	 */
 	public function get_step_groups_for_js() {
-			return array(
-				array(
-					'id'          => 'settings',
-					'description' => __( 'It includes all the items featured in WooCommerce | Settings.', 'woocommerce' ),
-					'label'       => __( 'Settings', 'woocommerce' ),
-					'items'       => array_map(
-						function ( $exporter ) {
-							return array(
-								'id'          => $exporter instanceof HasAlias ? $exporter->get_alias() : $exporter->get_step_name(),
-								'label'       => $exporter->get_label(),
-								'description' => $exporter->get_description(),
-							);
-						},
-						$this->get_woo_exporters()
-					),
+		$all_plugins = $this->wp_get_plugins();
+		$active_plugins = array_intersect_key($all_plugins, array_flip(get_option('active_plugins', array())));
+		$active_theme = $this->wp_get_theme();
+
+		return array(
+			array(
+				'id'          => 'settings',
+				'description' => __( 'It includes all the items featured in WooCommerce | Settings.', 'woocommerce' ),
+				'label'       => __( 'Settings', 'woocommerce' ),
+				'items'       => array_map(
+					function ( $exporter ) {
+						return array(
+							'id'          => $exporter instanceof HasAlias ? $exporter->get_alias() : $exporter->get_step_name(),
+							'label'       => $exporter->get_label(),
+							'description' => $exporter->get_description(),
+						);
+					},
+					$this->get_woo_exporters()
 				),
-				array(
-					'id'          => 'plugins',
-					'description' => __( 'It includes all the installed plugins and extensions.', 'woocommerce' ),
-					'label'       => __( 'Plugins and extensions', 'woocommerce' ),
-					'items'       => array_map(
-						function ( $key, $plugin ) {
-							return array(
-								'id'    => $key,
-								'label' => $plugin['Name'],
-							);
-						},
-						array_keys( $this->wp_get_plugins() ),
-						$this->wp_get_plugins()
-					),
+			),
+			array(
+				'id'          => 'plugins',
+				'description' => __( 'It includes all the installed plugins and extensions.', 'woocommerce' ),
+				'label'       => __( 'Plugins and extensions', 'woocommerce' ),
+				'items'       => array_map(
+					function ( $key, $plugin ) {
+						return array(
+							'id'    => $key,
+							'label' => $plugin['Name'],
+						);
+					},
+					array_keys( $active_plugins ),
+					$active_plugins
 				),
-				array(
-					'id'          => 'themes',
-					'description' => __( 'It includes all the installed themes.', 'woocommerce' ),
-					'label'       => __( 'Themes', 'woocommerce' ),
-					'items'       => array_map(
-						function ( $key, $theme ) {
-							return array(
-								'id'    => $key,
-								'label' => $theme['Name'],
-							);
-						},
-						array_keys( $this->wp_get_themes() ),
-						$this->wp_get_themes()
-					),
-				),
-			);
+			),
+			array(
+				'id'          => 'themes',
+				'description' => __( 'It includes all the installed themes.', 'woocommerce' ),
+				'label'       => __( 'Themes', 'woocommerce' ),
+				'items'       => array(
+					array(
+						'id'    => $active_theme->get_stylesheet(),
+						'label' => $active_theme->get('Name'),
+					)
+				)
+			),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -147,7 +147,7 @@ class Init {
 			),
 			array(
 				'id'          => 'plugins',
-				'description' => __( 'It includes all the installed plugins and extensions.', 'woocommerce' ),
+				'description' => __( 'It includes all the active plugins.', 'woocommerce' ),
 				'label'       => __( 'Plugins and extensions', 'woocommerce' ),
 				'items'       => array_map(
 					function ( $key, $plugin ) {

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -125,9 +125,9 @@ class Init {
 	 * @return array
 	 */
 	public function get_step_groups_for_js() {
-		$all_plugins = $this->wp_get_plugins();
-		$active_plugins = array_intersect_key($all_plugins, array_flip(get_option('active_plugins', array())));
-		$active_theme = $this->wp_get_theme();
+		$all_plugins    = $this->wp_get_plugins();
+		$active_plugins = array_intersect_key( $all_plugins, array_flip( get_option( 'active_plugins', array() ) ) );
+		$active_theme   = $this->wp_get_theme();
 
 		return array(
 			array(
@@ -167,9 +167,9 @@ class Init {
 				'items'       => array(
 					array(
 						'id'    => $active_theme->get_stylesheet(),
-						'label' => $active_theme->get('Name'),
-					)
-				)
+						'label' => $active_theme->get( 'Name' ),
+					),
+				),
 			),
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -162,7 +162,7 @@ class Init {
 			),
 			array(
 				'id'          => 'themes',
-				'description' => __( 'It includes all the installed themes.', 'woocommerce' ),
+				'description' => __( 'It includes all the active themes.', 'woocommerce' ),
 				'label'       => __( 'Themes', 'woocommerce' ),
 				'items'       => array(
 					array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

See https://github.com/woocommerce/woocommerce/issues/53673 (Blueprint: Remove non-active themes from list)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch. Make sure to enable `blueprint`.
2. Navigate to WooCommerce -> Settings -> Advanced -> Blueprint
3. Check "Plugins and extensions" and "Themes" sections.
4. Confirm we only show active theme and plugins.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Blueprint - only show active theme and plugins

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
