### PR TITLE
Check if terms is an array before calling array_shift. 

### DIFF
--- a/plugins/woocommerce/changelog/55286-fix-55102-uncaught-TypeError-arrayshift
+++ b/plugins/woocommerce/changelog/55286-fix-55102-uncaught-TypeError-arrayshift
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check if $terms is an array before calling array_shift to prevent fatal errors.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -186,6 +186,7 @@ class WC_Brands {
 		$product_brand = _x( 'uncategorized', 'slug', 'woocommerce' );
 
 		if ( is_array( $terms ) && ! empty( $terms ) ) {
+			// Replace the placeholder rewrite tag with the first term's slug.
 			$first_term = array_shift( $terms );
 			if ( $first_term instanceof WP_Term ) {
 				$product_brand = $first_term->slug;

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -183,6 +183,7 @@ class WC_Brands {
 		// Get the custom taxonomy terms in use by this post.
 		$terms = get_the_terms( $post->ID, 'product_brand' );
 
+		// If no terms are assigned to this post, use a string instead (can't leave the placeholder there).
 		$product_brand = _x( 'uncategorized', 'slug', 'woocommerce' );
 
 		if ( is_array( $terms ) && ! empty( $terms ) ) {

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -183,13 +183,13 @@ class WC_Brands {
 		// Get the custom taxonomy terms in use by this post.
 		$terms = get_the_terms( $post->ID, 'product_brand' );
 
-		if ( empty( $terms ) ) {
-			// If no terms are assigned to this post, use a string instead (can't leave the placeholder there).
-			$product_brand = _x( 'uncategorized', 'slug', 'woocommerce' );
-		} else {
-			// Replace the placeholder rewrite tag with the first term's slug.
-			$first_term    = array_shift( $terms );
-			$product_brand = $first_term->slug;
+		$product_brand = _x( 'uncategorized', 'slug', 'woocommerce' );
+
+		if ( is_array( $terms ) && ! empty( $terms ) ) {
+			$first_term = array_shift( $terms );
+			if ( $first_term instanceof WP_Term ) {
+				$product_brand = $first_term->slug;
+			}
 		}
 
 		$find = array(


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

An `array_shift()` throws a Fatal Error because we assume that get_terms will always return an array or an empty value. This PR adds in a check to ensure that `$terms` is an array before calling `array_shift()`. I also added a check to confirm the value assigned to `$first_term` is indeed a WP_Term ( This should cover arrays of strings, for example ).

Closes #55102.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

A way to reproduce:
1. Go to Products > Brands and create a brand. And assign it to a product.
2. Go to Settings > Permalinks and in `Product permalinks` select `Custom base` and add `/product/%product_brand%/`.
3. Add this temporary filter to make the `get_the_terms` function return an error.
```php
add_filter(
	'get_the_terms',
	function ( $terms, $post_id, $taxonomy ) {
		if ($taxonomy == 'product_brand') {
			return "Nothing to see here";
		}
		return $terms;
	}, 
	10, 
	3
);
```
4. Open the product page with the brands assigned ( Step 2 ) and confirm there's no fatal error
<!-- End testing instructions -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Check if $terms is an array before calling array_shift to prevent fatal errors.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
