### PR TITLE
[Experimental] Fix add to cart action url to be the same as the current url

### DIFF
--- a/plugins/woocommerce/changelog/fix-54854
+++ b/plugins/woocommerce/changelog/fix-54854
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix add to cart action url to be the same as the current url so it does not redirect after submitting the form
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -18,25 +18,6 @@ class AddToCartForm extends AbstractBlock {
 	protected $block_name = 'add-to-cart-form';
 
 	/**
-	 * Initializes the AddToCartForm block and hooks into the `wc_add_to_cart_message_html` filter
-	 * to prevent displaying the Cart Notice when the block is inside the Single Product block
-	 * and the Add to Cart button is clicked.
-	 *
-	 * It also hooks into the `woocommerce_add_to_cart_redirect` filter to prevent redirecting
-	 * to another page when the block is inside the Single Product block and the Add to Cart button
-	 * is clicked.
-	 *
-	 * @return void
-	 */
-	protected function initialize() {
-		parent::initialize();
-		// Scope the excecution of this hook to be only when the add to cart form is submitted.
-		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-			add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
-		}
-	}
-
-	/**
 	 * Get the block's attributes.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
@@ -144,6 +125,8 @@ class AddToCartForm extends AbstractBlock {
 			return '';
 		}
 
+		$is_descendent_of_single_product_block = is_null( $product ) || $post_id !== $product->get_id();
+
 		$previous_product = $product;
 		$product          = wc_get_product( $post_id );
 		if ( ! $product instanceof \WC_Product ) {
@@ -154,6 +137,14 @@ class AddToCartForm extends AbstractBlock {
 
 		$is_external_product_with_url = $product instanceof \WC_Product_External && $product->get_product_url();
 		$is_stepper_style             = 'stepper' === $attributes['quantitySelectorStyle'] && ! $product->is_sold_individually() && Features::is_enabled( 'add-to-cart-with-options-stepper-layout' );
+
+		add_filter( 'woocommerce_add_to_cart_form_action', function ( $url ) use ( $is_descendent_of_single_product_block ) {
+			if ( $is_descendent_of_single_product_block ) {
+				global $wp;
+				return home_url( add_query_arg( $_GET, $wp->request ) );
+			}
+			return $url;
+		}, 10, 1 );
 
 		ob_start();
 
@@ -174,9 +165,7 @@ class AddToCartForm extends AbstractBlock {
 		$product_name = $product->get_name();
 		$product_html = $is_stepper_style ? $this->add_steppers( $product_html, $product_name ) : $product_html;
 
-		$parsed_attributes                     = $this->parse_attributes( $attributes );
-		$is_descendent_of_single_product_block = is_null( $previous_product ) || $post_id !== $previous_product->get_id();
-
+		$parsed_attributes  = $this->parse_attributes( $attributes );
 		$product_html       = $is_stepper_style ? $this->add_stepper_classes_to_add_to_cart_form_input( $product_html ) : $product_html;
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 
@@ -216,19 +205,5 @@ class AddToCartForm extends AbstractBlock {
 		$product = $previous_product;
 
 		return $form;
-	}
-
-	/**
-	 * Hooks into the `woocommerce_add_to_cart_redirect` filter to redirect to
-	 * the request referer when the add to cart return to url is not set.
-	 *
-	 * @param string $url The URL to redirect to after the product is added to the cart.
-	 * @return string The filtered redirect URL.
-	 */
-	public function add_to_cart_redirect_filter( $url ) {
-		if ( $url || 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
-			return $url;
-		}
-		return wp_validate_redirect( wp_get_referer(), $url );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -212,8 +212,8 @@ class AddToCartForm extends AbstractBlock {
 	 *
 	 * @return string The current URL.
 	 */
-	function add_to_cart_form_action() {
+	public function add_to_cart_form_action() {
 		global $wp;
-		return home_url( add_query_arg( $_GET, $wp->request ) );
+		return home_url( add_query_arg( $_GET, $wp->request ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #53284

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `Redirect to the cart page after successful addition` is unchecked under `/wp-admin/admin.php?page=wc-settings&tab=products`
2. Create a new post
5. Add the single product block
6. Select a simple product and save the post
7. Go to view the post created
8. The simple product should be shown in the frontend
9. Select 1 and click add to cart
10. Notice that the form does not perform a new redirect and it remains in the same page.
11. The same should also happens when trying to add a product cart form the single product page.
12. If the check `Redirect to the cart page after successful addition` is checked
13. Then a redirection to the cart page should happens after adding a product to the cart

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
