### PR TITLE
Update payment button guidelines docs

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -1737,7 +1737,7 @@
           "post_title": "User Experience Guidelines - Payment Button Size and Anatomy",
           "menu_title": "Payment Button Size",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/ux-guidelines-payments/payment-button-size.md",
-          "hash": "b9165eb27a79bb696d7f0fcea1ef8a36f56ffd01501447f4c266c95f515a8ee1",
+          "hash": "0be63cb8f44339510f92b6ce2cd9c39b751f2d468e49a34fbd73a548f1f79c6d",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/ux-guidelines-payments/payment-button-size.md",
           "id": "0920df1611e1b1b3e2f33c810a8f8e8ae09dd67c"
         },
@@ -1745,7 +1745,7 @@
           "post_title": "User Experience Guidelines - Payment Button Layout",
           "menu_title": "Payment Button Layout",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/ux-guidelines-payments/payment-button-layout.md",
-          "hash": "bc518454d8552c5da08d9635799c578d730341b115f7f8a63e9123628242c772",
+          "hash": "662daf80937372a1b8848a58e38417a5ab69c0c0f4fe55a59509d74494561af2",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/ux-guidelines-payments/payment-button-layout.md",
           "id": "96caecc340794e5c80af271e5cc844e0b3d80a04"
         }
@@ -1928,5 +1928,5 @@
       "categories": []
     }
   ],
-  "hash": "ffb2b8739849e1c07de692d4707b5dcf9f224796b26582d93f66394b443cc5f0"
+  "hash": "ddc7ee8f558eb847ae57ebe8b8401b1eceab8b31b356d27387b1b12b57482ed6"
 }

--- a/docs/ux-guidelines-payments/payment-button-layout.md
+++ b/docs/ux-guidelines-payments/payment-button-layout.md
@@ -33,4 +33,4 @@ Express payment buttons on mobile should occupy the full width. Don't use the ex
 
 Maintain the minimum amount of clear space on all sides of the payment button. The clear space adapts based on the size of the button.
 
-![Clear space.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2024/01/Clear-space.png)
+![Clear space.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2025/02/Clear-space-updated.png)

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -5,11 +5,11 @@ menu_title: Payment Button Size
 
 Payment buttons must be consistent in visual appearance to other buttons in the shopper experience.
 
-Height for payment buttons ranges from 40px (Small) to 56px (Large). The default button height is 48px. The following presets can be used for button height.
+Height for payment buttons ranges from 40px (Small) to 55px (Large). The default button height is 48px. The following presets can be used for button height.
 
 - Small: Height 40px
 - Default: Height 48px
-- Large: Height 56
+- Large: Height 55px
 
 ### Anatomy
 

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -31,7 +31,7 @@ The spacing between and around the Label and Payment Logo adapts based on the si
 
 The height of the button can adapt based on the needs of the theme.
 
-![Layout and spacing.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2024/01/Layout-and-spacing.png)
+![Layout and spacing](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2025/02/Layout-and-spacing-1-updated.png)
 
 ### Button size
 

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -25,7 +25,7 @@ Don't place any text outside the surface area of the button.
 
 The spacing between and around the Label and Payment Logo adapts based on the size of the button.
 
-![Layout and spacing 0.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2024/01/Layout-and-spacing-0.png)
+![Layout and spacing 0.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2025/02/Layout-and-spacing-Updated.png)
 
 ### Adaptive height
 

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -14,7 +14,8 @@ Height for payment buttons ranges from 40px (Small) to 55px (Large). The default
 ### Anatomy
 
 Payment buttons consist of up to three elements: a button component, payment logo, and optional label.
-[Anatomy.png]
+
+![Anatomy of a payment button](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2025/02/Anatomy-updated.png)
 
 Don't place any text outside the surface area of the button.
 

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -49,7 +49,7 @@ Use the same width size for all payment buttons. Don't make the width larger or 
 
 Buttons have a minimum width to ensure readability.
 
-![Layout and spacing-2.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2024/01/Layout-and-spacing-2.png)
+![Layout and spacing-2.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2025/02/Layout-and-spacing-2-Updated.png)
 
 Follow the minimum width of each payment button size. Don't squeeze payment buttons in a single line.
 

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -59,7 +59,7 @@ Follow the minimum width of each payment button size. Don't squeeze payment butt
 Use the same corner radius for all payment buttons. Don't make the corner radius larger or smaller than other payment buttons.
 
 - Default corner radius: 4px
-- Maximum corner radius: ½ button height
+- Maximum corner radius: half of the button height
 
 ![Corner radius.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2024/01/Corner-radius.png)
 

--- a/docs/ux-guidelines-payments/payment-button-size.md
+++ b/docs/ux-guidelines-payments/payment-button-size.md
@@ -34,7 +34,7 @@ The height of the button can adapt based on the needs of the theme.
 
 ### Button size
 
-Make payment buttons the same size, no bigger or smaller than other payment buttons, including the CTAs "Add to cart" and "Proceed to checkout"
+Make payment buttons the same size, no bigger or smaller than other payment buttons, including the CTAs "Add to cart" and "Proceed to checkout".
 
 ![Same button size.png](https://developer.woocommerce.com/docs/wp-content/uploads/sites/3/2024/01/Same-button-size.png)
 
@@ -65,16 +65,17 @@ Use the same corner radius for all payment buttons. Don't make the corner radius
 
 ### Button Label
 
-Provide variant buttons to accommodate merchant needs and payment experiences.
-Buy
-Pay
-Donate
-Book
-Checkout
-Subscribe
-Continue
-Order
-Icon only
+Provide variant buttons to accommodate merchant needs and payment experiences. 
+
+- Buy
+- Pay
+- Donate
+- Book
+- Checkout
+- Subscribe
+- Continue
+- Order
+- Icon only
 
 The button label should appear in sentence case, with only the first letter of the first word capitalized.
 

--- a/plugins/woocommerce/changelog/fix-button-guidelines
+++ b/plugins/woocommerce/changelog/fix-button-guidelines
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Docs update only
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

From #49644 the tasks are:

- [x] On the [button layout](https://developer.woocommerce.com/docs/user-experience-guidelines-payment-button-layout/) page, we'll replace the image [Clear-space] with the one in the attached folder [Clear-space-updated]. - Done in abe621efb57366e008d4131838d60a0c2cbb9dfc
- [x] On the [button size and anatomy](https://developer.woocommerce.com/docs/user-experience-guidelines-payment-button-size-and-anatomy/) page replace the value 56 with 55 for button height everywhere it's mentioned in the body copy. - Done in f1b2a7277b45046fd43d63adaf97fc05c597ad76
- [x]  Replace the following images with their updated counterparts in the folder:
  - [x] Anatomy ([Anatomy.png]) - done in 200bd194356ec30caea513c6f6247d7ae21719ea
  - [x] Layout-and-spacing-1 - Done in 29e4eabd21b5a5d015985086aad88ef296eb2d2c
  - [x] Layout-and-spacing-2 - Done in 7af3237ec736b0880e2298431d4db4b660e37909
  - [x] Layout-and-spacing - Done in f92e758e0510664a163ae5d9d58f1d0b0610bbe8
- [x] On the **Button size and anatomy** page there are periods missing from the **Button size** and **Button label** sentences so we should add those in. - done in f591e72e9dd632345bcef2d530ecc15ae421845f
- [x] In **Button shape** I'm seeing a typo "Maximum corner radius: Â½ button height". We should remove the A in there. - Done in 80448a828390aa9fa4bffe02883224bc6d6c37b5



<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Hard to test as it involves the docs site. Besides setting up the docs ingestion locally and ensuring the post displays correctly I'm not sure what we can test more than the following:

1. View the documents here and compare them to the ones online at https://developer.woocommerce.com/docs/user-experience-guidelines-payment-button-layout/
2. Check the images updated in these docs replace the correct ones. Compare the preview of these markdown files to the docs site and ensure the images are in the correct order.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
