### PR TITLE
Add check for the product var before using it

### DIFF
--- a/plugins/woocommerce/changelog/55243-55099-fix-get_permalink-fatal
+++ b/plugins/woocommerce/changelog/55243-55099-fix-get_permalink-fatal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add check to ensure the product variable is a WC_Product before using it.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1148,6 +1148,9 @@ class WC_Cart extends WC_Legacy_Cart {
 				)
 			) {
 				$product = wc_get_product( $product_id );
+				if ( ! ( $product instanceof WC_Product ) ) {
+					throw new Exception( __( 'The selected product is invalid' ) );
+				}
 
 				/* translators: 1: product link, 2: product name */
 				throw new Exception( sprintf( __( 'The selected product isn\'t a variation of %2$s, please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( $product->get_permalink() ), esc_html( $product->get_name() ) ) );

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1149,7 +1149,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			) {
 				$product = wc_get_product( $product_id );
 				if ( ! ( $product instanceof WC_Product ) ) {
-					throw new Exception( __( 'The selected product is invalid' ) );
+					throw new Exception( __( 'The selected product is invalid', 'woocommerce' ) );
 				}
 
 				/* translators: 1: product link, 2: product name */

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1149,7 +1149,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			) {
 				$product = wc_get_product( $product_id );
 				if ( ! ( $product instanceof WC_Product ) ) {
-					throw new Exception( __( 'The selected product is invalid', 'woocommerce' ) );
+					throw new Exception( __( 'The selected product is invalid.', 'woocommerce' ) );
 				}
 
 				/* translators: 1: product link, 2: product name */

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -97,6 +97,38 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox should throw a notice to the cart if using an invalid product_id.
+	 */
+	public function test_add_variation_to_the_cart_invalid_product() {
+		WC()->cart->empty_cart();
+		WC()->session->set( 'wc_notices', null );
+
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$single_product   = WC_Helper_Product::create_simple_product();
+
+		// Add variation using parent id.
+		WC()->cart->add_to_cart(
+			-1,
+			1,
+			$single_product->get_id()
+		);
+		$notices = WC()->session->get( 'wc_notices', array() );
+
+		// Check for cart contents.
+		$this->assertCount( 0, WC()->cart->get_cart_contents() );
+		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
+
+		$this->assertArrayHasKey( 'error', $notices );
+		$this->assertCount( 1, $notices['error'] );
+		$expected = sprintf( 'The selected product is invalid' );
+		$this->assertEquals( $expected, $notices['error'][0]['notice'] );
+
+		// Reset cart.
+		WC()->cart->empty_cart();
+		WC()->customer->set_is_vat_exempt( false );
+	}
+
+	/**
 	 * @testdox variable product should not be added to the cart if variation_id=0.
 	 */
 	public function test_add_variation_to_the_cart_zero_variation_id() {

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -103,8 +103,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 		WC()->session->set( 'wc_notices', null );
 
-		$variable_product = WC_Helper_Product::create_variation_product();
-		$single_product   = WC_Helper_Product::create_simple_product();
+		$single_product = WC_Helper_Product::create_simple_product();
 
 		// Add variation using parent id.
 		WC()->cart->add_to_cart(

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -119,7 +119,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		$this->assertArrayHasKey( 'error', $notices );
 		$this->assertCount( 1, $notices['error'] );
-		$expected = sprintf( 'The selected product is invalid' );
+		$expected = sprintf( 'The selected product is invalid.' );
 		$this->assertEquals( $expected, $notices['error'][0]['notice'] );
 
 		// Reset cart.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a check to ensure `$product` is an instance of `WC_Product` before calling `get_permalink` on it.
This was causing a fatal error before.

Closes https://github.com/woocommerce/woocommerce/issues/55099

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Make sure the unit tests are passing.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add check to ensure the product variable is a WC_Product before using it.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
