### PR TITLE
[API tests] Unskip pressable wpcom `coupons.test.js` on WPCOM

### DIFF
--- a/plugins/woocommerce/changelog/dev-api-tests-unskip-pressable-wpcom-coupons
+++ b/plugins/woocommerce/changelog/dev-api-tests-unskip-pressable-wpcom-coupons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip API test `coupons.test.js` on WPCOM.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/coupons/coupons.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/coupons/coupons.test.js
@@ -1,8 +1,4 @@
-const {
-	test,
-	expect,
-	tags,
-} = require( '../../../fixtures/api-tests-fixtures' );
+const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { coupon, order } = require( '../../../data' );
 
 test.describe( 'Coupons API tests', () => {
@@ -73,30 +69,26 @@ test.describe( 'Coupons API tests', () => {
 		);
 	} );
 
-	test(
-		'can permanently delete a coupon',
-		{ tag: tags.SKIP_ON_WPCOM },
-		async ( { request } ) => {
-			//call API to delete previously created coupon
-			const response = await request.delete(
-				`./wp-json/wc/v3/coupons/${ couponId }`,
-				{
-					data: { force: true },
-				}
-			);
+	test( 'can permanently delete a coupon', async ( { request } ) => {
+		//call API to delete previously created coupon
+		const response = await request.delete(
+			`./wp-json/wc/v3/coupons/${ couponId }`,
+			{
+				data: { force: true },
+			}
+		);
 
-			//validate response
-			expect( response.status() ).toEqual( 200 );
+		//validate response
+		expect( response.status() ).toEqual( 200 );
 
-			//call API to retrieve previously deleted coupon
-			const getCouponResponse = await request.get(
-				`./wp-json/wc/v3/coupons/${ couponId }`
-			);
+		//call API to retrieve previously deleted coupon
+		const getCouponResponse = await request.get(
+			`./wp-json/wc/v3/coupons/${ couponId }`
+		);
 
-			//validate response
-			expect( getCouponResponse.status() ).toEqual( 404 );
-		}
-	);
+		//validate response
+		expect( getCouponResponse.status() ).toEqual( 404 );
+	} );
 } );
 
 test.describe( 'Batch update coupons', () => {
@@ -188,42 +180,38 @@ test.describe( 'Batch update coupons', () => {
 		expect( updatedCoupons[ 1 ].amount ).toEqual( '25.00' );
 	} );
 
-	test(
-		'can batch delete coupons',
-		{ tag: tags.SKIP_ON_WPCOM },
-		async ( { request } ) => {
-			// Batch delete the 2 coupons.
-			const couponIdsToDelete = expectedCoupons.map( ( { id } ) => id );
-			const batchDeletePayload = {
-				delete: couponIdsToDelete,
-			};
+	test( 'can batch delete coupons', async ( { request } ) => {
+		// Batch delete the 2 coupons.
+		const couponIdsToDelete = expectedCoupons.map( ( { id } ) => id );
+		const batchDeletePayload = {
+			delete: couponIdsToDelete,
+		};
 
-			//Call API to batch delete the coupons
-			const batchDeleteResponse = await request.post(
-				'wp-json/wc/v3/coupons/batch',
-				{
-					data: batchDeletePayload,
-				}
-			);
-			const batchDeletePayloadJSON = await batchDeleteResponse.json();
-
-			// Verify that the response shows the 2 coupons.
-			const deletedCouponIds = batchDeletePayloadJSON.delete.map(
-				( { id } ) => id
-			);
-			expect( batchDeleteResponse.status() ).toEqual( 200 );
-			expect( deletedCouponIds ).toEqual( couponIdsToDelete );
-
-			// Verify that the 2 deleted coupons cannot be retrieved.
-			for ( const couponId of couponIdsToDelete ) {
-				//Call the API to attempte to retrieve the coupons
-				const response = await request.get(
-					`wp-json/wc/v3/coupons/${ couponId }`
-				);
-				expect( response.status() ).toEqual( 404 );
+		//Call API to batch delete the coupons
+		const batchDeleteResponse = await request.post(
+			'wp-json/wc/v3/coupons/batch',
+			{
+				data: batchDeletePayload,
 			}
+		);
+		const batchDeletePayloadJSON = await batchDeleteResponse.json();
+
+		// Verify that the response shows the 2 coupons.
+		const deletedCouponIds = batchDeletePayloadJSON.delete.map(
+			( { id } ) => id
+		);
+		expect( batchDeleteResponse.status() ).toEqual( 200 );
+		expect( deletedCouponIds ).toEqual( couponIdsToDelete );
+
+		// Verify that the 2 deleted coupons cannot be retrieved.
+		for ( const couponId of couponIdsToDelete ) {
+			//Call the API to attempte to retrieve the coupons
+			const response = await request.get(
+				`wp-json/wc/v3/coupons/${ couponId }`
+			);
+			expect( response.status() ).toEqual( 404 );
 		}
-	);
+	} );
 } );
 
 test.describe( 'List coupons', () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

This PR removes the `SKIP_ON_WPCOM` tag in the API test `coupons.test.js`. These tests ran fine on WPCOM without needing additional changes. Other changes in the diff were just spacing adjustments resulting from the tag removal.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the API tests in the CI check pass.
2. Run this test on WPCOM and make sure it passes. Check the Playwright HTML report to see if there's anything unusual.
    ```sh
    export E2E_ENV_KEY="..."
    pnpm test:e2e:wpcom api-wpcom coupons.test.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
