### PR TITLE
Update change-a-currency-symbol.md

### DIFF
--- a/docs/code-snippets/change-a-currency-symbol.md
+++ b/docs/code-snippets/change-a-currency-symbol.md
@@ -3,9 +3,9 @@ post_title: Change a currency symbol
 tags: code-snippet
 ---
 
-See the [currency list](https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-core-functions.html#source-view.475) for reference on currency codes.
+In WooCommerce, each currency is associated with a code and a symbol. For example, the Australian dollar has the code `AUD` and the symbol `$` (if you are interested, you can see a full list of codes and symbols in the [source code](https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-core-functions.html#source-view.662)). 
 
-Add this code to your child theme's `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme's functions.php file, as this will be wiped entirely when you update the theme.
+However, there may be situations where you wish to change the symbol. Taking our example of the Australian dollar, it uses the same symbol as many other dollar currencies and so, in certain situations where this could lead to confusion, it might be useful to change it to `AUD$`. The following snippet outlines how this might be done:
 
 ```php
 if ( ! function_exists( 'YOUR_PREFIX_change_currency_symbol' ) ) {
@@ -26,3 +26,7 @@ if ( ! function_exists( 'YOUR_PREFIX_change_currency_symbol' ) ) {
   add_filter( 'woocommerce_currency_symbol', 'YOUR_PREFIX_change_currency_symbol', 10, 2 );  
 }
 ```
+
+You can add additional cases within the switch statements to make the same sort of change for any other currencies you support.
+
+Add this code to your child theme's `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme's functions.php file, as this will be wiped entirely when you update the theme.

--- a/docs/code-snippets/change-a-currency-symbol.md
+++ b/docs/code-snippets/change-a-currency-symbol.md
@@ -3,7 +3,7 @@ post_title: Change a currency symbol
 tags: code-snippet
 ---
 
-In WooCommerce, each currency is associated with a code and a symbol. For example, the Australian dollar has the code `AUD` and the symbol `$` (if you are interested, you can see a full list of codes and symbols in the [source code](https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-core-functions.html#source-view.662)). 
+In WooCommerce, each currency is associated with a code and a symbol. For example, the Australian dollar has the code `AUD` and the symbol `$` (if you are interested, you can see a full list of codes and symbols in the [source code](https://github.com/woocommerce/woocommerce/blob/9.6.1/plugins/woocommerce/includes/wc-core-functions.php#L682)). 
 
 However, there may be situations where you wish to change the symbol. Taking our example of the Australian dollar, it uses the same symbol as many other dollar currencies and so, in certain situations where this could lead to confusion, it might be useful to change it to `AUD$`. The following snippet outlines how this might be done:
 

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -508,7 +508,7 @@
           "post_title": "Change a currency symbol",
           "tags": "code-snippet",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/code-snippets/change-a-currency-symbol.md",
-          "hash": "1e25d4cf42f3b5907befc8d3b6d3999ca31c2f97b9512eadb749935685d1a7d6",
+          "hash": "81da31279a278ad1281dcec75f3c72049d7732bf318618da5d9e5cd337eff79b",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/code-snippets/change-a-currency-symbol.md",
           "id": "35ff98a542ad0b092aa44a049c6015cd43ed5857"
         },
@@ -1928,5 +1928,5 @@
       "categories": []
     }
   ],
-  "hash": "775dfab002800edfc09df9507dc70e63f17ea9d8398d63612130f783fe587602"
+  "hash": "faae7fe63e7520363bb251a185a474b2cbbf399c074fd3d500b791bdee522ff8"
 }


### PR DESCRIPTION
As part of our [code snippets review](https://github.com/woocommerce/woocommerce/issues/54438), I'm updating the *Change a Currency Symbol* post to add some additional context as to why this might be needed.

The snippet itself remains unchanged (and I have verified it continues to work). Even so, if you wish, feel free to test and review it as part of this code review.

Fixes #55158.