### PR TITLE
[e2e tests] Fix allure-playwright output path

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-allure-reporting-path
+++ b/plugins/woocommerce/changelog/e2e-fix-allure-reporting-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix allure playwright output path

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -200,15 +200,13 @@ Use the `allure generate` command to generate an HTML report from the `allure-re
 the test run. Then, use the `allure open` command to open it on your browser. For example, assuming that:
 
 - You're at the root of the WooCommerce monorepo
-- You did not specify a custom location for `allure-results` (you did not assign a value to `ALLURE_RESULTS_DIR`)
 - You want to generate the `allure-report` folder in `plugins/woocommerce/tests/e2e-pw/test-results`
 
 Then you would need to use the following commands:
 
 ```bash
-cd plugins/woocommerce
-pnpm exec allure generate --clean tests/e2e-pw/test-results/allure-results --output tests/e2e-pw/test-results/allure-report
-pnpm exec allure open tests/e2e-pw/test-results/allure-report
+pnpm exec allure generate --clean plugins/woocommerce/tests/e2e-pw/test-results/allure-results --output plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+pnpm exec allure open plugins/woocommerce/tests/e2e-pw/test-results/allure-report
 ```
 
 A browser window should open the Allure report.

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -10,8 +10,7 @@ if ( ! process.env.BASE_URL ) {
 	process.env.BASE_URL = 'http://localhost:8086';
 }
 
-const { ALLURE_RESULTS_DIR, BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } =
-	process.env;
+const { BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } = process.env;
 
 export const TESTS_ROOT_PATH = __dirname;
 export const TESTS_RESULTS_PATH = `${ TESTS_ROOT_PATH }/test-results`;
@@ -25,9 +24,7 @@ const reporter = [
 	[
 		'allure-playwright',
 		{
-			outputFolder:
-				ALLURE_RESULTS_DIR ??
-				`${ TESTS_ROOT_PATH }/test-results/allure-results`,
+			resultsDir: `${ TESTS_ROOT_PATH }/test-results/allure-results`,
 			detail: true,
 			suiteTitle: true,
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[55251](https://github.com/woocommerce/woocommerce/pull/55251) bumped allure-playwright to the latest version and this introduced a breaking change that was missed. The output directory field was renamed from `outputFolder` to `resultsDir` and the results were not generated in the expected path but in the default one.

Other than the path fix I removed the `ALLURE_RESULTS_DIR` env variable which is never used.

### How to test the changes in this Pull Request:

CI green.
Run any test. Check that `test-results/allure-result` folder is generated and it contains valid results.