### PR TITLE
Fix: Ensure 'view' action is excluded by key instead of translated name (#54879)

### DIFF
--- a/plugins/woocommerce/changelog/55197-trunk
+++ b/plugins/woocommerce/changelog/55197-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes exclusion of 'View' action by key instead of translated name in the `order-details.php` template.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.6.0
+ * @version 9.8.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -32,9 +32,10 @@ $show_purchase_note = $order->has_status( apply_filters( 'woocommerce_purchase_n
 $downloads          = $order->get_downloadable_items();
 $actions            = array_filter(
 	wc_get_account_orders_actions( $order ),
-	function ( $action ) {
-		return 'View' !== $action['name'];
-	}
+	function ( $key ) {
+		return 'view' !== $key;
+	},
+	ARRAY_FILTER_USE_KEY
 );
 
 // We make sure the order belongs to the user. This will also be true if the user is a guest, and the order belongs to a guest (userID === 0).


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Fixes the issue where the 'View' action (translated as "Bekijken" in Dutch) was incorrectly excluded due to filtering based on the action name rather than the array key.  
- Excludes the 'view' action from the $actions array by filtering based on the key, ensuring it is correctly excluded, regardless of language.  


Closes #54879.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Switch your WordPress installation to Dutch (or any language where "View" is translated).  
2. Complete an order as a guest.  
3. After the order is completed, ensure the "View" action is correctly excluded from the available actions on the Order Details page.

#### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1084" alt="Screenshot 2025-02-11 at 11 16 15" src="https://github.com/user-attachments/assets/f7d1f336-d530-4828-b588-3700a08345fe" />
</td>
<td valign="top">After:
<br><br>
<img width="1096" alt="Screenshot 2025-02-11 at 11 18 30" src="https://github.com/user-attachments/assets/6bd7868d-8899-49ee-8cfc-a132e05fb62a" />
</td>
</tr>
</table>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixes exclusion of 'View' action by key instead of translated name in the `order-details.php` template.

</details>