### PR TITLE
Add product_brand Term to Product Single HTML template.

### DIFF
--- a/plugins/woocommerce/changelog/55298-add-add-product_brand-to-single-product-HTML-template
+++ b/plugins/woocommerce/changelog/55298-add-add-product_brand-to-single-product-HTML-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product_brand Term to Product Single HTML template.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -394,7 +394,8 @@ class WC_Brands {
 	public function show_brand() {
 		global $post;
 
-		if ( is_singular( 'product' ) ) {
+		$has_block_template = apply_filters( 'woocommerce_has_block_template', false, 'taxonomy-product_brand' );
+		if ( is_singular( 'product' ) &&  ! $has_block_template ) {
 			$terms       = get_the_terms( $post->ID, 'product_brand' );
 			$brand_count = is_array( $terms ) ? count( $terms ) : 0;
 

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -394,7 +394,8 @@ class WC_Brands {
 	public function show_brand() {
 		global $post;
 
-		$has_block_template = apply_filters( 'woocommerce_has_block_template', false, 'taxonomy-product_brand' );
+		$has_block_template = apply_filters( 'woocommerce_has_block_template', false, 'taxonomy-product_brand' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+
 		if ( is_singular( 'product' ) &&  ! $has_block_template ) {
 			$terms       = get_the_terms( $post->ID, 'product_brand' );
 			$brand_count = is_array( $terms ) ? count( $terms ) : 0;
@@ -403,7 +404,18 @@ class WC_Brands {
 			$labels   = $taxonomy->labels;
 
 			/* translators: %s - Label name */
-			echo wc_get_brands( $post->ID, ', ', ' <span class="posted_in">' . sprintf( _n( '%s: ', '%s: ', $brand_count, 'woocommerce' ), $labels->singular_name, $labels->name ), '</span>' ); // phpcs:ignore WordPress.Security.EscapeOutput
+			$brand_output = wc_get_brands( $post->ID, ', ', ' <span class="posted_in">' . sprintf( _n( '%s: ', '%s: ', $brand_count, 'woocommerce' ), $labels->singular_name, $labels->name ), '</span>' );
+
+			/**
+			 * Filter the brand output in product meta.
+			 *
+			 * @since 9.8.0
+			 *
+			 * @param string $brand_output The HTML output for brands.
+			 * @param array  $terms        Array of brand term objects.
+			 * @param int    $post_id      The product ID.
+			 */
+			echo apply_filters( 'woocommerce_product_brands_output', $brand_output, $terms, $post->ID ); // phpcs:ignore WordPress.Security.EscapeOutput
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -396,7 +396,7 @@ class WC_Brands {
 
 		$has_block_template = apply_filters( 'woocommerce_has_block_template', false, 'taxonomy-product_brand' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
-		if ( is_singular( 'product' ) &&  ! $has_block_template ) {
+		if ( is_singular( 'product' ) && ! $has_block_template ) {
 			$terms       = get_the_terms( $post->ID, 'product_brand' );
 			$brand_count = is_array( $terms ) ? count( $terms ) : 0;
 

--- a/plugins/woocommerce/templates/templates/blockified/single-product.html
+++ b/plugins/woocommerce/templates/templates/blockified/single-product.html
@@ -34,6 +34,9 @@
 					<!-- wp:post-terms {"term":"product_cat","prefix":"Category: "} /-->
 
 					<!-- wp:post-terms {"term":"product_tag","prefix":"Tags: "} /-->
+
+					<!-- wp:post-terms {"term":"product_brand","prefix":"Brands: "} /-->
+
 				</div>
 				<!-- /wp:group -->
 			</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add product_brand Term to Product Single HTML template.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to Products > Brands and create a brand. And assign it to a product.
2. Activate one FSE theme like TwentyTwentyThree.
3. Go to Appearance -> Editor. Click on the WP logo and go to templates. Edit the WooCommerce Single Product template
4. Confirm you can see the brands block as follow:

https://github.com/user-attachments/assets/a75de481-97cb-4b60-9f23-6f9efc919984

5.  View a product with a brand taxonomy assigned and confirm the brand taxonomy is displayed correctly.
6. Switch to a non-FSE theme, and confirm Brands display correctly on the page.


##### Test `woocommerce_product_brands_output` filter.

7. Switch to no-FSE theme.
8. Add this temporary filter to the brands on the page:

```
add_filter('woocommerce_product_brands_output', '__return_empty_string');
```
9. View a product with a brand taxonomy assigned and confirm that the brand doesn't show.

<!-- End testing instructions -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add product_brand Term to Product Single HTML template.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
