### PR TITLE
[API tests] Unskip `products-crud` on WPCOM and Pressable.

### DIFF
--- a/plugins/woocommerce/changelog/55358-dev-test-api-unskip-products-crud
+++ b/plugins/woocommerce/changelog/55358-dev-test-api-unskip-products-crud
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip products-crud.test.js on WPCOM and Pressable.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -1,7 +1,6 @@
 const {
 	test: baseTest,
 	expect,
-	tags,
 } = require( '../../../fixtures/api-tests-fixtures' );
 const { BASE_URL } = process.env;
 const { admin } = require( '../../../test-data/data' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -959,91 +959,93 @@ test.describe( 'Products API tests: CRUD', () => {
 			);
 		} );
 
-		test(
-			'can batch update product shipping classes',
-			{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
-			async ( { request } ) => {
-				// Batch create product shipping classes.
-				const response = await request.post(
-					`wp-json/wc/v3/products/shipping_classes/batch`,
-					{
-						data: {
-							create: [
-								{
-									name: 'Small Items',
-								},
-								{
-									name: 'Large Items',
-								},
-							],
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.create[ 0 ].name ).toEqual(
-					'Small Items'
-				);
-				expect( responseJSON.create[ 1 ].name ).toEqual(
-					'Large Items'
-				);
-				const shippingClass1Id = responseJSON.create[ 0 ].id;
-				const shippingClass2Id = responseJSON.create[ 1 ].id;
+		test( 'can batch update product shipping classes', async ( {
+			request,
+		} ) => {
+			// Batch create product shipping classes.
+			const smallItems = `Small Items ${ Date.now() }`;
+			const largeItems = `Large Items ${ Date.now() + 1 }`;
+			const response = await request.post(
+				`wp-json/wc/v3/products/shipping_classes/batch`,
+				{
+					data: {
+						create: [
+							{
+								name: smallItems,
+							},
+							{
+								name: largeItems,
+							},
+						],
+					},
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			const smallItemsJSON = responseJSON.create.find(
+				( { name } ) => name === smallItems
+			);
+			const largeItemsJSON = responseJSON.create.find(
+				( { name } ) => name === largeItems
+			);
 
-				// Batch create a new shipping class, update a shipping class and delete another.
-				const responseBatchUpdate = await request.post(
-					`wp-json/wc/v3/products/shipping_classes/batch`,
-					{
-						data: {
-							create: [
-								{
-									name: 'Express',
-								},
-							],
-							update: [
-								{
-									id: shippingClass1Id,
-									description: 'Priority shipping.',
-								},
-							],
-							delete: [ shippingClass2Id ],
-						},
-					}
-				);
-				const responseBatchUpdateJSON =
-					await responseBatchUpdate.json();
-				const shippingClass3Id = responseBatchUpdateJSON.create[ 0 ].id;
-				expect( response.status() ).toEqual( 200 );
+			expect( smallItemsJSON ).toBeDefined();
+			expect( largeItemsJSON ).toBeDefined();
 
-				const responseUpdatedShippingClass = await request.get(
-					`wp-json/wc/v3/products/shipping_classes/${ shippingClass1Id }`
-				);
-				const responseUpdatedShippingClassJSON =
-					await responseUpdatedShippingClass.json();
-				expect( responseUpdatedShippingClassJSON.description ).toEqual(
-					'Priority shipping.'
-				);
+			const smallItemsID = smallItemsJSON.id;
+			const largeItemsID = largeItemsJSON.id;
 
-				// Verify that the product tag can no longer be retrieved.
-				const getDeletedProductShippingClassResponse =
-					await request.get(
-						`wp-json/wc/v3/products/shipping_classes/${ shippingClass2Id }`
-					);
-				expect(
-					getDeletedProductShippingClassResponse.status()
-				).toEqual( 404 );
+			// Batch create a new shipping class, update a shipping class and delete another.
+			const responseBatchUpdate = await request.post(
+				`wp-json/wc/v3/products/shipping_classes/batch`,
+				{
+					data: {
+						create: [
+							{
+								name: 'Express',
+							},
+						],
+						update: [
+							{
+								id: smallItemsID,
+								description: 'Priority shipping.',
+							},
+						],
+						delete: [ largeItemsID ],
+					},
+				}
+			);
+			const responseBatchUpdateJSON = await responseBatchUpdate.json();
+			const shippingClass3Id = responseBatchUpdateJSON.create[ 0 ].id;
+			expect( response.status() ).toEqual( 200 );
 
-				// Batch delete the created tags
-				await request.post(
-					`wp-json/wc/v3/products/shipping_classes/batch`,
-					{
-						data: {
-							delete: [ shippingClass1Id, shippingClass3Id ],
-						},
-					}
-				);
-			}
-		);
+			const responseUpdatedShippingClass = await request.get(
+				`wp-json/wc/v3/products/shipping_classes/${ smallItemsID }`
+			);
+			const responseUpdatedShippingClassJSON =
+				await responseUpdatedShippingClass.json();
+			expect( responseUpdatedShippingClassJSON.description ).toEqual(
+				'Priority shipping.'
+			);
+
+			// Verify that the product tag can no longer be retrieved.
+			const getDeletedProductShippingClassResponse = await request.get(
+				`wp-json/wc/v3/products/shipping_classes/${ largeItemsID }`
+			);
+			expect( getDeletedProductShippingClassResponse.status() ).toEqual(
+				404
+			);
+
+			// Batch delete the created tags
+			await request.post(
+				`wp-json/wc/v3/products/shipping_classes/batch`,
+				{
+					data: {
+						delete: [ smallItemsID, shippingClass3Id ],
+					},
+				}
+			);
+		} );
 	} );
 
 	test.describe( 'Product tags tests: CRUD', () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -590,301 +590,278 @@ test.describe( 'Products API tests: CRUD', () => {
 		} );
 	} );
 
-	test.describe(
-		'Product review tests: CRUD',
-		{ tag: tags.SKIP_ON_WPCOM },
-		() => {
-			let productReviewId;
-			let reviewsTestProduct;
+	test.describe( 'Product review tests: CRUD', () => {
+		let productReviewId;
+		let reviewsTestProduct;
 
-			test.beforeAll( async ( { simpleTestProduct } ) => {
-				reviewsTestProduct = simpleTestProduct;
-			} );
+		test.beforeAll( async ( { simpleTestProduct } ) => {
+			reviewsTestProduct = simpleTestProduct;
+		} );
 
-			test( 'can add a product review', async ( { request } ) => {
-				const response = await request.post(
-					'wp-json/wc/v3/products/reviews',
-					{
-						data: {
-							product_id: reviewsTestProduct.id,
-							review: 'Nice simple product!',
-							reviewer: 'John Doe',
-							reviewer_email: 'john.doe@example.com',
-							rating: 5,
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				productReviewId = responseJSON.id;
-
-				expect( response.status() ).toEqual( 201 );
-				expect( typeof productReviewId ).toEqual( 'number' );
-				expect( responseJSON.id ).toEqual( productReviewId );
-				expect( responseJSON.product_name ).toEqual(
-					'A Simple Product'
-				);
-				expect( responseJSON.status ).toEqual( 'approved' );
-				expect( responseJSON.reviewer ).toEqual( 'John Doe' );
-				expect( responseJSON.reviewer_email ).toEqual(
-					'john.doe@example.com'
-				);
-				expect( responseJSON.review ).toEqual( 'Nice simple product!' );
-				expect( responseJSON.rating ).toEqual( 5 );
-				expect( responseJSON.verified ).toEqual( false );
-			} );
-
-			test( 'cannot add a product review with invalid product_id', async ( {
-				request,
-			} ) => {
-				const response = await request.post(
-					'wp-json/wc/v3/products/reviews',
-					{
-						data: {
-							product_id: 999,
-							review: 'A non existent product!',
-							reviewer: 'John Do Not',
-							reviewer_email: 'john.do.not@example.com',
-							rating: 5,
-						},
-					}
-				);
-				const responseJSON = await response.json();
-
-				expect( response.status() ).toEqual( 404 );
-				expect( responseJSON.code ).toEqual(
-					'woocommerce_rest_product_invalid_id'
-				);
-				expect( responseJSON.message ).toEqual( 'Invalid product ID.' );
-			} );
-
-			test( 'cannot add a duplicate product review', async ( {
-				request,
-			} ) => {
-				const response = await request.post(
-					'wp-json/wc/v3/products/reviews',
-					{
-						data: {
-							product_id: reviewsTestProduct.id,
-							review: 'Nice simple product!',
-							reviewer: 'John Doe',
-							reviewer_email: 'john.doe@example.com',
-							rating: 5,
-						},
-					}
-				);
-				const responseJSON = await response.json();
-
-				expect( response.status() ).toEqual( 409 );
-				expect( responseJSON.code ).toEqual(
-					'woocommerce_rest_comment_duplicate'
-				);
-				expect( responseJSON.message ).toEqual(
-					'Duplicate comment detected; it looks as though you&#8217;ve already said that!'
-				);
-			} );
-
-			test( 'can retrieve a product review', async ( { request } ) => {
-				const response = await request.get(
-					`wp-json/wc/v3/products/reviews/${ productReviewId }`
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.id ).toEqual( productReviewId );
-				expect( responseJSON.product_id ).toEqual(
-					reviewsTestProduct.id
-				);
-				expect( responseJSON.product_name ).toEqual(
-					'A Simple Product'
-				);
-				expect( responseJSON.status ).toEqual( 'approved' );
-				expect( responseJSON.reviewer ).toEqual( 'John Doe' );
-				expect( responseJSON.reviewer_email ).toEqual(
-					'john.doe@example.com'
-				);
-				expect( responseJSON.review ).toEqual(
-					'<p>Nice simple product!</p>\n'
-				);
-				expect( responseJSON.rating ).toEqual( 5 );
-				expect( responseJSON.verified ).toEqual( false );
-			} );
-
-			test( 'can retrieve all product reviews', async ( { request } ) => {
-				// call API to retrieve all product reviews
-				const response = await request.get(
-					'./wp-json/wc/v3/products/reviews'
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( Array.isArray( responseJSON ) ).toBe( true );
-				expect( responseJSON.length ).toBeGreaterThan( 0 );
-			} );
-
-			test( 'can update a product review', async ( { request } ) => {
-				// call API to retrieve all product reviews
-				const response = await request.put(
-					`wp-json/wc/v3/products/reviews/${ productReviewId }`,
-					{
-						data: {
-							rating: 1,
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.id ).toEqual( productReviewId );
-				expect( responseJSON.product_id ).toEqual(
-					reviewsTestProduct.id
-				);
-				expect( responseJSON.product_name ).toEqual(
-					'A Simple Product'
-				);
-				expect( responseJSON.status ).toEqual( 'approved' );
-				expect( responseJSON.reviewer ).toEqual( 'John Doe' );
-				expect( responseJSON.reviewer_email ).toEqual(
-					'john.doe@example.com'
-				);
-				expect( responseJSON.review ).toEqual( 'Nice simple product!' );
-				expect( responseJSON.rating ).toEqual( 1 );
-				expect( responseJSON.verified ).toEqual( false );
-			} );
-
-			test( 'can permanently delete a product review', async ( {
-				request,
-			} ) => {
-				// Delete the product review.
-				const response = await request.delete(
-					`wp-json/wc/v3/products/reviews/${ productReviewId }`,
-					{
-						data: {
-							force: true,
-						},
-					}
-				);
-				expect( response.status() ).toEqual( 200 );
-
-				// Verify that the product review can no longer be retrieved.
-				const getDeletedProductReviewResponse = await request.get(
-					`wp-json/wc/v3/products/reviews/${ productReviewId }`
-				);
-				expect( getDeletedProductReviewResponse.status() ).toEqual(
-					404
-				);
-			} );
-
-			test( 'can batch update product reviews', async ( { request } ) => {
-				// Batch create product reviews.
-				const response = await request.post(
-					`wp-json/wc/v3/products/reviews/batch`,
-					{
-						data: {
-							create: [
-								{
-									product_id: reviewsTestProduct.id,
-									review: 'Nice product!',
-									reviewer: 'John Doe',
-									reviewer_email: 'john.doe@example.com',
-									rating: 4,
-								},
-								{
-									product_id: reviewsTestProduct.id,
-									review: 'I love this thing!',
-									reviewer: 'Jane Doe',
-									reviewer_email: 'Jane.doe@example.com',
-									rating: 5,
-								},
-							],
-						},
-					}
-				);
-				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.create[ 0 ].product_id ).toEqual(
-					reviewsTestProduct.id
-				);
-				expect( responseJSON.create[ 0 ].review ).toEqual(
-					'Nice product!'
-				);
-				expect( responseJSON.create[ 0 ].reviewer ).toEqual(
-					'John Doe'
-				);
-				expect( responseJSON.create[ 0 ].reviewer_email ).toEqual(
-					'john.doe@example.com'
-				);
-				expect( responseJSON.create[ 0 ].rating ).toEqual( 4 );
-
-				expect( responseJSON.create[ 1 ].product_id ).toEqual(
-					reviewsTestProduct.id
-				);
-				expect( responseJSON.create[ 1 ].review ).toEqual(
-					'I love this thing!'
-				);
-				expect( responseJSON.create[ 1 ].reviewer ).toEqual(
-					'Jane Doe'
-				);
-				expect( responseJSON.create[ 1 ].reviewer_email ).toEqual(
-					'Jane.doe@example.com'
-				);
-				expect( responseJSON.create[ 1 ].rating ).toEqual( 5 );
-				const review1Id = responseJSON.create[ 0 ].id;
-				const review2Id = responseJSON.create[ 1 ].id;
-
-				// Batch create a new review, update a review and delete another.
-				const responseBatchUpdate = await request.post(
-					`wp-json/wc/v3/products/reviews/batch`,
-					{
-						data: {
-							create: [
-								{
-									product_id: reviewsTestProduct.id,
-									review: 'Ok product.',
-									reviewer: 'Jack Doe',
-									reviewer_email: 'jack.doe@example.com',
-									rating: 3,
-								},
-							],
-							update: [
-								{
-									id: review1Id,
-									review: 'On reflection, I hate this thing!',
-									rating: 1,
-								},
-							],
-							delete: [ review2Id ],
-						},
-					}
-				);
-				const responseBatchUpdateJSON =
-					await responseBatchUpdate.json();
-				const review3Id = responseBatchUpdateJSON.create[ 0 ].id;
-				expect( response.status() ).toEqual( 200 );
-
-				const responseUpdatedReview = await request.get(
-					`wp-json/wc/v3/products/reviews/${ review1Id }`
-				);
-				const responseUpdatedReviewJSON =
-					await responseUpdatedReview.json();
-				expect( responseUpdatedReviewJSON.review ).toEqual(
-					'<p>On reflection, I hate this thing!</p>\n'
-				);
-				expect( responseUpdatedReviewJSON.rating ).toEqual( 1 );
-
-				// Verify that the deleted review can no longer be retrieved.
-				const getDeletedProductReviewResponse = await request.get(
-					`wp-json/wc/v3/products/reviews/${ review2Id }`
-				);
-				expect( getDeletedProductReviewResponse.status() ).toEqual(
-					404
-				);
-
-				// Batch delete the created tags
-				await request.post( `wp-json/wc/v3/products/reviews/batch`, {
+		test( 'can add a product review', async ( { request } ) => {
+			const response = await request.post(
+				'wp-json/wc/v3/products/reviews',
+				{
 					data: {
-						delete: [ review1Id, review3Id ],
+						product_id: reviewsTestProduct.id,
+						review: 'Nice simple product!',
+						reviewer: 'John Doe',
+						reviewer_email: 'john.doe@example.com',
+						rating: 5,
 					},
-				} );
+				}
+			);
+			const responseJSON = await response.json();
+			productReviewId = responseJSON.id;
+
+			expect( response.status() ).toEqual( 201 );
+			expect( typeof productReviewId ).toEqual( 'number' );
+			expect( responseJSON.id ).toEqual( productReviewId );
+			expect( responseJSON.product_name ).toEqual( 'A Simple Product' );
+			expect( responseJSON.status ).toEqual( 'approved' );
+			expect( responseJSON.reviewer ).toEqual( 'John Doe' );
+			expect( responseJSON.reviewer_email ).toEqual(
+				'john.doe@example.com'
+			);
+			expect( responseJSON.review ).toEqual( 'Nice simple product!' );
+			expect( responseJSON.rating ).toEqual( 5 );
+			expect( responseJSON.verified ).toEqual( false );
+		} );
+
+		test( 'cannot add a product review with invalid product_id', async ( {
+			request,
+		} ) => {
+			const response = await request.post(
+				'wp-json/wc/v3/products/reviews',
+				{
+					data: {
+						product_id: 999,
+						review: 'A non existent product!',
+						reviewer: 'John Do Not',
+						reviewer_email: 'john.do.not@example.com',
+						rating: 5,
+					},
+				}
+			);
+			const responseJSON = await response.json();
+
+			expect( response.status() ).toEqual( 404 );
+			expect( responseJSON.code ).toEqual(
+				'woocommerce_rest_product_invalid_id'
+			);
+			expect( responseJSON.message ).toEqual( 'Invalid product ID.' );
+		} );
+
+		test( 'cannot add a duplicate product review', async ( {
+			request,
+		} ) => {
+			const response = await request.post(
+				'wp-json/wc/v3/products/reviews',
+				{
+					data: {
+						product_id: reviewsTestProduct.id,
+						review: 'Nice simple product!',
+						reviewer: 'John Doe',
+						reviewer_email: 'john.doe@example.com',
+						rating: 5,
+					},
+				}
+			);
+			const responseJSON = await response.json();
+
+			expect( response.status() ).toEqual( 409 );
+			expect( responseJSON.code ).toEqual(
+				'woocommerce_rest_comment_duplicate'
+			);
+			expect( responseJSON.message ).toEqual(
+				'Duplicate comment detected; it looks as though you&#8217;ve already said that!'
+			);
+		} );
+
+		test( 'can retrieve a product review', async ( { request } ) => {
+			const response = await request.get(
+				`wp-json/wc/v3/products/reviews/${ productReviewId }`
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.id ).toEqual( productReviewId );
+			expect( responseJSON.product_id ).toEqual( reviewsTestProduct.id );
+			expect( responseJSON.product_name ).toEqual( 'A Simple Product' );
+			expect( responseJSON.status ).toEqual( 'approved' );
+			expect( responseJSON.reviewer ).toEqual( 'John Doe' );
+			expect( responseJSON.reviewer_email ).toEqual(
+				'john.doe@example.com'
+			);
+			expect( responseJSON.review ).toEqual(
+				'<p>Nice simple product!</p>\n'
+			);
+			expect( responseJSON.rating ).toEqual( 5 );
+			expect( responseJSON.verified ).toEqual( false );
+		} );
+
+		test( 'can retrieve all product reviews', async ( { request } ) => {
+			// call API to retrieve all product reviews
+			const response = await request.get(
+				'./wp-json/wc/v3/products/reviews'
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( Array.isArray( responseJSON ) ).toBe( true );
+			expect( responseJSON.length ).toBeGreaterThan( 0 );
+		} );
+
+		test( 'can update a product review', async ( { request } ) => {
+			// call API to retrieve all product reviews
+			const response = await request.put(
+				`wp-json/wc/v3/products/reviews/${ productReviewId }`,
+				{
+					data: {
+						rating: 1,
+					},
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.id ).toEqual( productReviewId );
+			expect( responseJSON.product_id ).toEqual( reviewsTestProduct.id );
+			expect( responseJSON.product_name ).toEqual( 'A Simple Product' );
+			expect( responseJSON.status ).toEqual( 'approved' );
+			expect( responseJSON.reviewer ).toEqual( 'John Doe' );
+			expect( responseJSON.reviewer_email ).toEqual(
+				'john.doe@example.com'
+			);
+			expect( responseJSON.review ).toEqual( 'Nice simple product!' );
+			expect( responseJSON.rating ).toEqual( 1 );
+			expect( responseJSON.verified ).toEqual( false );
+		} );
+
+		test( 'can permanently delete a product review', async ( {
+			request,
+		} ) => {
+			// Delete the product review.
+			const response = await request.delete(
+				`wp-json/wc/v3/products/reviews/${ productReviewId }`,
+				{
+					data: {
+						force: true,
+					},
+				}
+			);
+			expect( response.status() ).toEqual( 200 );
+
+			// Verify that the product review can no longer be retrieved.
+			const getDeletedProductReviewResponse = await request.get(
+				`wp-json/wc/v3/products/reviews/${ productReviewId }`
+			);
+			expect( getDeletedProductReviewResponse.status() ).toEqual( 404 );
+		} );
+
+		test( 'can batch update product reviews', async ( { request } ) => {
+			// Batch create product reviews.
+			const response = await request.post(
+				`wp-json/wc/v3/products/reviews/batch`,
+				{
+					data: {
+						create: [
+							{
+								product_id: reviewsTestProduct.id,
+								review: 'Nice product!',
+								reviewer: 'John Doe',
+								reviewer_email: 'john.doe@example.com',
+								rating: 4,
+							},
+							{
+								product_id: reviewsTestProduct.id,
+								review: 'I love this thing!',
+								reviewer: 'Jane Doe',
+								reviewer_email: 'Jane.doe@example.com',
+								rating: 5,
+							},
+						],
+					},
+				}
+			);
+			const responseJSON = await response.json();
+			expect( response.status() ).toEqual( 200 );
+			expect( responseJSON.create[ 0 ].product_id ).toEqual(
+				reviewsTestProduct.id
+			);
+			expect( responseJSON.create[ 0 ].review ).toEqual(
+				'Nice product!'
+			);
+			expect( responseJSON.create[ 0 ].reviewer ).toEqual( 'John Doe' );
+			expect( responseJSON.create[ 0 ].reviewer_email ).toEqual(
+				'john.doe@example.com'
+			);
+			expect( responseJSON.create[ 0 ].rating ).toEqual( 4 );
+
+			expect( responseJSON.create[ 1 ].product_id ).toEqual(
+				reviewsTestProduct.id
+			);
+			expect( responseJSON.create[ 1 ].review ).toEqual(
+				'I love this thing!'
+			);
+			expect( responseJSON.create[ 1 ].reviewer ).toEqual( 'Jane Doe' );
+			expect( responseJSON.create[ 1 ].reviewer_email ).toEqual(
+				'Jane.doe@example.com'
+			);
+			expect( responseJSON.create[ 1 ].rating ).toEqual( 5 );
+			const review1Id = responseJSON.create[ 0 ].id;
+			const review2Id = responseJSON.create[ 1 ].id;
+
+			// Batch create a new review, update a review and delete another.
+			const responseBatchUpdate = await request.post(
+				`wp-json/wc/v3/products/reviews/batch`,
+				{
+					data: {
+						create: [
+							{
+								product_id: reviewsTestProduct.id,
+								review: 'Ok product.',
+								reviewer: 'Jack Doe',
+								reviewer_email: 'jack.doe@example.com',
+								rating: 3,
+							},
+						],
+						update: [
+							{
+								id: review1Id,
+								review: 'On reflection, I hate this thing!',
+								rating: 1,
+							},
+						],
+						delete: [ review2Id ],
+					},
+				}
+			);
+			const responseBatchUpdateJSON = await responseBatchUpdate.json();
+			const review3Id = responseBatchUpdateJSON.create[ 0 ].id;
+			expect( response.status() ).toEqual( 200 );
+
+			const responseUpdatedReview = await request.get(
+				`wp-json/wc/v3/products/reviews/${ review1Id }`
+			);
+			const responseUpdatedReviewJSON =
+				await responseUpdatedReview.json();
+			expect( responseUpdatedReviewJSON.review ).toEqual(
+				'<p>On reflection, I hate this thing!</p>\n'
+			);
+			expect( responseUpdatedReviewJSON.rating ).toEqual( 1 );
+
+			// Verify that the deleted review can no longer be retrieved.
+			const getDeletedProductReviewResponse = await request.get(
+				`wp-json/wc/v3/products/reviews/${ review2Id }`
+			);
+			expect( getDeletedProductReviewResponse.status() ).toEqual( 404 );
+
+			// Batch delete the created tags
+			await request.post( `wp-json/wc/v3/products/reviews/batch`, {
+				data: {
+					delete: [ review1Id, review3Id ],
+				},
 			} );
-		}
-	);
+		} );
+	} );
 
 	test.describe( 'Product shipping classes tests: CRUD', () => {
 		let productShippingClassId;

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -2,9 +2,9 @@ const {
 	test: baseTest,
 	expect,
 } = require( '../../../fixtures/api-tests-fixtures' );
-const { BASE_URL } = process.env;
+const { IS_WPCOM, IS_PRESSABLE } = process.env;
 const { admin } = require( '../../../test-data/data' );
-const shouldSkip = BASE_URL !== undefined;
+const shouldSkip = IS_WPCOM || IS_PRESSABLE;
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -2,9 +2,9 @@ const {
 	test: baseTest,
 	expect,
 } = require( '../../../fixtures/api-tests-fixtures' );
-const { IS_WPCOM, IS_PRESSABLE } = process.env;
+const { BASE_URL } = process.env;
 const { admin } = require( '../../../test-data/data' );
-const shouldSkip = IS_WPCOM || IS_PRESSABLE;
+const shouldSkip = BASE_URL !== undefined;
 
 /**
  * Internal dependencies
@@ -1327,7 +1327,7 @@ test.describe( 'Products API tests: CRUD', () => {
 			);
 			expect( response.status() ).toEqual( 200 );
 
-			// if we're running on CI, then skip -- because objects are cached and they don't disappear instantly.
+			// if we're running against other environments, then skip -- because objects could be cached and they don't disappear instantly.
 			// eslint-disable-next-line playwright/no-conditional-in-test
 			if ( ! shouldSkip ) {
 				// Verify that the product variation can no longer be retrieved.
@@ -1417,7 +1417,7 @@ test.describe( 'Products API tests: CRUD', () => {
 				'35.99'
 			);
 
-			// if we're running on CI, then skip -- because objects are cached and they don't disappear instantly.
+			// if we're running against other environments, then skip -- because objects could be cached and they don't disappear instantly.
 			// eslint-disable-next-line playwright/no-conditional-in-test
 			if ( ! shouldSkip ) {
 				// Verify that the deleted product variation can no longer be retrieved.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

The `describe( 'Product review tests: CRUD' )` suite passed in WPCOM and Pressable immediately after removing the skip tags, so no further changes were done in here.

In `test( 'can batch update product shipping classes' )` I suffixed the shipping classes with a random string to ensure uniqueness on every run. The reason why it fails on WPCOM and Pressable is because it tries to create duplicates of already existing shipping classes, possibly those that were left over by previous failed runs.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure CI checks pass.
2. Run on WPCOM and Pressable, make sure it passes.
```bash
export E2E_ENV_KEY="..."
pnpm test:e2e:wpcom products-crud.test.js
pnpm test:e2e:pressable products-crud.test.js 
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Unskip products-crud.test.js on WPCOM and Pressable.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
