### PR TITLE
[dev] Include Solaris team in automated team review assignment config

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -23,3 +23,11 @@ when:
     assign:
       teams:
         - flux
+  - author:
+      teamIs:
+        - solaris
+      ignore:
+        nameIs:
+    assign:
+      teams:
+        - solaris


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Include Solaris in the configuration for auto team review assignment.

### How to test the changes in this Pull Request:

To be tested after merge. For a PR opened by a member of Solaris the team should be automatically added as a reviewer.
