### PR TITLE
Remove Woo Logo From Block Inserter, Classic Template Block, and Classic Shortcake Block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/editor.scss
@@ -33,20 +33,14 @@
 	.wp-block-woocommerce-classic-shortcode__placeholder-copy__icon-container {
 		margin: 0 0 $gap;
 
+		h1 {
+			color: #{$studio-woocommerce-purple};
+			@include font-size(large);
+			margin: 0;
+		}
 		span {
 			@include font-size(larger);
 			display: block;
-		}
-		.woo-icon-wrapper {
-			color: #{$studio-woocommerce-purple};
-			display: flex;
-			gap: 0.5rem;
-			align-items: center;
-			@include font-size(large);
-
-			svg {
-				vertical-align: middle;
-			}
 		}
 	}
 	p {

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
@@ -24,7 +24,6 @@ import { shortcode, Icon } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
-import { woo } from '@woocommerce/icons';
 import { findBlock } from '@woocommerce/utils';
 
 /**
@@ -219,10 +218,9 @@ const Edit = ( { clientId, attributes }: BlockEditProps< Attributes > ) => {
 				</div>
 				<div className="wp-block-woocommerce-classic-shortcode__placeholder-copy">
 					<div className="wp-block-woocommerce-classic-shortcode__placeholder-copy__icon-container">
-						<span className="woo-icon-wrapper">
-							<Icon icon={ woo } />{ ' ' }
+						<h1>
 							{ __( 'WooCommerce', 'woocommerce' ) }
-						</span>
+						</h1>
 						<span>{ placeholderTitle }</span>
 					</div>
 					<p>{ placeholderDescription }</p>

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-shortcode/index.tsx
@@ -218,9 +218,7 @@ const Edit = ( { clientId, attributes }: BlockEditProps< Attributes > ) => {
 				</div>
 				<div className="wp-block-woocommerce-classic-shortcode__placeholder-copy">
 					<div className="wp-block-woocommerce-classic-shortcode__placeholder-copy__icon-container">
-						<h1>
-							{ __( 'WooCommerce', 'woocommerce' ) }
-						</h1>
+						<h1>{ __( 'WooCommerce', 'woocommerce' ) }</h1>
 						<span>{ placeholderTitle }</span>
 					</div>
 					<p>{ placeholderDescription }</p>

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/editor.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/editor.scss
@@ -33,20 +33,14 @@
 	.wp-block-woocommerce-classic-template__placeholder-copy__icon-container {
 		margin: 0 0 $gap;
 
+		h1 {
+			color: #{$studio-woocommerce-purple};
+			@include font-size(large);
+			margin: 0;
+		}
 		span {
 			@include font-size(larger);
 			display: block;
-		}
-		.woo-icon-wrapper {
-			color: #{$studio-woocommerce-purple};
-			display: flex;
-			gap: 0.5rem;
-			align-items: center;
-			@include font-size(large);
-
-			svg {
-				vertical-align: middle;
-			}
 		}
 	}
 	p {

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
@@ -247,9 +247,7 @@ const Edit = ( {
 				</div>
 				<div className="wp-block-woocommerce-classic-template__placeholder-copy">
 					<div className="wp-block-woocommerce-classic-template__placeholder-copy__icon-container">
-						<h1>
-							{ __( 'WooCommerce', 'woocommerce' ) }
-						</h1>
+						<h1>{ __( 'WooCommerce', 'woocommerce' ) }</h1>
 						<span>
 							{ __(
 								'Classic Template Placeholder',

--- a/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/classic-template/index.tsx
@@ -22,7 +22,6 @@ import { useDispatch, subscribe, useSelect, select } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
-import { woo } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -248,10 +247,9 @@ const Edit = ( {
 				</div>
 				<div className="wp-block-woocommerce-classic-template__placeholder-copy">
 					<div className="wp-block-woocommerce-classic-template__placeholder-copy__icon-container">
-						<span className="woo-icon-wrapper">
-							<Icon icon={ woo } />{ ' ' }
+						<h1>
 							{ __( 'WooCommerce', 'woocommerce' ) }
-						</span>
+						</h1>
 						<span>
 							{ __(
 								'Classic Template Placeholder',

--- a/plugins/woocommerce-blocks/assets/js/index.js
+++ b/plugins/woocommerce-blocks/assets/js/index.js
@@ -1,11 +1,4 @@
 /**
- * External dependencies
- */
-import { updateCategory } from '@wordpress/blocks';
-import { woo } from '@woocommerce/icons';
-import { Icon } from '@wordpress/icons';
-
-/**
  * Internal dependencies
  */
 import '../css/editor.scss';
@@ -14,13 +7,3 @@ import './filters/block-list-block';
 import './filters/get-block-attributes';
 import './base/components/notice-banner/style.scss';
 import './atomic/utils/blocks-registration-manager';
-
-// Icons are set on the front-end to make use of WordPress SVG primitive,
-// See: https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#wp-blocks-updatecategory
-
-updateCategory( 'woocommerce', { icon: <Icon icon={ woo } /> } );
-updateCategory( 'woocommerce-product-elements', {
-	icon: (
-		<Icon icon={ woo } className="wc-block-editor-components-block-icon" />
-	),
-} );

--- a/plugins/woocommerce/changelog/55034-remove-inserter-and-classic-placeholder-woo-logo
+++ b/plugins/woocommerce/changelog/55034-remove-inserter-and-classic-placeholder-woo-logo
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove Woo Logo From Block Inserter, Classic Template Block, and Classic Shortcake Block.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request removes the Woo logo from several places within the block editor. In particular, the `"WooCommerce"` Block Inserter category, the `"WooCommerce Product Elements"` block inserter category, Classic Template block, and Classic Shortcode block.

Closes #55034.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new post and open the inserter.
2. Find the "WooCommerce" category in the block inserter and confirm that no icon is present in the header.
3. Find the "WooCommerce Product Elements" category in the block inserter and confirm that no icon is present in the header.
4. Add a "Classic Checkout" block to the page and confirm that no icon is present in the header.
5. Add a "Classic Cart" block to the page and confirm that no icon is present in the header.
6. Add a "Product (Classic)" block to the page and confirm that no icon is present in the header.
7. Add a "Product Collection" block to the page. Select the "Add to cart" button.

#55034 contains images of the original blocks that you can reference to see the difference.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
