### PR TITLE
Enable Batch for all Store API endpoints and add support for GET batch requests in Store API

### DIFF
--- a/plugins/woocommerce/changelog/55306-add-batch-support-for-get
+++ b/plugins/woocommerce/changelog/55306-add-batch-support-for-get
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add experimental, opt-in support for batch GET requests in Store API.

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -67,7 +67,7 @@ class Batch extends AbstractRoute implements RouteInterface {
 						'properties' => array(
 							'method'  => array(
 								'type'    => 'string',
-								'enum'    => array( 'POST', 'PUT', 'PATCH', 'DELETE' ),
+								'enum'    => apply_filters( '__experimental_woocommerce_store_api_batch_request_methods', array( 'POST', 'PUT', 'PATCH', 'DELETE' ) ),
 								'default' => 'POST',
 							),
 							'path'    => array(

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Batch.php
@@ -67,6 +67,13 @@ class Batch extends AbstractRoute implements RouteInterface {
 						'properties' => array(
 							'method'  => array(
 								'type'    => 'string',
+								/**
+								 * Filters the allowed methods for store API batch requests.
+								 *
+								 * @since 9.8.0
+								 *
+								 * @param string[] $methods Allowed methods.
+								 */
 								'enum'    => apply_filters( '__experimental_woocommerce_store_api_batch_request_methods', array( 'POST', 'PUT', 'PATCH', 'DELETE' ) ),
 								'default' => 'POST',
 							),

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -46,6 +46,7 @@ class Cart extends AbstractCartRoute {
 				],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
+			'allow_batch' => [ 'v1' => true ],
 		];
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Cart.php
@@ -45,7 +45,7 @@ class Cart extends AbstractCartRoute {
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
-			'schema' => [ $this->schema, 'get_public_item_schema' ],
+			'schema'      => [ $this->schema, 'get_public_item_schema' ],
 			'allow_batch' => [ 'v1' => true ],
 		];
 	}

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -50,6 +50,7 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -49,6 +49,7 @@ class ProductAttributes extends AbstractRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -63,6 +63,7 @@ class ProductAttributesById extends AbstractRoute {
 						)
 					),
 				),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategories.php
@@ -49,6 +49,7 @@ class ProductCategories extends AbstractTermsRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -63,6 +63,7 @@ class ProductCategoriesById extends AbstractRoute {
 						)
 					),
 				),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -54,6 +54,7 @@ class ProductCollectionData extends AbstractRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductReviews.php
@@ -52,6 +52,7 @@ class ProductReviews extends AbstractRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductTags.php
@@ -42,6 +42,7 @@ class ProductTags extends AbstractTermsRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php
@@ -56,6 +56,7 @@ class Products extends AbstractRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_collection_params(),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsById.php
@@ -63,6 +63,7 @@ class ProductsById extends AbstractRoute {
 						)
 					),
 				),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductsBySlug.php
@@ -63,6 +63,7 @@ class ProductsBySlug extends AbstractRoute {
 						)
 					),
 				),
+				'allow_batch'         => [ 'v1' => true ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -44,11 +44,6 @@ class Batch extends ControllerTestCase {
 		);
 	}
 
-	protected function tearDown(): void {
-		//remove_all_filters( '__experimental_woocommerce_store_api_batch_request_methods' );
-		parent::tearDown();
-	}
-
 	/**
 	 * Test that a batch of requests are successful.
 	 */

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -152,23 +152,34 @@ class Batch extends ControllerTestCase {
 	 * Do a batch request with a get request.
 	 */
 	public function test_batch_get_requests() {
-		add_filter( '__experimental_woocommerce_store_api_batch_request_methods', function( $methods ) {
-			$methods[] = 'GET';
-			return $methods;
-		}, 10, 1 );
+		add_filter(
+			'__experimental_woocommerce_store_api_batch_request_methods',
+			function ( $methods ) {
+				$methods[] = 'GET';
+				return $methods;
+			},
+			10,
+			1
+		);
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'requests' => array(
-					array( 'method' => 'GET', 'path' => '/wc/store/v1/products' ),
-					array( 'method' => 'GET', 'path' => '/wc/store/v1/products/collection_data' ),
+					array(
+						'method' => 'GET',
+						'path'   => '/wc/store/v1/products',
+					),
+					array(
+						'method' => 'GET',
+						'path'   => '/wc/store/v1/products/collection-data',
+					),
 				),
 			)
 		);
 
-		$response = rest_get_server()->dispatch( $request );
+		$response      = rest_get_server()->dispatch( $request );
 		$response_data = $response->get_data();
 
 		$this->assertEquals( 2, count( $response_data['responses'] ) );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -147,4 +147,33 @@ class Batch extends ControllerTestCase {
 
 		$this->assertEquals( 'rest_invalid_param', $response_data['code'] );
 	}
+
+	/**
+	 * Do a batch request with a get request.
+	 */
+	public function test_batch_get_requests() {
+		add_filter( '__experimental_woocommerce_store_api_batch_request_methods', function( $methods ) {
+			$methods[] = 'GET';
+			return $methods;
+		}, 10, 1 );
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'requests' => array(
+					array( 'method' => 'GET', 'path' => '/wc/store/v1/products' ),
+					array( 'method' => 'GET', 'path' => '/wc/store/v1/products/collection_data' ),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 2, count( $response_data['responses'] ) );
+		$this->assertEquals( 200, $response_data['responses'][0]['status'] );
+
+		remove_all_filters( '__experimental_woocommerce_store_api_batch_request_methods' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Batch.php
@@ -17,6 +17,13 @@ class Batch extends ControllerTestCase {
 	 * Setup test product data. Called before every test.
 	 */
 	protected function setUp(): void {
+		add_filter(
+			'__experimental_woocommerce_store_api_batch_request_methods',
+			function ( $methods ) {
+				$methods[] = 'GET';
+				return $methods;
+			}
+		);
 		parent::setUp();
 
 		$fixtures = new FixtureData();
@@ -35,6 +42,11 @@ class Batch extends ControllerTestCase {
 				)
 			),
 		);
+	}
+
+	protected function tearDown(): void {
+		//remove_all_filters( '__experimental_woocommerce_store_api_batch_request_methods' );
+		parent::tearDown();
 	}
 
 	/**
@@ -122,46 +134,11 @@ class Batch extends ControllerTestCase {
 		$this->assertEquals( 201, $response_data['responses'][1]['status'], $response_data['responses'][1]['status'] );
 	}
 
-	/**
-	 * Get Requests not supported by batch.
-	 */
-	public function test_get_cart_route_batch() {
-		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
-		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
-		$request->set_body_params(
-			array(
-				'requests' => array(
-					array(
-						'method' => 'GET',
-						'path'   => '/wc/store/v1/cart',
-						'body'   => array(
-							'id'       => 99,
-							'quantity' => 1,
-						),
-					),
-				),
-			)
-		);
-		$response      = rest_get_server()->dispatch( $request );
-		$response_data = $response->get_data();
-
-		$this->assertEquals( 'rest_invalid_param', $response_data['code'] );
-	}
 
 	/**
 	 * Do a batch request with a get request.
 	 */
 	public function test_batch_get_requests() {
-		add_filter(
-			'__experimental_woocommerce_store_api_batch_request_methods',
-			function ( $methods ) {
-				$methods[] = 'GET';
-				return $methods;
-			},
-			10,
-			1
-		);
-
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
@@ -184,7 +161,5 @@ class Batch extends ControllerTestCase {
 
 		$this->assertEquals( 2, count( $response_data['responses'] ) );
 		$this->assertEquals( 200, $response_data['responses'][0]['status'] );
-
-		remove_all_filters( '__experimental_woocommerce_store_api_batch_request_methods' );
 	}
 }


### PR DESCRIPTION
This PR is part of modernizing Store API and filling missing gaps, it is cherry-picked from https://github.com/woocommerce/woocommerce/pull/54287

In this PR, I add support for doing batch GET requests, this is behind a filter flag that merchants can enable for now. Once we think this is stable, we can enable it by default. I also enable Batch for all Store API endpoints (GET ones).

GET requests were never enabled for the core batch method, but because we're calling it programmatically, it works fine.
The main risk with batch GET is that it can be expensive to run if too many things are called, so it's behind a flag now.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Add the following snippet somewhere:
```php
add_filter( '__experimental_woocommerce_store_api_batch_request_methods', function( $methods ) {
	$methods[] = 'GET';
	return $methods;
}, 10, 1 );
```
1. In an HTTP client, make a batch request to `SITE/wp-json/wc/store/batch` with the following body:
```json
{
	"requests": [
		{
			"method": "GET",
			"path": "/wc/store/v1/products"
		},
		{
			"method": "GET",
			"path": "/wc/store/v1/products/collection-data"
		}
	]
}
```
3. Make sure the result has 2 responses, one for each request.
4. Do one for Cart and Checkout
```php
add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
```
```json
{
	"requests": [
		{
			"method": "GET",
			"path": "/wc/store/v1/cart"
		},
		{
			"method": "GET",
			"path": "/wc/store/v1/checkout"
		}
	]
}
```
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add experimental, opt-in support for batch GET requests in Store API.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
