### PR TITLE
[Experimental] Add to Cart with Options block: avoid requesting template part before knowing the theme slug

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -77,6 +77,13 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 			} = select( coreStore );
 
 			const currentTheme = getCurrentTheme()?.stylesheet;
+
+			if ( ! currentTheme ) {
+				return {
+					templatePartId: null,
+				};
+			}
+
 			const templatePartSlug = `${ productType }-product-add-to-cart-with-options`;
 			const themeTemplatePartId = `${ currentTheme }//${ templatePartSlug }`;
 			const wooCommerceTemplatePartId = `woocommerce/woocommerce//${ templatePartSlug }`;
@@ -111,6 +118,14 @@ export const AddToCartWithOptionsEditTemplatePart = ( {
 	);
 
 	const blockProps = useBlockProps();
+
+	if ( ! templatePartId ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
 
 	return (
 		<TemplatePartInnerBlocks

--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-undefined-theme
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-undefined-theme
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Avoid requesting template part before knowing the theme slug in the Add to Cart with Options block
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes an unnecessary request to load the _Add to Cart with Options_ template part when we didn't have the theme slug yet.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Open the _Network_ tab of your browser devtools (<kbd>F12</kbd>).
2. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_ and update the _Add to Cart with Options_ block to the blockified version.
3. Verify there were no requests to `/wp-json/wp/v2/template-parts/undefined//simple-product-add-to-cart-with-options`.