### PR TITLE
[API Tests] Unskip `system-status-crud.test.js` on WPCOM

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-api-unskip-wpcom-system-status-crud-2
+++ b/plugins/woocommerce/changelog/dev-e2e-api-unskip-wpcom-system-status-crud-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip api test `system-status-crud.test.js` on WPCOM, Pressable.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
@@ -252,7 +252,7 @@ const getExpectedOtherTables = ( dbPrefix ) => {
 
 /* eslint-disable playwright/no-nested-step */
 test.describe( 'System Status API tests', () => {
-	test.only( 'can view all system status items', async ( { request } ) => {
+	test( 'can view all system status items', async ( { request } ) => {
 		let responseJSON,
 			databasePrefix,
 			databaseSize,

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
@@ -1,598 +1,519 @@
-const {
-	test,
-	expect,
-	tags,
-} = require( '../../../fixtures/api-tests-fixtures' );
+const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 
 const { BASE_URL } = process.env;
+const { any } = expect;
 const shouldSkip = BASE_URL !== undefined && ! BASE_URL.includes( 'localhost' );
 
 test.describe( 'System Status API tests', () => {
-	test(
-		'can view all system status items',
-		{ tag: tags.SKIP_ON_WPCOM },
-		async ( { request } ) => {
-			// call API to view all system status items
-			const response = await request.get(
-				'./wp-json/wc/v3/system_status'
-			);
-			const responseJSON = await response.json();
-			expect( response.status() ).toEqual( 200 );
+	test.only( 'can view all system status items', async ( { request } ) => {
+		// call API to view all system status items
+		const response = await request.get( './wp-json/wc/v3/system_status' );
+		const responseJSON = await response.json();
+		expect( response.status() ).toEqual( 200 );
 
-			// local environment differs from external hosts.  Local listed first.
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.objectContaining( {
-						environment: expect.objectContaining( {
-							home_url: expect.any( String ),
-							site_url: expect.any( String ),
-							version: expect.any( String ),
-							log_directory: expect.any( String ),
-							log_directory_writable: expect.any( Boolean ),
-							wp_version: expect.any( String ),
-							wp_multisite: expect.any( Boolean ),
-							wp_memory_limit: expect.any( Number ),
-							wp_debug_mode: expect.any( Boolean ),
-							wp_cron: expect.any( Boolean ),
-							language: expect.any( String ),
-							external_object_cache: null,
-							server_info: expect.any( String ),
-							php_version: expect.any( String ),
-							php_post_max_size: expect.any( Number ),
-							php_max_execution_time: expect.any( Number ),
-							php_max_input_vars: expect.any( Number ),
-							curl_version: expect.any( String ),
-							suhosin_installed: expect.any( Boolean ),
-							max_upload_size: expect.any( Number ),
-							mysql_version: expect.any( String ),
-							mysql_version_string: expect.any( String ),
-							default_timezone: expect.any( String ),
-							fsockopen_or_curl_enabled: expect.any( Boolean ),
-							soapclient_enabled: expect.any( Boolean ),
-							domdocument_enabled: expect.any( Boolean ),
-							gzip_enabled: expect.any( Boolean ),
-							mbstring_enabled: expect.any( Boolean ),
-							remote_post_successful: expect.any( Boolean ),
-							remote_post_response: expect.any( String ),
-							remote_get_successful: expect.any( Boolean ),
-							remote_get_response: expect.any( String ),
-						} ),
-					} )
-				);
-			} else {
-				expect( responseJSON ).toEqual(
-					expect.objectContaining( {
-						environment: expect.objectContaining( {
-							home_url: expect.any( String ),
-							site_url: expect.any( String ),
-							version: expect.any( String ),
-							log_directory: expect.any( String ),
-							log_directory_writable: expect.any( Boolean ),
-							wp_version: expect.any( String ),
-							wp_multisite: expect.any( Boolean ),
-							wp_memory_limit: expect.any( Number ),
-							wp_debug_mode: expect.any( Boolean ),
-							wp_cron: expect.any( Boolean ),
-							language: expect.any( String ),
-							external_object_cache: expect.any( Boolean ),
-							server_info: expect.any( String ),
-							php_version: expect.any( String ),
-							php_post_max_size: expect.any( Number ),
-							php_max_execution_time: expect.any( Number ),
-							php_max_input_vars: expect.any( Number ),
-							curl_version: expect.any( String ),
-							suhosin_installed: expect.any( Boolean ),
-							max_upload_size: expect.any( Number ),
-							mysql_version: expect.any( String ),
-							mysql_version_string: expect.any( String ),
-							default_timezone: expect.any( String ),
-							fsockopen_or_curl_enabled: expect.any( Boolean ),
-							soapclient_enabled: expect.any( Boolean ),
-							domdocument_enabled: expect.any( Boolean ),
-							gzip_enabled: expect.any( Boolean ),
-							mbstring_enabled: expect.any( Boolean ),
-							remote_post_successful: expect.any( Boolean ),
-							remote_post_response: expect.any( Number ),
-							remote_get_successful: expect.any( Boolean ),
-							remote_get_response: expect.any( Number ),
-						} ),
-					} )
-				);
-			}
+		await test.step( 'Verify "environment" fields', async () => {
+			const { environment } = responseJSON;
+			expect( environment ).toBeDefined();
 
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					database: expect.objectContaining( {
-						wc_database_version: expect.any( String ),
-						database_prefix: expect.any( String ),
-						maxmind_geoip_database: expect.any( String ),
-						database_tables: expect.objectContaining( {
-							woocommerce: expect.objectContaining( {
-								wp_woocommerce_sessions:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_api_keys:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_attribute_taxonomies:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_downloadable_product_permissions:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_order_items:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_order_itemmeta:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_tax_rates:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_tax_rate_locations:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_shipping_zones:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_shipping_zone_locations:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_shipping_zone_methods:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_payment_tokens:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_payment_tokenmeta:
-									expect.objectContaining( {
-										data: expect.any( String ),
-										index: expect.any( String ),
-										engine: expect.any( String ),
-									} ),
-								wp_woocommerce_log: expect.objectContaining( {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								} ),
-							} ),
-							other: expect.objectContaining( {
-								wp_actionscheduler_actions: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_actionscheduler_claims: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_actionscheduler_groups: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_actionscheduler_logs: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_commentmeta: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_comments: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_links: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_options: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_postmeta: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_posts: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_termmeta: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_terms: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_term_relationships: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_term_taxonomy: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_usermeta: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_users: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_admin_notes: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_admin_note_actions: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_category_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_customer_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_download_log: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_order_coupon_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_order_product_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_order_stats: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_order_tax_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_product_attributes_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_product_download_directories: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_product_meta_lookup: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_rate_limits: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_reserved_stock: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_tax_rate_classes: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-								wp_wc_webhooks: {
-									data: expect.any( String ),
-									index: expect.any( String ),
-									engine: expect.any( String ),
-								},
-							} ),
-						} ),
-						database_size: {
-							data: expect.any( Number ),
-							index: expect.any( Number ),
-						},
-					} ),
-				} )
-			);
+			const {
+				home_url,
+				site_url,
+				version,
+				log_directory,
+				log_directory_writable,
+				wp_version,
+				wp_multisite,
+				wp_memory_limit,
+				wp_debug_mode,
+				wp_cron,
+				language,
+				external_object_cache,
+				server_info,
+				php_version,
+				php_post_max_size,
+				php_max_execution_time,
+				php_max_input_vars,
+				curl_version,
+				suhosin_installed,
+				max_upload_size,
+				mysql_version,
+				mysql_version_string,
+				default_timezone,
+				fsockopen_or_curl_enabled,
+				soapclient_enabled,
+				domdocument_enabled,
+				gzip_enabled,
+				mbstring_enabled,
+				remote_post_successful,
+				remote_post_response,
+				remote_get_successful,
+				remote_get_response,
+			} = environment;
 
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					active_plugins: expect.arrayContaining( [
-						{
-							plugin: expect.any( String ),
-							name: expect.any( String ),
-							version: expect.any( String ),
-							version_latest: expect.any( String ),
-							url: expect.any( String ),
-							author_name: expect.any( String ),
-							author_url: expect.any( String ),
-							network_activated: expect.any( Boolean ),
-						},
-						{
-							plugin: expect.any( String ),
-							name: expect.any( String ),
-							version: expect.any( String ),
-							version_latest: expect.any( String ),
-							url: expect.any( String ),
-							author_name: expect.any( String ),
-							author_url: expect.any( String ),
-							network_activated: expect.any( Boolean ),
-						},
-						{
-							plugin: expect.any( String ),
-							name: expect.any( String ),
-							version: expect.any( String ),
-							version_latest: expect.any( String ),
-							url: expect.any( String ),
-							author_name: expect.any( String ),
-							author_url: expect.any( String ),
-							network_activated: expect.any( Boolean ),
-						},
-						{
-							plugin: expect.any( String ),
-							name: expect.any( String ),
-							version: expect.any( String ),
-							version_latest: expect.any( String ),
-							url: expect.any( String ),
-							author_name: expect.any( String ),
-							author_url: expect.any( String ),
-							network_activated: expect.any( Boolean ),
-						},
-					] ),
-				} )
+			expect( home_url ).toEqual( any( String ) );
+			expect( site_url ).toEqual( any( String ) );
+			expect( version ).toEqual( any( String ) );
+			expect( log_directory ).toEqual( any( String ) );
+			expect( log_directory_writable ).toEqual( any( Boolean ) );
+			expect( wp_version ).toEqual( any( String ) );
+			expect( wp_multisite ).toEqual( any( Boolean ) );
+			expect( wp_memory_limit ).toEqual( any( Number ) );
+			expect( wp_debug_mode ).toEqual( any( Boolean ) );
+			expect( wp_cron ).toEqual( any( Boolean ) );
+			expect( language ).toEqual( any( String ) );
+			expect(
+				external_object_cache === null ||
+					typeof external_object_cache === 'boolean'
+			).toBeTruthy();
+			expect( server_info ).toEqual( any( String ) );
+			expect( php_version ).toEqual( any( String ) );
+			expect( php_post_max_size ).toEqual( any( Number ) );
+			expect( php_max_execution_time ).toEqual( any( Number ) );
+			expect( php_max_input_vars ).toEqual( any( Number ) );
+			expect( curl_version ).toEqual( any( String ) );
+			expect( suhosin_installed ).toEqual( any( Boolean ) );
+			expect( max_upload_size ).toEqual( any( Number ) );
+			expect( mysql_version ).toEqual( any( String ) );
+			expect( mysql_version_string ).toEqual( any( String ) );
+			expect( default_timezone ).toEqual( any( String ) );
+			expect( fsockopen_or_curl_enabled ).toEqual( any( Boolean ) );
+			expect( soapclient_enabled ).toEqual( any( Boolean ) );
+			expect( domdocument_enabled ).toEqual( any( Boolean ) );
+			expect( gzip_enabled ).toEqual( any( Boolean ) );
+			expect( mbstring_enabled ).toEqual( any( Boolean ) );
+			expect( remote_post_successful ).toEqual( any( Boolean ) );
+			expect( [ 'number', 'string' ] ).toContain(
+				typeof remote_post_response
 			);
+			expect( remote_get_successful ).toEqual( any( Boolean ) );
+			expect( [ 'number', 'string' ] ).toContain(
+				typeof remote_get_response
+			);
+		} );
 
-			// local environment differs from external hosts.  Local listed first.
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.objectContaining( {
-						dropins_mu_plugins: expect.objectContaining( {
-							dropins: expect.arrayContaining( [] ),
-							mu_plugins: expect.arrayContaining( [] ),
-						} ),
-					} )
-				);
-			} else {
-				expect( responseJSON ).toEqual(
-					expect.objectContaining( {
-						dropins_mu_plugins: expect.objectContaining( {
-							dropins: expect.arrayContaining( [
-								{
-									name: expect.any( String ),
-									plugin: expect.any( String ),
-								},
-								{
-									name: expect.any( String ),
-									plugin: expect.any( String ),
-								},
-							] ),
-							mu_plugins: [],
-						} ),
-					} )
-				);
-			}
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					theme: expect.objectContaining( {
-						name: expect.any( String ),
-						version: expect.any( String ),
-						version_latest: expect.any( String ),
-						author_url: expect.any( String ),
-						is_child_theme: expect.any( Boolean ),
-						is_block_theme: expect.any( Boolean ),
-						has_woocommerce_support: expect.any( Boolean ),
-						has_woocommerce_file: expect.any( Boolean ),
-						has_outdated_templates: expect.any( Boolean ),
-						overrides: expect.any( Array ),
-						parent_name: expect.any( String ),
-						parent_version: expect.any( String ),
-						parent_version_latest: expect.any( String ),
-						parent_author_url: expect.any( String ),
-					} ),
-				} )
-			);
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					settings: expect.objectContaining( {
-						api_enabled: expect.any( Boolean ),
-						force_ssl: expect.any( Boolean ),
-						currency: expect.any( String ),
-						currency_symbol: expect.any( String ),
-						currency_position: expect.any( String ),
-						thousand_separator: expect.any( String ),
-						decimal_separator: expect.any( String ),
-						number_of_decimals: expect.any( Number ),
-						geolocation_enabled: expect.any( Boolean ),
-						taxonomies: {
-							external: expect.any( String ),
-							grouped: expect.any( String ),
-							simple: expect.any( String ),
-							variable: expect.any( String ),
-						},
-						product_visibility_terms: {
-							'exclude-from-catalog': expect.any( String ),
-							'exclude-from-search': expect.any( String ),
-							featured: expect.any( String ),
-							outofstock: expect.any( String ),
-							'rated-1': expect.any( String ),
-							'rated-2': expect.any( String ),
-							'rated-3': expect.any( String ),
-							'rated-4': expect.any( String ),
-							'rated-5': expect.any( String ),
-						},
-						woocommerce_com_connected: expect.any( String ),
-					} ),
-				} )
-			);
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					security: expect.objectContaining( {
-						secure_connection: expect.any( Boolean ),
-						hide_errors: expect.any( Boolean ),
-					} ),
-				} )
-			);
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					pages: expect.arrayContaining( [
-						{
-							page_name: expect.any( String ),
-							page_id: expect.any( String ),
-							page_set: expect.any( Boolean ),
-							page_exists: expect.any( Boolean ),
-							page_visible: expect.any( Boolean ),
-							shortcode: expect.any( String ),
-							block: expect.any( String ),
-							shortcode_required: expect.any( Boolean ),
-							shortcode_present: expect.any( Boolean ),
-							block_present: expect.any( Boolean ),
-							block_required: expect.any( Boolean ),
-						},
-						{
-							page_name: expect.any( String ),
-							page_id: expect.any( String ),
-							page_set: expect.any( Boolean ),
-							page_exists: expect.any( Boolean ),
-							page_visible: expect.any( Boolean ),
-							shortcode: expect.any( String ),
-							block: expect.any( String ),
-							shortcode_required: expect.any( Boolean ),
-							shortcode_present: expect.any( Boolean ),
-							block_present: expect.any( Boolean ),
-							block_required: expect.any( Boolean ),
-						},
-						{
-							page_name: expect.any( String ),
-							page_id: expect.any( String ),
-							page_set: expect.any( Boolean ),
-							page_exists: expect.any( Boolean ),
-							page_visible: expect.any( Boolean ),
-							shortcode: expect.any( String ),
-							block: expect.any( String ),
-							shortcode_required: expect.any( Boolean ),
-							shortcode_present: expect.any( Boolean ),
-							block_present: expect.any( Boolean ),
-							block_required: expect.any( Boolean ),
-						},
-						{
-							page_name: expect.any( String ),
-							page_id: expect.any( String ),
-							page_set: expect.any( Boolean ),
-							page_exists: expect.any( Boolean ),
-							page_visible: expect.any( Boolean ),
-							shortcode: expect.any( String ),
-							block: expect.any( String ),
-							shortcode_required: expect.any( Boolean ),
-							shortcode_present: expect.any( Boolean ),
-							block_present: expect.any( Boolean ),
-							block_required: expect.any( Boolean ),
-						},
-						{
-							page_name: expect.any( String ),
-							page_id: expect.any( String ),
-							page_set: expect.any( Boolean ),
-							page_exists: expect.any( Boolean ),
-							page_visible: expect.any( Boolean ),
-							shortcode: expect.any( String ),
-							block: expect.any( String ),
-							shortcode_required: expect.any( Boolean ),
-							shortcode_present: expect.any( Boolean ),
-							block_present: expect.any( Boolean ),
-							block_required: expect.any( Boolean ),
-						},
-					] ),
-				} )
-			);
-			expect( responseJSON ).toEqual(
-				expect.objectContaining( {
-					post_type_counts: expect.arrayContaining( [
-						{
-							type: expect.any( String ),
-							count: expect.any( String ),
-						},
-						{
-							type: expect.any( String ),
-							count: expect.any( String ),
-						},
-						{
-							type: expect.any( String ),
-							count: expect.any( String ),
-						},
-					] ),
-				} )
-			);
-		}
-	);
+		await test.step( 'Verify "database" fields', async () => {
+			const { database } = responseJSON;
+			expect( database ).toBeDefined();
+
+			const {
+				wc_database_version,
+				database_prefix,
+				maxmind_geoip_database,
+				database_tables,
+				database_size,
+			} = database;
+
+			expect( wc_database_version ).toEqual( any( String ) );
+			expect( database_prefix ).toEqual( any( String ) );
+			expect( maxmind_geoip_database ).toEqual( any( String ) );
+
+			await test.step( 'Verify "database_tables" fields', async () => {
+				expect( database_tables ).toBeDefined();
+
+				await test.step( 'Verify "woocommerce" fields', async () => {
+					const { woocommerce } = database_tables;
+					expect( woocommerce ).toBeDefined();
+
+					const {
+						[ `${ database_prefix }woocommerce_sessions` ]:
+							woocommerce_sessions,
+						[ `${ database_prefix }woocommerce_api_keys` ]:
+							woocommerce_api_keys,
+						[ `${ database_prefix }woocommerce_attribute_taxonomies` ]:
+							woocommerce_attribute_taxonomies,
+						[ `${ database_prefix }woocommerce_downloadable_product_permissions` ]:
+							woocommerce_downloadable_product_permissions,
+						[ `${ database_prefix }woocommerce_order_items` ]:
+							woocommerce_order_items,
+						[ `${ database_prefix }woocommerce_order_itemmeta` ]:
+							woocommerce_order_itemmeta,
+						[ `${ database_prefix }woocommerce_tax_rates` ]:
+							woocommerce_tax_rates,
+						[ `${ database_prefix }woocommerce_tax_rate_locations` ]:
+							woocommerce_tax_rate_locations,
+						[ `${ database_prefix }woocommerce_shipping_zones` ]:
+							woocommerce_shipping_zones,
+						[ `${ database_prefix }woocommerce_shipping_zone_locations` ]:
+							woocommerce_shipping_zone_locations,
+						[ `${ database_prefix }woocommerce_shipping_zone_methods` ]:
+							woocommerce_shipping_zone_methods,
+						[ `${ database_prefix }woocommerce_payment_tokens` ]:
+							woocommerce_payment_tokens,
+						[ `${ database_prefix }woocommerce_payment_tokenmeta` ]:
+							woocommerce_payment_tokenmeta,
+						[ `${ database_prefix }woocommerce_log` ]:
+							woocommerce_log,
+					} = woocommerce;
+
+					const woocommerce_tables = [
+						woocommerce_sessions,
+						woocommerce_api_keys,
+						woocommerce_attribute_taxonomies,
+						woocommerce_downloadable_product_permissions,
+						woocommerce_order_items,
+						woocommerce_order_itemmeta,
+						woocommerce_tax_rates,
+						woocommerce_tax_rate_locations,
+						woocommerce_shipping_zones,
+						woocommerce_shipping_zone_locations,
+						woocommerce_shipping_zone_methods,
+						woocommerce_payment_tokens,
+						woocommerce_payment_tokenmeta,
+						woocommerce_log,
+					];
+
+					for ( const table of woocommerce_tables ) {
+						await test.step( `Verify "${ table }"`, () => {
+							expect( table ).toBeDefined();
+							const { data, index, engine } = table;
+							expect( data ).toEqual( any( String ) );
+							expect( index ).toEqual( any( String ) );
+							expect( engine ).toEqual( any( String ) );
+						} );
+					}
+				} );
+
+				await test.step( 'Verify "other" fields', async () => {
+					const { other } = database_tables;
+					expect( other ).toBeDefined();
+
+					const {
+						[ `${ database_prefix }actionscheduler_actions` ]:
+							actionscheduler_actions,
+						[ `${ database_prefix }actionscheduler_claims` ]:
+							actionscheduler_claims,
+						[ `${ database_prefix }actionscheduler_groups` ]:
+							actionscheduler_groups,
+						[ `${ database_prefix }actionscheduler_logs` ]:
+							actionscheduler_logs,
+						[ `${ database_prefix }commentmeta` ]: commentmeta,
+						[ `${ database_prefix }comments` ]: comments,
+						[ `${ database_prefix }links` ]: links,
+						[ `${ database_prefix }options` ]: options,
+						[ `${ database_prefix }postmeta` ]: postmeta,
+						[ `${ database_prefix }posts` ]: posts,
+						[ `${ database_prefix }termmeta` ]: termmeta,
+						[ `${ database_prefix }terms` ]: terms,
+						[ `${ database_prefix }term_relationships` ]:
+							term_relationships,
+						[ `${ database_prefix }term_taxonomy` ]: term_taxonomy,
+						[ `${ database_prefix }usermeta` ]: usermeta,
+						[ `${ database_prefix }users` ]: users,
+						[ `${ database_prefix }wc_admin_notes` ]:
+							wc_admin_notes,
+						[ `${ database_prefix }wc_admin_note_actions` ]:
+							wc_admin_note_actions,
+						[ `${ database_prefix }wc_category_lookup` ]:
+							wc_category_lookup,
+						[ `${ database_prefix }wc_customer_lookup` ]:
+							wc_customer_lookup,
+						[ `${ database_prefix }wc_download_log` ]:
+							wc_download_log,
+						[ `${ database_prefix }wc_order_coupon_lookup` ]:
+							wc_order_coupon_lookup,
+						[ `${ database_prefix }wc_order_product_lookup` ]:
+							wc_order_product_lookup,
+						[ `${ database_prefix }wc_order_stats` ]:
+							wc_order_stats,
+						[ `${ database_prefix }wc_order_tax_lookup` ]:
+							wc_order_tax_lookup,
+						[ `${ database_prefix }wc_product_attributes_lookup` ]:
+							wc_product_attributes_lookup,
+						[ `${ database_prefix }wc_product_download_directories` ]:
+							wc_product_download_directories,
+						[ `${ database_prefix }wc_product_meta_lookup` ]:
+							wc_product_meta_lookup,
+						[ `${ database_prefix }wc_rate_limits` ]:
+							wc_rate_limits,
+						[ `${ database_prefix }wc_reserved_stock` ]:
+							wc_reserved_stock,
+						[ `${ database_prefix }wc_tax_rate_classes` ]:
+							wc_tax_rate_classes,
+						[ `${ database_prefix }wc_webhooks` ]: wc_webhooks,
+					} = other;
+
+					const other_tables = [
+						actionscheduler_actions,
+						actionscheduler_claims,
+						actionscheduler_groups,
+						actionscheduler_logs,
+						commentmeta,
+						comments,
+						links,
+						options,
+						postmeta,
+						posts,
+						termmeta,
+						terms,
+						term_relationships,
+						term_taxonomy,
+						usermeta,
+						users,
+						wc_admin_notes,
+						wc_admin_note_actions,
+						wc_category_lookup,
+						wc_customer_lookup,
+						wc_download_log,
+						wc_order_coupon_lookup,
+						wc_order_product_lookup,
+						wc_order_stats,
+						wc_order_tax_lookup,
+						wc_product_attributes_lookup,
+						wc_product_download_directories,
+						wc_product_meta_lookup,
+						wc_rate_limits,
+						wc_reserved_stock,
+						wc_tax_rate_classes,
+						wc_webhooks,
+					];
+
+					for ( const table of other_tables ) {
+						await test.step( `Verify "${ table }"`, () => {
+							expect( table ).toBeDefined();
+							const { data, index, engine } = table;
+							expect( data ).toEqual( any( String ) );
+							expect( index ).toEqual( any( String ) );
+							expect( engine ).toEqual( any( String ) );
+						} );
+					}
+				} );
+			} );
+
+			await test.step( 'Verify "database_size" fields', async () => {
+				const { data, index } = database_size;
+				expect( data ).toEqual( any( Number ) );
+				expect( index ).toEqual( any( Number ) );
+			} );
+		} );
+
+		// expect( responseJSON ).toEqual(
+		// 	expect.objectContaining( {
+		// 		active_plugins: expect.arrayContaining( [
+		// 			{
+		// 				plugin: expect.any( String ),
+		// 				name: expect.any( String ),
+		// 				version: expect.any( String ),
+		// 				version_latest: expect.any( String ),
+		// 				url: expect.any( String ),
+		// 				author_name: expect.any( String ),
+		// 				author_url: expect.any( String ),
+		// 				network_activated: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				plugin: expect.any( String ),
+		// 				name: expect.any( String ),
+		// 				version: expect.any( String ),
+		// 				version_latest: expect.any( String ),
+		// 				url: expect.any( String ),
+		// 				author_name: expect.any( String ),
+		// 				author_url: expect.any( String ),
+		// 				network_activated: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				plugin: expect.any( String ),
+		// 				name: expect.any( String ),
+		// 				version: expect.any( String ),
+		// 				version_latest: expect.any( String ),
+		// 				url: expect.any( String ),
+		// 				author_name: expect.any( String ),
+		// 				author_url: expect.any( String ),
+		// 				network_activated: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				plugin: expect.any( String ),
+		// 				name: expect.any( String ),
+		// 				version: expect.any( String ),
+		// 				version_latest: expect.any( String ),
+		// 				url: expect.any( String ),
+		// 				author_name: expect.any( String ),
+		// 				author_url: expect.any( String ),
+		// 				network_activated: expect.any( Boolean ),
+		// 			},
+		// 		] ),
+		// 	} )
+		// );
+
+		// local environment differs from external hosts.  Local listed first.
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		// if ( ! shouldSkip ) {
+		// 	expect( responseJSON ).toEqual(
+		// 		expect.objectContaining( {
+		// 			dropins_mu_plugins: expect.objectContaining( {
+		// 				dropins: expect.arrayContaining( [] ),
+		// 				mu_plugins: expect.arrayContaining( [] ),
+		// 			} ),
+		// 		} )
+		// 	);
+		// } else {
+		// 	expect( responseJSON ).toEqual(
+		// 		expect.objectContaining( {
+		// 			dropins_mu_plugins: expect.objectContaining( {
+		// 				dropins: expect.arrayContaining( [
+		// 					{
+		// 						name: expect.any( String ),
+		// 						plugin: expect.any( String ),
+		// 					},
+		// 					{
+		// 						name: expect.any( String ),
+		// 						plugin: expect.any( String ),
+		// 					},
+		// 				] ),
+		// 				mu_plugins: [],
+		// 			} ),
+		// 		} )
+		// 	);
+		// }
+		// expect( responseJSON ).toEqual(
+		// 	expect.objectContaining( {
+		// 		theme: expect.objectContaining( {
+		// 			name: expect.any( String ),
+		// 			version: expect.any( String ),
+		// 			version_latest: expect.any( String ),
+		// 			author_url: expect.any( String ),
+		// 			is_child_theme: expect.any( Boolean ),
+		// 			is_block_theme: expect.any( Boolean ),
+		// 			has_woocommerce_support: expect.any( Boolean ),
+		// 			has_woocommerce_file: expect.any( Boolean ),
+		// 			has_outdated_templates: expect.any( Boolean ),
+		// 			overrides: expect.any( Array ),
+		// 			parent_name: expect.any( String ),
+		// 			parent_version: expect.any( String ),
+		// 			parent_version_latest: expect.any( String ),
+		// 			parent_author_url: expect.any( String ),
+		// 		} ),
+		// 	} )
+		// );
+		// expect( responseJSON ).toEqual(
+		// 	expect.objectContaining( {
+		// 		settings: expect.objectContaining( {
+		// 			api_enabled: expect.any( Boolean ),
+		// 			force_ssl: expect.any( Boolean ),
+		// 			currency: expect.any( String ),
+		// 			currency_symbol: expect.any( String ),
+		// 			currency_position: expect.any( String ),
+		// 			thousand_separator: expect.any( String ),
+		// 			decimal_separator: expect.any( String ),
+		// 			number_of_decimals: expect.any( Number ),
+		// 			geolocation_enabled: expect.any( Boolean ),
+		// 			taxonomies: {
+		// 				external: expect.any( String ),
+		// 				grouped: expect.any( String ),
+		// 				simple: expect.any( String ),
+		// 				variable: expect.any( String ),
+		// 			},
+		// 			product_visibility_terms: {
+		// 				'exclude-from-catalog': expect.any( String ),
+		// 				'exclude-from-search': expect.any( String ),
+		// 				featured: expect.any( String ),
+		// 				outofstock: expect.any( String ),
+		// 				'rated-1': expect.any( String ),
+		// 				'rated-2': expect.any( String ),
+		// 				'rated-3': expect.any( String ),
+		// 				'rated-4': expect.any( String ),
+		// 				'rated-5': expect.any( String ),
+		// 			},
+		// 			woocommerce_com_connected: expect.any( String ),
+		// 		} ),
+		// 	} )
+		// );
+		// expect( responseJSON ).toEqual(
+		// 	expect.objectContaining( {
+		// 		security: expect.objectContaining( {
+		// 			secure_connection: expect.any( Boolean ),
+		// 			hide_errors: expect.any( Boolean ),
+		// 		} ),
+		// 	} )
+		// );
+		// expect( responseJSON ).toEqual(
+		// 	expect.objectContaining( {
+		// 		pages: expect.arrayContaining( [
+		// 			{
+		// 				page_name: expect.any( String ),
+		// 				page_id: expect.any( String ),
+		// 				page_set: expect.any( Boolean ),
+		// 				page_exists: expect.any( Boolean ),
+		// 				page_visible: expect.any( Boolean ),
+		// 				shortcode: expect.any( String ),
+		// 				block: expect.any( String ),
+		// 				shortcode_required: expect.any( Boolean ),
+		// 				shortcode_present: expect.any( Boolean ),
+		// 				block_present: expect.any( Boolean ),
+		// 				block_required: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				page_name: expect.any( String ),
+		// 				page_id: expect.any( String ),
+		// 				page_set: expect.any( Boolean ),
+		// 				page_exists: expect.any( Boolean ),
+		// 				page_visible: expect.any( Boolean ),
+		// 				shortcode: expect.any( String ),
+		// 				block: expect.any( String ),
+		// 				shortcode_required: expect.any( Boolean ),
+		// 				shortcode_present: expect.any( Boolean ),
+		// 				block_present: expect.any( Boolean ),
+		// 				block_required: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				page_name: expect.any( String ),
+		// 				page_id: expect.any( String ),
+		// 				page_set: expect.any( Boolean ),
+		// 				page_exists: expect.any( Boolean ),
+		// 				page_visible: expect.any( Boolean ),
+		// 				shortcode: expect.any( String ),
+		// 				block: expect.any( String ),
+		// 				shortcode_required: expect.any( Boolean ),
+		// 				shortcode_present: expect.any( Boolean ),
+		// 				block_present: expect.any( Boolean ),
+		// 				block_required: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				page_name: expect.any( String ),
+		// 				page_id: expect.any( String ),
+		// 				page_set: expect.any( Boolean ),
+		// 				page_exists: expect.any( Boolean ),
+		// 				page_visible: expect.any( Boolean ),
+		// 				shortcode: expect.any( String ),
+		// 				block: expect.any( String ),
+		// 				shortcode_required: expect.any( Boolean ),
+		// 				shortcode_present: expect.any( Boolean ),
+		// 				block_present: expect.any( Boolean ),
+		// 				block_required: expect.any( Boolean ),
+		// 			},
+		// 			{
+		// 				page_name: expect.any( String ),
+		// 				page_id: expect.any( String ),
+		// 				page_set: expect.any( Boolean ),
+		// 				page_exists: expect.any( Boolean ),
+		// 				page_visible: expect.any( Boolean ),
+		// 				shortcode: expect.any( String ),
+		// 				block: expect.any( String ),
+		// 				shortcode_required: expect.any( Boolean ),
+		// 				shortcode_present: expect.any( Boolean ),
+		// 				block_present: expect.any( Boolean ),
+		// 				block_required: expect.any( Boolean ),
+		// 			},
+		// 		] ),
+		// 	} )
+		// );
+		// expect( responseJSON ).toEqual(
+		// 	expect.objectContaining( {
+		// 		post_type_counts: expect.arrayContaining( [
+		// 			{
+		// 				type: expect.any( String ),
+		// 				count: expect.any( String ),
+		// 			},
+		// 			{
+		// 				type: expect.any( String ),
+		// 				count: expect.any( String ),
+		// 			},
+		// 			{
+		// 				type: expect.any( String ),
+		// 				count: expect.any( String ),
+		// 			},
+		// 		] ),
+		// 	} )
+		// );
+	} );
 
 	test( 'can view all system status tools', async ( { request } ) => {
 		// call API to view system status tools

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js
@@ -1,429 +1,409 @@
 const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const { any, anything } = expect;
 
-const { BASE_URL } = process.env;
-const { any } = expect;
-const shouldSkip = BASE_URL !== undefined && ! BASE_URL.includes( 'localhost' );
+const schemas = {
+	environment: [
+		{ field: 'home_url', type: any( String ) },
+		{ field: 'site_url', type: any( String ) },
+		{ field: 'version', type: any( String ) },
+		{ field: 'log_directory', type: any( String ) },
+		{ field: 'log_directory_writable', type: any( Boolean ) },
+		{ field: 'wp_version', type: any( String ) },
+		{ field: 'wp_multisite', type: any( Boolean ) },
+		{ field: 'wp_memory_limit', type: any( Number ) },
+		{ field: 'wp_debug_mode', type: any( Boolean ) },
+		{ field: 'wp_cron', type: any( Boolean ) },
+		{ field: 'language', type: any( String ) },
+		{ field: 'server_info', type: any( String ) },
+		{ field: 'php_version', type: any( String ) },
+		{ field: 'php_post_max_size', type: any( Number ) },
+		{ field: 'php_max_execution_time', type: any( Number ) },
+		{ field: 'php_max_input_vars', type: any( Number ) },
+		{ field: 'curl_version', type: any( String ) },
+		{ field: 'suhosin_installed', type: any( Boolean ) },
+		{ field: 'max_upload_size', type: any( Number ) },
+		{ field: 'mysql_version', type: any( String ) },
+		{ field: 'mysql_version_string', type: any( String ) },
+		{ field: 'default_timezone', type: any( String ) },
+		{ field: 'fsockopen_or_curl_enabled', type: any( Boolean ) },
+		{ field: 'soapclient_enabled', type: any( Boolean ) },
+		{ field: 'domdocument_enabled', type: any( Boolean ) },
+		{ field: 'gzip_enabled', type: any( Boolean ) },
+		{ field: 'mbstring_enabled', type: any( Boolean ) },
+		{ field: 'remote_post_successful', type: any( Boolean ) },
+		{
+			field: 'remote_post_response',
+			type: process.env.IS_WPCOM ? any( Number ) : any( String ),
+		},
+		{ field: 'remote_get_successful', type: any( Boolean ) },
+		{
+			field: 'remote_get_response',
+			type: process.env.IS_WPCOM ? any( Number ) : any( String ),
+		},
+	],
+	database: [
+		{ field: 'wc_database_version', type: any( String ) },
+		{ field: 'database_prefix', type: any( String ) },
+		{ field: 'maxmind_geoip_database', type: any( String ) },
+		{ field: 'database_tables', type: anything() },
+		{ field: 'database_size', type: anything() },
+	],
+	database_tables_woocommerce_other: [
+		{ field: 'data', type: any( String ) },
+		{ field: 'index', type: any( String ) },
+		{ field: 'engine', type: any( String ) },
+	],
+	active_plugins: [
+		{ field: 'plugin', type: any( String ) },
+		{ field: 'name', type: any( String ) },
+		{ field: 'version', type: any( String ) },
+		{ field: 'version_latest', type: any( String ) },
+		{ field: 'url', type: any( String ) },
+		{ field: 'author_name', type: any( String ) },
+		{ field: 'author_url', type: any( String ) },
+		{ field: 'network_activated', type: any( Boolean ) },
+	],
+	theme: [
+		{ field: 'name', type: any( String ) },
+		{ field: 'version', type: any( String ) },
+		{ field: 'version_latest', type: any( String ) },
+		{ field: 'author_url', type: any( String ) },
+		{ field: 'is_child_theme', type: any( Boolean ) },
+		{ field: 'is_block_theme', type: any( Boolean ) },
+		{ field: 'has_woocommerce_support', type: any( Boolean ) },
+		{ field: 'has_woocommerce_file', type: any( Boolean ) },
+		{ field: 'has_outdated_templates', type: any( Boolean ) },
+		{ field: 'overrides', type: any( Array ) },
+		{ field: 'parent_name', type: any( String ) },
+		{ field: 'parent_version', type: any( String ) },
+		{ field: 'parent_version_latest', type: any( String ) },
+		{ field: 'parent_author_url', type: any( String ) },
+	],
+	settings: [
+		{ field: 'api_enabled', type: any( Boolean ) },
+		{ field: 'force_ssl', type: any( Boolean ) },
+		{ field: 'currency', type: any( String ) },
+		{ field: 'currency_symbol', type: any( String ) },
+		{ field: 'currency_position', type: any( String ) },
+		{ field: 'thousand_separator', type: any( String ) },
+		{ field: 'decimal_separator', type: any( String ) },
+		{ field: 'number_of_decimals', type: any( Number ) },
+		{ field: 'geolocation_enabled', type: any( Boolean ) },
+		{ field: 'taxonomies', type: anything() },
+		{ field: 'product_visibility_terms', type: anything() },
+		{ field: 'woocommerce_com_connected', type: any( String ) },
+	],
+	settings_taxonomies: [
+		{ field: 'external', type: any( String ) },
+		{ field: 'grouped', type: any( String ) },
+		{ field: 'simple', type: any( String ) },
+		{ field: 'variable', type: any( String ) },
+	],
+	settings_product_visibility_terms: [
+		{ field: 'exclude-from-catalog', type: any( String ) },
+		{ field: 'exclude-from-search', type: any( String ) },
+		{ field: 'featured', type: any( String ) },
+		{ field: 'outofstock', type: any( String ) },
+		{ field: 'rated-1', type: any( String ) },
+		{ field: 'rated-2', type: any( String ) },
+		{ field: 'rated-3', type: any( String ) },
+		{ field: 'rated-4', type: any( String ) },
+		{ field: 'rated-5', type: any( String ) },
+	],
+	security: [
+		{ field: 'secure_connection', type: any( Boolean ) },
+		{ field: 'hide_errors', type: any( Boolean ) },
+	],
+	pages: [
+		{ field: 'page_name', type: any( String ) },
+		{ field: 'page_id', type: any( String ) },
+		{ field: 'page_set', type: any( Boolean ) },
+		{ field: 'page_exists', type: any( Boolean ) },
+		{ field: 'page_visible', type: any( Boolean ) },
+		{ field: 'shortcode', type: any( String ) },
+		{ field: 'block', type: any( String ) },
+		{ field: 'shortcode_required', type: any( Boolean ) },
+		{ field: 'shortcode_present', type: any( Boolean ) },
+		{ field: 'block_present', type: any( Boolean ) },
+		{ field: 'block_required', type: any( Boolean ) },
+	],
+};
 
+const getExpectedWooCommerceTables = ( dbPrefix ) => {
+	return [
+		`${ dbPrefix }woocommerce_sessions`,
+		`${ dbPrefix }woocommerce_api_keys`,
+		`${ dbPrefix }woocommerce_attribute_taxonomies`,
+		`${ dbPrefix }woocommerce_downloadable_product_permissions`,
+		`${ dbPrefix }woocommerce_order_items`,
+		`${ dbPrefix }woocommerce_order_itemmeta`,
+		`${ dbPrefix }woocommerce_tax_rates`,
+		`${ dbPrefix }woocommerce_tax_rate_locations`,
+		`${ dbPrefix }woocommerce_shipping_zones`,
+		`${ dbPrefix }woocommerce_shipping_zone_locations`,
+		`${ dbPrefix }woocommerce_shipping_zone_methods`,
+		`${ dbPrefix }woocommerce_payment_tokens`,
+		`${ dbPrefix }woocommerce_payment_tokenmeta`,
+		`${ dbPrefix }woocommerce_log`,
+	];
+};
+
+const getExpectedOtherTables = ( dbPrefix ) => {
+	return [
+		`${ dbPrefix }actionscheduler_actions`,
+		`${ dbPrefix }actionscheduler_claims`,
+		`${ dbPrefix }actionscheduler_groups`,
+		`${ dbPrefix }actionscheduler_logs`,
+		`${ dbPrefix }commentmeta`,
+		`${ dbPrefix }comments`,
+		`${ dbPrefix }links`,
+		`${ dbPrefix }options`,
+		`${ dbPrefix }postmeta`,
+		`${ dbPrefix }posts`,
+		`${ dbPrefix }termmeta`,
+		`${ dbPrefix }terms`,
+		`${ dbPrefix }term_relationships`,
+		`${ dbPrefix }term_taxonomy`,
+		`${ dbPrefix }usermeta`,
+		`${ dbPrefix }users`,
+		`${ dbPrefix }wc_admin_notes`,
+		`${ dbPrefix }wc_admin_note_actions`,
+		`${ dbPrefix }wc_category_lookup`,
+		`${ dbPrefix }wc_customer_lookup`,
+		`${ dbPrefix }wc_download_log`,
+		`${ dbPrefix }wc_order_coupon_lookup`,
+		`${ dbPrefix }wc_order_product_lookup`,
+		`${ dbPrefix }wc_order_stats`,
+		`${ dbPrefix }wc_order_tax_lookup`,
+		`${ dbPrefix }wc_product_attributes_lookup`,
+		`${ dbPrefix }wc_product_download_directories`,
+		`${ dbPrefix }wc_product_meta_lookup`,
+		`${ dbPrefix }wc_rate_limits`,
+		`${ dbPrefix }wc_reserved_stock`,
+		`${ dbPrefix }wc_tax_rate_classes`,
+		`${ dbPrefix }wc_webhooks`,
+	];
+};
+
+/* eslint-disable playwright/no-nested-step */
 test.describe( 'System Status API tests', () => {
 	test.only( 'can view all system status items', async ( { request } ) => {
-		// call API to view all system status items
-		const response = await request.get( './wp-json/wc/v3/system_status' );
-		const responseJSON = await response.json();
-		expect( response.status() ).toEqual( 200 );
+		let responseJSON,
+			databasePrefix,
+			databaseSize,
+			databaseTables,
+			woocommerceTables,
+			otherTables,
+			activePlugins,
+			dropinsMuPlugins,
+			taxonomiesJSON,
+			productVisibilityTerms;
+
+		await test.step( 'Call API to view all system status items', async () => {
+			const response = await request.get(
+				'./wp-json/wc/v3/system_status'
+			);
+			responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+		} );
 
 		await test.step( 'Verify "environment" fields', async () => {
 			const { environment } = responseJSON;
 			expect( environment ).toBeDefined();
 
-			const {
-				home_url,
-				site_url,
-				version,
-				log_directory,
-				log_directory_writable,
-				wp_version,
-				wp_multisite,
-				wp_memory_limit,
-				wp_debug_mode,
-				wp_cron,
-				language,
-				external_object_cache,
-				server_info,
-				php_version,
-				php_post_max_size,
-				php_max_execution_time,
-				php_max_input_vars,
-				curl_version,
-				suhosin_installed,
-				max_upload_size,
-				mysql_version,
-				mysql_version_string,
-				default_timezone,
-				fsockopen_or_curl_enabled,
-				soapclient_enabled,
-				domdocument_enabled,
-				gzip_enabled,
-				mbstring_enabled,
-				remote_post_successful,
-				remote_post_response,
-				remote_get_successful,
-				remote_get_response,
-			} = environment;
+			for ( const { field, type } of schemas.environment ) {
+				await test.step( `Verify "environment.${ field }"`, () => {
+					expect( environment[ field ] ).toEqual( type );
+				} );
+			}
 
-			expect( home_url ).toEqual( any( String ) );
-			expect( site_url ).toEqual( any( String ) );
-			expect( version ).toEqual( any( String ) );
-			expect( log_directory ).toEqual( any( String ) );
-			expect( log_directory_writable ).toEqual( any( Boolean ) );
-			expect( wp_version ).toEqual( any( String ) );
-			expect( wp_multisite ).toEqual( any( Boolean ) );
-			expect( wp_memory_limit ).toEqual( any( Number ) );
-			expect( wp_debug_mode ).toEqual( any( Boolean ) );
-			expect( wp_cron ).toEqual( any( Boolean ) );
-			expect( language ).toEqual( any( String ) );
-			expect(
-				external_object_cache === null ||
-					typeof external_object_cache === 'boolean'
-			).toBeTruthy();
-			expect( server_info ).toEqual( any( String ) );
-			expect( php_version ).toEqual( any( String ) );
-			expect( php_post_max_size ).toEqual( any( Number ) );
-			expect( php_max_execution_time ).toEqual( any( Number ) );
-			expect( php_max_input_vars ).toEqual( any( Number ) );
-			expect( curl_version ).toEqual( any( String ) );
-			expect( suhosin_installed ).toEqual( any( Boolean ) );
-			expect( max_upload_size ).toEqual( any( Number ) );
-			expect( mysql_version ).toEqual( any( String ) );
-			expect( mysql_version_string ).toEqual( any( String ) );
-			expect( default_timezone ).toEqual( any( String ) );
-			expect( fsockopen_or_curl_enabled ).toEqual( any( Boolean ) );
-			expect( soapclient_enabled ).toEqual( any( Boolean ) );
-			expect( domdocument_enabled ).toEqual( any( Boolean ) );
-			expect( gzip_enabled ).toEqual( any( Boolean ) );
-			expect( mbstring_enabled ).toEqual( any( Boolean ) );
-			expect( remote_post_successful ).toEqual( any( Boolean ) );
-			expect( [ 'number', 'string' ] ).toContain(
-				typeof remote_post_response
-			);
-			expect( remote_get_successful ).toEqual( any( Boolean ) );
-			expect( [ 'number', 'string' ] ).toContain(
-				typeof remote_get_response
-			);
+			// Handle special case of environment.external_object_cache which is null on wp-env
+			// but could be a Boolean in other environments.
+			await test.step( 'Verify "environment.external_object_cache"', () => {
+				const { external_object_cache } = environment;
+
+				expect(
+					typeof external_object_cache === 'boolean' ||
+						external_object_cache === null
+				).toBeTruthy();
+			} );
 		} );
 
 		await test.step( 'Verify "database" fields', async () => {
 			const { database } = responseJSON;
 			expect( database ).toBeDefined();
 
-			const {
-				wc_database_version,
-				database_prefix,
-				maxmind_geoip_database,
-				database_tables,
-				database_size,
-			} = database;
-
-			expect( wc_database_version ).toEqual( any( String ) );
-			expect( database_prefix ).toEqual( any( String ) );
-			expect( maxmind_geoip_database ).toEqual( any( String ) );
-
-			await test.step( 'Verify "database_tables" fields', async () => {
-				expect( database_tables ).toBeDefined();
-
-				await test.step( 'Verify "woocommerce" fields', async () => {
-					const { woocommerce } = database_tables;
-					expect( woocommerce ).toBeDefined();
-
-					const {
-						[ `${ database_prefix }woocommerce_sessions` ]:
-							woocommerce_sessions,
-						[ `${ database_prefix }woocommerce_api_keys` ]:
-							woocommerce_api_keys,
-						[ `${ database_prefix }woocommerce_attribute_taxonomies` ]:
-							woocommerce_attribute_taxonomies,
-						[ `${ database_prefix }woocommerce_downloadable_product_permissions` ]:
-							woocommerce_downloadable_product_permissions,
-						[ `${ database_prefix }woocommerce_order_items` ]:
-							woocommerce_order_items,
-						[ `${ database_prefix }woocommerce_order_itemmeta` ]:
-							woocommerce_order_itemmeta,
-						[ `${ database_prefix }woocommerce_tax_rates` ]:
-							woocommerce_tax_rates,
-						[ `${ database_prefix }woocommerce_tax_rate_locations` ]:
-							woocommerce_tax_rate_locations,
-						[ `${ database_prefix }woocommerce_shipping_zones` ]:
-							woocommerce_shipping_zones,
-						[ `${ database_prefix }woocommerce_shipping_zone_locations` ]:
-							woocommerce_shipping_zone_locations,
-						[ `${ database_prefix }woocommerce_shipping_zone_methods` ]:
-							woocommerce_shipping_zone_methods,
-						[ `${ database_prefix }woocommerce_payment_tokens` ]:
-							woocommerce_payment_tokens,
-						[ `${ database_prefix }woocommerce_payment_tokenmeta` ]:
-							woocommerce_payment_tokenmeta,
-						[ `${ database_prefix }woocommerce_log` ]:
-							woocommerce_log,
-					} = woocommerce;
-
-					const woocommerce_tables = [
-						woocommerce_sessions,
-						woocommerce_api_keys,
-						woocommerce_attribute_taxonomies,
-						woocommerce_downloadable_product_permissions,
-						woocommerce_order_items,
-						woocommerce_order_itemmeta,
-						woocommerce_tax_rates,
-						woocommerce_tax_rate_locations,
-						woocommerce_shipping_zones,
-						woocommerce_shipping_zone_locations,
-						woocommerce_shipping_zone_methods,
-						woocommerce_payment_tokens,
-						woocommerce_payment_tokenmeta,
-						woocommerce_log,
-					];
-
-					for ( const table of woocommerce_tables ) {
-						await test.step( `Verify "${ table }"`, () => {
-							expect( table ).toBeDefined();
-							const { data, index, engine } = table;
-							expect( data ).toEqual( any( String ) );
-							expect( index ).toEqual( any( String ) );
-							expect( engine ).toEqual( any( String ) );
-						} );
-					}
+			for ( const { field, type } of schemas.database ) {
+				await test.step( `Verify "database.${ field }"`, () => {
+					expect( database[ field ] ).toEqual( type );
 				} );
+			}
 
-				await test.step( 'Verify "other" fields', async () => {
-					const { other } = database_tables;
-					expect( other ).toBeDefined();
-
-					const {
-						[ `${ database_prefix }actionscheduler_actions` ]:
-							actionscheduler_actions,
-						[ `${ database_prefix }actionscheduler_claims` ]:
-							actionscheduler_claims,
-						[ `${ database_prefix }actionscheduler_groups` ]:
-							actionscheduler_groups,
-						[ `${ database_prefix }actionscheduler_logs` ]:
-							actionscheduler_logs,
-						[ `${ database_prefix }commentmeta` ]: commentmeta,
-						[ `${ database_prefix }comments` ]: comments,
-						[ `${ database_prefix }links` ]: links,
-						[ `${ database_prefix }options` ]: options,
-						[ `${ database_prefix }postmeta` ]: postmeta,
-						[ `${ database_prefix }posts` ]: posts,
-						[ `${ database_prefix }termmeta` ]: termmeta,
-						[ `${ database_prefix }terms` ]: terms,
-						[ `${ database_prefix }term_relationships` ]:
-							term_relationships,
-						[ `${ database_prefix }term_taxonomy` ]: term_taxonomy,
-						[ `${ database_prefix }usermeta` ]: usermeta,
-						[ `${ database_prefix }users` ]: users,
-						[ `${ database_prefix }wc_admin_notes` ]:
-							wc_admin_notes,
-						[ `${ database_prefix }wc_admin_note_actions` ]:
-							wc_admin_note_actions,
-						[ `${ database_prefix }wc_category_lookup` ]:
-							wc_category_lookup,
-						[ `${ database_prefix }wc_customer_lookup` ]:
-							wc_customer_lookup,
-						[ `${ database_prefix }wc_download_log` ]:
-							wc_download_log,
-						[ `${ database_prefix }wc_order_coupon_lookup` ]:
-							wc_order_coupon_lookup,
-						[ `${ database_prefix }wc_order_product_lookup` ]:
-							wc_order_product_lookup,
-						[ `${ database_prefix }wc_order_stats` ]:
-							wc_order_stats,
-						[ `${ database_prefix }wc_order_tax_lookup` ]:
-							wc_order_tax_lookup,
-						[ `${ database_prefix }wc_product_attributes_lookup` ]:
-							wc_product_attributes_lookup,
-						[ `${ database_prefix }wc_product_download_directories` ]:
-							wc_product_download_directories,
-						[ `${ database_prefix }wc_product_meta_lookup` ]:
-							wc_product_meta_lookup,
-						[ `${ database_prefix }wc_rate_limits` ]:
-							wc_rate_limits,
-						[ `${ database_prefix }wc_reserved_stock` ]:
-							wc_reserved_stock,
-						[ `${ database_prefix }wc_tax_rate_classes` ]:
-							wc_tax_rate_classes,
-						[ `${ database_prefix }wc_webhooks` ]: wc_webhooks,
-					} = other;
-
-					const other_tables = [
-						actionscheduler_actions,
-						actionscheduler_claims,
-						actionscheduler_groups,
-						actionscheduler_logs,
-						commentmeta,
-						comments,
-						links,
-						options,
-						postmeta,
-						posts,
-						termmeta,
-						terms,
-						term_relationships,
-						term_taxonomy,
-						usermeta,
-						users,
-						wc_admin_notes,
-						wc_admin_note_actions,
-						wc_category_lookup,
-						wc_customer_lookup,
-						wc_download_log,
-						wc_order_coupon_lookup,
-						wc_order_product_lookup,
-						wc_order_stats,
-						wc_order_tax_lookup,
-						wc_product_attributes_lookup,
-						wc_product_download_directories,
-						wc_product_meta_lookup,
-						wc_rate_limits,
-						wc_reserved_stock,
-						wc_tax_rate_classes,
-						wc_webhooks,
-					];
-
-					for ( const table of other_tables ) {
-						await test.step( `Verify "${ table }"`, () => {
-							expect( table ).toBeDefined();
-							const { data, index, engine } = table;
-							expect( data ).toEqual( any( String ) );
-							expect( index ).toEqual( any( String ) );
-							expect( engine ).toEqual( any( String ) );
-						} );
-					}
-				} );
-			} );
-
-			await test.step( 'Verify "database_size" fields', async () => {
-				const { data, index } = database_size;
-				expect( data ).toEqual( any( Number ) );
-				expect( index ).toEqual( any( Number ) );
-			} );
+			databaseSize = database.database_size;
+			databasePrefix = database.database_prefix;
+			databaseTables = database.database_tables;
 		} );
 
-		// expect( responseJSON ).toEqual(
-		// 	expect.objectContaining( {
-		// 		active_plugins: expect.arrayContaining( [
-		// 			{
-		// 				plugin: expect.any( String ),
-		// 				name: expect.any( String ),
-		// 				version: expect.any( String ),
-		// 				version_latest: expect.any( String ),
-		// 				url: expect.any( String ),
-		// 				author_name: expect.any( String ),
-		// 				author_url: expect.any( String ),
-		// 				network_activated: expect.any( Boolean ),
-		// 			},
-		// 			{
-		// 				plugin: expect.any( String ),
-		// 				name: expect.any( String ),
-		// 				version: expect.any( String ),
-		// 				version_latest: expect.any( String ),
-		// 				url: expect.any( String ),
-		// 				author_name: expect.any( String ),
-		// 				author_url: expect.any( String ),
-		// 				network_activated: expect.any( Boolean ),
-		// 			},
-		// 			{
-		// 				plugin: expect.any( String ),
-		// 				name: expect.any( String ),
-		// 				version: expect.any( String ),
-		// 				version_latest: expect.any( String ),
-		// 				url: expect.any( String ),
-		// 				author_name: expect.any( String ),
-		// 				author_url: expect.any( String ),
-		// 				network_activated: expect.any( Boolean ),
-		// 			},
-		// 			{
-		// 				plugin: expect.any( String ),
-		// 				name: expect.any( String ),
-		// 				version: expect.any( String ),
-		// 				version_latest: expect.any( String ),
-		// 				url: expect.any( String ),
-		// 				author_name: expect.any( String ),
-		// 				author_url: expect.any( String ),
-		// 				network_activated: expect.any( Boolean ),
-		// 			},
-		// 		] ),
-		// 	} )
-		// );
+		await test.step( 'Verify "database.database_tables" fields', async () => {
+			const { woocommerce, other } = databaseTables;
+			expect( woocommerce ).toBeDefined();
+			expect( other ).toBeDefined();
 
-		// local environment differs from external hosts.  Local listed first.
-		// eslint-disable-next-line playwright/no-conditional-in-test
-		// if ( ! shouldSkip ) {
-		// 	expect( responseJSON ).toEqual(
-		// 		expect.objectContaining( {
-		// 			dropins_mu_plugins: expect.objectContaining( {
-		// 				dropins: expect.arrayContaining( [] ),
-		// 				mu_plugins: expect.arrayContaining( [] ),
-		// 			} ),
-		// 		} )
-		// 	);
-		// } else {
-		// 	expect( responseJSON ).toEqual(
-		// 		expect.objectContaining( {
-		// 			dropins_mu_plugins: expect.objectContaining( {
-		// 				dropins: expect.arrayContaining( [
-		// 					{
-		// 						name: expect.any( String ),
-		// 						plugin: expect.any( String ),
-		// 					},
-		// 					{
-		// 						name: expect.any( String ),
-		// 						plugin: expect.any( String ),
-		// 					},
-		// 				] ),
-		// 				mu_plugins: [],
-		// 			} ),
-		// 		} )
-		// 	);
-		// }
-		// expect( responseJSON ).toEqual(
-		// 	expect.objectContaining( {
-		// 		theme: expect.objectContaining( {
-		// 			name: expect.any( String ),
-		// 			version: expect.any( String ),
-		// 			version_latest: expect.any( String ),
-		// 			author_url: expect.any( String ),
-		// 			is_child_theme: expect.any( Boolean ),
-		// 			is_block_theme: expect.any( Boolean ),
-		// 			has_woocommerce_support: expect.any( Boolean ),
-		// 			has_woocommerce_file: expect.any( Boolean ),
-		// 			has_outdated_templates: expect.any( Boolean ),
-		// 			overrides: expect.any( Array ),
-		// 			parent_name: expect.any( String ),
-		// 			parent_version: expect.any( String ),
-		// 			parent_version_latest: expect.any( String ),
-		// 			parent_author_url: expect.any( String ),
-		// 		} ),
-		// 	} )
-		// );
-		// expect( responseJSON ).toEqual(
-		// 	expect.objectContaining( {
-		// 		settings: expect.objectContaining( {
-		// 			api_enabled: expect.any( Boolean ),
-		// 			force_ssl: expect.any( Boolean ),
-		// 			currency: expect.any( String ),
-		// 			currency_symbol: expect.any( String ),
-		// 			currency_position: expect.any( String ),
-		// 			thousand_separator: expect.any( String ),
-		// 			decimal_separator: expect.any( String ),
-		// 			number_of_decimals: expect.any( Number ),
-		// 			geolocation_enabled: expect.any( Boolean ),
-		// 			taxonomies: {
-		// 				external: expect.any( String ),
-		// 				grouped: expect.any( String ),
-		// 				simple: expect.any( String ),
-		// 				variable: expect.any( String ),
-		// 			},
-		// 			product_visibility_terms: {
-		// 				'exclude-from-catalog': expect.any( String ),
-		// 				'exclude-from-search': expect.any( String ),
-		// 				featured: expect.any( String ),
-		// 				outofstock: expect.any( String ),
-		// 				'rated-1': expect.any( String ),
-		// 				'rated-2': expect.any( String ),
-		// 				'rated-3': expect.any( String ),
-		// 				'rated-4': expect.any( String ),
-		// 				'rated-5': expect.any( String ),
-		// 			},
-		// 			woocommerce_com_connected: expect.any( String ),
-		// 		} ),
-		// 	} )
-		// );
-		// expect( responseJSON ).toEqual(
-		// 	expect.objectContaining( {
-		// 		security: expect.objectContaining( {
-		// 			secure_connection: expect.any( Boolean ),
-		// 			hide_errors: expect.any( Boolean ),
-		// 		} ),
-		// 	} )
-		// );
+			woocommerceTables = woocommerce;
+			otherTables = other;
+		} );
+
+		await test.step( 'Verify "database.database_tables.woocommerce" fields', async () => {
+			const wooTableNames =
+				getExpectedWooCommerceTables( databasePrefix );
+
+			for ( const tableName of wooTableNames ) {
+				const thisTable = woocommerceTables[ tableName ];
+				expect( thisTable ).toBeDefined();
+
+				for ( const {
+					field,
+					type,
+				} of schemas.database_tables_woocommerce_other ) {
+					await test.step( `Verify "database.database_tables.woocommerce.${ tableName }.${ field }"`, () => {
+						expect( thisTable[ field ] ).toEqual( type );
+					} );
+				}
+			}
+		} );
+
+		await test.step( 'Verify "database.database_tables.other" fields', async () => {
+			const otherTableNames = getExpectedOtherTables( databasePrefix );
+
+			for ( const tableName of otherTableNames ) {
+				const thisTable = otherTables[ tableName ];
+				expect( thisTable ).toBeDefined();
+
+				for ( const {
+					field,
+					type,
+				} of schemas.database_tables_woocommerce_other ) {
+					await test.step( `Verify "database.database_tables.other.${ tableName }.${ field }"`, () => {
+						expect( thisTable[ field ] ).toEqual( type );
+					} );
+				}
+			}
+		} );
+
+		await test.step( 'Verify "database.database_size" fields', async () => {
+			const { data, index } = databaseSize;
+			expect( data ).toEqual( any( Number ) );
+			expect( index ).toEqual( any( Number ) );
+		} );
+
+		await test.step( 'Verify "active_plugins"', async () => {
+			const { active_plugins } = responseJSON;
+			expect( active_plugins ).toEqual( any( Array ) );
+			expect( active_plugins.length ).toBeGreaterThan( 0 );
+
+			activePlugins = active_plugins;
+		} );
+
+		for ( const aPlugin of activePlugins ) {
+			for ( const { field, type } of schemas.active_plugins ) {
+				await test.step( `Verify "active_plugins.${ aPlugin.plugin }.${ field }"`, async () => {
+					expect( aPlugin[ field ] ).toEqual( type );
+				} );
+			}
+		}
+
+		await test.step( 'Verify "dropins_mu_plugins"', async () => {
+			const { dropins_mu_plugins } = responseJSON;
+			expect( dropins_mu_plugins ).toBeDefined();
+			dropinsMuPlugins = dropins_mu_plugins;
+		} );
+
+		await test.step( 'Verify "dropins_mu_plugins.dropins"', async () => {
+			const { dropins } = dropinsMuPlugins;
+			expect( dropins ).toEqual( any( Array ) );
+
+			for ( const dropin of dropins ) {
+				const { name, plugin } = dropin;
+				await test.step( `Verify dropin "${ name }"`, async () => {
+					expect( name ).toEqual( any( String ) );
+					expect( plugin ).toEqual( any( String ) );
+				} );
+			}
+		} );
+
+		await test.step( 'Verify "dropins_mu_plugins.mu_plugins"', async () => {
+			const { mu_plugins } = dropinsMuPlugins;
+			expect( mu_plugins ).toEqual( any( Array ) );
+		} );
+
+		await test.step( 'Verify "theme"', async () => {
+			const { theme } = responseJSON;
+			expect( theme ).toBeDefined();
+
+			for ( const { field, type } of schemas.theme ) {
+				await test.step( `Verify "theme.${ field }"`, () => {
+					expect( theme[ field ] ).toEqual( type );
+				} );
+			}
+		} );
+
+		await test.step( 'Verify "settings"', async () => {
+			const { settings } = responseJSON;
+			expect( settings ).toBeDefined();
+
+			for ( const { field, type } of schemas.settings ) {
+				await test.step( `Verify "settings.${ field }"`, async () => {
+					expect( settings[ field ] ).toEqual( type );
+				} );
+			}
+
+			taxonomiesJSON = settings.taxonomies;
+			productVisibilityTerms = settings.product_visibility_terms;
+		} );
+
+		await test.step( 'Verify "settings.taxonomies"', async () => {
+			for ( const { field, type } of schemas.settings_taxonomies ) {
+				await test.step( `Verify "settings.taxonomies.${ field }"`, async () => {
+					expect( taxonomiesJSON[ field ] ).toEqual( type );
+				} );
+			}
+		} );
+
+		await test.step( 'Verify "settings.product_visibility_terms"', async () => {
+			for ( const {
+				field,
+				type,
+			} of schemas.settings_product_visibility_terms ) {
+				await test.step( `Verify "settings.product_visibility_terms.${ field }"`, async () => {
+					expect( productVisibilityTerms[ field ] ).toEqual( type );
+				} );
+			}
+		} );
+
+		await test.step( 'Verify "security" fields', async () => {
+			const { security } = responseJSON;
+			expect( security ).toBeDefined();
+
+			for ( const { field, type } of schemas.security ) {
+				await test.step( `Verify "security.${ field }"`, () => {
+					expect( security[ field ] ).toEqual( type );
+				} );
+			}
+		} );
+
+		await test.step( 'Verify "pages', async () => {
+			const { pages } = responseJSON;
+			expect( pages ).toEqual( any( Array ) );
+
+			for ( const page of pages ) {
+				for ( const { field, type } of schemas.pages ) {
+					await test.step( `Verify page "${ page.page_name }"`, async () => {
+						expect( page[ field ] ).toEqual( type );
+					} );
+				}
+			}
+		} );
+
 		// expect( responseJSON ).toEqual(
 		// 	expect.objectContaining( {
 		// 		pages: expect.arrayContaining( [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

This PR updates the test `can view all system status items` to make it compatible with WPCOM, Pressable, and multisites. Other tests were untouched. 

The failures were due to schema differences of the endpoint responses between wp-env and WPCOM. The failures were scattered across different parts and assertions in this test. As mentioned in #53214, it had been difficult to troubleshoot these scattered failures so as much as I wanted to make the changes minimal, I ended up needing to restructure this test. 

These changes are:
- Organized the contents of this test into `test.step()`s and also added explicit messages in some of the `expect()` calls to make them more verbose and easier to identify failures.
    - In certain parts, I nested the test steps so I had to disable the `playwright/no-nested-step` rule to prevent eslint warnings. I limited the nesting to two levels only to hopefully maintain readability.
- Put all [`schemas`](https://github.com/woocommerce/woocommerce/blob/970818f4052b9f2493e03d8115ee9a85fac6c7f5/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js#L72) in a single place to decouple them from the assertions, which also helps make individual `test.step()`s to be shorter.
- Created a custom matcher [`expect.anyOf()`](https://github.com/woocommerce/woocommerce/blob/970818f4052b9f2493e03d8115ee9a85fac6c7f5/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js#L12) to relax some assertions on object properties that have different data types between wp-env and WPCOM.
- Keys in the `database.database_tables.woocommerce` object respect the database prefix. This is why the assertions for this object are failing on multisites -- multisites have a db prefix like `wp_2_` instead of the default `wp_`. To address this, I created the [`getExpectedWooCommerceTables()`](https://github.com/woocommerce/woocommerce/blob/970818f4052b9f2493e03d8115ee9a85fac6c7f5/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js#L235) function to return the correctly db-prefixed key names.

There were a few oddities that needed special handling:
- The properties `environment.remote_get_response` and `environment.remote_post_response`:
    - In WPCOM they are numbers. But in wpenv they are strings -- but here's the weird thing: they're boolean (with value `false`) if the wp-env is newly launched. They only become strings on succeeding runs of this test :shrug:. To address this, I set the assertion of those 2 properties to be of type boolean, string, or number.
- The property `environment.external_object_cache`:
    - It is `null` on wp-env, but boolean in other environments not just in WPCOM, since hosts can use an external object cache. The weird thing here is that in JavaScript, the `typeof null` evaluates to `object` instead of `null` as mentioned [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null). To handle this, I placed it on its own separate assertion.
- The `database.database_tables.other` object:
    - Some keys in this object follow the database prefix like `wp_2_wc_admin_notes`. Unfortunately some don't, like `wp_usermeta` :man_shrugging:  To handle this I had to rely on their [suffixes](https://github.com/woocommerce/woocommerce/blob/970818f4052b9f2493e03d8115ee9a85fac6c7f5/plugins/woocommerce/tests/e2e-pw/tests/api-tests/system-status/system-status-crud.test.js#L200) instead of their full key name.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure  `system-status-crud.test.js` pass together with all API tests in CI.
2. Test it on WPCOM, Pressable, and Multisite. Inspect their HTML reports and see if there's anything unusual, or if the format is confusing:
    ```sh
    # Test on WPCOM and Pressable
    export E2E_ENV_KEY="..."
    pnpm test:e2e:wpcom api-wpcom system-status-crud.test.js
    pnpm test:e2e:pressable api-pressable system-status-crud.test.js
    
    # Test on multisite
    export BASE_URL=https://your.multisite.url
    # Set other variables here like admin and customer credentials of your multisite
    pnpm test:api system-status-crud.test.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
