### PR TITLE
[Store API] Load cart during rest_api_init for Store API requests

### DIFF
--- a/plugins/woocommerce/changelog/update-store-api-init-cart-early
+++ b/plugins/woocommerce/changelog/update-store-api-init-cart-early
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Load cart during rest_api_init for Store API requests.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -111,8 +111,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$this->load_cart_session( $request );
-
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
 
@@ -160,25 +158,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		$response->header( 'Cart-Hash', WC()->cart->get_cart_hash() );
 
 		return $response;
-	}
-
-	/**
-	 * Load the cart session before handling responses.
-	 *
-	 * @param \WP_REST_Request $request Request object.
-	 */
-	protected function load_cart_session( \WP_REST_Request $request ) {
-		if ( $this->has_cart_token( $request ) ) {
-			// Overrides the core session class.
-			add_filter(
-				'woocommerce_session_handler',
-				function () {
-					return SessionHandler::class;
-				}
-			);
-		}
-		$this->cart_controller->load_cart();
-		$this->cart_controller->normalize_cart();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -123,8 +123,6 @@ class Checkout extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$this->load_cart_session( $request );
-
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
 

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
 use Automattic\WooCommerce\StoreApi\RoutesController;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 
 /**
  * StoreApi Main Class.
@@ -38,6 +39,10 @@ final class StoreApi {
 					return;
 				}
 				self::container()->get( Authentication::class )->init();
+
+				$cart_controller = new CartController();
+				$cart_controller->load_cart();
+				$cart_controller->normalize_cart();
 			},
 			11
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I have extracted this change from https://github.com/woocommerce/woocommerce/pull/55047/files#diff-06f7ff3b0e7a657b9691cff165a10019e8b3b648b2fc115f56c46d43c14ad9bd to reduce the scope of the other PR.

We have some upcoming use-cases where we need to access the cart early when the Store API request is being generated. To that end, this PR moves the Cart Token handling and cart init to `rest_api_init`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

The cart token is not something you can test without a REST API client. This test is aimed at developers.

1. Using REST API client,  post to `store.local/wp-json/wc/store/v1/cart` and add an item to cart, e.g. 

```json
{
	"id": 16
}
```

2. GET `store.local/wp-json/wc/store/v1/cart`. Product is there.
3. Look at headers and copy the cart token.
4. Clear cookies.
5. GET `store.local/wp-json/wc/store/v1/cart`. Cart is empty.
6. Add `cart-token` header with the token you copied earlier.
7. GET `store.local/wp-json/wc/store/v1/cart`. Cart has the product again.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
