### PR TITLE
Prevent possible fatal when calling `woocommerce_output_all_notices()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-55101
+++ b/plugins/woocommerce/changelog/fix-55101
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error when outputting WC notices in an invalid context.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4137,6 +4137,10 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  * @since 3.5.0
  */
 function woocommerce_output_all_notices() {
+	if ( ! function_exists( 'wc_print_notices' ) ) {
+		return;
+	}
+
 	echo '<div class="woocommerce-notices-wrapper">';
 	wc_print_notices();
 	echo '</div>';

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4138,6 +4138,11 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  */
 function woocommerce_output_all_notices() {
 	if ( ! function_exists( 'wc_print_notices' ) ) {
+		wc_doing_it_wrong(
+			__FUNCTION__,
+			'Function should only be used during frontend requests.',
+			'9.8.0'
+		);
 		return;
 	}
 


### PR DESCRIPTION
in the wrong context

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Under normal circumstances, functions in `wc-template-functions.php` are made available [everywhere](https://github.com/woocommerce/woocommerce/blob/ffff59f12979d9debea531db0cd99efbce4de94e/plugins/woocommerce/includes/class-woocommerce.php#L289), but `woocommerce_output_all_notices()`, a function defined in this file, depends on `wc_print_notices()` which comes from a file that is only included on [frontend requests](https://github.com/woocommerce/woocommerce/blob/ffff59f12979d9debea531db0cd99efbce4de94e/plugins/woocommerce/includes/class-woocommerce.php#L810).

Though unlikely, this means that `woocommerce_output_all_notices()` could end up being called in a context where `wc_print_notices()` is not defined.

This PR adds a defensive check to prevent this from bubbling up into a fatal error.

Closes #55101.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Drop the following PHP as a .php file inside `wp-content/mu-plugins` or run it as a code snippet in a different way:
   ```php
   <?php
   add_action(
	   'admin_footer',
	   function() {
		   woocommerce_output_all_notices();
	   }
   );
   ```
1. Visit the admin of your site.
1. No error should be logged.
1. (Optional) Check out `trunk` and follow the instructions above. This time, a fatal will be triggered (check your logs):
   > `PHP Fatal error:  Uncaught Error: Call to undefined function wc_print_notices() in /[...]/woocommerce/plugins/woocommerce/includes/wc-template-functions.php:4150`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
