### PR TITLE
[e2e tests] Update gitignore to exclude env paths containing _local

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-gitignore-local-envs
+++ b/plugins/woocommerce/changelog/e2e-update-gitignore-local-envs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: updated gitignore to exclude paths containing _local

--- a/plugins/woocommerce/tests/e2e-pw/.gitignore
+++ b/plugins/woocommerce/tests/e2e-pw/.gitignore
@@ -1,4 +1,5 @@
 /.state
 /test-results
 /envs/_default
+/envs/_local*
 /playwright-report

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -143,6 +143,10 @@ If you need to create a new pre-defined environment, you can follow these steps:
   run `E2E_ENV_KEY='your-key' ./tests/e2e-pw/bin/dotenv.sh -e my-new-env`. This script command will encrypt the `.env`
   file into `tests/e2e-pw/envs/my-new-env/.env.enc`.
 
+> [!TIP]
+> Creating an environment directory starting with `_local` will make it ignored by git, so you can store your local environment configurations without worrying about accidentally committing them.
+> Example: _local_my-own-jn-testing-site
+
 ## Writing e2e tests
 
 There are no hard rules for writing tests, but use your common sense when it comes to code duplication and layers of


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update .gitignore file to ignore anything under a directory in envs starting with `_local`. This is useful to define more local environments that you don't want to be pushed to remote.

### How to test the changes in this Pull Request:

Create a directory `plugins/woocommerce/tests/e2e-pw/envs/_local-abc` and add any file under it. Check git status and make sure the file is not marked as new.
