### PR TITLE
[Experimental] Product filters: mobile stacking

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-filters/style.scss
@@ -146,4 +146,16 @@
 			}
 		}
 	}
+
+	@include breakpoint("<600px") {
+		.wc-block-product-filters__overlay-content {
+			.wp-block-group {
+				display: block;
+
+				> div {
+					margin: 20px 0;
+				}
+			}
+		}
+	}
 }

--- a/plugins/woocommerce/changelog/product-filters-mobile-stacking-in-group
+++ b/plugins/woocommerce/changelog/product-filters-mobile-stacking-in-group
@@ -1,0 +1,3 @@
+Significance: patch
+Type: tweak
+Comment: Product filters: ensure mobile stacking in group row


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR ensures if users uses a group/row block within the Product Filters block to display filters horizontally will show the filters stacked (one on top of each other) in the mobile dialog view.

I understand this will not cover every case but hopefully the most used case to display filters horizontally.

| Before | After |
|--------|--------|
|![Google Chrome - Shop – woo-blocks-dev 2025-02-05 at 12 35 52 PM](https://github.com/user-attachments/assets/89c9cf04-7a54-4c08-880b-21c294003f36)|![Google Chrome - Shop – woo-blocks-dev 2025-02-05 at 12 34 57 PM](https://github.com/user-attachments/assets/5f434cb4-9891-4629-8fdb-f8372e24c024)| 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Add the Product Filters (Experimental) block to the top of the Product Collection block and add a group/row block to contain each of the individual filter blocks like this:
![Google Chrome - Product Catalog ‹ Template ‹ woo-blocks-dev ‹ Editor — WordPress 2025-02-05 at 12 33 52 PM](https://github.com/user-attachments/assets/f82abb3e-6843-4440-b2ca-a425d3928209)
3. Save and go to the frontend.
4. If in Chrome open dev inspector and set it to mobile view < 600px.
5. Click on the Filter Products dialog toggle.
6. Ensure you see the filters as stacked instead of horizontal as shown in the "after" screenshot above.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
