### PR TITLE
Product Gallery: optimise zoom in so styles are only applied to selected image + unify context usage

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -40,24 +40,9 @@ const productGallery = {
 			const { selectedImageNumber, imageIds, imageId } = getContext();
 			return selectedImageNumber === imageIds.indexOf( imageId ) + 1;
 		},
-		get isDialogOpen() {
-			return getContext().isDialogOpen;
-		},
-		get disableLeft() {
-			return getContext().disableLeft;
-		},
-		get disableRight() {
-			return getContext().disableRight;
-		},
 		get imageIndex(): number {
 			const { imageIds, imageId } = getContext();
 			return imageIds.indexOf( imageId );
-		},
-		get imageIds() {
-			return getContext().imageIds;
-		},
-		get selectedImageNumber() {
-			return getContext().selectedImageNumber;
 		},
 		get thumbnailTabIndex(): string {
 			return state.isSelected ? '0' : '-1';
@@ -87,7 +72,7 @@ const productGallery = {
 			if ( event ) {
 				event.stopPropagation();
 			}
-			const { imageIds, selectedImageNumber } = state;
+			const { selectedImageNumber, imageIds } = getContext();
 			const newImageNumber = Math.min(
 				imageIds.length,
 				selectedImageNumber + 1
@@ -98,7 +83,7 @@ const productGallery = {
 			if ( event ) {
 				event.stopPropagation();
 			}
-			const { selectedImageNumber } = state;
+			const { selectedImageNumber } = getContext();
 			const newImageNumber = Math.max( 1, selectedImageNumber - 1 );
 			actions.selectImage( newImageNumber );
 		},
@@ -266,7 +251,7 @@ const productGallery = {
 			};
 		},
 		dialogStateChange: () => {
-			const { isDialogOpen, selectedImageNumber } = state;
+			const { selectedImageNumber, isDialogOpen } = getContext();
 			const { ref: dialogRef } = getElement() || {};
 
 			if ( isDialogOpen && dialogRef instanceof HTMLElement ) {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image/frontend.tsx
@@ -30,13 +30,18 @@ const productGalleryLargeImage = {
 	state: {
 		get styles() {
 			const { styles } = getContext();
-			return Object.entries( styles ?? [] ).reduce(
-				( acc, [ key, value ] ) => {
-					const style = `${ key }:${ value };`;
-					return acc.length > 0 ? `${ acc } ${ style }` : style;
-				},
-				''
-			);
+			const { isSelected } = state;
+			return isSelected
+				? Object.entries( styles ?? [] ).reduce(
+						( acc, [ key, value ] ) => {
+							const style = `${ key }:${ value };`;
+							return acc.length > 0
+								? `${ acc } ${ style }`
+								: style;
+						},
+						''
+				  )
+				: '';
 		},
 	},
 	actions: {

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image/frontend.tsx
@@ -82,12 +82,14 @@ const productGalleryLargeImage = {
 			}
 
 			const { ref } = getElement();
-			// Scroll to the selected image with a smooth animation.
-			ref.scrollIntoView( {
-				behavior: 'smooth',
-				block: 'nearest',
-				inline: 'center',
-			} );
+			if ( ref ) {
+				// Scroll to the selected image with a smooth animation.
+				ref.scrollIntoView( {
+					behavior: 'smooth',
+					block: 'nearest',
+					inline: 'center',
+				} );
+			}
 		},
 	},
 };

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -123,7 +123,7 @@ test.describe( `${ blockData.name }`, () => {
 					( el ) => el.style
 				);
 
-				expect( styleOnHover.transform ).toBe( 'scale(1.3)' );
+				expect( styleOnHover.transform ).toBe( '' );
 			} );
 		} );
 		test( 'should not work on frontend when is disabled', async ( {

--- a/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -90,21 +90,42 @@ test.describe( `${ blockData.name }`, () => {
 				page: 'frontend',
 			} );
 
-			// img[style] is the selector because the style attribute is Interactivity API.
-			const imgElement = blockFrontend.locator( 'img' ).first();
-			const style = await imgElement.evaluate( ( el ) => el.style );
+			const selectedImage = blockFrontend.locator( 'img' ).first();
 
-			expect( style.transform ).toBe( 'scale(1)' );
+			await test.step( 'for selected image', async () => {
+				// img[style] is the selector because the style attribute is Interactivity API.
 
-			await imgElement.hover();
+				const style = await selectedImage.evaluate(
+					( el ) => el.style
+				);
 
-			const styleOnHover = await imgElement.evaluate(
-				( el ) => el.style
-			);
+				expect( style.transform ).toBe( 'scale(1)' );
 
-			expect( styleOnHover.transform ).toBe( 'scale(1.3)' );
+				await selectedImage.hover();
+
+				const styleOnHover = await selectedImage.evaluate(
+					( el ) => el.style
+				);
+
+				expect( styleOnHover.transform ).toBe( 'scale(1.3)' );
+			} );
+
+			await test.step( 'styles are not applied to other images', async () => {
+				// img[style] is the selector because the style attribute is Interactivity API.
+				const hiddenImage = blockFrontend.locator( 'img' ).nth( 1 );
+				const style = await hiddenImage.evaluate( ( el ) => el.style );
+
+				expect( style.transform ).toBe( '' );
+
+				await selectedImage.hover();
+
+				const styleOnHover = await hiddenImage.evaluate(
+					( el ) => el.style
+				);
+
+				expect( styleOnHover.transform ).toBe( 'scale(1.3)' );
+			} );
 		} );
-
 		test( 'should not work on frontend when is disabled', async ( {
 			pageObject,
 			editor,

--- a/plugins/woocommerce/changelog/update-product-gallery-unify-context-usage
+++ b/plugins/woocommerce/changelog/update-product-gallery-unify-context-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Gallery: apply zoom styles only to selected image

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
@@ -122,7 +122,7 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 
 		return sprintf(
 			'<button
-				data-wc-bind--disabled="state.disable%1$s"
+				data-wc-bind--disabled="context.disable%1$s"
 				class="wc-block-product-gallery-large-image-next-previous--button wc-block-product-gallery-large-image-next-previous-%2$s"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" width="49" height="48" viewBox="0 0 49 48" fill="none">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
@@ -116,10 +116,9 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 		$button_side_class         = 'left';
 		$button_disabled_directive = 'context.disableLeft';
 
-
 		if ( 'next' === $button_type ) {
-			$icon_path         = $next_button_icon_path;
-			$button_side_class = 'right';
+			$icon_path                 = $next_button_icon_path;
+			$button_side_class         = 'right';
 			$button_disabled_directive = 'context.disableRight';
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImageNextPrevious.php
@@ -114,15 +114,18 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 		$next_button_icon_path     = 'M21.7001 12L19.3 14L28.5 24L19.3 34L21.7001 36L32.5 24L21.7001 12Z';
 		$icon_path                 = $previous_button_icon_path;
 		$button_side_class         = 'left';
+		$button_disabled_directive = 'context.disableLeft';
+
 
 		if ( 'next' === $button_type ) {
 			$icon_path         = $next_button_icon_path;
 			$button_side_class = 'right';
+			$button_disabled_directive = 'context.disableRight';
 		}
 
 		return sprintf(
 			'<button
-				data-wc-bind--disabled="context.disable%1$s"
+				data-wc-bind--disabled="%1$s"
 				class="wc-block-product-gallery-large-image-next-previous--button wc-block-product-gallery-large-image-next-previous-%2$s"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" width="49" height="48" viewBox="0 0 49 48" fill="none">
@@ -140,7 +143,7 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 					</defs>
 				</svg>
 			</button>',
-			ucfirst( $button_side_class ),
+			$button_disabled_directive,
 			$button_side_class,
 			$icon_path
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR includes two types of changes:
1. Optimise zoom on hover. Previously the `transform` styles were applied to all of the images in the gallery. After this PR they're applied only to the selected image. Changes in [this file](https://github.com/woocommerce/woocommerce/pull/55237/files#diff-2c862b20e50e9058f66a2c2cb1052b226fe73590d00e6b92448ce3a61a16fbb6) are responsible for that.
2. The rest of changes are to unify the usage of iAPI context. There's no point of writing getters for context properties. It should be only used to derive state from context so as an example:

```
		// DON'T
		get disableLeft() {
			return getContext().disableLeft;
		},

		// DO
                 get thumbnailTabIndex(): string {
			return state.isSelected ? '0' : '-1';
		},
```

So the rest of changes are unifying it.

Closes https://github.com/woocommerce/woocommerce/issues/54966

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Editor > Single Product template.
2. Replace the Product Image Gallery block with the Product Gallery (beta) block.
3. Go to the frontend
4. Open dev tools by inspecting the large image


Before | After
-- | --
Take a look like `style` attribute is applied also to other `img` elements, not visible on the page | Only visible images get the updated style
![zoom-bvefore](https://github.com/user-attachments/assets/9ab45d75-5e65-4108-a5a3-f22543e5440a) | ![zoom-afterdf](https://github.com/user-attachments/assets/fe9e578b-01e4-4e03-945b-2dbb409dba2c)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
