### PR TITLE
[Payments NOX] Introduce A/B test for test-drive-first vs straight-to-live WooPayments onboarding flow

### DIFF
--- a/plugins/woocommerce/changelog/dev-a-b-test-drive-mode
+++ b/plugins/woocommerce/changelog/dev-a-b-test-drive-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Override the NOX onboarding flow router for test account onboarding with an experiment.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -286,17 +286,6 @@ export const OtherPaymentGateways = ( {
 		categoryIdWithPopoverVisible,
 	] );
 
-
-
-
-	if ( ! isFetching && suggestions.length === 0 ) {
-		return (
-			<div className="more-payment-options">
-				{ morePaymentOptionsLink }
-			</div>
-		);
-	}
-
 	return (
 		<div
 			className={

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -202,32 +202,28 @@ export const SettingsPaymentsMethods = () => {
 		recordEvent( 'wcpay_settings_payment_methods_continue', {
 			selected_payment_methods: Object.keys( paymentMethodsState )
 				.filter(
-					( paymentMethod ) =>
-						paymentMethodsState[ paymentMethod ] === true
+					( paymentMethod ) => paymentMethodsState[ paymentMethod ]
 				)
 				.join( ', ' ),
 			deselected_payment_methods: Object.keys( paymentMethodsState )
 				.filter(
-					( paymentMethod ) =>
-						paymentMethodsState[ paymentMethod ] === false
+					( paymentMethod ) => ! paymentMethodsState[ paymentMethod ]
 				)
 				.join( ', ' ),
 		} );
 
 		setIsCompleted( true );
+
 		// Get the onboarding URL or fallback to the test drive account link
 		const onboardUrl =
 			wooPayments?.onboarding?._links.onboard.href ||
 			getWooPaymentsTestDriveAccountLink();
 
-		// Combine the onboard URL with the query string
-		const fullOnboardUrl =
+		// Combine the onboard URL with the query string and redirect to the onboard URL.
+		window.location.href =
 			onboardUrl +
 			'&capabilities=' +
 			encodeURIComponent( JSON.stringify( paymentMethodsState ) );
-
-		// Redirect to the onboard URL
-		window.location.href = fullOnboardUrl;
 	}, [ paymentMethodsState, wooPayments ] );
 
 	useEffect( () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-methods.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-methods.tsx
@@ -85,9 +85,10 @@ const combineRequestMethods = (
  * Combines Apple Pay and Google Pay into a single method if both exist and allows users
  * to toggle the enabled/disabled state of each payment method.
  */
-export const SettingsPaymentsMethods: React.FC<
-	SettingsPaymentsMethodsProps
-> = ( { paymentMethodsState, setPaymentMethodsState } ) => {
+export const SettingsPaymentsMethods = ( {
+	paymentMethodsState,
+	setPaymentMethodsState,
+}: SettingsPaymentsMethodsProps ) => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	const { paymentMethods, isFetching } = useSelect( ( select ) => {
@@ -121,7 +122,7 @@ export const SettingsPaymentsMethods: React.FC<
 		if ( initialPaymentMethodsState !== null && ! isFetching ) {
 			setPaymentMethodsState( initialPaymentMethodsState );
 		}
-	}, [ isFetching ] );
+	}, [ isFetching, setPaymentMethodsState, initialPaymentMethodsState ] );
 
 	return (
 		<div className="settings-payments-methods__container">

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
 use WC_Abstract_Order;
 use WC_Payment_Gateway;
+use WooCommerce\Admin\Experimental_Abtest;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -192,6 +193,13 @@ class WooPayments extends PaymentGateway {
 			$this->has_enabled_other_ecommerce_gateways() &&
 			$this->has_orders()
 		) {
+			$live_onboarding = true;
+		}
+
+		// We run an experiment to determine the efficiency of test-account-first onboarding vs straight-to-live onboarding.
+		// If the experiment is active and the store is in the treatment group, we will do live onboarding.
+		// Otherwise, we will do test-account-first onboarding (control group).
+		if ( ! $live_onboarding && Experimental_Abtest::in_treatment( 'woocommerce_payment_settings_onboarding_2025_v1' ) ) {
 			$live_onboarding = true;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
@@ -155,38 +155,43 @@ class WooPayments extends PaymentGateway {
 			return add_query_arg( $params, $connect_url );
 		}
 
-		// We don't have an account yet, so the onboarding link is to kickstart the process.
+		// We don't have an account yet, so the onboarding link is used to kickstart the process.
 
-		// Apply our routing logic to determine if we should do a live onboarding/account.
+		// Default to test-account-first onboarding.
 		$live_onboarding = false;
 
-		$onboarding_profile = get_option( OnboardingProfile::DATA_OPTION, array() );
-
 		/*
-		 * For answers provided in the onboarding profile, we will only consider live onboarding if:
-		 * Merchant selected “I’m already selling” and answered either:
-		 * - Yes, I’m selling online.
-		 * - I’m selling both online and offline.
+		 * Apply our routing logic to determine if we should do a live onboarding/account.
 		 *
-		 * For existing stores, we will only consider live onboarding if all are true:
+		 * For new stores (not yet launched aka in Coming Soon mode),
+		 * based on the answers provided in the onboarding profile, we will do live onboarding if:
+		 * - Merchant selected “I’m already selling” AND answered either:
+		 *   - Yes, I’m selling online.
+		 *   - I’m selling both online and offline.
+		 *
+		 * For launched stores, we will only consider live onboarding if all are true:
 		 * - Store is at least 90 days old.
 		 * - Store has an active payments gateway (other than WooPayments).
 		 * - Store has processed a live electronic payment in the past 90 days (any gateway).
 		 *
 		 * @see plugins/woocommerce/client/admin/client/core-profiler/pages/UserProfile.tsx for the values.
 		 */
-		if (
-			isset( $onboarding_profile['business_choice'] ) && 'im_already_selling' === $onboarding_profile['business_choice'] &&
-			isset( $onboarding_profile['selling_online_answer'] ) && (
-				'yes_im_selling_online' === $onboarding_profile['selling_online_answer'] ||
-				'im_selling_both_online_and_offline' === $onboarding_profile['selling_online_answer']
-			)
-		) {
-			$live_onboarding = true;
-		} elseif ( WCAdminHelper::is_wc_admin_active_for( 90 * DAY_IN_SECONDS ) &&
+		if ( filter_var( get_option( 'woocommerce_coming_soon' ), FILTER_VALIDATE_BOOLEAN ) ) {
+			$onboarding_profile = get_option( OnboardingProfile::DATA_OPTION, array() );
+			if (
+				isset( $onboarding_profile['business_choice'] ) && 'im_already_selling' === $onboarding_profile['business_choice'] &&
+				isset( $onboarding_profile['selling_online_answer'] ) && (
+					'yes_im_selling_online' === $onboarding_profile['selling_online_answer'] ||
+					'im_selling_both_online_and_offline' === $onboarding_profile['selling_online_answer']
+				)
+			) {
+				$live_onboarding = true;
+			}
+		} elseif (
+			WCAdminHelper::is_wc_admin_active_for( 90 * DAY_IN_SECONDS ) &&
 			$this->has_enabled_other_ecommerce_gateways() &&
-			$this->has_orders() ) {
-
+			$this->has_orders()
+		) {
 			$live_onboarding = true;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We override the WooPayments NOX test account onboarding flow via an Explat experiment.

Closes #54671  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prep work

1. Create a new JurassicNinja site with WooCommerce using this PR's live branch and the WooCommerce Beta Tester plugin, WITHOUT the Drop-in Cache (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=dev/a-b-test-drive-mode))
2. If you created the site using the direct create link, access the files of the newly created site through SFTP and delete the `wp-content/object-cache.php` file so you disable the object cache.
3. Access the WP admin of the newly created site, click on the WooCommerce menu item, and you should be taken to the WooCommerce profiler. Click "Skip guided setup" and choose `US` as the store's base location country.
4. Go to Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature.
5. Make sure your store is in coming soon mode.

#### Test the onboarding flow routing

1. Go to Tools > WCA Test Helper > Tools and "Reset Onboarding Wizard":
![Screenshot 2024-12-13 at 11 37 40](https://github.com/user-attachments/assets/22bb6561-7e01-4bdb-9184-8fd4a8ea8825)
2. Click on WooCommerce to kickstart the WC onboarding wizard. Don't skip it, click on "Set up my store" and on the second step select "I'm already selling" and then "Yes, I'm selling online". The rest of the info doesn't matter.
![Screenshot 2024-12-13 at 11 38 32](https://github.com/user-attachments/assets/f88f3a1c-2841-4b12-ad45-5d6fcb79d4a3)
3. Click on "Continue" and finish the onboarding (skip the extensions step so you don't install anything).
4. Go to Plugins and make sure WooPayments is not installed.
5. Go to WooCommerce > Settings > Advanced > WooCommerce.com and enable tracking:
![Screenshot 2025-02-14 at 10 52 28](https://github.com/user-attachments/assets/d82cc9d4-307f-4593-aa90-c3eb29cd9552)
6. Click on the Payments menu item and you will end up on the new Payments settings page.
7. Click on "Install" for WooPayments and, after you select the recommended payment methods, you should be taken through the live onboarding process (the WooPayments onboarding wizard and embedded Stripe KYC) not the test account flow (without the onboarding wizard). No need to continue with the onboarding.

#### Test the experiment treatment

1. Go to Plugins > Add new and install and activate the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin.
2. Go to Tools > WCA Test Helper > Tools and "Reset Onboarding Wizard".
3. Click on WooCommerce to kickstart the WC onboarding wizard. Don't skip it, click on "Set up my store" and on the second step select "I'm just starting my business".
4. Click on "Continue", set your store's location to United States and finish the onboarding (skip the extensions step so you don't install anything).
5. Go to Plugins and make sure WooPayments is not active.
6. Go to WooCommerce > Settings > Advanced > WooCommerce.com and enable tracking:
![Screenshot 2025-02-14 at 10 52 28](https://github.com/user-attachments/assets/7d8bb08d-fc2d-4704-b3b7-e0be42dc8ed9)
7. Click on the Payments menu item and you will end up on the new Payments settings page.
8. Click on "Enable" for WooPayments and, after you select the recommended payment methods, you should be taken through the **test account onboarding flow** (without the onboarding wizard).
9. Reset the WooPayments account either through the context menu on the Payments Settings page or the WooPayments Overview page:
![Screenshot 2025-02-14 at 10 45 55](https://github.com/user-attachments/assets/08c9b3b7-5be6-4747-96d1-2ba9e84c59f7)
10. Go to Tools > Transients and search for `abtest_variation_`. You should see an entry called `abtest_variation_woocommerce_payment_settings_onboarding_2025_v1` with the value `control`.
11. Click on edit for this transient and change its value to `treatment`:
![Screenshot 2025-02-14 at 10 47 10](https://github.com/user-attachments/assets/1ec64b42-3788-407f-887e-1ab002e65940)
![Screenshot 2025-02-14 at 10 47 37](https://github.com/user-attachments/assets/0b550b04-73e5-43a7-8404-1c66ecd18c81)
12. Go to WooCommerce > Settings > Payments.
13. Click on "Complete setup" for WooPayments and, after you select the recommended payment methods, you should be taken through the **live onboarding process** (the WooPayments onboarding wizard and embedded Stripe KYC) not the test account flow (without the onboarding wizard). No need to continue with the onboarding.
![Screenshot 2025-02-14 at 10 54 23](https://github.com/user-attachments/assets/17d2d6dc-229b-4bed-b4f6-3ab3647f3f3e)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
