### PR TITLE
Fix user capability check for getJetpackConnectionData

### DIFF
--- a/packages/js/data/changelog/fix-jetpack-connection-data-api-error
+++ b/packages/js/data/changelog/fix-jetpack-connection-data-api-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix user capability check for connection data

--- a/packages/js/data/src/plugins/resolvers.ts
+++ b/packages/js/data/src/plugins/resolvers.ts
@@ -116,7 +116,7 @@ export function* getJetpackConnectionData() {
 	yield setIsRequesting( 'getJetpackConnectionData', true );
 
 	try {
-		yield checkUserCapability( 'manage_woocommerce' );
+		yield checkUserCapability( 'jetpack_connect_user' );
 
 		const url = JETPACK_NAMESPACE + '/connection/data';
 

--- a/packages/js/data/src/plugins/resolvers.ts
+++ b/packages/js/data/src/plugins/resolvers.ts
@@ -114,12 +114,15 @@ export function* isJetpackConnected() {
 
 export function* getJetpackConnectionData() {
 	yield setIsRequesting( 'getJetpackConnectionData', true );
-
 	try {
-		yield checkUserCapability( 'jetpack_connect_user' );
+		const isConnected = yield resolveSelect(
+			STORE_NAME,
+			'isJetpackConnected'
+		);
+		// See API side permission check here: https://github.com/Automattic/jetpack-connection/blob/trunk/src/class-manager.php#L1560-L1568.
+		yield checkUserCapability( isConnected ? 'read' : 'manage_options' );
 
 		const url = JETPACK_NAMESPACE + '/connection/data';
-
 		const results: JetpackConnectionDataResponse = yield apiFetch( {
 			path: url,
 			method: 'GET',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/44009

This PR is to fix the issue that when non-admin users visit WooCommerce > Home, they will see the following JS error:


<img width="1235" alt="Screenshot 2024-01-23 at 14 19 17" src="https://github.com/woocommerce/woocommerce/assets/15730971/9d8d70e1-29b6-4ffa-b861-3f9bbed99565">

---

`Failed to load resource: the server responded with a status of 403 ()`

This leads to the following response from `wp-json/jetpack/v4/connection/data?_locale=user`

```json
{
    "code": "invalid_user_permission_user_connection_data",
    "message": "You do not have the correct user permissions to perform this action.\n\t\t\tPlease contact your site admin if you think this is a mistake.",
    "data": {
        "status": 403
    }
}
```

Because `jetpack_connect_user` capability is not available for non-admin users, so the API returns 401 unauthorized.

```php
 public static function user_connection_data_permission_check() {
            if ( current_user_can( 'jetpack_connect_user' ) ) {
                    return true;
            }

            return new WP_Error(
                    'invalid_user_permission_user_connection_data',
                    self::get_user_permissions_error_msg(),
                    array( 'status' => rest_authorization_required_code() )
            );
    }
```

This PR is to fix this issue by checking for the correct [`jetpack_connect_user` capability](https://github.com/Automattic/jetpack-connection/blob/trunk/src/class-manager.php#L1560-L1568) before making the API request. We're using this API to decide whether to add the mobile item to the help menu and show different steps for the mobile app task modal. 

In https://github.com/woocommerce/woocommerce/pull/40613, we've updated the mobile app onboarding model to include two steps and support non-admin users in signing in to the mobile app. There seems to be a lot of unnecessary code, including the help menu logic. I'll create a follow-up PR to remove them.

Note that the `try...catch` block in resolver doesn't catch the [`apiFetch`](https://github.com/WordPress/gutenberg/blob/3416bf4b0db6679b86e8e4226cbdb0d3387b25d7/packages/data-controls/src/index.ts#L29-L34) error because apiFetch method from `@wordpress/data-controls` yields control object, which is not a promise. I think we need to review all data resolvers and add a custom control handler to catch the error. to ensure they handle errors correctly. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**If you test this PR before the https://github.com/woocommerce/woocommerce/pull/55278 is merged**

1. Create a new JN site
2. Skip Core Profiler
3. Create a user with `Shop Manager` role
4. Log in as the user with the Shop Manager role
5. Visit `WooCommerce > Home`
6. See no API error/request related to JetPack connection data in the console/network tab
7. Connect the site with Jetpack using the Admin user (hasConnectedOwner)
8. Log in as the user with the Shop Manager role
9. Visit `WooCommerce > Home`
10. See API request to JetPack connection data in the network tab and receive a 200 response

**If you test this PR after the https://github.com/woocommerce/woocommerce/pull/55278 is merged**

1. Create a new JN site
2. Skip Core Profiler
3. Create a user with `Shop Manager` role
4. Log in as the user with the Shop Manager role
5. Run `window.wp.data.resolveSelect( 'wc/admin/plugins' ).getJetpackConnectionData()` in the console
6. See no API request related to JetPack connection data `jetpack/v4/connection/data` in the network tab
7. Connect the site with Jetpack using the Admin user (hasConnectedOwner)
8. Run `window.wp.data.resolveSelect( 'wc/admin/plugins' ).getJetpackConnectionData()` in the console
9. See API request to JetPack connection data in the network tab and receive a 200 response

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
