### PR TITLE
[API Tests] Unskip api test `customers-crud.test.js` on WPCOM and Pressable

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-api-unskip-customers-crud
+++ b/plugins/woocommerce/changelog/dev-e2e-api-unskip-customers-crud
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Comment: Unskip the API test `customers-crud.test.js` on WPCOM and Pressable.

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/site.setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/site.setup.js
@@ -104,3 +104,9 @@ setup( 'convert Cart and Checkout pages to shortcode', async ( { wpApi } ) => {
 setup( 'disable coming soon', async ( { baseURL } ) => {
 	await setComingSoon( { baseURL, enabled: 'no' } );
 } );
+
+setup( 'determine if multisite', async ( { api } ) => {
+	const response = await api.get( 'system_status' );
+	const { environment } = response.data;
+	process.env.IS_MULTISITE = environment.wp_multisite;
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -3,22 +3,22 @@ const { admin } = require( '../../../test-data/data' );
 
 test.describe( 'Customers API tests: CRUD', () => {
 	let adminId;
-		let customerId;
-		let subscriberUserId;
-		let subscriberUserCreatedDuringTests = false;
+	let customerId;
+	let subscriberUserId;
+	let subscriberUserCreatedDuringTests = false;
 
-		test.beforeAll( async ( { request } ) => {
-			// Call the API to return all users and determine if a
-			// subscriber user has been created
-			const customersResponse = await request.get(
-				'./wp-json/wc/v3/customers',
-				{
-					params: {
-						role: 'all',
-					},
-				}
-			);
-			const customersResponseJSON = await customersResponse.json();
+	test.beforeAll( async ( { request } ) => {
+		// Call the API to return all users and determine if a
+		// subscriber user has been created
+		const customersResponse = await request.get(
+			'./wp-json/wc/v3/customers',
+			{
+				params: {
+					role: 'all',
+				},
+			}
+		);
+		const customersResponseJSON = await customersResponse.json();
 
 		// Get the admin user ID
 		const adminJSON = customersResponseJSON.find(
@@ -26,375 +26,142 @@ test.describe( 'Customers API tests: CRUD', () => {
 		);
 		adminId = adminJSON.id;
 
-			for ( const element of customersResponseJSON ) {
-				if ( element.role === 'subscriber' ) {
-					subscriberUserId = element.id;
-					break;
+		for ( const element of customersResponseJSON ) {
+			if ( element.role === 'subscriber' ) {
+				subscriberUserId = element.id;
+				break;
+			}
+		}
+
+		// If a subscriber user has not been created then create one
+		if ( ! subscriberUserId ) {
+			const now = Date.now();
+			const userResponse = await request.post( './wp-json/wp/v2/users', {
+				data: {
+					username: `customer_${ now }`,
+					email: `customer_${ now }@woocommercecoretestsuite.com`,
+					first_name: 'Jane',
+					last_name: 'Smith',
+					roles: [ 'subscriber' ],
+					password: 'password',
+					name: 'Jane',
+				},
+			} );
+
+			expect( userResponse.status() ).toEqual( 201 );
+
+			const userResponseJSON = await userResponse.json();
+			// set subscriber user id to newly created user
+			subscriberUserId = userResponseJSON.id;
+			subscriberUserCreatedDuringTests = true;
+		}
+
+		// Verify the subscriber user has been created
+		const response = await request.get(
+			`./wp-json/wc/v3/customers/${ subscriberUserId }`
+		);
+		const responseJSON = await response.json();
+		expect( response.status() ).toEqual( 200 );
+		expect( responseJSON.role ).toEqual( 'subscriber' );
+	} );
+
+	test.afterAll( async ( { request } ) => {
+		// delete subscriber user if one was created during the execution of these tests
+		if ( subscriberUserCreatedDuringTests ) {
+			await request.delete(
+				`./wp-json/wc/v3/customers/${ subscriberUserId }`,
+				{
+					data: {
+						force: true,
+					},
 				}
-			}
+			);
+		}
+	} );
 
-			// If a subscriber user has not been created then create one
-			if ( ! subscriberUserId ) {
-				const now = Date.now();
-				const userResponse = await request.post(
-					'./wp-json/wp/v2/users',
-					{
-						data: {
-							username: `customer_${ now }`,
-							email: `customer_${ now }@woocommercecoretestsuite.com`,
-							first_name: 'Jane',
-							last_name: 'Smith',
-							roles: [ 'subscriber' ],
-							password: 'password',
-							name: 'Jane',
-						},
-					}
-				);
+	test.describe( 'Retrieve after env setup', () => {
+		/**
+		 * when the environment is created,
+		 * (https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#woocommerce-playwright-end-to-end-tests),
+		 * we have an admin user and a subscriber user that can both be
+		 * accessed through their ids
+		 * neither of these are returned as part of the get all customers call
+		 * unless the role 'all' is passed as a search param
+		 * but they can be accessed by specific id reference
+		 */
+		test( 'can retrieve admin user', async ( { request } ) => {
+			// call API to retrieve the previously saved customer
+			const response = await request.get(
+				`./wp-json/wc/v3/customers/${ adminId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.is_paying_customer ).toEqual( false );
+			expect( responseJSON.role ).toEqual( 'administrator' );
+			// this test was updated to allow for local test setup and other test sites.
+			expect( responseJSON.username ).toEqual( admin.username );
+		} );
 
-				expect( userResponse.status() ).toEqual( 201 );
-
-				const userResponseJSON = await userResponse.json();
-				// set subscriber user id to newly created user
-				subscriberUserId = userResponseJSON.id;
-				subscriberUserCreatedDuringTests = true;
-			}
-
-			// Verify the subscriber user has been created
+		test( 'can retrieve subscriber user', async ( { request } ) => {
+			// if environment was created with subscriber user
+			// call API to retrieve the customer
 			const response = await request.get(
 				`./wp-json/wc/v3/customers/${ subscriberUserId }`
 			);
 			const responseJSON = await response.json();
 			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.is_paying_customer ).toEqual( false );
 			expect( responseJSON.role ).toEqual( 'subscriber' );
 		} );
 
-		test.afterAll( async ( { request } ) => {
-			// delete subscriber user if one was created during the execution of these tests
-			if ( subscriberUserCreatedDuringTests ) {
-				await request.delete(
-					`./wp-json/wc/v3/customers/${ subscriberUserId }`,
-					{
-						data: {
-							force: true,
-						},
-					}
-				);
-			}
+		test( 'retrieve user with id 0 is invalid', async ( { request } ) => {
+			// call API to retrieve the previously saved customer
+			const response = await request.get( './wp-json/wc/v3/customers/0' );
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 404 );
+			expect( responseJSON.code ).toEqual(
+				'woocommerce_rest_invalid_id'
+			);
+			expect( responseJSON.message ).toEqual( 'Invalid resource ID.' );
 		} );
 
-		test.describe( 'Retrieve after env setup', () => {
-			/**
-			 * when the environment is created,
-			 * (https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#woocommerce-playwright-end-to-end-tests),
-			 * we have an admin user and a subscriber user that can both be
-			 * accessed through their ids
-			 * neither of these are returned as part of the get all customers call
-			 * unless the role 'all' is passed as a search param
-			 * but they can be accessed by specific id reference
-			 */
-			test( 'can retrieve admin user', async ( { request } ) => {
-				// call API to retrieve the previously saved customer
-				const response = await request.get(
-				`./wp-json/wc/v3/customers/${ adminId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.is_paying_customer ).toEqual( false );
-				expect( responseJSON.role ).toEqual( 'administrator' );
-				// this test was updated to allow for local test setup and other test sites.
-				expect( responseJSON.username ).toEqual( admin.username );
-			} );
-
-			test( 'can retrieve subscriber user', async ( { request } ) => {
-				// if environment was created with subscriber user
-			// call API to retrieve the customer
-				const response = await request.get(
-					`./wp-json/wc/v3/customers/${ subscriberUserId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.is_paying_customer ).toEqual( false );
-				expect( responseJSON.role ).toEqual( 'subscriber' );
-			} );
-
-			test( 'retrieve user with id 0 is invalid', async ( {
-				request,
-			} ) => {
-				// call API to retrieve the previously saved customer
-				const response = await request.get(
-					'./wp-json/wc/v3/customers/0'
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 404 );
-				expect( responseJSON.code ).toEqual(
-					'woocommerce_rest_invalid_id'
-				);
-				expect( responseJSON.message ).toEqual(
-					'Invalid resource ID.'
-				);
-			} );
-
-			test( 'can retrieve customers', async ( { request } ) => {
-				// call API to retrieve all customers should initially return empty array
-				const response = await request.get(
-					'./wp-json/wc/v3/customers'
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( Array.isArray( responseJSON ) ).toBe( true );
-				expect( responseJSON.length ).toBeGreaterThanOrEqual( 1 );
-			} );
-
-			// however, if we pass in the search string for role 'all' then all users are returned
-			test( 'can retrieve all customers', async ( { request } ) => {
-				// call API to retrieve all customers should initially return empty array
-				// unless the role 'all' is passed as a search string, in which case the admin
-				// and subscriber users will be returned
-				const response = await request.get(
-					'./wp-json/wc/v3/customers',
-					{
-						params: {
-							role: 'all',
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( Array.isArray( responseJSON ) ).toBe( true );
-				expect( responseJSON.length ).toBeGreaterThanOrEqual( 3 );
-			} );
+		test( 'can retrieve customers', async ( { request } ) => {
+			// call API to retrieve all customers should initially return empty array
+			const response = await request.get( './wp-json/wc/v3/customers' );
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThanOrEqual( 1 );
 		} );
 
-		test.describe( 'Create a customer', () => {
-			test( 'can create a customer', async ( { request } ) => {
-				// call API to create a customer
-				const username = `john.doe.${ Date.now() }`;
-				const email = `john.doe.${ Date.now() }@example.com`;
-				const response = await request.post(
-					'./wp-json/wc/v3/customers',
-					{
-						data: {
-							email,
-							first_name: 'John',
-							last_name: 'Doe',
-							username,
-							billing: {
-								first_name: 'John',
-								last_name: 'Doe',
-								company: '',
-								address_1: '969 Market',
-								address_2: '',
-								city: 'San Francisco',
-								state: 'CA',
-								postcode: '94103',
-								country: 'US',
-								email,
-								phone: '(555) 555-5555',
-							},
-							shipping: {
-								first_name: 'John',
-								last_name: 'Doe',
-								company: '',
-								address_1: '969 Market',
-								address_2: '',
-								city: 'San Francisco',
-								state: 'CA',
-								postcode: '94103',
-								country: 'US',
-							},
-						},
-					}
-				);
-				const responseJSON = await response.json();
-
-				// Save the customer ID. It will be used by the retrieve, update, and delete tests.
-				customerId = responseJSON.id;
-
-				expect( response.status() ).toEqual( 201 );
-				expect( typeof responseJSON.id ).toEqual( 'number' );
-				// Verify that the customer role is 'customer'
-				expect( responseJSON.role ).toEqual( 'customer' );
+		// however, if we pass in the search string for role 'all' then all users are returned
+		test( 'can retrieve all customers', async ( { request } ) => {
+			// call API to retrieve all customers should initially return empty array
+			// unless the role 'all' is passed as a search string, in which case the admin
+			// and subscriber users will be returned
+			const response = await request.get( './wp-json/wc/v3/customers', {
+				params: {
+					role: 'all',
+				},
 			} );
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThanOrEqual( 3 );
 		} );
+	} );
 
-		test.describe( 'Retrieve after create', () => {
-			test( 'can retrieve a customer', async ( { request } ) => {
-				// call API to retrieve the previously saved customer
-				const response = await request.get(
-					`./wp-json/wc/v3/customers/${ customerId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.id ).toEqual( customerId );
-				expect( responseJSON.is_paying_customer ).toEqual( false );
-				expect( responseJSON.role ).toEqual( 'customer' );
-			} );
-
-			test( 'can retrieve all customers after create', async ( {
-				request,
-			} ) => {
-				// call API to retrieve all customers
-				const response = await request.get(
-					'./wp-json/wc/v3/customers'
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( Array.isArray( responseJSON ) ).toBe( true );
-				expect( responseJSON.length ).toBeGreaterThan( 0 );
-			} );
-		} );
-
-		test.describe( 'Update a customer', () => {
-			test( `can update the admin user/customer`, async ( {
-				request,
-			} ) => {
-				/**
-				 * update customer names (regular, billing and shipping) to admin
-				 * (these were initialised blank when the environment is created,
-				 * (https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#woocommerce-playwright-end-to-end-tests
-				 */
-				const response = await request.put(
-				`./wp-json/wc/v3/customers/${ adminId }`,
-					{
-						data: {
-							first_name: 'admin',
-							billing: {
-								first_name: 'admin',
-							},
-							shipping: {
-								first_name: 'admin',
-							},
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.first_name ).toEqual( 'admin' );
-				expect( responseJSON.billing.first_name ).toEqual( 'admin' );
-				expect( responseJSON.shipping.first_name ).toEqual( 'admin' );
-			} );
-
-			test( 'retrieve after update admin', async ( { request } ) => {
-				// call API to retrieve the admin customer we updated above
-				const response = await request.get(
-				`./wp-json/wc/v3/customers/${ adminId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.first_name ).toEqual( 'admin' );
-				expect( responseJSON.billing.first_name ).toEqual( 'admin' );
-				expect( responseJSON.shipping.first_name ).toEqual( 'admin' );
-			} );
-
-			test( `can update the subscriber user/customer`, async ( {
-				request,
-			} ) => {
-				// update customer names (billing and shipping) to Jane
-				// (these were initialised blank, only regular first_name was populated)
-				const response = await request.put(
-					`./wp-json/wc/v3/customers/${ subscriberUserId }`,
-					{
-						data: {
-							first_name: 'Jane',
-							billing: {
-								first_name: 'Jane',
-							},
-							shipping: {
-								first_name: 'Jane',
-							},
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.id ).toEqual( subscriberUserId );
-				expect( responseJSON.first_name ).toEqual( 'Jane' );
-				expect( responseJSON.billing.first_name ).toEqual( 'Jane' );
-				expect( responseJSON.shipping.first_name ).toEqual( 'Jane' );
-			} );
-
-			test( 'retrieve after update subscriber', async ( { request } ) => {
-				// call API to retrieve the subscriber customer we updated above
-				const response = await request.get(
-					`./wp-json/wc/v3/customers/${ subscriberUserId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.first_name ).toEqual( 'Jane' );
-				expect( responseJSON.billing.first_name ).toEqual( 'Jane' );
-				expect( responseJSON.shipping.first_name ).toEqual( 'Jane' );
-			} );
-
-			test( `can update a customer`, async ( { request } ) => {
-				// update customer names (regular, billing and shipping) from John to Jack
-				const response = await request.put(
-					`./wp-json/wc/v3/customers/${ customerId }`,
-					{
-						data: {
-							first_name: 'Jack',
-							billing: {
-								first_name: 'Jack',
-							},
-							shipping: {
-								first_name: 'Jack',
-							},
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.first_name ).toEqual( 'Jack' );
-				expect( responseJSON.billing.first_name ).toEqual( 'Jack' );
-				expect( responseJSON.shipping.first_name ).toEqual( 'Jack' );
-			} );
-
-			test( 'retrieve after update customer', async ( { request } ) => {
-				// call API to retrieve the updated customer we created above
-				const response = await request.get(
-					`./wp-json/wc/v3/customers/${ customerId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.first_name ).toEqual( 'Jack' );
-				expect( responseJSON.billing.first_name ).toEqual( 'Jack' );
-				expect( responseJSON.shipping.first_name ).toEqual( 'Jack' );
-			} );
-		} );
-
-		test.describe( 'Delete a customer', () => {
-			test( 'can permanently delete an customer', async ( {
-				request,
-			} ) => {
-				// Delete the customer.
-				const response = await request.delete(
-					`./wp-json/wc/v3/customers/${ customerId }`,
-					{
-						data: {
-							force: true,
-						},
-					}
-				);
-				expect( response.status() ).toEqual( 200 );
-
-				// Verify that the customer can no longer be retrieved.
-				const getDeletedCustomerResponse = await request.get(
-					`./wp-json/wc/v3/customers/${ customerId }`
-				);
-				expect( getDeletedCustomerResponse.status() ).toEqual( 404 );
-			} );
-		} );
-
-		test.describe( 'Batch update customers', () => {
-			/**
-			 * 2 Customers to be created in one batch.
-			 */
-			const now = Date.now();
-			const expectedCustomers = [
-				{
-					email: `john.doe.${ now }@example.com`,
+	test.describe( 'Create a customer', () => {
+		test( 'can create a customer', async ( { request } ) => {
+			// call API to create a customer
+			const username = `john.doe.${ Date.now() }`;
+			const email = `john.doe.${ Date.now() }@example.com`;
+			const response = await request.post( './wp-json/wc/v3/customers', {
+				data: {
+					email,
 					first_name: 'John',
 					last_name: 'Doe',
-					username: `john.doe.${ now }`,
+					username,
 					billing: {
 						first_name: 'John',
 						last_name: 'Doe',
@@ -405,7 +172,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 						state: 'CA',
 						postcode: '94103',
 						country: 'US',
-						email: `john.doe.${ now }@example.com`,
+						email,
 						phone: '(555) 555-5555',
 					},
 					shipping: {
@@ -420,156 +187,362 @@ test.describe( 'Customers API tests: CRUD', () => {
 						country: 'US',
 					},
 				},
+			} );
+			const responseJSON = await response.json();
+
+			// Save the customer ID. It will be used by the retrieve, update, and delete tests.
+			customerId = responseJSON.id;
+
+			expect( response.status() ).toEqual( 201 );
+			expect( typeof responseJSON.id ).toEqual( 'number' );
+			// Verify that the customer role is 'customer'
+			expect( responseJSON.role ).toEqual( 'customer' );
+		} );
+	} );
+
+	test.describe( 'Retrieve after create', () => {
+		test( 'can retrieve a customer', async ( { request } ) => {
+			// call API to retrieve the previously saved customer
+			const response = await request.get(
+				`./wp-json/wc/v3/customers/${ customerId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.id ).toEqual( customerId );
+			expect( responseJSON.is_paying_customer ).toEqual( false );
+			expect( responseJSON.role ).toEqual( 'customer' );
+		} );
+
+		test( 'can retrieve all customers after create', async ( {
+			request,
+		} ) => {
+			// call API to retrieve all customers
+			const response = await request.get( './wp-json/wc/v3/customers' );
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	test.describe( 'Update a customer', () => {
+		test( `can update the admin user/customer`, async ( { request } ) => {
+			/**
+			 * update customer names (regular, billing and shipping) to admin
+			 * (these were initialised blank when the environment is created,
+			 * (https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#woocommerce-playwright-end-to-end-tests
+			 */
+			const response = await request.put(
+				`./wp-json/wc/v3/customers/${ adminId }`,
 				{
-					email: `joao.silva.${ now }@example.com`,
+					data: {
+						first_name: 'admin',
+						billing: {
+							first_name: 'admin',
+						},
+						shipping: {
+							first_name: 'admin',
+						},
+					},
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.first_name ).toEqual( 'admin' );
+			expect( responseJSON.billing.first_name ).toEqual( 'admin' );
+			expect( responseJSON.shipping.first_name ).toEqual( 'admin' );
+		} );
+
+		test( 'retrieve after update admin', async ( { request } ) => {
+			// call API to retrieve the admin customer we updated above
+			const response = await request.get(
+				`./wp-json/wc/v3/customers/${ adminId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.first_name ).toEqual( 'admin' );
+			expect( responseJSON.billing.first_name ).toEqual( 'admin' );
+			expect( responseJSON.shipping.first_name ).toEqual( 'admin' );
+		} );
+
+		test( `can update the subscriber user/customer`, async ( {
+			request,
+		} ) => {
+			// update customer names (billing and shipping) to Jane
+			// (these were initialised blank, only regular first_name was populated)
+			const response = await request.put(
+				`./wp-json/wc/v3/customers/${ subscriberUserId }`,
+				{
+					data: {
+						first_name: 'Jane',
+						billing: {
+							first_name: 'Jane',
+						},
+						shipping: {
+							first_name: 'Jane',
+						},
+					},
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.id ).toEqual( subscriberUserId );
+			expect( responseJSON.first_name ).toEqual( 'Jane' );
+			expect( responseJSON.billing.first_name ).toEqual( 'Jane' );
+			expect( responseJSON.shipping.first_name ).toEqual( 'Jane' );
+		} );
+
+		test( 'retrieve after update subscriber', async ( { request } ) => {
+			// call API to retrieve the subscriber customer we updated above
+			const response = await request.get(
+				`./wp-json/wc/v3/customers/${ subscriberUserId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.first_name ).toEqual( 'Jane' );
+			expect( responseJSON.billing.first_name ).toEqual( 'Jane' );
+			expect( responseJSON.shipping.first_name ).toEqual( 'Jane' );
+		} );
+
+		test( `can update a customer`, async ( { request } ) => {
+			// update customer names (regular, billing and shipping) from John to Jack
+			const response = await request.put(
+				`./wp-json/wc/v3/customers/${ customerId }`,
+				{
+					data: {
+						first_name: 'Jack',
+						billing: {
+							first_name: 'Jack',
+						},
+						shipping: {
+							first_name: 'Jack',
+						},
+					},
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.first_name ).toEqual( 'Jack' );
+			expect( responseJSON.billing.first_name ).toEqual( 'Jack' );
+			expect( responseJSON.shipping.first_name ).toEqual( 'Jack' );
+		} );
+
+		test( 'retrieve after update customer', async ( { request } ) => {
+			// call API to retrieve the updated customer we created above
+			const response = await request.get(
+				`./wp-json/wc/v3/customers/${ customerId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.first_name ).toEqual( 'Jack' );
+			expect( responseJSON.billing.first_name ).toEqual( 'Jack' );
+			expect( responseJSON.shipping.first_name ).toEqual( 'Jack' );
+		} );
+	} );
+
+	test.describe( 'Delete a customer', () => {
+		test( 'can permanently delete an customer', async ( { request } ) => {
+			// Delete the customer.
+			const response = await request.delete(
+				`./wp-json/wc/v3/customers/${ customerId }`,
+				{
+					data: {
+						force: true,
+					},
+				}
+			);
+			expect( response.status() ).toEqual( 200 );
+
+			// Verify that the customer can no longer be retrieved.
+			const getDeletedCustomerResponse = await request.get(
+				`./wp-json/wc/v3/customers/${ customerId }`
+			);
+			expect( getDeletedCustomerResponse.status() ).toEqual( 404 );
+		} );
+	} );
+
+	test.describe( 'Batch update customers', () => {
+		/**
+		 * 2 Customers to be created in one batch.
+		 */
+		const now = Date.now();
+		const expectedCustomers = [
+			{
+				email: `john.doe.${ now }@example.com`,
+				first_name: 'John',
+				last_name: 'Doe',
+				username: `john.doe.${ now }`,
+				billing: {
+					first_name: 'John',
+					last_name: 'Doe',
+					company: '',
+					address_1: '969 Market',
+					address_2: '',
+					city: 'San Francisco',
+					state: 'CA',
+					postcode: '94103',
+					country: 'US',
+					email: `john.doe.${ now }@example.com`,
+					phone: '(555) 555-5555',
+				},
+				shipping: {
+					first_name: 'John',
+					last_name: 'Doe',
+					company: '',
+					address_1: '969 Market',
+					address_2: '',
+					city: 'San Francisco',
+					state: 'CA',
+					postcode: '94103',
+					country: 'US',
+				},
+			},
+			{
+				email: `joao.silva.${ now }@example.com`,
+				first_name: 'João',
+				last_name: 'Silva',
+				username: `joao.silva.${ now }`,
+				billing: {
 					first_name: 'João',
 					last_name: 'Silva',
-					username: `joao.silva.${ now }`,
-					billing: {
-						first_name: 'João',
-						last_name: 'Silva',
-						company: '',
-						address_1: 'Av. Brasil, 432',
-						address_2: '',
-						city: 'Rio de Janeiro',
-						state: 'RJ',
-						postcode: '12345-000',
-						country: 'BR',
-						email: `joao.silva.${ now }@example.com`,
-						phone: '(55) 5555-5555',
-					},
-					shipping: {
-						first_name: 'João',
-						last_name: 'Silva',
-						company: '',
-						address_1: 'Av. Brasil, 432',
-						address_2: '',
-						city: 'Rio de Janeiro',
-						state: 'RJ',
-						postcode: '12345-000',
-						country: 'BR',
-					},
+					company: '',
+					address_1: 'Av. Brasil, 432',
+					address_2: '',
+					city: 'Rio de Janeiro',
+					state: 'RJ',
+					postcode: '12345-000',
+					country: 'BR',
+					email: `joao.silva.${ now }@example.com`,
+					phone: '(55) 5555-5555',
 				},
-			];
+				shipping: {
+					first_name: 'João',
+					last_name: 'Silva',
+					company: '',
+					address_1: 'Av. Brasil, 432',
+					address_2: '',
+					city: 'Rio de Janeiro',
+					state: 'RJ',
+					postcode: '12345-000',
+					country: 'BR',
+				},
+			},
+		];
 
-			// set payload to use batch create: action
-			const batchCreate2CustomersPayload = {
-				create: expectedCustomers,
+		// set payload to use batch create: action
+		const batchCreate2CustomersPayload = {
+			create: expectedCustomers,
+		};
+
+		test( 'can batch create customers', async ( { request } ) => {
+			// Batch create 2 new customers.
+			// call API to batch create customers
+			const response = await request.post(
+				'wp-json/wc/v3/customers/batch',
+				{
+					data: batchCreate2CustomersPayload,
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+
+			// Verify that the 2 new customers were created
+			const actualCustomers = responseJSON.create;
+			expect( actualCustomers ).toHaveLength( expectedCustomers.length );
+
+			for ( let i = 0; i < actualCustomers.length; i++ ) {
+				const { id, first_name } = actualCustomers[ i ];
+				const expectedCustomerName = expectedCustomers[ i ].first_name;
+
+				expect( id ).toBeDefined();
+				expect( first_name ).toEqual( expectedCustomerName );
+
+				// Save the customer id
+				expectedCustomers[ i ].id = id;
+			}
+		} );
+
+		test( 'can batch update customers', async ( { request } ) => {
+			// set payload to use batch update: action
+			const newEmail = `emailupdated.${ Date.now() }@example.com`;
+			const newAddress = '123 Addressupdate Street';
+			const batchUpdatePayload = {
+				update: [
+					{
+						id: expectedCustomers[ 0 ].id,
+						email: newEmail,
+					},
+					{
+						id: expectedCustomers[ 1 ].id,
+						billing: {
+							address_1: newAddress,
+						},
+					},
+				],
 			};
 
-			test( 'can batch create customers', async ( { request } ) => {
-				// Batch create 2 new customers.
-				// call API to batch create customers
-				const response = await request.post(
-					'wp-json/wc/v3/customers/batch',
-					{
-						data: batchCreate2CustomersPayload,
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-
-				// Verify that the 2 new customers were created
-				const actualCustomers = responseJSON.create;
-				expect( actualCustomers ).toHaveLength(
-					expectedCustomers.length
-				);
-
-				for ( let i = 0; i < actualCustomers.length; i++ ) {
-					const { id, first_name } = actualCustomers[ i ];
-					const expectedCustomerName =
-						expectedCustomers[ i ].first_name;
-
-					expect( id ).toBeDefined();
-					expect( first_name ).toEqual( expectedCustomerName );
-
-					// Save the customer id
-					expectedCustomers[ i ].id = id;
+			// Call API to update the customers
+			const response = await request.post(
+				'wp-json/wc/v3/customers/batch',
+				{
+					data: batchUpdatePayload,
 				}
-			} );
+			);
+			const responseJSON = await response.json();
 
-			test( 'can batch update customers', async ( { request } ) => {
-				// set payload to use batch update: action
-				const newEmail = `emailupdated.${ Date.now() }@example.com`;
-				const newAddress = '123 Addressupdate Street';
-				const batchUpdatePayload = {
-					update: [
-						{
-							id: expectedCustomers[ 0 ].id,
-							email: newEmail,
-						},
-						{
-							id: expectedCustomers[ 1 ].id,
-							billing: {
-								address_1: newAddress,
-							},
-						},
-					],
-				};
+			// Verify the response code and the number of customers that were updated.
+			const updatedCustomers = responseJSON.update;
+			expect( response.status() ).toEqual( 200 );
+			expect( updatedCustomers ).toHaveLength( 2 );
 
-				// Call API to update the customers
-				const response = await request.post(
-					'wp-json/wc/v3/customers/batch',
-					{
-						data: batchUpdatePayload,
-					}
-				);
-				const responseJSON = await response.json();
+			// Verify that the 1st customer was updated to have a new email address.
+			expect( updatedCustomers[ 0 ].id ).toEqual(
+				expectedCustomers[ 0 ].id
+			);
+			expect( updatedCustomers[ 0 ].email ).toEqual( newEmail );
 
-				// Verify the response code and the number of customers that were updated.
-				const updatedCustomers = responseJSON.update;
-				expect( response.status() ).toEqual( 200 );
-				expect( updatedCustomers ).toHaveLength( 2 );
-
-				// Verify that the 1st customer was updated to have a new email address.
-				expect( updatedCustomers[ 0 ].id ).toEqual(
-					expectedCustomers[ 0 ].id
-				);
-				expect( updatedCustomers[ 0 ].email ).toEqual( newEmail );
-
-				// Verify that the amount of the 2nd customer was updated to have a new billing address.
-				expect( updatedCustomers[ 1 ].id ).toEqual(
-					expectedCustomers[ 1 ].id
-				);
-				expect( updatedCustomers[ 1 ].billing.address_1 ).toEqual(
-					newAddress
-				);
-			} );
-
-			test( 'can batch delete customers', async ( { request } ) => {
-				// Batch delete the 2 customers.
-				const customerIdsToDelete = expectedCustomers.map(
-					( { id } ) => id
-				);
-				const batchDeletePayload = {
-					delete: customerIdsToDelete,
-				};
-
-				//Call API to batch delete the customers
-				const response = await request.post(
-					'wp-json/wc/v3/customers/batch',
-					{
-						data: batchDeletePayload,
-					}
-				);
-				const responseJSON = await response.json();
-
-				// Verify that the response shows the 2 customers.
-				const deletedCustomerIds = responseJSON.delete.map(
-					( { id } ) => id
-				);
-				expect( response.status() ).toEqual( 200 );
-				expect( deletedCustomerIds ).toEqual( customerIdsToDelete );
-
-				// Verify that the 2 deleted customers cannot be retrieved.
-				for ( const id of customerIdsToDelete ) {
-					//Call the API to attempte to retrieve the customers
-					const r = await request.get(
-						`wp-json/wc/v3/customers/${ id }`
-					);
-					expect( r.status() ).toEqual( 404 );
-				}
-			} );
+			// Verify that the amount of the 2nd customer was updated to have a new billing address.
+			expect( updatedCustomers[ 1 ].id ).toEqual(
+				expectedCustomers[ 1 ].id
+			);
+			expect( updatedCustomers[ 1 ].billing.address_1 ).toEqual(
+				newAddress
+			);
 		} );
-	}
-);
+
+		test( 'can batch delete customers', async ( { request } ) => {
+			// Batch delete the 2 customers.
+			const customerIdsToDelete = expectedCustomers.map(
+				( { id } ) => id
+			);
+			const batchDeletePayload = {
+				delete: customerIdsToDelete,
+			};
+
+			//Call API to batch delete the customers
+			const response = await request.post(
+				'wp-json/wc/v3/customers/batch',
+				{
+					data: batchDeletePayload,
+				}
+			);
+			const responseJSON = await response.json();
+
+			// Verify that the response shows the 2 customers.
+			const deletedCustomerIds = responseJSON.delete.map(
+				( { id } ) => id
+			);
+			expect( response.status() ).toEqual( 200 );
+			expect( deletedCustomerIds ).toEqual( customerIdsToDelete );
+
+			// Verify that the 2 deleted customers cannot be retrieved.
+			for ( const id of customerIdsToDelete ) {
+				//Call the API to attempte to retrieve the customers
+				const r = await request.get(
+					`wp-json/wc/v3/customers/${ id }`
+				);
+				expect( r.status() ).toEqual( 404 );
+			}
+		} );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -1,8 +1,6 @@
 const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { admin } = require( '../../../test-data/data' );
 
-let isMultisite;
-
 test.describe( 'Customers API tests: CRUD', () => {
 	let adminId;
 	let customerId;
@@ -65,20 +63,6 @@ test.describe( 'Customers API tests: CRUD', () => {
 		const responseJSON = await response.json();
 		expect( response.status() ).toEqual( 200 );
 		expect( responseJSON.role ).toEqual( 'subscriber' );
-
-		// Determine whether this is a multisite to conditionally skip multisite-incompatible tests.
-		const systemStatusResponse = await request.get(
-			'./wp-json/wc/v3/system_status',
-			{
-				data: { _fields: [ 'environment.wp_multisite' ] },
-				failOnStatusCode: true,
-			}
-		);
-		const ssrJSON = await systemStatusResponse.json();
-		expect( ssrJSON ).toMatchObject( {
-			environment: { wp_multisite: expect.any( Boolean ) },
-		} );
-		isMultisite = ssrJSON.environment.wp_multisite;
 	} );
 
 	test.afterAll( async ( { request } ) => {
@@ -359,7 +343,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 	test.describe( 'Delete a customer', () => {
 		test( 'can permanently delete an customer', async ( { request } ) => {
 			test.skip(
-				isMultisite,
+				process.env.IS_MULTISITE === 'true',
 				'Skip tests on deleting a customer on multisites until bug #384 in private repo is resolved.'
 			);
 
@@ -533,7 +517,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 
 		test( 'can batch delete customers', async ( { request } ) => {
 			test.skip(
-				isMultisite,
+				process.env.IS_MULTISITE === 'true',
 				'Skip tests on deleting a customer on multisites until bug #384 in private repo is resolved.'
 			);
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -1,14 +1,7 @@
-const {
-	test,
-	expect,
-	tags,
-} = require( '../../../fixtures/api-tests-fixtures' );
+const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { admin } = require( '../../../test-data/data' );
 
-test.describe(
-	'Customers API tests: CRUD',
-	{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
-	() => {
+test.describe( 'Customers API tests: CRUD', () => {
 		let customerId;
 		let subscriberUserId;
 		let subscriberUserCreatedDuringTests = false;

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -88,7 +88,6 @@ test.describe( 'Customers API tests: CRUD', () => {
 			 * (https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#woocommerce-playwright-end-to-end-tests),
 			 * we have an admin user and a subscriber user that can both be
 			 * accessed through their ids
-			 * admin user will have id 1 and subscriber user will have id 2
 			 * neither of these are returned as part of the get all customers call
 			 * unless the role 'all' is passed as a search param
 			 * but they can be accessed by specific id reference
@@ -108,7 +107,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 
 			test( 'can retrieve subscriber user', async ( { request } ) => {
 				// if environment was created with subscriber user
-				// call API to retrieve the customer with id 2
+			// call API to retrieve the customer
 				const response = await request.get(
 					`./wp-json/wc/v3/customers/${ subscriberUserId }`
 				);

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -2,6 +2,7 @@ const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { admin } = require( '../../../test-data/data' );
 
 test.describe( 'Customers API tests: CRUD', () => {
+	let adminId;
 		let customerId;
 		let subscriberUserId;
 		let subscriberUserCreatedDuringTests = false;
@@ -18,6 +19,12 @@ test.describe( 'Customers API tests: CRUD', () => {
 				}
 			);
 			const customersResponseJSON = await customersResponse.json();
+
+		// Get the admin user ID
+		const adminJSON = customersResponseJSON.find(
+			( { username } ) => username === admin.username
+		);
+		adminId = adminJSON.id;
 
 			for ( const element of customersResponseJSON ) {
 				if ( element.role === 'subscriber' ) {
@@ -89,7 +96,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 			test( 'can retrieve admin user', async ( { request } ) => {
 				// call API to retrieve the previously saved customer
 				const response = await request.get(
-					'./wp-json/wc/v3/customers/1'
+				`./wp-json/wc/v3/customers/${ adminId }`
 				);
 				const responseJSON = await response.json();
 				expect( response.status() ).toEqual( 200 );
@@ -248,7 +255,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 				 * (https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#woocommerce-playwright-end-to-end-tests
 				 */
 				const response = await request.put(
-					`./wp-json/wc/v3/customers/1`,
+				`./wp-json/wc/v3/customers/${ adminId }`,
 					{
 						data: {
 							first_name: 'admin',
@@ -271,7 +278,7 @@ test.describe( 'Customers API tests: CRUD', () => {
 			test( 'retrieve after update admin', async ( { request } ) => {
 				// call API to retrieve the admin customer we updated above
 				const response = await request.get(
-					'./wp-json/wc/v3/customers/1'
+				`./wp-json/wc/v3/customers/${ adminId }`
 				);
 				const responseJSON = await response.json();
 				expect( response.status() ).toEqual( 200 );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/customers/customers-crud.test.js
@@ -33,20 +33,23 @@ test.describe( 'Customers API tests: CRUD', () => {
 			}
 		}
 
-		// If a subscriber user has not been created then create one
-		if ( ! subscriberUserId ) {
-			const now = Date.now();
-			const userResponse = await request.post( './wp-json/wp/v2/users', {
-				data: {
-					username: `customer_${ now }`,
-					email: `customer_${ now }@woocommercecoretestsuite.com`,
-					first_name: 'Jane',
-					last_name: 'Smith',
-					roles: [ 'subscriber' ],
-					password: 'password',
-					name: 'Jane',
-				},
-			} );
+			// If a subscriber user has not been created then create one
+			if ( ! subscriberUserId ) {
+				const now = Date.now();
+				const userResponse = await request.post(
+					'./wp-json/wp/v2/users',
+					{
+						data: {
+							username: `customer${ now }`,
+							email: `customer${ now }@woocommercecoretestsuite.com`,
+							first_name: 'Jane',
+							last_name: 'Smith',
+							roles: [ 'subscriber' ],
+							password: 'password',
+							name: 'Jane',
+						},
+					}
+				);
 
 			expect( userResponse.status() ).toEqual( 201 );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of #54662.

This PR makes the api test `customers-crud.test.js` runnable on WPCOM and Pressable, and also on multisites, by applying these changes:
- Replace hard-coded user IDs with actual ones
- Remove special characters in usernames when creating a new user. Multisites don't like special characters in usernames.
- On multisites, skip tests on customer deletion due to a currently existing bug on multisite environments.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure all api tests pass in CI.
2. Test on WPCOM and Pressable, making sure that the api test `customers-crud.test.js` pass, with no tests skipped:
    ```sh
    export E2E_ENV_KEY="..."
    
    # Run on WPCOM
    pnpm test:e2e:wpcom api-wpcom customers-crud.test.js
    
    # Run on Pressable
    pnpm test:e2e:pressable api-pressable customers-crud.test.js
    ```
4. Set up a multisite either on JN or your local machine, and run `customers-crud.test.js`against it. Make sure the individual tests pass, but these two tests should be skipped:
    - `can permanently delete an customer`
    - `can batch delete customers`

   ```sh
   export BASE_URL="https://your.multisite-url.com"
   # Set other important environment variables like the admin and customer credentials in your multisite
   pnpm test:api customers-crud.test.js
   ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
