### PR TITLE
[API Tests] Make `payment-gateways-crud` compatible with WPCOM, Pressable, Multisite

### DIFF
--- a/plugins/woocommerce/changelog/dev-api-tests-unskip-payment-gateways-crud
+++ b/plugins/woocommerce/changelog/dev-api-tests-unskip-payment-gateways-crud
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip api test `payment-gateways-crud.test.js` on WPCOM, Pressable, and multisite.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
@@ -1,180 +1,184 @@
 const {
 	test,
-	expect,
-	tags,
+	expect: baseExpect,
 } = require( '../../../fixtures/api-tests-fixtures' );
 
+const expect = baseExpect.extend( {
+	toBeValidLocalPickupObject( receivedObj ) {
+		const value = 'Any &quot;Local pickup&quot; method';
+		const key = Object.keys( receivedObj ).find( ( k ) =>
+			[ 'pickup_location', 'local_pickup' ].includes( k )
+		);
+		const pass = key && receivedObj[ key ] === value;
+		const message = () =>
+			'\n\n' +
+			`Received: ${ JSON.stringify( receivedObj ) }\n` +
+			`Expected: Object that either has a 'local_pickup' or 'pickup_location' key, and has value "${ value }"`;
+
+		return {
+			message,
+			pass,
+		};
+	},
+} );
+
 test.describe( 'Payment Gateways API tests', () => {
-	test(
-		'can view all payment gateways',
-		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
-		async ( { request } ) => {
-			// call API to retrieve the payment gateways
-			const response = await request.get(
-				'./wp-json/wc/v3/payment_gateways'
-			);
-			const responseJSON = await response.json();
-			expect( response.status() ).toEqual( 200 );
-			expect( Array.isArray( responseJSON ) ).toBe( true );
+	test( 'can view all payment gateways', async ( { request } ) => {
+		// call API to retrieve the payment gateways
+		const response = await request.get(
+			'./wp-json/wc/v3/payment_gateways'
+		);
+		const responseJSON = await response.json();
+		expect( response.status() ).toEqual( 200 );
+		expect( Array.isArray( responseJSON ) ).toBe( true );
 
-			const localPickupKey =
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				process.env.BASE_URL &&
-				! process.env.BASE_URL.includes( 'localhost' )
-					? 'pickup_location'
-					: 'local_pickup';
-			console.log( 'localPickupKey=', localPickupKey );
-
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'bacs',
-						title: 'Direct bank transfer',
-						description:
-							'Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order will not be shipped until the funds have cleared in our account.',
-						order: '',
-						enabled: false,
-						method_title: 'Direct bank transfer',
-						method_description:
-							'Take payments in person via BACS. More commonly known as direct bank/wire transfer.',
-						method_supports: [ 'products' ],
-						settings: {
-							title: {
-								id: 'title',
-								label: 'Title',
-								description:
-									'This controls the title which the user sees during checkout.',
-								type: 'safe_text',
-								value: 'Direct bank transfer',
-								default: 'Direct bank transfer',
-								tip: 'This controls the title which the user sees during checkout.',
-								placeholder: '',
-							},
-							instructions: {
-								id: 'instructions',
-								label: 'Instructions',
-								description:
-									'Instructions that will be added to the thank you page and emails.',
-								type: 'textarea',
-								value: '',
-								default: '',
-								tip: 'Instructions that will be added to the thank you page and emails.',
-								placeholder: '',
-							},
+		expect( responseJSON ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					id: 'bacs',
+					title: 'Direct bank transfer',
+					description:
+						'Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order will not be shipped until the funds have cleared in our account.',
+					order: '',
+					enabled: false,
+					method_title: 'Direct bank transfer',
+					method_description:
+						'Take payments in person via BACS. More commonly known as direct bank/wire transfer.',
+					method_supports: [ 'products' ],
+					settings: {
+						title: {
+							id: 'title',
+							label: 'Title',
+							description:
+								'This controls the title which the user sees during checkout.',
+							type: 'safe_text',
+							value: 'Direct bank transfer',
+							default: 'Direct bank transfer',
+							tip: 'This controls the title which the user sees during checkout.',
+							placeholder: '',
 						},
-					} ),
-
-					expect.objectContaining( {
-						id: 'cheque',
-						title: 'Check payments',
-						description:
-							'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
-						order: '',
-						enabled: false,
-						method_title: 'Check payments',
-						method_description:
-							'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
-						method_supports: [ 'products' ],
-						settings: {
-							title: {
-								id: 'title',
-								label: 'Title',
-								description:
-									'This controls the title which the user sees during checkout.',
-								type: 'safe_text',
-								value: 'Check payments',
-								default: 'Check payments',
-								tip: 'This controls the title which the user sees during checkout.',
-								placeholder: '',
-							},
-							instructions: {
-								id: 'instructions',
-								label: 'Instructions',
-								description:
-									'Instructions that will be added to the thank you page and emails.',
-								type: 'textarea',
-								value: '',
-								default: '',
-								tip: 'Instructions that will be added to the thank you page and emails.',
-								placeholder: '',
-							},
+						instructions: {
+							id: 'instructions',
+							label: 'Instructions',
+							description:
+								'Instructions that will be added to the thank you page and emails.',
+							type: 'textarea',
+							value: '',
+							default: '',
+							tip: 'Instructions that will be added to the thank you page and emails.',
+							placeholder: '',
 						},
-					} ),
+					},
+				} ),
 
-					expect.objectContaining( {
-						id: 'cod',
-						title: 'Cash on delivery',
-						description: 'Pay with cash upon delivery.',
-						order: '',
-						enabled: false,
-						method_title: 'Cash on delivery',
-						method_description:
-							'Let your shoppers pay upon delivery — by cash or other methods of payment.',
-						method_supports: [ 'products' ],
-						settings: {
-							title: {
-								id: 'title',
-								label: 'Title',
-								description:
-									'Payment method description that the customer will see on your checkout.',
-								type: 'safe_text',
-								value: 'Cash on delivery',
-								default: 'Cash on delivery',
-								tip: 'Payment method description that the customer will see on your checkout.',
-								placeholder: '',
-							},
-							instructions: {
-								id: 'instructions',
-								label: 'Instructions',
-								description:
-									'Instructions that will be added to the thank you page.',
-								type: 'textarea',
-								value: 'Pay with cash upon delivery.',
-								default: 'Pay with cash upon delivery.',
-								tip: 'Instructions that will be added to the thank you page.',
-								placeholder: '',
-							},
-							enable_for_methods: {
-								id: 'enable_for_methods',
-								label: 'Enable for shipping methods',
-								description:
-									'If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.',
-								type: 'multiselect',
-								value: '',
-								default: '',
-								tip: 'If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.',
-								placeholder: '',
-								options: expect.objectContaining( {
-									'Flat rate': {
-										flat_rate:
-											'Any &quot;Flat rate&quot; method',
-									},
-									'Free shipping': {
-										free_shipping:
-											'Any &quot;Free shipping&quot; method',
-									},
-									'Local pickup': expect.objectContaining( {
-										[ localPickupKey ]:
-											'Any &quot;Local pickup&quot; method',
-									} ),
-								} ),
-							},
-							enable_for_virtual: {
-								id: 'enable_for_virtual',
-								label: 'Accept COD if the order is virtual',
-								description: '',
-								type: 'checkbox',
-								value: 'yes',
-								default: 'yes',
-								tip: '',
-								placeholder: '',
-							},
+				expect.objectContaining( {
+					id: 'cheque',
+					title: 'Check payments',
+					description:
+						'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
+					order: '',
+					enabled: false,
+					method_title: 'Check payments',
+					method_description:
+						'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
+					method_supports: [ 'products' ],
+					settings: {
+						title: {
+							id: 'title',
+							label: 'Title',
+							description:
+								'This controls the title which the user sees during checkout.',
+							type: 'safe_text',
+							value: 'Check payments',
+							default: 'Check payments',
+							tip: 'This controls the title which the user sees during checkout.',
+							placeholder: '',
 						},
-					} ),
-				] )
-			);
-		}
-	);
+						instructions: {
+							id: 'instructions',
+							label: 'Instructions',
+							description:
+								'Instructions that will be added to the thank you page and emails.',
+							type: 'textarea',
+							value: '',
+							default: '',
+							tip: 'Instructions that will be added to the thank you page and emails.',
+							placeholder: '',
+						},
+					},
+				} ),
+
+				expect.objectContaining( {
+					id: 'cod',
+					title: 'Cash on delivery',
+					description: 'Pay with cash upon delivery.',
+					order: '',
+					enabled: false,
+					method_title: 'Cash on delivery',
+					method_description:
+						'Let your shoppers pay upon delivery — by cash or other methods of payment.',
+					method_supports: [ 'products' ],
+					settings: {
+						title: {
+							id: 'title',
+							label: 'Title',
+							description:
+								'Payment method description that the customer will see on your checkout.',
+							type: 'safe_text',
+							value: 'Cash on delivery',
+							default: 'Cash on delivery',
+							tip: 'Payment method description that the customer will see on your checkout.',
+							placeholder: '',
+						},
+						instructions: {
+							id: 'instructions',
+							label: 'Instructions',
+							description:
+								'Instructions that will be added to the thank you page.',
+							type: 'textarea',
+							value: 'Pay with cash upon delivery.',
+							default: 'Pay with cash upon delivery.',
+							tip: 'Instructions that will be added to the thank you page.',
+							placeholder: '',
+						},
+						enable_for_methods: {
+							id: 'enable_for_methods',
+							label: 'Enable for shipping methods',
+							description:
+								'If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.',
+							type: 'multiselect',
+							value: '',
+							default: '',
+							tip: 'If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.',
+							placeholder: '',
+							options: expect.objectContaining( {
+								'Flat rate': {
+									flat_rate:
+										'Any &quot;Flat rate&quot; method',
+								},
+								'Free shipping': {
+									free_shipping:
+										'Any &quot;Free shipping&quot; method',
+								},
+								'Local pickup':
+									expect.toBeValidLocalPickupObject(),
+							} ),
+						},
+						enable_for_virtual: {
+							id: 'enable_for_virtual',
+							label: 'Accept COD if the order is virtual',
+							description: '',
+							type: 'checkbox',
+							value: 'yes',
+							default: 'yes',
+							tip: '',
+							placeholder: '',
+						},
+					},
+				} ),
+			] )
+		);
+	} );
 
 	test( 'can view a payment gateway', async ( { request } ) => {
 		// call API to retrieve a single payment gateway

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
@@ -7,8 +7,8 @@ const expect = baseExpect.extend( {
 	toBeValidLocalPickupObject( receivedObj ) {
 		const value = 'Any &quot;Local pickup&quot; method';
 		const pass =
-			receivedObj[ 'pickup_location' ] === value ||
-			receivedObj[ 'local_pickup' ] === value;
+			receivedObj.pickup_location === value ||
+			receivedObj.local_pickup === value;
 		const message = () =>
 			'\n\n' +
 			`Received: ${ JSON.stringify( receivedObj ) }\n` +

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/payment-gateways/payment-gateways-crud.test.js
@@ -6,10 +6,9 @@ const {
 const expect = baseExpect.extend( {
 	toBeValidLocalPickupObject( receivedObj ) {
 		const value = 'Any &quot;Local pickup&quot; method';
-		const key = Object.keys( receivedObj ).find( ( k ) =>
-			[ 'pickup_location', 'local_pickup' ].includes( k )
-		);
-		const pass = key && receivedObj[ key ] === value;
+		const pass =
+			receivedObj[ 'pickup_location' ] === value ||
+			receivedObj[ 'local_pickup' ] === value;
 		const message = () =>
 			'\n\n' +
 			`Received: ${ JSON.stringify( receivedObj ) }\n` +


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

This PR unskips the api test `can view all payment gateways` in `payment-gateways-crud.test.js` on WPCOM, Pressable, and also makes it work on a multisite. 

The reason it fails on other environments is because of the inconsistency on the key name of the "Local pickup" object: it's `local_pickup` on some environments, but `pickup_location` on some.

Based on my findings, these were the key names per environment I looked at:
- wp-env: started off with `local_pickup` but eventually started showing `pickup_location` at some point.
- WPCOM: `local_pickup`
- Pressable:
    - Pressable site we use for our automated tests: `local_pickup`
    - One of my own Pressable sites: `pickup_location`
- Studio by WPCOM: `pickup_location`
- JN: `pickup_location`
- Local subdomain multisite:
    - main site: `pickup_location`
    - sub-site: `local_pickup`

At first I thought the key name is related to the value of the `WP_ENVIRONMENT_TYPE` in WP config, but it seems that it isn't after changing its value to different types.

I didn't have a chance to dig deeper as to what causes this key name variation. I therefore think the best approach here is to have an assertion that would consider both  `pickup_location` and `local_pickup` regardless of the environment. Initially I thought this is possible through computed property names, but I couldn't find a way to do it because it seems difficult to access the parent "Local pickup" object through this approach.

In the end, I created a custom matcher `expect.toBeValidLocalPickupObject()` to make the assertion environment-agnostic and to have an easy way to access the "Local pickup" object itself.

The "Local pickup" object now looks like:
```js
'Local pickup': expect.toBeValidLocalPickupObject()
```
The rest of the changes you see on the diff are spacing adjustments due to this custom matcher and the removal of the skip tags.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the API tests in CI pass.
2. Test this on WPCOM, Pressable, and multisite. Make sure the test `can view all payment gateways` passes in all these environments:
    ```sh
    export E2E_ENV_KEY="..."
    
    # Test on WPCOM
    pnpm test:e2e:wpcom api-wpcom payment-gateways-crud.test.js

    # Test on Pressable
    pnpm test:e2e:pressable api-pressable payment-gateways-crud.test.js

   # Test on Multisite
   export BASE_URL=https://your.multisite.url
   # Set other important env vars here like admin and customer credentials of your multisite.
   pnpm test:api payment-gateways-crud.test.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
