### PR TITLE
Add defensive check after filter for cart items

### DIFF
--- a/plugins/woocommerce/changelog/fix-55103-null-cart-item
+++ b/plugins/woocommerce/changelog/fix-55103-null-cart-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add defensive check to ensure the product object exists in items in the cart session

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -218,7 +218,14 @@ final class WC_Cart_Session {
 				 */
 				$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
 				if ( ! isset( $cart_contents[ $key ]['data'] ) || ! $cart_contents[ $key ]['data'] instanceof WC_Product ) {
-					// If the cart contents is missing the product object after filtering, add it back in.
+					// If the cart contents is missing the product object after filtering, something is wrong.
+					wc_doing_it_wrong(
+						__METHOD__,
+						'When filtering cart items with woocommerce_get_cart_item_from_session, each item must have a data key containing a product object.',
+						'9.8.0'
+					);
+
+					// Add the product back in.
 					$cart_contents[ $key ]['data'] = $product;
 				}
 

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -207,7 +207,20 @@ final class WC_Cart_Session {
 					)
 				);
 
+				/**
+				 * Filter to modify or add session data to the cart contents.
+				 *
+				 * @since 3.2.0
+				 *
+				 * @param array  $session_data Data for an item in the cart.
+				 * @param array  $values       Data for an item in the cart, without the product object.
+				 * @param string $key          The cart item hash.
+				 */
 				$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
+				if ( ! isset( $cart_contents[ $key ]['data'] ) || ! $cart_contents[ $key ]['data'] instanceof WC_Product ) {
+					// If the cart contents is missing the product object after filtering, add it back in.
+					$cart_contents[ $key ]['data'] = $product;
+				}
 
 				// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
 				$this->cart->set_cart_contents( $cart_contents );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If an extension uses the `woocommerce_get_cart_item_from_session` filter and modifies the array of cart item data, it can cause a fatal error if the modified data does not include the specific `data` key containing an instance of the cart item's corresponding product object. This simply ensures that even if an extension is using that filter incorrectly, it will not cause a fatal error.

Fixes #55103

### How to test the changes in this Pull Request:

1. Before checking out this branch, visit the shop page on your test site. Add a product to the cart, and then go to the Cart page.
2. Add this test snippet to your site:
    ```php
	add_filter(
		'woocommerce_get_cart_item_from_session',
		function ( $session_data, $values ) {
			return $values;
		},
		10,
		2
	);
    ```
3. Refresh the cart page. Now you should see the fatal error reported in #55103.
4. Now check out this branch. Refresh the cart page again. The error should be gone, and the cart page should load successfully, and show that your cart has the product that you originally added.
