### PR TITLE
[dev] CI: fix node version warning in changelog-auto-add.yml

### DIFF
--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -30,8 +30,13 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+
             - name: Setup PNPM
-              uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
+              uses: pnpm/action-setup@v4
 
             - name: Generate Changelog File
               env:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1739216834743629-slack-C03CPM3UXDJ

This PR adds node setup step to install the intended version of node.

### How to test the changes in this Pull Request:

- CI-checks shall pass
- Example [run](https://github.com/woocommerce/woocommerce/actions/runs/13261927457/job/37020274376?pr=55322)