### PR TITLE
Add some defensive checks around product template functions

### DIFF
--- a/plugins/woocommerce/changelog/fix-54294
+++ b/plugins/woocommerce/changelog/fix-54294
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when calling various template functions with no global product set.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1809,9 +1809,11 @@ if ( ! function_exists( 'woocommerce_template_single_rating' ) ) {
 	 * Output the product rating.
 	 */
 	function woocommerce_template_single_rating() {
-		if ( post_type_supports( 'product', 'comments' ) ) {
-			wc_get_template( 'single-product/rating.php' );
+		if ( ! post_type_supports( 'product', 'comments' ) || ! is_a( $GLOBALS['product'] ?? null, \WC_Product::class ) ) {
+			return;
 		}
+
+		wc_get_template( 'single-product/rating.php' );
 	}
 }
 if ( ! function_exists( 'woocommerce_template_single_price' ) ) {
@@ -1820,6 +1822,10 @@ if ( ! function_exists( 'woocommerce_template_single_price' ) ) {
 	 * Output the product price.
 	 */
 	function woocommerce_template_single_price() {
+		if ( ! is_a( $GLOBALS['product'] ?? null, \WC_Product::class ) ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/price.php' );
 	}
 }
@@ -1829,6 +1835,10 @@ if ( ! function_exists( 'woocommerce_template_single_excerpt' ) ) {
 	 * Output the product short description (excerpt).
 	 */
 	function woocommerce_template_single_excerpt() {
+		if ( ! isset( $GLOBALS['post']->post_excerpt ) ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/short-description.php' );
 	}
 }
@@ -1838,6 +1848,10 @@ if ( ! function_exists( 'woocommerce_template_single_meta' ) ) {
 	 * Output the product meta.
 	 */
 	function woocommerce_template_single_meta() {
+		if ( ! is_a( $GLOBALS['product'] ?? null, \WC_Product::class ) ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/meta.php' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Particularly in connection with certain themes or site builders, it's not uncommon for WC functions or templates to be included in a context where not all the variables are set. For example, the "single product" template without a `$product` defined beforehand.

This PR introduces various defensive checks to prevent fatal errors when interacting with template functions that expect a product to be defined. This is, in essence, a continuation of #53167.

Closes #54294 (which only referred to one of the possible errors being addressed here).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. We can simulate no global product being defined (as expected by the templates) by using WP-CLI as it doesn't have this context already set. Open a WP-CLI shell by running `wp shell` and execute the following commands:
   ```
   wp> woocommerce_template_single_rating();
   wp> woocommerce_template_single_price();
   wp> woocommerce_template_single_excerpt();
   wp> woocommerce_template_single_meta();
   wp> do_action( 'woocommerce_single_product_summary' );
   ```
1. No fatal error/warning/notice should be logged.
1. **Optional:** Check out `trunk` and repeat the above. You'll see various errors/notices is logged:
   > `Fatal error: Uncaught Error: Call to a member function get_rating_count() on null in /[...]/woocommerce/plugins/woocommerce/templates/single-product/rating.php:28`
   
   > `Fatal error: Uncaught Error: Call to a member function get_price_html() on null in /[...]/woocommerce/plugins/woocommerce/templates/single-product/price.php:25`
   
   > `Warning: Attempt to read property "post_excerpt" on null in /[...]/woocommerce/plugins/woocommerce/templates/single-product/short-description.php on line 24`
   > `Deprecated: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /[...]/_www/sites/proton.test/wp-includes/shortcodes.php on line 246`
   > `Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /[...]/_www/sites/proton.test/wp-includes/class-wp-block-parser.php on line 247`
   > `Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /[...]/_www/sites/proton.test/wp-includes/class-wp-block-parser.php on line 324`
   
   > `Fatal error: Uncaught Error: Call to a member function get_sku() on null in /[...]/woocommerce/plugins/woocommerce/templates/single-product/meta.php:30`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
