### PR TITLE
Ensure Mini Cart item count remains visible

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/utils/set-styles.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/utils/set-styles.ts
@@ -7,7 +7,12 @@ function getClosestColor(
 	}
 	const color = window.getComputedStyle( element )[ colorType ];
 	if ( color !== 'rgba(0, 0, 0, 0)' && color !== 'transparent' ) {
-		return color;
+		const matches = color.match( /\d+/g );
+		if ( ! matches || matches.length < 3 ) {
+			return null;
+		}
+		const [ r, g, b ] = matches.slice( 0, 3 );
+		return `rgb(${ r }, ${ g }, ${ b })`;
 	}
 	return getClosestColor( element.parentElement, colorType );
 }

--- a/plugins/woocommerce/changelog/55178-fix-make-Mini-Cart-item-count-visible
+++ b/plugins/woocommerce/changelog/55178-fix-make-Mini-Cart-item-count-visible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure that the Mini Cart item count remains visible even when the inherited color has an alpha channel, which would make the item count color transparent.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Mini Cart item count inherits its color from the background color of its parent element. When the background color includes an alpha channel, making the parent element transparent, the item count can become invisible. This PR updates the functionality to derive the color while removing the alpha channel, ensuring visibility.

Closes #55085.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [Simple Custom CSS and JS](https://wordpress.org/plugins/custom-css-js/) plugin.
2. Add the following CSS code:

```css
.wc-block-mini-cart__button {
  background-color: rgba(255, 255, 255, 0);
}
```

3. Go to `Appearance » Editor » Patterns » Header » Header`.
4. Select the Mini-Cart block.
5. Set `Show Cart Item Count:` to `Only if cart has items`.
6. Go to the frontend.
7. Add a product to the cart.
8. See that the Mini Cart icon count is not visible.
9. Test it in Chrome, Firefox, Safari
10. Test it in different WP themes

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="68" alt="Screenshot 2025-02-06 at 16 05 26" src="https://github.com/user-attachments/assets/c5ae296b-5380-415b-a13d-a0c86714b877" />
</td>
<td valign="top">After:
<br><br>
<img width="64" alt="Screenshot 2025-02-06 at 16 04 33" src="https://github.com/user-attachments/assets/2364f7cb-43c8-40a5-bd2c-e4d4a9c46265" />
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Ensure that the Mini Cart item count remains visible even when the inherited color has an alpha channel, which would make the item count color transparent.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
