### PR TITLE
[API tests] Unskip `settings-crud` test on WPCOM and Pressable

### DIFF
--- a/plugins/woocommerce/changelog/55357-dev-test-api-unskip-settings-crud
+++ b/plugins/woocommerce/changelog/55357-dev-test-api-unskip-settings-crud
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip settings-crud test on WPCOM and Pressable

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1129,7 +1129,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'textarea',
 						default: '',
 						tip: 'List additional tax classes you need below (1 per line, e.g. Reduced Rates). These are in addition to "Standard rate" which exists by default.',
-						value: '',
+						value: expect.any( String ),
 					} ),
 				] )
 			);

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -2004,6 +2004,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 			);
 
 			// Skip these tests in WPCOM because they're not configurable there by design.
+			// eslint-disable-next-line playwright/no-conditional-in-test
 			if ( ! process.env.IS_WPCOM ) {
 				expect( responseJSON ).toEqual(
 					expect.arrayContaining( [

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -392,45 +392,33 @@ test.describe( 'Settings API tests: CRUD', () => {
 				] )
 			);
 
-			// different on external host
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_all_except_countries',
-							label: 'Sell to all countries, except for&hellip;',
-							description: '',
-							type: 'multiselect',
-							default: '',
-							value: '',
-							options: expect.objectContaining( countries ),
-						} ),
-					] )
-				);
-			} else {
-				// Test is failing on external hosts
-			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_all_except_countries',
+						label: 'Sell to all countries, except for&hellip;',
+						description: '',
+						type: 'multiselect',
+						default: '',
+						value: expect.any( Object ),
+						options: expect.objectContaining( countries ),
+					} ),
+				] )
+			);
 
-			// different on external host
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_specific_allowed_countries',
-							label: 'Sell to specific countries',
-							description: '',
-							type: 'multiselect',
-							default: '',
-							value: '',
-							options: expect.objectContaining( countries ),
-						} ),
-					] )
-				);
-			} else {
-				// Test is failing on external hosts
-			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_specific_allowed_countries',
+						label: 'Sell to specific countries',
+						description: '',
+						type: 'multiselect',
+						default: '',
+						value: expect.any( Object ),
+						options: expect.objectContaining( countries ),
+					} ),
+				] )
+			);
 
 			expect( responseJSON ).toEqual(
 				expect.arrayContaining( [
@@ -454,25 +442,19 @@ test.describe( 'Settings API tests: CRUD', () => {
 				] )
 			);
 
-			// different on external host
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_specific_ship_to_countries',
-							label: 'Ship to specific countries',
-							description: '',
-							type: 'multiselect',
-							default: '',
-							value: '',
-							options: expect.objectContaining( countries ),
-						} ),
-					] )
-				);
-			} else {
-				// Test is failing on external hosts
-			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_specific_ship_to_countries',
+						label: 'Ship to specific countries',
+						description: '',
+						type: 'multiselect',
+						default: '',
+						value: expect.any( Object ),
+						options: expect.objectContaining( countries ),
+					} ),
+				] )
+			);
 
 			expect( responseJSON ).toEqual(
 				expect.arrayContaining( [
@@ -537,26 +519,21 @@ test.describe( 'Settings API tests: CRUD', () => {
 				] )
 			);
 
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_currency',
-							label: 'Currency',
-							description:
-								'This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.',
-							type: 'select',
-							default: 'USD',
-							options: expect.objectContaining( currencies ),
-							tip: 'This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.',
-							value: 'USD',
-						} ),
-					] )
-				);
-			} else {
-				// This test is also failing on external hosts
-			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_currency',
+						label: 'Currency',
+						description:
+							'This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.',
+						type: 'select',
+						default: 'USD',
+						options: expect.objectContaining( currencies ),
+						tip: 'This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.',
+						value: 'USD',
+					} ),
+				] )
+			);
 
 			expect( responseJSON ).toEqual(
 				expect.arrayContaining( [

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -2092,140 +2092,143 @@ test.describe( 'Settings API tests: CRUD', () => {
 	test.describe( 'List all Email New Order settings', () => {
 		test.beforeAll( enableEmailImprovementsFeature );
 		test.afterAll( disableEmailImprovementsFeature );
-		test( 'can retrieve all email new order settings', async ( {
-			request,
-		} ) => {
-			// call API to retrieve all settings options
-			const response = await request.get(
-				'./wp-json/wc/v3/settings/email_new_order'
-			);
-			const responseJSON = await response.json();
-			expect( response.status() ).toEqual( 200 );
-			expect( Array.isArray( responseJSON ) ).toBe( true );
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'enabled',
-						label: 'Enable/Disable',
-						description: '',
-						type: 'checkbox',
-						default: 'yes',
-						value: 'yes',
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'recipient',
-						label: 'Recipient(s)',
-						description: expect.stringContaining(
-							'Enter recipients (comma separated) for this email. Defaults to'
-						),
-						type: 'text',
-						default: '',
-						tip: expect.stringContaining(
-							'Enter recipients (comma separated) for this email. Defaults to'
-						),
-						value: expect.any( String ),
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'subject',
-						label: 'Subject',
-						description:
-							'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
-						type: 'text',
-						default: '',
-						tip: 'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
-						value: '',
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'heading',
-						label: 'Email heading',
-						description:
-							'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
-						type: 'text',
-						default: '',
-						tip: 'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
-						value: '',
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'additional_content',
-						label: 'Additional content',
-						description:
-							'Text to appear below the main email content. Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
-						type: 'textarea',
-						default: 'Congratulations on the sale!',
-						tip: 'Text to appear below the main email content. Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
-						value: 'Congratulations on the sale!',
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'email_type',
-						label: 'Email type',
-						description: 'Choose which format of email to send.',
-						type: 'select',
-						default: 'html',
-						options: {
-							plain: 'Plain text',
-							html: 'HTML',
-							multipart: 'Multipart',
-						},
-						tip: 'Choose which format of email to send.',
-						value: 'html',
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'cc',
-						label: 'Cc(s)',
-						description: expect.stringContaining(
-							'Enter Cc recipients (comma-separated) for this email.'
-						),
-						type: 'text',
-						default: '',
-						tip: expect.stringContaining(
-							'Enter Cc recipients (comma-separated) for this email.'
-						),
-						value: expect.any( String ),
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'bcc',
-						label: 'Bcc(s)',
-						description: expect.stringContaining(
-							'Enter Bcc recipients (comma-separated) for this email.'
-						),
-						type: 'text',
-						default: '',
-						tip: expect.stringContaining(
-							'Enter Bcc recipients (comma-separated) for this email.'
-						),
-						value: expect.any( String ),
-					} ),
-				] )
-			);
-		} );
+		test(
+			'can retrieve all email new order settings',
+			{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
+			async ( { request } ) => {
+				// call API to retrieve all settings options
+				const response = await request.get(
+					'./wp-json/wc/v3/settings/email_new_order'
+				);
+				const responseJSON = await response.json();
+				expect( response.status() ).toEqual( 200 );
+				expect( Array.isArray( responseJSON ) ).toBe( true );
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'enabled',
+							label: 'Enable/Disable',
+							description: '',
+							type: 'checkbox',
+							default: 'yes',
+							value: 'yes',
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'recipient',
+							label: 'Recipient(s)',
+							description: expect.stringContaining(
+								'Enter recipients (comma separated) for this email. Defaults to'
+							),
+							type: 'text',
+							default: '',
+							tip: expect.stringContaining(
+								'Enter recipients (comma separated) for this email. Defaults to'
+							),
+							value: expect.any( String ),
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'subject',
+							label: 'Subject',
+							description:
+								'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
+							type: 'text',
+							default: '',
+							tip: 'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
+							value: '',
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'heading',
+							label: 'Email heading',
+							description:
+								'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
+							type: 'text',
+							default: '',
+							tip: 'Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
+							value: '',
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'additional_content',
+							label: 'Additional content',
+							description:
+								'Text to appear below the main email content. Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
+							type: 'textarea',
+							default: 'Congratulations on the sale!',
+							tip: 'Text to appear below the main email content. Available placeholders: <code>{site_title}</code>, <code>{site_address}</code>, <code>{site_url}</code>, <code>{store_email}</code>, <code>{order_date}</code>, <code>{order_number}</code>',
+							value: 'Congratulations on the sale!',
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'email_type',
+							label: 'Email type',
+							description:
+								'Choose which format of email to send.',
+							type: 'select',
+							default: 'html',
+							options: {
+								plain: 'Plain text',
+								html: 'HTML',
+								multipart: 'Multipart',
+							},
+							tip: 'Choose which format of email to send.',
+							value: 'html',
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'cc',
+							label: 'Cc(s)',
+							description: expect.stringContaining(
+								'Enter Cc recipients (comma-separated) for this email.'
+							),
+							type: 'text',
+							default: '',
+							tip: expect.stringContaining(
+								'Enter Cc recipients (comma-separated) for this email.'
+							),
+							value: expect.any( String ),
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'bcc',
+							label: 'Bcc(s)',
+							description: expect.stringContaining(
+								'Enter Bcc recipients (comma-separated) for this email.'
+							),
+							type: 'text',
+							default: '',
+							tip: expect.stringContaining(
+								'Enter Bcc recipients (comma-separated) for this email.'
+							),
+							value: expect.any( String ),
+						} ),
+					] )
+				);
+			}
+		);
 	} );
 
 	test.describe( 'List all Email Failed Order settings', () => {
@@ -2233,7 +2236,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 		test.afterAll( disableEmailImprovementsFeature );
 		test(
 			'can retrieve all email failed order settings',
-			{ tag: tags.SKIP_ON_PRESSABLE },
+			{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
 			async ( { request } ) => {
 				// call API to retrieve all settings options
 				const response = await request.get(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -2034,8 +2034,9 @@ test.describe( 'Settings API tests: CRUD', () => {
 					} ),
 				] )
 			);
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
+
+			// Skip these tests in WPCOM because they're not configurable there by design.
+			if ( ! process.env.IS_WPCOM ) {
 				expect( responseJSON ).toEqual(
 					expect.arrayContaining( [
 						expect.objectContaining( {
@@ -2050,34 +2051,33 @@ test.describe( 'Settings API tests: CRUD', () => {
 						} ),
 					] )
 				);
-			} else {
-				// Test is failing on external hosts
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'woocommerce_show_marketplace_suggestions',
+							label: 'Show Suggestions',
+							description:
+								'Display suggestions within WooCommerce',
+							type: 'checkbox',
+							default: 'yes',
+							tip: 'Leave this box unchecked if you do not want to pull suggested extensions from WooCommerce.com. You will see a static list of extensions instead.',
+							value: 'yes',
+						} ),
+					] )
+				);
+				expect( responseJSON ).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( {
+							id: 'woocommerce_analytics_enabled',
+							label: 'Analytics',
+							description: 'Enable WooCommerce Analytics',
+							type: 'checkbox',
+							default: 'yes',
+							value: 'yes',
+						} ),
+					] )
+				);
 			}
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'woocommerce_show_marketplace_suggestions',
-						label: 'Show Suggestions',
-						description: 'Display suggestions within WooCommerce',
-						type: 'checkbox',
-						default: 'yes',
-						tip: 'Leave this box unchecked if you do not want to pull suggested extensions from WooCommerce.com. You will see a static list of extensions instead.',
-						value: 'yes',
-					} ),
-				] )
-			);
-			expect( responseJSON ).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						id: 'woocommerce_analytics_enabled',
-						label: 'Analytics',
-						description: 'Enable WooCommerce Analytics',
-						type: 'checkbox',
-						default: 'yes',
-						value: 'yes',
-					} ),
-				] )
-			);
 		} );
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -399,7 +399,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						description: '',
 						type: 'multiselect',
 						default: '',
-						value: expect.any( Object ),
+						value: expect.anything(),
 						options: expect.objectContaining( countries ),
 					} ),
 				] )
@@ -413,7 +413,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						description: '',
 						type: 'multiselect',
 						default: '',
-						value: expect.any( Object ),
+						value: expect.anything(),
 						options: expect.objectContaining( countries ),
 					} ),
 				] )
@@ -449,7 +449,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						description: '',
 						type: 'multiselect',
 						default: '',
-						value: expect.any( Object ),
+						value: expect.anything(),
 						options: expect.objectContaining( countries ),
 					} ),
 				] )

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1044,164 +1044,159 @@ test.describe( 'Settings API tests: CRUD', () => {
 	} );
 
 	test.describe( 'List all Tax settings options', () => {
-		test(
-			'can retrieve all tax settings',
-			{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
-			async ( { request } ) => {
-				// call API to retrieve all settings options
-				const response = await request.get(
-					'./wp-json/wc/v3/settings/tax'
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( Array.isArray( responseJSON ) ).toBe( true );
-				expect( responseJSON.length ).toBeGreaterThan( 0 );
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_prices_include_tax',
-							label: 'Prices entered with tax',
-							description: '',
-							type: 'radio',
-							default: 'no',
-							options: {
-								yes: 'Yes, I will enter prices inclusive of tax',
-								no: 'No, I will enter prices exclusive of tax',
-							},
-							tip: 'This option is important as it will affect how you input prices. Changing it will not update existing products.',
-							value: 'no',
-						} ),
-					] )
-				);
+		test( 'can retrieve all tax settings', async ( { request } ) => {
+			// call API to retrieve all settings options
+			const response = await request.get(
+				'./wp-json/wc/v3/settings/tax'
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThan( 0 );
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_prices_include_tax',
+						label: 'Prices entered with tax',
+						description: '',
+						type: 'radio',
+						default: 'no',
+						options: {
+							yes: 'Yes, I will enter prices inclusive of tax',
+							no: 'No, I will enter prices exclusive of tax',
+						},
+						tip: 'This option is important as it will affect how you input prices. Changing it will not update existing products.',
+						value: 'no',
+					} ),
+				] )
+			);
 
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_tax_based_on',
-							label: 'Calculate tax based on',
-							description: '',
-							type: 'select',
-							default: 'shipping',
-							options: {
-								shipping: 'Customer shipping address',
-								billing: 'Customer billing address',
-								base: 'Shop base address',
-							},
-							tip: 'This option determines which address is used to calculate tax.',
-							value: 'shipping',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_shipping_tax_class',
-							label: 'Shipping tax class',
-							description:
-								'Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves.',
-							type: 'select',
-							default: 'inherit',
-							options: {
-								inherit:
-									'Shipping tax class based on cart items',
-								'': 'Standard',
-								'reduced-rate': 'Reduced rate',
-								'zero-rate': 'Zero rate',
-							},
-							tip: 'Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves.',
-							value: 'inherit',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_tax_round_at_subtotal',
-							label: 'Rounding',
-							description:
-								'Round tax at subtotal level, instead of rounding per line',
-							type: 'checkbox',
-							default: 'no',
-							value: 'no',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_tax_classes',
-							label: 'Additional tax classes',
-							description: '',
-							type: 'textarea',
-							default: '',
-							tip: 'List additional tax classes you need below (1 per line, e.g. Reduced Rates). These are in addition to "Standard rate" which exists by default.',
-							value: '',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_tax_display_shop',
-							label: 'Display prices in the shop',
-							description: '',
-							type: 'select',
-							default: 'excl',
-							options: {
-								incl: 'Including tax',
-								excl: 'Excluding tax',
-							},
-							value: 'excl',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_tax_display_cart',
-							label: 'Display prices during cart and checkout',
-							description: '',
-							type: 'select',
-							default: 'excl',
-							options: {
-								incl: 'Including tax',
-								excl: 'Excluding tax',
-							},
-							value: 'excl',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_price_display_suffix',
-							label: 'Price display suffix',
-							description: '',
-							type: 'text',
-							default: '',
-							tip: 'Define text to show after your product prices. This could be, for example, "inc. Vat" to explain your pricing. You can also have prices substituted here using one of the following: {price_including_tax}, {price_excluding_tax}.',
-							value: '',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_tax_total_display',
-							label: 'Display tax totals',
-							description: '',
-							type: 'select',
-							default: 'itemized',
-							options: {
-								single: 'As a single total',
-								itemized: 'Itemized',
-							},
-							value: 'itemized',
-						} ),
-					] )
-				);
-			}
-		);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_tax_based_on',
+						label: 'Calculate tax based on',
+						description: '',
+						type: 'select',
+						default: 'shipping',
+						options: {
+							shipping: 'Customer shipping address',
+							billing: 'Customer billing address',
+							base: 'Shop base address',
+						},
+						tip: 'This option determines which address is used to calculate tax.',
+						value: 'shipping',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_shipping_tax_class',
+						label: 'Shipping tax class',
+						description:
+							'Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves.',
+						type: 'select',
+						default: 'inherit',
+						options: {
+							inherit: 'Shipping tax class based on cart items',
+							'': 'Standard',
+							'reduced-rate': 'Reduced rate',
+							'zero-rate': 'Zero rate',
+						},
+						tip: 'Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves.',
+						value: 'inherit',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_tax_round_at_subtotal',
+						label: 'Rounding',
+						description:
+							'Round tax at subtotal level, instead of rounding per line',
+						type: 'checkbox',
+						default: 'no',
+						value: 'no',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_tax_classes',
+						label: 'Additional tax classes',
+						description: '',
+						type: 'textarea',
+						default: '',
+						tip: 'List additional tax classes you need below (1 per line, e.g. Reduced Rates). These are in addition to "Standard rate" which exists by default.',
+						value: '',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_tax_display_shop',
+						label: 'Display prices in the shop',
+						description: '',
+						type: 'select',
+						default: 'excl',
+						options: {
+							incl: 'Including tax',
+							excl: 'Excluding tax',
+						},
+						value: 'excl',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_tax_display_cart',
+						label: 'Display prices during cart and checkout',
+						description: '',
+						type: 'select',
+						default: 'excl',
+						options: {
+							incl: 'Including tax',
+							excl: 'Excluding tax',
+						},
+						value: 'excl',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_price_display_suffix',
+						label: 'Price display suffix',
+						description: '',
+						type: 'text',
+						default: '',
+						tip: 'Define text to show after your product prices. This could be, for example, "inc. Vat" to explain your pricing. You can also have prices substituted here using one of the following: {price_including_tax}, {price_excluding_tax}.',
+						value: '',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_tax_total_display',
+						label: 'Display tax totals',
+						description: '',
+						type: 'select',
+						default: 'itemized',
+						options: {
+							single: 'As a single total',
+							itemized: 'Itemized',
+						},
+						value: 'itemized',
+					} ),
+				] )
+			);
+		} );
 	} );
 
 	test.describe( 'List all Shipping settings options', () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1174,7 +1174,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'text',
 						default: '',
 						tip: 'Define text to show after your product prices. This could be, for example, "inc. Vat" to explain your pricing. You can also have prices substituted here using one of the following: {price_including_tax}, {price_excluding_tax}.',
-						value: '',
+						value: expect.any( String ),
 					} ),
 				] )
 			);

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -7,7 +7,6 @@ const {
 const { setOption } = require( '../../../utils/options' );
 
 const { BASE_URL } = process.env;
-const shouldSkip = ! BASE_URL.includes( 'localhost' );
 
 const {
 	countries,
@@ -1787,45 +1786,37 @@ test.describe( 'Settings API tests: CRUD', () => {
 			expect( response.status() ).toEqual( 200 );
 			expect( Array.isArray( responseJSON ) ).toBe( true );
 
-			// not present in external host
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_cart_page_id',
-							label: 'Cart page',
-							description:
-								'Page where shoppers review their shopping cart',
-							type: 'select',
-							default: '',
-							tip: 'Page where shoppers review their shopping cart',
-							value: expect.any( String ),
-							options: expect.any( Object ),
-						} ),
-					] )
-				);
-			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_cart_page_id',
+						label: 'Cart page',
+						description:
+							'Page where shoppers review their shopping cart',
+						type: 'select',
+						default: '',
+						tip: 'Page where shoppers review their shopping cart',
+						value: expect.any( String ),
+						options: expect.any( Object ),
+					} ),
+				] )
+			);
 
-			// not present in external host
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_checkout_page_id',
-							label: 'Checkout page',
-							description:
-								'Page where shoppers go to finalize their purchase',
-							type: 'select',
-							default: expect.any( Number ),
-							tip: 'Page where shoppers go to finalize their purchase',
-							value: expect.any( String ),
-							options: expect.any( Object ),
-						} ),
-					] )
-				);
-			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_checkout_page_id',
+						label: 'Checkout page',
+						description:
+							'Page where shoppers go to finalize their purchase',
+						type: 'select',
+						default: expect.any( Number ),
+						tip: 'Page where shoppers go to finalize their purchase',
+						value: expect.any( String ),
+						options: expect.any( Object ),
+					} ),
+				] )
+			);
 
 			expect( responseJSON ).toEqual(
 				expect.arrayContaining( [

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1800,7 +1800,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 		} );
 	} );
 
-	test.describe.only( 'List all Advanced settings options', () => {
+	test.describe( 'List all Advanced settings options', () => {
 		test( 'can retrieve all advanced settings', async ( { request } ) => {
 			// call API to retrieve all settings options
 			const response = await request.get(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -2047,7 +2047,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 							type: 'checkbox',
 							default: 'no',
 							tip: 'To opt out, leave this box unticked. Your store remains untracked, and no data will be collected. Read about what usage data is tracked at: <a href="https://woocommerce.com/usage-tracking" target="_blank">WooCommerce.com Usage Tracking Documentation</a>.',
-							value: 'no',
+							value: expect.any( String ),
 						} ),
 					] )
 				);
@@ -2061,7 +2061,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 							type: 'checkbox',
 							default: 'yes',
 							tip: 'Leave this box unchecked if you do not want to pull suggested extensions from WooCommerce.com. You will see a static list of extensions instead.',
-							value: 'yes',
+							value: expect.any( String ),
 						} ),
 					] )
 				);
@@ -2073,7 +2073,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 							description: 'Enable WooCommerce Analytics',
 							type: 'checkbox',
 							default: 'yes',
-							value: 'yes',
+							value: expect.any( String ),
 						} ),
 					] )
 				);

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1800,294 +1800,286 @@ test.describe( 'Settings API tests: CRUD', () => {
 		} );
 	} );
 
-	test.describe(
-		'List all Advanced settings options',
-		{ tag: tags.SKIP_ON_WPCOM },
-		() => {
-			test( 'can retrieve all advanced settings', async ( {
-				request,
-			} ) => {
-				// call API to retrieve all settings options
-				const response = await request.get(
-					'./wp-json/wc/v3/settings/advanced'
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( Array.isArray( responseJSON ) ).toBe( true );
+	test.describe.only( 'List all Advanced settings options', () => {
+		test( 'can retrieve all advanced settings', async ( { request } ) => {
+			// call API to retrieve all settings options
+			const response = await request.get(
+				'./wp-json/wc/v3/settings/advanced'
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
 
-				// not present in external host
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				if ( ! shouldSkip ) {
-					expect( responseJSON ).toEqual(
-						expect.arrayContaining( [
-							expect.objectContaining( {
-								id: 'woocommerce_cart_page_id',
-								label: 'Cart page',
-								description:
-									'Page where shoppers review their shopping cart',
-								type: 'select',
-								default: '',
-								tip: 'Page where shoppers review their shopping cart',
-								value: expect.any( String ),
-								options: expect.any( Object ),
-							} ),
-						] )
-					);
-				}
-
-				// not present in external host
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				if ( ! shouldSkip ) {
-					expect( responseJSON ).toEqual(
-						expect.arrayContaining( [
-							expect.objectContaining( {
-								id: 'woocommerce_checkout_page_id',
-								label: 'Checkout page',
-								description:
-									'Page where shoppers go to finalize their purchase',
-								type: 'select',
-								default: expect.any( Number ),
-								tip: 'Page where shoppers go to finalize their purchase',
-								value: expect.any( String ),
-								options: expect.any( Object ),
-							} ),
-						] )
-					);
-				}
-
+			// not present in external host
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			if ( ! shouldSkip ) {
 				expect( responseJSON ).toEqual(
 					expect.arrayContaining( [
 						expect.objectContaining( {
-							id: 'woocommerce_myaccount_page_id',
-							label: 'My account page',
+							id: 'woocommerce_cart_page_id',
+							label: 'Cart page',
 							description:
-								'Page contents: [woocommerce_my_account]',
+								'Page where shoppers review their shopping cart',
 							type: 'select',
 							default: '',
-							tip: 'Page contents: [woocommerce_my_account]',
+							tip: 'Page where shoppers review their shopping cart',
 							value: expect.any( String ),
 							options: expect.any( Object ),
 						} ),
 					] )
 				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_checkout_pay_endpoint',
-							label: 'Pay',
-							description:
-								'Endpoint for the "Checkout &rarr; Pay" page.',
-							type: 'text',
-							default: 'order-pay',
-							tip: 'Endpoint for the "Checkout &rarr; Pay" page.',
-							value: 'order-pay',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_checkout_order_received_endpoint',
-							label: 'Order received',
-							description:
-								'Endpoint for the "Checkout &rarr; Order received" page.',
-							type: 'text',
-							default: 'order-received',
-							tip: 'Endpoint for the "Checkout &rarr; Order received" page.',
-							value: 'order-received',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_add_payment_method_endpoint',
-							label: 'Add payment method',
-							description:
-								'Endpoint for the "Checkout &rarr; Add payment method" page.',
-							type: 'text',
-							default: 'add-payment-method',
-							tip: 'Endpoint for the "Checkout &rarr; Add payment method" page.',
-							value: 'add-payment-method',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_delete_payment_method_endpoint',
-							label: 'Delete payment method',
-							description:
-								'Endpoint for the delete payment method page.',
-							type: 'text',
-							default: 'delete-payment-method',
-							tip: 'Endpoint for the delete payment method page.',
-							value: 'delete-payment-method',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_orders_endpoint',
-							label: 'Orders',
-							description:
-								'Endpoint for the "My account &rarr; Orders" page.',
-							type: 'text',
-							default: 'orders',
-							tip: 'Endpoint for the "My account &rarr; Orders" page.',
-							value: 'orders',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_view_order_endpoint',
-							label: 'View order',
-							description:
-								'Endpoint for the "My account &rarr; View order" page.',
-							type: 'text',
-							default: 'view-order',
-							tip: 'Endpoint for the "My account &rarr; View order" page.',
-							value: 'view-order',
-						} ),
-					] )
-				);
+			}
 
+			// not present in external host
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			if ( ! shouldSkip ) {
 				expect( responseJSON ).toEqual(
 					expect.arrayContaining( [
 						expect.objectContaining( {
-							id: 'woocommerce_myaccount_downloads_endpoint',
-							label: 'Downloads',
+							id: 'woocommerce_checkout_page_id',
+							label: 'Checkout page',
 							description:
-								'Endpoint for the "My account &rarr; Downloads" page.',
-							type: 'text',
-							default: 'downloads',
-							tip: 'Endpoint for the "My account &rarr; Downloads" page.',
-							value: 'downloads',
+								'Page where shoppers go to finalize their purchase',
+							type: 'select',
+							default: expect.any( Number ),
+							tip: 'Page where shoppers go to finalize their purchase',
+							value: expect.any( String ),
+							options: expect.any( Object ),
 						} ),
 					] )
 				);
+			}
 
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_page_id',
+						label: 'My account page',
+						description: 'Page contents: [woocommerce_my_account]',
+						type: 'select',
+						default: '',
+						tip: 'Page contents: [woocommerce_my_account]',
+						value: expect.any( String ),
+						options: expect.any( Object ),
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_checkout_pay_endpoint',
+						label: 'Pay',
+						description:
+							'Endpoint for the "Checkout &rarr; Pay" page.',
+						type: 'text',
+						default: 'order-pay',
+						tip: 'Endpoint for the "Checkout &rarr; Pay" page.',
+						value: 'order-pay',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_checkout_order_received_endpoint',
+						label: 'Order received',
+						description:
+							'Endpoint for the "Checkout &rarr; Order received" page.',
+						type: 'text',
+						default: 'order-received',
+						tip: 'Endpoint for the "Checkout &rarr; Order received" page.',
+						value: 'order-received',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_add_payment_method_endpoint',
+						label: 'Add payment method',
+						description:
+							'Endpoint for the "Checkout &rarr; Add payment method" page.',
+						type: 'text',
+						default: 'add-payment-method',
+						tip: 'Endpoint for the "Checkout &rarr; Add payment method" page.',
+						value: 'add-payment-method',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_delete_payment_method_endpoint',
+						label: 'Delete payment method',
+						description:
+							'Endpoint for the delete payment method page.',
+						type: 'text',
+						default: 'delete-payment-method',
+						tip: 'Endpoint for the delete payment method page.',
+						value: 'delete-payment-method',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_orders_endpoint',
+						label: 'Orders',
+						description:
+							'Endpoint for the "My account &rarr; Orders" page.',
+						type: 'text',
+						default: 'orders',
+						tip: 'Endpoint for the "My account &rarr; Orders" page.',
+						value: 'orders',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_view_order_endpoint',
+						label: 'View order',
+						description:
+							'Endpoint for the "My account &rarr; View order" page.',
+						type: 'text',
+						default: 'view-order',
+						tip: 'Endpoint for the "My account &rarr; View order" page.',
+						value: 'view-order',
+					} ),
+				] )
+			);
+
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_downloads_endpoint',
+						label: 'Downloads',
+						description:
+							'Endpoint for the "My account &rarr; Downloads" page.',
+						type: 'text',
+						default: 'downloads',
+						tip: 'Endpoint for the "My account &rarr; Downloads" page.',
+						value: 'downloads',
+					} ),
+				] )
+			);
+
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_edit_account_endpoint',
+						label: 'Edit account',
+						description:
+							'Endpoint for the "My account &rarr; Edit account" page.',
+						type: 'text',
+						default: 'edit-account',
+						tip: 'Endpoint for the "My account &rarr; Edit account" page.',
+						value: 'edit-account',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_edit_address_endpoint',
+						label: 'Addresses',
+						description:
+							'Endpoint for the "My account &rarr; Addresses" page.',
+						type: 'text',
+						default: 'edit-address',
+						tip: 'Endpoint for the "My account &rarr; Addresses" page.',
+						value: 'edit-address',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_payment_methods_endpoint',
+						label: 'Payment methods',
+						description:
+							'Endpoint for the "My account &rarr; Payment methods" page.',
+						type: 'text',
+						default: 'payment-methods',
+						tip: 'Endpoint for the "My account &rarr; Payment methods" page.',
+						value: 'payment-methods',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_myaccount_lost_password_endpoint',
+						label: 'Lost password',
+						description:
+							'Endpoint for the "My account &rarr; Lost password" page.',
+						type: 'text',
+						default: 'lost-password',
+						tip: 'Endpoint for the "My account &rarr; Lost password" page.',
+						value: 'lost-password',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_logout_endpoint',
+						label: 'Logout',
+						description:
+							'Endpoint for the triggering logout. You can add this to your menus via a custom link: yoursite.com/?customer-logout=true',
+						type: 'text',
+						default: 'customer-logout',
+						tip: 'Endpoint for the triggering logout. You can add this to your menus via a custom link: yoursite.com/?customer-logout=true',
+						value: 'customer-logout',
+					} ),
+				] )
+			);
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			if ( ! shouldSkip ) {
 				expect( responseJSON ).toEqual(
 					expect.arrayContaining( [
 						expect.objectContaining( {
-							id: 'woocommerce_myaccount_edit_account_endpoint',
-							label: 'Edit account',
+							id: 'woocommerce_allow_tracking',
+							label: 'Enable tracking',
 							description:
-								'Endpoint for the "My account &rarr; Edit account" page.',
-							type: 'text',
-							default: 'edit-account',
-							tip: 'Endpoint for the "My account &rarr; Edit account" page.',
-							value: 'edit-account',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_edit_address_endpoint',
-							label: 'Addresses',
-							description:
-								'Endpoint for the "My account &rarr; Addresses" page.',
-							type: 'text',
-							default: 'edit-address',
-							tip: 'Endpoint for the "My account &rarr; Addresses" page.',
-							value: 'edit-address',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_payment_methods_endpoint',
-							label: 'Payment methods',
-							description:
-								'Endpoint for the "My account &rarr; Payment methods" page.',
-							type: 'text',
-							default: 'payment-methods',
-							tip: 'Endpoint for the "My account &rarr; Payment methods" page.',
-							value: 'payment-methods',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_myaccount_lost_password_endpoint',
-							label: 'Lost password',
-							description:
-								'Endpoint for the "My account &rarr; Lost password" page.',
-							type: 'text',
-							default: 'lost-password',
-							tip: 'Endpoint for the "My account &rarr; Lost password" page.',
-							value: 'lost-password',
-						} ),
-					] )
-				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_logout_endpoint',
-							label: 'Logout',
-							description:
-								'Endpoint for the triggering logout. You can add this to your menus via a custom link: yoursite.com/?customer-logout=true',
-							type: 'text',
-							default: 'customer-logout',
-							tip: 'Endpoint for the triggering logout. You can add this to your menus via a custom link: yoursite.com/?customer-logout=true',
-							value: 'customer-logout',
-						} ),
-					] )
-				);
-				// eslint-disable-next-line playwright/no-conditional-in-test
-				if ( ! shouldSkip ) {
-					expect( responseJSON ).toEqual(
-						expect.arrayContaining( [
-							expect.objectContaining( {
-								id: 'woocommerce_allow_tracking',
-								label: 'Enable tracking',
-								description:
-									'Allow usage of WooCommerce to be tracked',
-								type: 'checkbox',
-								default: 'no',
-								tip: 'To opt out, leave this box unticked. Your store remains untracked, and no data will be collected. Read about what usage data is tracked at: <a href="https://woocommerce.com/usage-tracking" target="_blank">WooCommerce.com Usage Tracking Documentation</a>.',
-								value: 'no',
-							} ),
-						] )
-					);
-				} else {
-					// Test is failing on external hosts
-				}
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_show_marketplace_suggestions',
-							label: 'Show Suggestions',
-							description:
-								'Display suggestions within WooCommerce',
+								'Allow usage of WooCommerce to be tracked',
 							type: 'checkbox',
-							default: 'yes',
-							tip: 'Leave this box unchecked if you do not want to pull suggested extensions from WooCommerce.com. You will see a static list of extensions instead.',
-							value: 'yes',
+							default: 'no',
+							tip: 'To opt out, leave this box unticked. Your store remains untracked, and no data will be collected. Read about what usage data is tracked at: <a href="https://woocommerce.com/usage-tracking" target="_blank">WooCommerce.com Usage Tracking Documentation</a>.',
+							value: 'no',
 						} ),
 					] )
 				);
-				expect( responseJSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							id: 'woocommerce_analytics_enabled',
-							label: 'Analytics',
-							description: 'Enable WooCommerce Analytics',
-							type: 'checkbox',
-							default: 'yes',
-							value: 'yes',
-						} ),
-					] )
-				);
-			} );
-		}
-	);
+			} else {
+				// Test is failing on external hosts
+			}
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_show_marketplace_suggestions',
+						label: 'Show Suggestions',
+						description: 'Display suggestions within WooCommerce',
+						type: 'checkbox',
+						default: 'yes',
+						tip: 'Leave this box unchecked if you do not want to pull suggested extensions from WooCommerce.com. You will see a static list of extensions instead.',
+						value: 'yes',
+					} ),
+				] )
+			);
+			expect( responseJSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'woocommerce_analytics_enabled',
+						label: 'Analytics',
+						description: 'Enable WooCommerce Analytics',
+						type: 'checkbox',
+						default: 'yes',
+						value: 'yes',
+					} ),
+				] )
+			);
+		} );
+	} );
 
 	test.describe( 'List all Email New Order settings', () => {
 		test.beforeAll( enableEmailImprovementsFeature );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1098,14 +1098,12 @@ test.describe( 'Settings API tests: CRUD', () => {
 							'Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves.',
 						type: 'select',
 						default: 'inherit',
-						options: {
+						options: expect.objectContaining( {
 							inherit: 'Shipping tax class based on cart items',
 							'': 'Standard',
-							'reduced-rate': 'Reduced rate',
-							'zero-rate': 'Zero rate',
-						},
+						} ),
 						tip: 'Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves.',
-						value: 'inherit',
+						value: expect.any( String ),
 					} ),
 				] )
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

This PR makes the `settings-crud.test.js` runnable on WPCOM and Pressable. The list below were the key changes made, and they also explain the causes of previous failures in those environments:

- Relaxed very strict assertions by replacing hard-coded string property values with `expect.any()` or `expect.objectContaining()` 
- In the commit  [Skip specific assertions in WPCOM](https://github.com/woocommerce/woocommerce/pull/55357/commits/921f4bdafde2cf6b9b38adf8016a6e7b871cb551) I skipped 3 settings from being tested in WPCOM because these settings don't show up there, and couldn't be altered even via WP CLI.

I intentionally skipped these two tests on WPCOM and Pressable because they have been regularly receiving small copy changes such that the Woo version in WPCOM and Pressable are playing catch-up with them. Also, these tests are still behind a feature flag so I think they're ok to skip for now:
- `can retrieve all email new order settings`
- `can retrieve all email failed order settings`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the api tests in CI checks pass.
2. Run the test file on WPCOM and Pressable and make sure they pass. In WPCOM, make sure the 2 tests I mentioned above were indeed skipped.
    ```bash
    export E2E_ENV_KEY="..."
    pnpm test:e2e:pressable settings-crud.test.js
    pnpm test:e2e:wpcom settings-crud.test.js
    ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Unskip settings-crud test on WPCOM and Pressable
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
