### PR TITLE
[Checkout] Prevent a delay in rendering checkout payment methods on first load.

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/resolvers.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/resolvers.ts
@@ -31,22 +31,20 @@ export const getCartData =
 			apiFetch.setCartHash( response?.headers );
 		}
 
-		response
-			.json()
-			.then( function ( cartData: CartResponse ) {
-				const { receiveCart, receiveError } = dispatch;
+		try {
+			const cartData: CartResponse = await response.json();
+			const { receiveCart, receiveError } = dispatch;
 
-				if ( ! cartData ) {
-					receiveError( CART_API_ERROR );
-					return;
-				}
-
-				receiveCart( cartData );
-			} )
-			.catch( () => {
-				const { receiveError } = dispatch;
+			if ( ! cartData ) {
 				receiveError( CART_API_ERROR );
-			} );
+				return;
+			}
+
+			receiveCart( cartData );
+		} catch ( error ) {
+			const { receiveError } = dispatch;
+			receiveError( CART_API_ERROR );
+		}
 	};
 
 /**

--- a/plugins/woocommerce/changelog/fix-payment-method-block-delay
+++ b/plugins/woocommerce/changelog/fix-payment-method-block-delay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a delay in rendering checkout payment methods on first load.

--- a/plugins/woocommerce/changelog/fix-payment-method-block-delay
+++ b/plugins/woocommerce/changelog/fix-payment-method-block-delay
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent a delay in rendering checkout payment methods on first load.
+Prevent a delay in rendering the checkout block payment methods on first load.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a delay with cart data hydration that causes payment methods to be missing during first render. With this fix in place, data is immediately available.

This issue was introduced with https://github.com/woocommerce/woocommerce/pull/53611 which included some updated logic in `getCartData` to update the cart hash from the cart data response. A promise was used to catch errors.

This promise is the reason for delay; we believe that due to the promise, the payment methods are rendered empty, and from that point, updating payment methods is debounced. Making this synchronous will ensure cart data exists before the first render, which avoids the debounce, and prevents the error state being displayed to the customer.

To see the original issue without this PR, add something to cart, go to the checkout page, zoom out so you can see the payment methods without scrolling, then refresh. You'll see a red notice for a short while before payment methods are shown. 

| Before | After |
|--------|-------|
| ![Screen Recording 2025-02-06 at 13 05 59](https://github.com/user-attachments/assets/bfec176d-617b-4700-a8eb-8d90712c0122)  | ![Screen Recording 2025-02-06 at 13 04 30](https://github.com/user-attachments/assets/d4c8c2e7-1ecb-4660-a9a8-10c191c51163) |

This seems to be related to the below issue, although I couldn't replicate them being missing indefinitely, only after a short delay. Someone who can reproduce the issue should test after this PR is in place before closing.

Ref: #54805

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add item to cart
2. Go to checkout page
3. Zoom out so you can see payment methods
4. Refresh page
5. Payment methods will be visible without first seeing a "no payment methods exist" error.
6. Checkout as normal

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
