### PR TITLE
[API tests] Unskip `product-list` on WPCOM and Pressable

### DIFF
--- a/plugins/woocommerce/changelog/55359-dev-test-api-unskip-product-list
+++ b/plugins/woocommerce/changelog/55359-dev-test-api-unskip-product-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip product-list.test.js on WPCOM and Pressable

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -2770,7 +2770,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result2JSON ).toEqual( expect.arrayContaining( after ) );
 		} );
 
-		test.only( 'attributes', async ( { request } ) => {
+		test( 'attributes', async ( { request } ) => {
 			const red = sampleData.attributes.colors.find(
 				( term ) => term.name === 'Red'
 			);
@@ -2827,7 +2827,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result2JSON ).toHaveLength( 0 );
 		} );
 
-		test.only( 'shipping class', async ( { request } ) => {
+		test( 'shipping class', async ( { request } ) => {
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					shipping_class: sampleData.shippingClasses.freightJSON.id,
@@ -2867,7 +2867,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( resultJSON[ 0 ].name ).toBe( `T-Shirt ${ RAND_NUM }` );
 		} );
 
-		test.only( 'tags', async ( { request } ) => {
+		test( 'tags', async ( { request } ) => {
 			const coolProducts = [
 				expect.objectContaining( {
 					name: `Sunglasses ${ RAND_NUM }`,
@@ -2927,23 +2927,23 @@ test.describe( 'Products API tests: List All Products', () => {
 		test.describe( 'orderby', () => {
 			const productNamesAsc = [
 				`Album ${ RAND_NUM }`,
-				`Beanie with Logo ${ RAND_NUM }`,
 				`Beanie ${ RAND_NUM }`,
+				`Beanie with Logo ${ RAND_NUM }`,
 				`Belt ${ RAND_NUM }`,
 				`Cap ${ RAND_NUM }`,
 				`Child Product ${ RAND_NUM }`,
+				`Hoodie ${ RAND_NUM }`,
 				`Hoodie with Logo ${ RAND_NUM }`,
 				`Hoodie with Pocket ${ RAND_NUM }`,
 				`Hoodie with Zipper ${ RAND_NUM }`,
-				`Hoodie ${ RAND_NUM }`,
 				`Logo Collection ${ RAND_NUM }`,
 				`Long Sleeve Tee ${ RAND_NUM }`,
 				`Parent Product ${ RAND_NUM }`,
 				`Polo ${ RAND_NUM }`,
 				`Single ${ RAND_NUM }`,
 				`Sunglasses ${ RAND_NUM }`,
-				`T-Shirt with Logo ${ RAND_NUM }`,
 				`T-Shirt ${ RAND_NUM }`,
+				`T-Shirt with Logo ${ RAND_NUM }`,
 				`V-Neck T-Shirt ${ RAND_NUM }`,
 				`WordPress Pennant ${ RAND_NUM }`,
 			];

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -1,11 +1,9 @@
-const {
-	test,
-	expect,
-	tags: pwTags,
-} = require( '../../../fixtures/api-tests-fixtures' );
+const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
+const { faker } = require( '@faker-js/faker' );
 
 test.describe( 'Products API tests: List All Products', () => {
 	const PRODUCTS_COUNT = 20;
+	const RAND_NUM = faker.number.int( { min: 1000, max: 9999 } );
 	let sampleData;
 
 	test.beforeAll( async ( { request } ) => {
@@ -14,7 +12,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Clothingxxx',
+						name: `Clothing${ RAND_NUM }`,
 					},
 				}
 			);
@@ -24,7 +22,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Accessoriesxxx',
+						name: `Accessories${ RAND_NUM }`,
 						parent: clothingJSON.id,
 					},
 				}
@@ -34,7 +32,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Hoodiesxxx',
+						name: `Hoodies${ RAND_NUM }`,
 						parent: clothingJSON.id,
 					},
 				}
@@ -44,7 +42,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Tshirtsxxx',
+						name: `Tshirts${ RAND_NUM }`,
 						parent: clothingJSON.id,
 					},
 				}
@@ -55,7 +53,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Decorxxx',
+						name: `Decor${ RAND_NUM }`,
 					},
 				}
 			);
@@ -65,7 +63,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Musicxxx',
+						name: `Music${ RAND_NUM }`,
 					},
 				}
 			);
@@ -87,7 +85,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/attributes',
 				{
 					data: {
-						name: 'Colorxxx',
+						name: `Color${ RAND_NUM }`,
 					},
 				}
 			);
@@ -98,7 +96,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/attributes',
 				{
 					data: {
-						name: 'Sizexxx',
+						name: `Size${ RAND_NUM }`,
 					},
 				}
 			);
@@ -142,10 +140,9 @@ test.describe( 'Products API tests: List All Products', () => {
 		};
 
 		const createSampleTags = async () => {
-			//const { body: cool } = await createProductTag( 'Cool' );
 			const cool = await request.post( './wp-json/wc/v3/products/tags', {
 				data: {
-					name: 'Coolxxx',
+					name: `Cool${ RAND_NUM }`,
 				},
 			} );
 			const coolJSON = await cool.json();
@@ -161,7 +158,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				'./wp-json/wc/v3/products/shipping_classes',
 				{
 					data: {
-						name: 'Freightxxx',
+						name: `Freight${ RAND_NUM }`,
 					},
 				}
 			);
@@ -177,20 +174,20 @@ test.describe( 'Products API tests: List All Products', () => {
 			let reducedRate = await request.get(
 				'./wp-json/wc/v3/taxes/classes/reduced-rate'
 			);
-			let reducedRateJSON = await reducedRate.json();
-			expect( Array.isArray( reducedRateJSON ) ).toBe( true );
+			const reducedRateStatus = reducedRate.status();
 
 			//if tax class does not exist then create it
-			if ( reducedRateJSON.length < 1 ) {
+			if ( reducedRateStatus === 404 ) {
 				reducedRate = await request.post(
 					'./wp-json/wc/v3/taxes/classes',
 					{
 						data: {
 							name: 'Reduced Rate',
+							slug: 'reduced-rate',
 						},
 					}
 				);
-				reducedRateJSON = await reducedRate.json();
+				const reducedRateJSON = await reducedRate.json();
 				return { reducedRateJSON };
 			}
 
@@ -216,7 +213,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					data: {
 						create: [
 							{
-								name: 'Beanie with Logo xxx',
+								name: `Beanie with Logo ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-01T15:50:20',
 								type: 'simple',
 								status: 'publish',
@@ -289,7 +286,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'T-Shirt with Logo xxx',
+								name: `T-Shirt with Logo ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-02T15:50:20',
 								type: 'simple',
 								status: 'publish',
@@ -362,7 +359,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Single xxx',
+								name: `Single ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-03T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -433,7 +430,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Album xxx',
+								name: `Album ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-04T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -509,7 +506,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Polo xxx',
+								name: `Polo ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-05T15:50:19',
 								type: 'simple',
 								status: 'pending',
@@ -582,7 +579,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Long Sleeve Tee xxx',
+								name: `Long Sleeve Tee ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-06T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -624,7 +621,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								},
 								shipping_required: true,
 								shipping_taxable: true,
-								shipping_class: 'freightxxx',
+								shipping_class: `freight${ RAND_NUM }`,
 								reviews_allowed: true,
 								average_rating: '0.00',
 								rating_count: 0,
@@ -655,7 +652,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Hoodie with Zipper xxx',
+								name: `Hoodie with Zipper ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-07T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -2237,7 +2234,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		await deleteSampleData( sampleData );
 	}, 10000 );
 
-	test.describe.only( 'List all products', () => {
+	test.describe( 'List all products', () => {
 		test( 'defaults', async ( { request } ) => {
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
@@ -2522,7 +2519,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		test( 'featured', async ( { request } ) => {
 			const featured = [
 				expect.objectContaining( {
-					name: 'Hoodie with Zipper xxx',
+					name: `Hoodie with Zipper ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
 					name: 'Hoodie with Pocket xxx',
@@ -2570,7 +2567,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			];
 			const hoodies = [
 				expect.objectContaining( {
-					name: 'Hoodie with Zipper xxx',
+					name: `Hoodie with Zipper ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
 					name: 'Hoodie with Pocket xxx',
@@ -2671,7 +2668,9 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result1JSON = await result1.json();
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON ).toHaveLength( 1 );
-			expect( result1JSON[ 0 ].name ).toBe( 'Long Sleeve Tee xxx' );
+			expect( result1JSON[ 0 ].name ).toBe(
+				`Long Sleeve Tee ${ RAND_NUM }`
+			);
 			expect( result1JSON[ 0 ].price ).toBe( '25' );
 
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
@@ -2708,7 +2707,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		test( 'before / after', async ( { request } ) => {
 			const before = [
 				expect.objectContaining( {
-					name: 'Album xxx',
+					name: `Album ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
 					name: 'Single xxx',
@@ -2761,7 +2760,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result2JSON ).toEqual( expect.arrayContaining( after ) );
 		} );
 
-		test( 'attributes', async ( { request } ) => {
+		test.only( 'attributes', async ( { request } ) => {
 			const red = sampleData.attributes.colors.find(
 				( term ) => term.name === 'Red'
 			);
@@ -2806,7 +2805,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result1JSON = await result1.json();
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON ).toHaveLength( 1 );
-			expect( result1JSON[ 0 ].name ).toBe( 'Polo xxx' );
+			expect( result1JSON[ 0 ].name ).toBe( `Polo ${ RAND_NUM }` );
 
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
@@ -2818,7 +2817,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result2JSON ).toHaveLength( 0 );
 		} );
 
-		test( 'shipping class', async ( { request } ) => {
+		test.only( 'shipping class', async ( { request } ) => {
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					shipping_class: sampleData.shippingClasses.freightJSON.id,
@@ -2827,7 +2826,9 @@ test.describe( 'Products API tests: List All Products', () => {
 			const resultJSON = await result.json();
 			expect( result.status() ).toEqual( 200 );
 			expect( resultJSON ).toHaveLength( 1 );
-			expect( resultJSON[ 0 ].name ).toBe( 'Long Sleeve Tee xxx' );
+			expect( resultJSON[ 0 ].name ).toBe(
+				`Long Sleeve Tee ${ RAND_NUM }`
+			);
 		} );
 
 		test( 'tax class', async ( { request } ) => {
@@ -2856,7 +2857,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( resultJSON[ 0 ].name ).toBe( 'T-Shirt xxx' );
 		} );
 
-		test( 'tags', async ( { request } ) => {
+		test.only( 'tags', async ( { request } ) => {
 			const coolProducts = [
 				expect.objectContaining( {
 					name: 'Sunglasses xxx',
@@ -2913,7 +2914,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 		test.describe( 'orderby', () => {
 			const productNamesAsc = [
-				'Album xxx',
+				`Album ${ RAND_NUM }`,
 				'Beanie with Logo xxx',
 				'Beanie xxx',
 				'Belt xxx',
@@ -2921,12 +2922,12 @@ test.describe( 'Products API tests: List All Products', () => {
 				'Child Product xxx',
 				'Hoodie with Logo xxx',
 				'Hoodie with Pocket xxx',
-				'Hoodie with Zipper xxx',
+				`Hoodie with Zipper ${ RAND_NUM }`,
 				'Hoodie xxx',
 				'Logo Collection xxx',
-				'Long Sleeve Tee xxx',
+				`Long Sleeve Tee ${ RAND_NUM }`,
 				'Parent Product xxx',
-				'Polo xxx',
+				`Polo ${ RAND_NUM }`,
 				'Single xxx',
 				'Sunglasses xxx',
 				'T-Shirt with Logo xxx',
@@ -3063,8 +3064,10 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			test( 'slug orderby', async ( { request } ) => {
 				const productNamesBySlugAsc = [
-					'Polo xxx', // The Polo isn't published so it has an empty slug.
-					...productNamesAsc.filter( ( p ) => p !== 'Polo xxx' ),
+					`Polo ${ RAND_NUM }`, // The Polo isn't published so it has an empty slug.
+					...productNamesAsc.filter(
+						( p ) => p !== `Polo ${ RAND_NUM }`
+					),
 				];
 				const productNamesBySlugDesc = [
 					...productNamesBySlugAsc,
@@ -3109,7 +3112,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					'Child Product xxx',
 					'Single xxx',
 					'WordPress Pennant xxx',
-					'Album xxx',
+					`Album ${ RAND_NUM }`,
 					'V-Neck T-Shirt xxx',
 					'Cap xxx',
 					'Beanie with Logo xxx',
@@ -3117,11 +3120,11 @@ test.describe( 'Products API tests: List All Products', () => {
 					'Beanie xxx',
 					'T-Shirt xxx',
 					'Logo Collection xxx',
-					'Polo xxx',
-					'Long Sleeve Tee xxx',
+					`Polo ${ RAND_NUM }`,
+					`Long Sleeve Tee ${ RAND_NUM }`,
 					'Hoodie with Pocket xxx',
 					'Hoodie xxx',
-					'Hoodie with Zipper xxx',
+					`Hoodie with Zipper ${ RAND_NUM }`,
 					'Hoodie with Logo xxx',
 					'Belt xxx',
 					'Sunglasses xxx',
@@ -3153,17 +3156,17 @@ test.describe( 'Products API tests: List All Products', () => {
 					'Hoodie xxx',
 					'Logo Collection xxx',
 					'Hoodie with Logo xxx',
-					'Hoodie with Zipper xxx',
+					`Hoodie with Zipper ${ RAND_NUM }`,
 					'Hoodie with Pocket xxx',
-					'Long Sleeve Tee xxx',
+					`Long Sleeve Tee ${ RAND_NUM }`,
 					'V-Neck T-Shirt xxx',
-					'Polo xxx',
+					`Polo ${ RAND_NUM }`,
 					'T-Shirt xxx',
 					'Beanie xxx',
 					'T-Shirt with Logo xxx',
 					'Beanie with Logo xxx',
 					'Cap xxx',
-					'Album xxx',
+					`Album ${ RAND_NUM }`,
 					'WordPress Pennant xxx',
 					'Single xxx',
 					'Child Product xxx',

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -2237,1170 +2237,1077 @@ test.describe( 'Products API tests: List All Products', () => {
 		await deleteSampleData( sampleData );
 	}, 10000 );
 
-	test.describe(
-		'List all products',
-		{ tag: [ pwTags.SKIP_ON_PRESSABLE, pwTags.SKIP_ON_WPCOM ] },
-		() => {
-			test( 'defaults', async ( { request } ) => {
-				const result = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						search: 'xxx',
-					},
-				} );
-
-				expect( result.status() ).toEqual( 200 );
-				expect( result.headers()[ 'x-wp-total' ] ).toEqual(
-					PRODUCTS_COUNT.toString()
-				);
-				expect( result.headers()[ 'x-wp-totalpages' ] ).toEqual( '2' );
+	test.describe.only( 'List all products', () => {
+		test( 'defaults', async ( { request } ) => {
+			const result = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					search: 'xxx',
+				},
 			} );
 
-			test( 'pagination', async ( { request } ) => {
-				const pageSize = 6;
-				const page1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						per_page: pageSize,
-						search: 'xxx',
-					},
-				} );
-				const page1JSON = await page1.json();
-				const page2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						per_page: pageSize,
-						page: 2,
-						search: 'xxx',
-					},
-				} );
-				const page2JSON = await page2.json();
-				expect( page1.status() ).toEqual( 200 );
-				expect( page2.status() ).toEqual( 200 );
+			expect( result.status() ).toEqual( 200 );
+			expect( result.headers()[ 'x-wp-total' ] ).toEqual(
+				PRODUCTS_COUNT.toString()
+			);
+			expect( result.headers()[ 'x-wp-totalpages' ] ).toEqual( '2' );
+		} );
 
-				// Verify total page count.
-				expect( page1.headers()[ 'x-wp-total' ] ).toEqual(
-					PRODUCTS_COUNT.toString()
-				);
-				expect( page1.headers()[ 'x-wp-totalpages' ] ).toEqual( '4' );
-
-				// Verify we get pageSize'd arrays.
-				expect( Array.isArray( page1JSON ) ).toBe( true );
-				expect( Array.isArray( page2JSON ) ).toBe( true );
-				expect( page1JSON ).toHaveLength( pageSize );
-				expect( page2JSON ).toHaveLength( pageSize );
-
-				// Ensure all of the product IDs are unique (no page overlap).
-				const allProductIds = page1JSON
-					.concat( page2JSON )
-					.reduce( ( acc, product ) => {
-						acc[ product.id ] = 1;
-						return acc;
-					}, {} );
-				expect( Object.keys( allProductIds ) ).toHaveLength(
-					pageSize * 2
-				);
-
-				// Verify that offset takes precedent over page number.
-				const page2Offset = await request.get(
-					'wp-json/wc/v3/products',
-					{
-						params: {
-							per_page: pageSize,
-							page: 2,
-							offset: pageSize + 1,
-							search: 'xxx',
-						},
-					}
-				);
-				const page2OffsetJSON = await page2Offset.json();
-				// The offset pushes the result set 1 product past the start of page 2.
-				expect( page2OffsetJSON ).toEqual(
-					expect.not.arrayContaining( [
-						expect.objectContaining( {
-							id: page2JSON[ 0 ].id,
-						} ),
-					] )
-				);
-				expect( page2OffsetJSON[ 0 ].id ).toEqual( page2JSON[ 1 ].id );
-
-				// Verify the last page only has 2 products as we expect.
-				const lastPage = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						per_page: pageSize,
-						page: 4,
-						search: 'xxx',
-					},
-				} );
-				const lastPageJSON = await lastPage.json();
-				expect( Array.isArray( lastPageJSON ) ).toBe( true );
-				expect( lastPageJSON ).toHaveLength( 2 );
-
-				// Verify a page outside the total page count is empty.
-				const page6 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						per_page: pageSize,
-						page: 6,
-						search: 'xxx',
-					},
-				} );
-				const page6JSON = await page6.json();
-				expect( Array.isArray( page6JSON ) ).toBe( true );
-				expect( page6JSON ).toHaveLength( 0 );
+		test( 'pagination', async ( { request } ) => {
+			const pageSize = 6;
+			const page1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: pageSize,
+					search: 'xxx',
+				},
 			} );
-
-			test( 'search', async ( { request } ) => {
-				// Match in the short description.
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						search: 'external',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON.length ).toBeGreaterThanOrEqual( 1 );
-				expect( result1JSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							name: 'WordPress Pennant xxx',
-						} ),
-					] )
-				);
-
-				// Match in the product name.
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						search: 'pocket xxx',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 1 );
-				expect( result2JSON[ 0 ].name ).toBe(
-					'Hoodie with Pocket xxx'
-				);
+			const page1JSON = await page1.json();
+			const page2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: pageSize,
+					page: 2,
+					search: 'xxx',
+				},
 			} );
+			const page2JSON = await page2.json();
+			expect( page1.status() ).toEqual( 200 );
+			expect( page2.status() ).toEqual( 200 );
 
-			test( 'inclusion / exclusion', async ( { request } ) => {
-				const allProducts = await request.get(
-					'wp-json/wc/v3/products',
-					{
-						params: {
-							per_page: 20,
-							search: 'xxx',
-						},
-					}
-				);
-				const allProductsJSON = await allProducts.json();
-				expect( allProducts.status() ).toEqual( 200 );
-				const allProductIds = allProductsJSON.map(
-					( product ) => product.id
-				);
-				expect( allProductIds ).toHaveLength( PRODUCTS_COUNT );
+			// Verify total page count.
+			expect( page1.headers()[ 'x-wp-total' ] ).toEqual(
+				PRODUCTS_COUNT.toString()
+			);
+			expect( page1.headers()[ 'x-wp-totalpages' ] ).toEqual( '4' );
 
-				const productsToFilter = [
-					allProductIds[ 2 ],
-					allProductIds[ 4 ],
-					allProductIds[ 7 ],
-					allProductIds[ 13 ],
-				];
+			// Verify we get pageSize'd arrays.
+			expect( Array.isArray( page1JSON ) ).toBe( true );
+			expect( Array.isArray( page2JSON ) ).toBe( true );
+			expect( page1JSON ).toHaveLength( pageSize );
+			expect( page2JSON ).toHaveLength( pageSize );
 
-				const included = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						per_page: 20,
-						include: productsToFilter.join( ',' ),
-					},
-				} );
-				const includedJSON = await included.json();
-				expect( included.status() ).toEqual( 200 );
-				expect( includedJSON ).toHaveLength( productsToFilter.length );
-				expect( includedJSON ).toEqual(
-					expect.arrayContaining(
-						productsToFilter.map( ( id ) =>
-							expect.objectContaining( {
-								id,
-							} )
-						)
-					)
-				);
+			// Ensure all of the product IDs are unique (no page overlap).
+			const allProductIds = page1JSON
+				.concat( page2JSON )
+				.reduce( ( acc, product ) => {
+					acc[ product.id ] = 1;
+					return acc;
+				}, {} );
+			expect( Object.keys( allProductIds ) ).toHaveLength( pageSize * 2 );
 
-				const excluded = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						per_page: 20,
-						exclude: productsToFilter.join( ',' ),
-					},
-				} );
-				const excludedJSON = await excluded.json();
-				expect( excluded.status() ).toEqual( 200 );
-				expect( excludedJSON.length ).toBeGreaterThanOrEqual(
-					Number( PRODUCTS_COUNT - productsToFilter.length )
-				);
-				expect( excludedJSON ).toEqual(
-					expect.not.arrayContaining(
-						productsToFilter.map( ( id ) =>
-							expect.objectContaining( {
-								id,
-							} )
-						)
-					)
-				);
+			// Verify that offset takes precedent over page number.
+			const page2Offset = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: pageSize,
+					page: 2,
+					offset: pageSize + 1,
+					search: 'xxx',
+				},
 			} );
-
-			test( 'slug', async ( { request } ) => {
-				// Match by slug.
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						slug: 't-shirt-with-logo-xxx',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 1 );
-				expect( result1JSON[ 0 ].slug ).toBe( 't-shirt-with-logo-xxx' );
-
-				// No matches
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						slug: 'no-product-with-this-slug',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 0 );
-			} );
-
-			test( 'sku', async ( { request } ) => {
-				// Match by SKU.
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						sku: 'woo-sunglasses-product',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 1 );
-				expect( result1JSON[ 0 ].sku ).toBe( 'woo-sunglasses-product' );
-
-				// No matches
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						sku: 'no-product-with-this-sku',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 0 );
-			} );
-
-			test( 'type', async ( { request } ) => {
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						type: 'simple',
-						search: 'xxx',
-					},
-				} );
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1.headers()[ 'x-wp-total' ] ).toEqual( '16' );
-
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						type: 'external',
-						search: 'xxx',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 1 );
-				expect( result2JSON[ 0 ].name ).toBe( 'WordPress Pennant xxx' );
-
-				const result3 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						type: 'variable',
-						search: 'xxx',
-					},
-				} );
-				const result3JSON = await result3.json();
-				expect( result3.status() ).toEqual( 200 );
-				expect( result3JSON ).toHaveLength( 2 );
-
-				const result4 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						type: 'grouped',
-						search: 'xxx',
-					},
-				} );
-				const result4JSON = await result4.json();
-				expect( result4.status() ).toEqual( 200 );
-				expect( result4JSON ).toHaveLength( 1 );
-				expect( result4JSON[ 0 ].name ).toBe( 'Logo Collection xxx' );
-			} );
-
-			test( 'featured', async ( { request } ) => {
-				const featured = [
+			const page2OffsetJSON = await page2Offset.json();
+			// The offset pushes the result set 1 product past the start of page 2.
+			expect( page2OffsetJSON ).toEqual(
+				expect.not.arrayContaining( [
 					expect.objectContaining( {
-						name: 'Hoodie with Zipper xxx',
+						id: page2JSON[ 0 ].id,
 					} ),
-					expect.objectContaining( {
-						name: 'Hoodie with Pocket xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Sunglasses xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Cap xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'V-Neck T-Shirt xxx',
-					} ),
-				];
+				] )
+			);
+			expect( page2OffsetJSON[ 0 ].id ).toEqual( page2JSON[ 1 ].id );
 
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						featured: true,
-						search: 'xxx',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( featured.length );
-				expect( result1JSON ).toEqual(
-					expect.arrayContaining( featured )
-				);
-
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						featured: false,
-						search: 'xxx',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toEqual(
-					expect.not.arrayContaining( featured )
-				);
+			// Verify the last page only has 2 products as we expect.
+			const lastPage = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: pageSize,
+					page: 4,
+					search: 'xxx',
+				},
 			} );
+			const lastPageJSON = await lastPage.json();
+			expect( Array.isArray( lastPageJSON ) ).toBe( true );
+			expect( lastPageJSON ).toHaveLength( 2 );
 
-			test(
-				'categories',
-				{ tag: pwTags.SKIP_ON_WPCOM },
-				async ( { request } ) => {
-					const accessory = [
-						expect.objectContaining( {
-							name: 'Beanie xxx',
-						} ),
-					];
-					const hoodies = [
-						expect.objectContaining( {
-							name: 'Hoodie with Zipper xxx',
-						} ),
-						expect.objectContaining( {
-							name: 'Hoodie with Pocket xxx',
-						} ),
-						expect.objectContaining( {
-							name: 'Hoodie with Logo xxx',
-						} ),
-						expect.objectContaining( {
-							name: 'Hoodie xxx',
-						} ),
-					];
+			// Verify a page outside the total page count is empty.
+			const page6 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: pageSize,
+					page: 6,
+					search: 'xxx',
+				},
+			} );
+			const page6JSON = await page6.json();
+			expect( Array.isArray( page6JSON ) ).toBe( true );
+			expect( page6JSON ).toHaveLength( 0 );
+		} );
 
-					// Verify that subcategories are included.
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								per_page: 20,
-								category: sampleData.categories.clothingJSON.id,
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-					expect( result1.status() ).toEqual( 200 );
-					expect( result1JSON ).toEqual(
-						expect.arrayContaining( accessory )
-					);
-					expect( result1JSON ).toEqual(
-						expect.arrayContaining( hoodies )
-					);
-
-					// Verify sibling categories are not.
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								category: sampleData.categories.hoodiesJSON.id,
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-					expect( result2JSON ).toEqual(
-						expect.not.arrayContaining( accessory )
-					);
-					expect( result2JSON ).toEqual(
-						expect.arrayContaining( hoodies )
-					);
-				}
+		test( 'search', async ( { request } ) => {
+			// Match in the short description.
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					search: 'external',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON.length ).toBeGreaterThanOrEqual( 1 );
+			expect( result1JSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						name: 'WordPress Pennant xxx',
+					} ),
+				] )
 			);
 
-			test( 'on sale', async ( { request } ) => {
-				const onSale = [
-					expect.objectContaining( {
-						name: 'Beanie with Logo xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Hoodie with Pocket xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Single xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Cap xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Belt xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Beanie xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Hoodie xxx',
-					} ),
-				];
-
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						on_sale: true,
-						search: 'xxx',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( onSale.length );
-				expect( result1JSON ).toEqual(
-					expect.arrayContaining( onSale )
-				);
-
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						on_sale: false,
-						search: 'xxx',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toEqual(
-					expect.not.arrayContaining( onSale )
-				);
+			// Match in the product name.
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					search: 'pocket xxx',
+				},
 			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 1 );
+			expect( result2JSON[ 0 ].name ).toBe( 'Hoodie with Pocket xxx' );
+		} );
 
-			test( 'price', async ( { request } ) => {
-				const result1 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						min_price: 21,
-						max_price: 28,
-						search: 'xxx',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 1 );
-				expect( result1JSON[ 0 ].name ).toBe( 'Long Sleeve Tee xxx' );
-				expect( result1JSON[ 0 ].price ).toBe( '25' );
+		test( 'inclusion / exclusion', async ( { request } ) => {
+			const allProducts = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: 20,
+					search: 'xxx',
+				},
+			} );
+			const allProductsJSON = await allProducts.json();
+			expect( allProducts.status() ).toEqual( 200 );
+			const allProductIds = allProductsJSON.map(
+				( product ) => product.id
+			);
+			expect( allProductIds ).toHaveLength( PRODUCTS_COUNT );
 
-				const result2 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						max_price: 5,
-						search: 'xxx',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 1 );
-				expect( result2JSON[ 0 ].name ).toBe( 'Single xxx' );
-				expect( result2JSON[ 0 ].price ).toBe( '2' );
+			const productsToFilter = [
+				allProductIds[ 2 ],
+				allProductIds[ 4 ],
+				allProductIds[ 7 ],
+				allProductIds[ 13 ],
+			];
 
-				const result3 = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						min_price: 5,
-						order: 'asc',
-						orderby: 'price',
-						search: 'xxx',
-					},
-				} );
-				const result3JSON = await result3.json();
-				expect( result3.status() ).toEqual( 200 );
-				expect( result3JSON ).toEqual(
-					expect.not.arrayContaining( [
+			const included = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: 20,
+					include: productsToFilter.join( ',' ),
+				},
+			} );
+			const includedJSON = await included.json();
+			expect( included.status() ).toEqual( 200 );
+			expect( includedJSON ).toHaveLength( productsToFilter.length );
+			expect( includedJSON ).toEqual(
+				expect.arrayContaining(
+					productsToFilter.map( ( id ) =>
 						expect.objectContaining( {
-							name: 'Single xxx',
-						} ),
-					] )
-				);
-			} );
+							id,
+						} )
+					)
+				)
+			);
 
-			test( 'before / after', async ( { request } ) => {
-				const before = [
-					expect.objectContaining( {
-						name: 'Album xxx',
-					} ),
+			const excluded = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: 20,
+					exclude: productsToFilter.join( ',' ),
+				},
+			} );
+			const excludedJSON = await excluded.json();
+			expect( excluded.status() ).toEqual( 200 );
+			expect( excludedJSON.length ).toBeGreaterThanOrEqual(
+				Number( PRODUCTS_COUNT - productsToFilter.length )
+			);
+			expect( excludedJSON ).toEqual(
+				expect.not.arrayContaining(
+					productsToFilter.map( ( id ) =>
+						expect.objectContaining( {
+							id,
+						} )
+					)
+				)
+			);
+		} );
+
+		test( 'slug', async ( { request } ) => {
+			// Match by slug.
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					slug: 't-shirt-with-logo-xxx',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 1 );
+			expect( result1JSON[ 0 ].slug ).toBe( 't-shirt-with-logo-xxx' );
+
+			// No matches
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					slug: 'no-product-with-this-slug',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 0 );
+		} );
+
+		test( 'sku', async ( { request } ) => {
+			// Match by SKU.
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					sku: 'woo-sunglasses-product',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 1 );
+			expect( result1JSON[ 0 ].sku ).toBe( 'woo-sunglasses-product' );
+
+			// No matches
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					sku: 'no-product-with-this-sku',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 0 );
+		} );
+
+		test( 'type', async ( { request } ) => {
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					type: 'simple',
+					search: 'xxx',
+				},
+			} );
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1.headers()[ 'x-wp-total' ] ).toEqual( '16' );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					type: 'external',
+					search: 'xxx',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 1 );
+			expect( result2JSON[ 0 ].name ).toBe( 'WordPress Pennant xxx' );
+
+			const result3 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					type: 'variable',
+					search: 'xxx',
+				},
+			} );
+			const result3JSON = await result3.json();
+			expect( result3.status() ).toEqual( 200 );
+			expect( result3JSON ).toHaveLength( 2 );
+
+			const result4 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					type: 'grouped',
+					search: 'xxx',
+				},
+			} );
+			const result4JSON = await result4.json();
+			expect( result4.status() ).toEqual( 200 );
+			expect( result4JSON ).toHaveLength( 1 );
+			expect( result4JSON[ 0 ].name ).toBe( 'Logo Collection xxx' );
+		} );
+
+		test( 'featured', async ( { request } ) => {
+			const featured = [
+				expect.objectContaining( {
+					name: 'Hoodie with Zipper xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie with Pocket xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Sunglasses xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Cap xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'V-Neck T-Shirt xxx',
+				} ),
+			];
+
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					featured: true,
+					search: 'xxx',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( featured.length );
+			expect( result1JSON ).toEqual( expect.arrayContaining( featured ) );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					featured: false,
+					search: 'xxx',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining( featured )
+			);
+		} );
+
+		test( 'categories', async ( { request } ) => {
+			const accessory = [
+				expect.objectContaining( {
+					name: 'Beanie xxx',
+				} ),
+			];
+			const hoodies = [
+				expect.objectContaining( {
+					name: 'Hoodie with Zipper xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie with Pocket xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie with Logo xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie xxx',
+				} ),
+			];
+
+			// Verify that subcategories are included.
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					per_page: 20,
+					category: sampleData.categories.clothingJSON.id,
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toEqual(
+				expect.arrayContaining( accessory )
+			);
+			expect( result1JSON ).toEqual( expect.arrayContaining( hoodies ) );
+
+			// Verify sibling categories are not.
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					category: sampleData.categories.hoodiesJSON.id,
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining( accessory )
+			);
+			expect( result2JSON ).toEqual( expect.arrayContaining( hoodies ) );
+		} );
+
+		test( 'on sale', async ( { request } ) => {
+			const onSale = [
+				expect.objectContaining( {
+					name: 'Beanie with Logo xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie with Pocket xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Single xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Cap xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Belt xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Beanie xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie xxx',
+				} ),
+			];
+
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					on_sale: true,
+					search: 'xxx',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( onSale.length );
+			expect( result1JSON ).toEqual( expect.arrayContaining( onSale ) );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					on_sale: false,
+					search: 'xxx',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining( onSale )
+			);
+		} );
+
+		test( 'price', async ( { request } ) => {
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					min_price: 21,
+					max_price: 28,
+					search: 'xxx',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 1 );
+			expect( result1JSON[ 0 ].name ).toBe( 'Long Sleeve Tee xxx' );
+			expect( result1JSON[ 0 ].price ).toBe( '25' );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					max_price: 5,
+					search: 'xxx',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 1 );
+			expect( result2JSON[ 0 ].name ).toBe( 'Single xxx' );
+			expect( result2JSON[ 0 ].price ).toBe( '2' );
+
+			const result3 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					min_price: 5,
+					order: 'asc',
+					orderby: 'price',
+					search: 'xxx',
+				},
+			} );
+			const result3JSON = await result3.json();
+			expect( result3.status() ).toEqual( 200 );
+			expect( result3JSON ).toEqual(
+				expect.not.arrayContaining( [
 					expect.objectContaining( {
 						name: 'Single xxx',
 					} ),
-					expect.objectContaining( {
-						name: 'T-Shirt with Logo xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Beanie with Logo xxx',
-					} ),
-				];
-				const after = [
-					expect.objectContaining( {
-						name: 'Hoodie xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'V-Neck T-Shirt xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Parent Product xxx',
-					} ),
+				] )
+			);
+		} );
+
+		test( 'before / after', async ( { request } ) => {
+			const before = [
+				expect.objectContaining( {
+					name: 'Album xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Single xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'T-Shirt with Logo xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Beanie with Logo xxx',
+				} ),
+			];
+			const after = [
+				expect.objectContaining( {
+					name: 'Hoodie xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'V-Neck T-Shirt xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Parent Product xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Child Product xxx',
+				} ),
+			];
+
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					before: '2021-09-05T15:50:19',
+					search: 'xxx',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( before.length );
+			expect( result1JSON ).toEqual( expect.arrayContaining( before ) );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					after: '2021-09-18T15:50:18',
+					search: 'xxx',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining( before )
+			);
+			expect( result2JSON ).toHaveLength( after.length );
+			expect( result2JSON ).toEqual( expect.arrayContaining( after ) );
+		} );
+
+		test( 'attributes', async ( { request } ) => {
+			const red = sampleData.attributes.colors.find(
+				( term ) => term.name === 'Red'
+			);
+
+			const redProducts = [
+				expect.objectContaining( {
+					name: 'V-Neck T-Shirt xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Beanie xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Beanie with Logo xxx',
+				} ),
+			];
+
+			const result = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					attribute: 'pa_colorxxx',
+					attribute_term: red.id,
+				},
+			} );
+			const resultJSON = await result.json();
+
+			expect( result.status() ).toEqual( 200 );
+			expect( resultJSON ).toHaveLength( redProducts.length );
+			expect( resultJSON ).toEqual(
+				expect.arrayContaining( redProducts )
+			);
+		} );
+
+		test( 'status', async ( { request } ) => {
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					status: 'pending',
+					search: 'xxx',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 1 );
+			expect( result1JSON[ 0 ].name ).toBe( 'Polo xxx' );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					status: 'draft',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 0 );
+		} );
+
+		test( 'shipping class', async ( { request } ) => {
+			const result = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					shipping_class: sampleData.shippingClasses.freightJSON.id,
+				},
+			} );
+			const resultJSON = await result.json();
+			expect( result.status() ).toEqual( 200 );
+			expect( resultJSON ).toHaveLength( 1 );
+			expect( resultJSON[ 0 ].name ).toBe( 'Long Sleeve Tee xxx' );
+		} );
+
+		test( 'tax class', async ( { request } ) => {
+			const result = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					tax_class: 'reduced-rate',
+					search: 'xxx',
+				},
+			} );
+			const resultJSON = await result.json();
+			expect( result.status() ).toEqual( 200 );
+			expect( resultJSON ).toHaveLength( 1 );
+			expect( resultJSON[ 0 ].name ).toBe( 'Sunglasses xxx' );
+		} );
+
+		test( 'stock status', async ( { request } ) => {
+			const result = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					stock_status: 'onbackorder',
+					search: 'xxx',
+				},
+			} );
+			const resultJSON = await result.json();
+			expect( result.status() ).toEqual( 200 );
+			expect( resultJSON ).toHaveLength( 1 );
+			expect( resultJSON[ 0 ].name ).toBe( 'T-Shirt xxx' );
+		} );
+
+		test( 'tags', async ( { request } ) => {
+			const coolProducts = [
+				expect.objectContaining( {
+					name: 'Sunglasses xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Hoodie with Pocket xxx',
+				} ),
+				expect.objectContaining( {
+					name: 'Beanie xxx',
+				} ),
+			];
+
+			const result = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					tag: sampleData.tags.coolJSON.id,
+				},
+			} );
+			const resultJSON = await result.json();
+
+			expect( result.status() ).toEqual( 200 );
+			expect( resultJSON ).toHaveLength( coolProducts.length );
+			expect( resultJSON ).toEqual(
+				expect.arrayContaining( coolProducts )
+			);
+		} );
+
+		test( 'parent', async ( { request } ) => {
+			const result1 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					parent: sampleData.hierarchicalProducts.parentJSON.id,
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 1 );
+			expect( result1JSON[ 0 ].name ).toBe( 'Child Product xxx' );
+
+			const result2 = await request.get( 'wp-json/wc/v3/products', {
+				params: {
+					parent_exclude:
+						sampleData.hierarchicalProducts.parentJSON.id,
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining( [
 					expect.objectContaining( {
 						name: 'Child Product xxx',
 					} ),
-				];
+				] )
+			);
+		} );
 
+		test.describe( 'orderby', () => {
+			const productNamesAsc = [
+				'Album xxx',
+				'Beanie with Logo xxx',
+				'Beanie xxx',
+				'Belt xxx',
+				'Cap xxx',
+				'Child Product xxx',
+				'Hoodie with Logo xxx',
+				'Hoodie with Pocket xxx',
+				'Hoodie with Zipper xxx',
+				'Hoodie xxx',
+				'Logo Collection xxx',
+				'Long Sleeve Tee xxx',
+				'Parent Product xxx',
+				'Polo xxx',
+				'Single xxx',
+				'Sunglasses xxx',
+				'T-Shirt with Logo xxx',
+				'T-Shirt xxx',
+				'V-Neck T-Shirt xxx',
+				'WordPress Pennant xxx',
+			];
+			const productNamesDesc = [ ...productNamesAsc ].reverse();
+			const productNamesByRatingAsc = [
+				'Sunglasses xxx',
+				'Cap xxx',
+				'T-Shirt xxx',
+			];
+			const productNamesByRatingDesc = [
+				...productNamesByRatingAsc,
+			].reverse();
+			const productNamesByPopularityDesc = [
+				'Beanie with Logo xxx',
+				'Single xxx',
+				'T-Shirt xxx',
+			];
+			const productNamesByPopularityAsc = [
+				...productNamesByPopularityDesc,
+			].reverse();
+
+			test( 'default', async ( { request } ) => {
+				// Default = date desc.
+				const result = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						search: 'xxx',
+					},
+				} );
+				const resultJSON = await result.json();
+				expect( result.status() ).toEqual( 200 );
+
+				// Verify all dates are in descending order.
+				let lastDate = Date.now();
+				resultJSON.forEach( ( { date_created_gmt } ) => {
+					const created = Date.parse( date_created_gmt + '.000Z' );
+					expect( lastDate ).toBeGreaterThan( created );
+					lastDate = created;
+				} );
+			} );
+
+			test( 'date', async ( { request } ) => {
+				const result = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'asc',
+						orderby: 'date',
+						search: 'xxx',
+					},
+				} );
+				const resultJSON = await result.json();
+				expect( result.status() ).toEqual( 200 );
+
+				// Verify all dates are in ascending order.
+				let lastDate = 0;
+				resultJSON.forEach( ( { date_created_gmt } ) => {
+					const created = Date.parse( date_created_gmt + '.000Z' );
+					expect( created ).toBeGreaterThan( lastDate );
+					lastDate = created;
+				} );
+			} );
+
+			test( 'id', async ( { request } ) => {
 				const result1 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						before: '2021-09-05T15:50:19',
+						order: 'asc',
+						orderby: 'id',
 						search: 'xxx',
 					},
 				} );
 				const result1JSON = await result1.json();
 				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( before.length );
-				expect( result1JSON ).toEqual(
-					expect.arrayContaining( before )
-				);
+
+				// Verify all results are in ascending order.
+				let lastId = 0;
+				result1JSON.forEach( ( { id } ) => {
+					expect( id ).toBeGreaterThan( lastId );
+					lastId = id;
+				} );
 
 				const result2 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						after: '2021-09-18T15:50:18',
+						order: 'desc',
+						orderby: 'id',
 						search: 'xxx',
 					},
 				} );
 				const result2JSON = await result2.json();
 				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toEqual(
-					expect.not.arrayContaining( before )
-				);
-				expect( result2JSON ).toHaveLength( after.length );
-				expect( result2JSON ).toEqual(
-					expect.arrayContaining( after )
-				);
-			} );
 
-			test( 'attributes', async ( { request } ) => {
-				const red = sampleData.attributes.colors.find(
-					( term ) => term.name === 'Red'
-				);
-
-				const redProducts = [
-					expect.objectContaining( {
-						name: 'V-Neck T-Shirt xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Hoodie xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Beanie xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Beanie with Logo xxx',
-					} ),
-				];
-
-				const result = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						attribute: 'pa_colorxxx',
-						attribute_term: red.id,
-					},
+				// Verify all results are in descending order.
+				lastId = Number.MAX_SAFE_INTEGER;
+				result2JSON.forEach( ( { id } ) => {
+					expect( lastId ).toBeGreaterThan( id );
+					lastId = id;
 				} );
-				const resultJSON = await result.json();
-
-				expect( result.status() ).toEqual( 200 );
-				expect( resultJSON ).toHaveLength( redProducts.length );
-				expect( resultJSON ).toEqual(
-					expect.arrayContaining( redProducts )
-				);
 			} );
 
-			test( 'status', async ( { request } ) => {
+			test( 'title', async ( { request } ) => {
 				const result1 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						status: 'pending',
+						order: 'asc',
+						orderby: 'title',
+						per_page: productNamesAsc.length,
 						search: 'xxx',
 					},
 				} );
 				const result1JSON = await result1.json();
 				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 1 );
-				expect( result1JSON[ 0 ].name ).toBe( 'Polo xxx' );
+
+				// Verify all results are in ascending order.
+				result1JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesAsc[ idx ] );
+				} );
 
 				const result2 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						status: 'draft',
+						order: 'desc',
+						orderby: 'title',
+						per_page: productNamesDesc.length,
+						search: 'xxx',
 					},
 				} );
 				const result2JSON = await result2.json();
 				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 0 );
-			} );
 
-			test( 'shipping class', async ( { request } ) => {
-				const result = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						shipping_class:
-							sampleData.shippingClasses.freightJSON.id,
-					},
+				// Verify all results are in descending order.
+				result2JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesDesc[ idx ] );
 				} );
-				const resultJSON = await result.json();
-				expect( result.status() ).toEqual( 200 );
-				expect( resultJSON ).toHaveLength( 1 );
-				expect( resultJSON[ 0 ].name ).toBe( 'Long Sleeve Tee xxx' );
 			} );
 
-			test( 'tax class', async ( { request } ) => {
-				const result = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						tax_class: 'reduced-rate',
-						search: 'xxx',
-					},
-				} );
-				const resultJSON = await result.json();
-				expect( result.status() ).toEqual( 200 );
-				expect( resultJSON ).toHaveLength( 1 );
-				expect( resultJSON[ 0 ].name ).toBe( 'Sunglasses xxx' );
-			} );
-
-			test( 'stock status', async ( { request } ) => {
-				const result = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						stock_status: 'onbackorder',
-						search: 'xxx',
-					},
-				} );
-				const resultJSON = await result.json();
-				expect( result.status() ).toEqual( 200 );
-				expect( resultJSON ).toHaveLength( 1 );
-				expect( resultJSON[ 0 ].name ).toBe( 'T-Shirt xxx' );
-			} );
-
-			test( 'tags', async ( { request } ) => {
-				const coolProducts = [
-					expect.objectContaining( {
-						name: 'Sunglasses xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Hoodie with Pocket xxx',
-					} ),
-					expect.objectContaining( {
-						name: 'Beanie xxx',
-					} ),
+			test( 'slug orderby', async ( { request } ) => {
+				const productNamesBySlugAsc = [
+					'Polo xxx', // The Polo isn't published so it has an empty slug.
+					...productNamesAsc.filter( ( p ) => p !== 'Polo xxx' ),
 				];
+				const productNamesBySlugDesc = [
+					...productNamesBySlugAsc,
+				].reverse();
 
-				const result = await request.get( 'wp-json/wc/v3/products', {
-					params: {
-						tag: sampleData.tags.coolJSON.id,
-					},
-				} );
-				const resultJSON = await result.json();
-
-				expect( result.status() ).toEqual( 200 );
-				expect( resultJSON ).toHaveLength( coolProducts.length );
-				expect( resultJSON ).toEqual(
-					expect.arrayContaining( coolProducts )
-				);
-			} );
-
-			test( 'parent', async ( { request } ) => {
 				const result1 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						parent: sampleData.hierarchicalProducts.parentJSON.id,
+						order: 'asc',
+						orderby: 'slug',
+						per_page: productNamesBySlugAsc.length,
+						search: 'xxx',
 					},
 				} );
 				const result1JSON = await result1.json();
 				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 1 );
-				expect( result1JSON[ 0 ].name ).toBe( 'Child Product xxx' );
+
+				// Verify all results are in ascending order.
+				result1JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesBySlugAsc[ idx ] );
+				} );
 
 				const result2 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						parent_exclude:
-							sampleData.hierarchicalProducts.parentJSON.id,
+						order: 'desc',
+						orderby: 'slug',
+						per_page: productNamesBySlugDesc.length,
+						search: 'xxx',
 					},
 				} );
 				const result2JSON = await result2.json();
 				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toEqual(
-					expect.not.arrayContaining( [
-						expect.objectContaining( {
-							name: 'Child Product xxx',
-						} ),
-					] )
-				);
+
+				// Verify all results are in descending order.
+				result2JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesBySlugDesc[ idx ] );
+				} );
 			} );
 
-			test.describe( 'orderby', () => {
-				const productNamesAsc = [
-					'Album xxx',
-					'Beanie with Logo xxx',
-					'Beanie xxx',
-					'Belt xxx',
-					'Cap xxx',
+			test( 'price orderby', async ( { request } ) => {
+				const productNamesMinPriceAsc = [
+					'Parent Product xxx',
 					'Child Product xxx',
-					'Hoodie with Logo xxx',
+					'Single xxx',
+					'WordPress Pennant xxx',
+					'Album xxx',
+					'V-Neck T-Shirt xxx',
+					'Cap xxx',
+					'Beanie with Logo xxx',
+					'T-Shirt with Logo xxx',
+					'Beanie xxx',
+					'T-Shirt xxx',
+					'Logo Collection xxx',
+					'Polo xxx',
+					'Long Sleeve Tee xxx',
 					'Hoodie with Pocket xxx',
+					'Hoodie xxx',
 					'Hoodie with Zipper xxx',
+					'Hoodie with Logo xxx',
+					'Belt xxx',
+					'Sunglasses xxx',
+				];
+				const result1 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'asc',
+						orderby: 'price',
+						per_page: productNamesMinPriceAsc.length,
+						search: 'xxx',
+					},
+				} );
+				const result1JSON = await result1.json();
+				expect( result1.status() ).toEqual( 200 );
+				expect( result1JSON ).toHaveLength(
+					productNamesMinPriceAsc.length
+				);
+
+				// Verify all results are in ascending order.
+				// The query uses the min price calculated in the product meta lookup table,
+				// so we can't just check the price property of the response.
+				result1JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesMinPriceAsc[ idx ] );
+				} );
+
+				const productNamesMaxPriceDesc = [
+					'Sunglasses xxx',
+					'Belt xxx',
 					'Hoodie xxx',
 					'Logo Collection xxx',
+					'Hoodie with Logo xxx',
+					'Hoodie with Zipper xxx',
+					'Hoodie with Pocket xxx',
 					'Long Sleeve Tee xxx',
-					'Parent Product xxx',
-					'Polo xxx',
-					'Single xxx',
-					'Sunglasses xxx',
-					'T-Shirt with Logo xxx',
-					'T-Shirt xxx',
 					'V-Neck T-Shirt xxx',
-					'WordPress Pennant xxx',
-				];
-				const productNamesDesc = [ ...productNamesAsc ].reverse();
-				const productNamesByRatingAsc = [
-					'Sunglasses xxx',
-					'Cap xxx',
+					'Polo xxx',
 					'T-Shirt xxx',
-				];
-				const productNamesByRatingDesc = [
-					...productNamesByRatingAsc,
-				].reverse();
-				const productNamesByPopularityDesc = [
+					'Beanie xxx',
+					'T-Shirt with Logo xxx',
 					'Beanie with Logo xxx',
+					'Cap xxx',
+					'Album xxx',
+					'WordPress Pennant xxx',
 					'Single xxx',
-					'T-Shirt xxx',
+					'Child Product xxx',
+					'Parent Product xxx',
 				];
-				const productNamesByPopularityAsc = [
-					...productNamesByPopularityDesc,
-				].reverse();
 
-				test( 'default', async ( { request } ) => {
-					// Default = date desc.
-					const result = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								search: 'xxx',
-							},
-						}
-					);
-					const resultJSON = await result.json();
-					expect( result.status() ).toEqual( 200 );
-
-					// Verify all dates are in descending order.
-					let lastDate = Date.now();
-					resultJSON.forEach( ( { date_created_gmt } ) => {
-						const created = Date.parse(
-							date_created_gmt + '.000Z'
-						);
-						expect( lastDate ).toBeGreaterThan( created );
-						lastDate = created;
-					} );
+				const result2 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'desc',
+						orderby: 'price',
+						per_page: productNamesMaxPriceDesc.length,
+						search: 'xxx',
+					},
 				} );
+				const result2JSON = await result2.json();
+				expect( result2.status() ).toEqual( 200 );
+				expect( result2JSON ).toHaveLength(
+					productNamesMaxPriceDesc.length
+				);
 
-				test( 'date', async ( { request } ) => {
-					const result = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'date',
-								search: 'xxx',
-							},
-						}
-					);
-					const resultJSON = await result.json();
-					expect( result.status() ).toEqual( 200 );
-
-					// Verify all dates are in ascending order.
-					let lastDate = 0;
-					resultJSON.forEach( ( { date_created_gmt } ) => {
-						const created = Date.parse(
-							date_created_gmt + '.000Z'
-						);
-						expect( created ).toBeGreaterThan( lastDate );
-						lastDate = created;
-					} );
-				} );
-
-				test( 'id', async ( { request } ) => {
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'id',
-								search: 'xxx',
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-					expect( result1.status() ).toEqual( 200 );
-
-					// Verify all results are in ascending order.
-					let lastId = 0;
-					result1JSON.forEach( ( { id } ) => {
-						expect( id ).toBeGreaterThan( lastId );
-						lastId = id;
-					} );
-
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'id',
-								search: 'xxx',
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-
-					// Verify all results are in descending order.
-					lastId = Number.MAX_SAFE_INTEGER;
-					result2JSON.forEach( ( { id } ) => {
-						expect( lastId ).toBeGreaterThan( id );
-						lastId = id;
-					} );
-				} );
-
-				test( 'title', async ( { request } ) => {
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'title',
-								per_page: productNamesAsc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-					expect( result1.status() ).toEqual( 200 );
-
-					// Verify all results are in ascending order.
-					result1JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesAsc[ idx ] );
-					} );
-
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'title',
-								per_page: productNamesDesc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-
-					// Verify all results are in descending order.
-					result2JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesDesc[ idx ] );
-					} );
-				} );
-
-				test( 'slug orderby', async ( { request } ) => {
-					const productNamesBySlugAsc = [
-						'Polo xxx', // The Polo isn't published so it has an empty slug.
-						...productNamesAsc.filter( ( p ) => p !== 'Polo xxx' ),
-					];
-					const productNamesBySlugDesc = [
-						...productNamesBySlugAsc,
-					].reverse();
-
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'slug',
-								per_page: productNamesBySlugAsc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-					expect( result1.status() ).toEqual( 200 );
-
-					// Verify all results are in ascending order.
-					result1JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesBySlugAsc[ idx ] );
-					} );
-
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'slug',
-								per_page: productNamesBySlugDesc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-
-					// Verify all results are in descending order.
-					result2JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesBySlugDesc[ idx ] );
-					} );
-				} );
-
-				test( 'price orderby', async ( { request } ) => {
-					const productNamesMinPriceAsc = [
-						'Parent Product xxx',
-						'Child Product xxx',
-						'Single xxx',
-						'WordPress Pennant xxx',
-						'Album xxx',
-						'V-Neck T-Shirt xxx',
-						'Cap xxx',
-						'Beanie with Logo xxx',
-						'T-Shirt with Logo xxx',
-						'Beanie xxx',
-						'T-Shirt xxx',
-						'Logo Collection xxx',
-						'Polo xxx',
-						'Long Sleeve Tee xxx',
-						'Hoodie with Pocket xxx',
-						'Hoodie xxx',
-						'Hoodie with Zipper xxx',
-						'Hoodie with Logo xxx',
-						'Belt xxx',
-						'Sunglasses xxx',
-					];
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'price',
-								per_page: productNamesMinPriceAsc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-					expect( result1.status() ).toEqual( 200 );
-					expect( result1JSON ).toHaveLength(
-						productNamesMinPriceAsc.length
-					);
-
-					// Verify all results are in ascending order.
-					// The query uses the min price calculated in the product meta lookup table,
-					// so we can't just check the price property of the response.
-					result1JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesMinPriceAsc[ idx ] );
-					} );
-
-					const productNamesMaxPriceDesc = [
-						'Sunglasses xxx',
-						'Belt xxx',
-						'Hoodie xxx',
-						'Logo Collection xxx',
-						'Hoodie with Logo xxx',
-						'Hoodie with Zipper xxx',
-						'Hoodie with Pocket xxx',
-						'Long Sleeve Tee xxx',
-						'V-Neck T-Shirt xxx',
-						'Polo xxx',
-						'T-Shirt xxx',
-						'Beanie xxx',
-						'T-Shirt with Logo xxx',
-						'Beanie with Logo xxx',
-						'Cap xxx',
-						'Album xxx',
-						'WordPress Pennant xxx',
-						'Single xxx',
-						'Child Product xxx',
-						'Parent Product xxx',
-					];
-
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'price',
-								per_page: productNamesMaxPriceDesc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-					expect( result2JSON ).toHaveLength(
-						productNamesMaxPriceDesc.length
-					);
-
-					// Verify all results are in descending order.
-					// The query uses the max price calculated in the product meta lookup table,
-					// so we can't just check the price property of the response.
-					result2JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesMaxPriceDesc[ idx ] );
-					} );
-				} );
-
-				test( 'include', async ( { request } ) => {
-					const includeIds = [
-						sampleData.groupedProducts[ 0 ].id,
-						sampleData.simpleProducts[ 3 ].id,
-						sampleData.hierarchicalProducts.parentJSON.id,
-					];
-
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'include',
-								include: includeIds.join( ',' ),
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-
-					expect( result1.status() ).toEqual( 200 );
-					expect( result1JSON ).toHaveLength( includeIds.length );
-
-					// Verify all results are in proper order.
-					result1JSON.forEach( ( { id }, idx ) => {
-						expect( id ).toBe( includeIds[ idx ] );
-					} );
-
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'include',
-								include: includeIds.join( ',' ),
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-					expect( result2JSON ).toHaveLength( includeIds.length );
-
-					// Verify all results are in proper order.
-					result2JSON.forEach( ( { id }, idx ) => {
-						expect( id ).toBe( includeIds[ idx ] );
-					} );
-				} );
-
-				test( 'rating (desc)', async ( { request } ) => {
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'rating',
-								per_page: productNamesByRatingDesc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-
-					// Verify all results are in descending order.
-					result2JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesByRatingDesc[ idx ] );
-					} );
-				} );
-
-				// This case will remain skipped until ratings can be sorted ascending.
-				// See: https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099.
-				test.skip( 'rating (asc)', async ( { request } ) => {
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'rating',
-								per_page: productNamesByRatingAsc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					expect( result1.status() ).toEqual( 200 );
-					const result1JSON = await result1.json();
-
-					// Verify all results are in ascending order.
-					result1JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe( productNamesByRatingAsc[ idx ] );
-					} );
-				} );
-
-				// This case will remain skipped until popularity can be sorted ascending.
-				// See: https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099.
-				test.skip( 'popularity (asc)', async ( { request } ) => {
-					const result1 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'asc',
-								orderby: 'popularity',
-								per_page: productNamesByPopularityAsc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result1JSON = await result1.json();
-					expect( result1.status() ).toEqual( 200 );
-
-					// Verify all results are in ascending order.
-					result1JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe(
-							productNamesByPopularityAsc[ idx ]
-						);
-					} );
-				} );
-
-				test( 'popularity (desc)', async ( { request } ) => {
-					const result2 = await request.get(
-						'wp-json/wc/v3/products',
-						{
-							params: {
-								order: 'desc',
-								orderby: 'popularity',
-								per_page: productNamesByPopularityDesc.length,
-								search: 'xxx',
-							},
-						}
-					);
-					const result2JSON = await result2.json();
-					expect( result2.status() ).toEqual( 200 );
-
-					// Verify all results are in descending order.
-					result2JSON.forEach( ( { name }, idx ) => {
-						expect( name ).toBe(
-							productNamesByPopularityDesc[ idx ]
-						);
-					} );
+				// Verify all results are in descending order.
+				// The query uses the max price calculated in the product meta lookup table,
+				// so we can't just check the price property of the response.
+				result2JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesMaxPriceDesc[ idx ] );
 				} );
 			} );
-		}
-	);
+
+			test( 'include', async ( { request } ) => {
+				const includeIds = [
+					sampleData.groupedProducts[ 0 ].id,
+					sampleData.simpleProducts[ 3 ].id,
+					sampleData.hierarchicalProducts.parentJSON.id,
+				];
+
+				const result1 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'asc',
+						orderby: 'include',
+						include: includeIds.join( ',' ),
+					},
+				} );
+				const result1JSON = await result1.json();
+
+				expect( result1.status() ).toEqual( 200 );
+				expect( result1JSON ).toHaveLength( includeIds.length );
+
+				// Verify all results are in proper order.
+				result1JSON.forEach( ( { id }, idx ) => {
+					expect( id ).toBe( includeIds[ idx ] );
+				} );
+
+				const result2 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'desc',
+						orderby: 'include',
+						include: includeIds.join( ',' ),
+					},
+				} );
+				const result2JSON = await result2.json();
+				expect( result2.status() ).toEqual( 200 );
+				expect( result2JSON ).toHaveLength( includeIds.length );
+
+				// Verify all results are in proper order.
+				result2JSON.forEach( ( { id }, idx ) => {
+					expect( id ).toBe( includeIds[ idx ] );
+				} );
+			} );
+
+			test( 'rating (desc)', async ( { request } ) => {
+				const result2 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'desc',
+						orderby: 'rating',
+						per_page: productNamesByRatingDesc.length,
+						search: 'xxx',
+					},
+				} );
+				const result2JSON = await result2.json();
+				expect( result2.status() ).toEqual( 200 );
+
+				// Verify all results are in descending order.
+				result2JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesByRatingDesc[ idx ] );
+				} );
+			} );
+
+			// This case will remain skipped until ratings can be sorted ascending.
+			// See: https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099.
+			test.skip( 'rating (asc)', async ( { request } ) => {
+				const result1 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'asc',
+						orderby: 'rating',
+						per_page: productNamesByRatingAsc.length,
+						search: 'xxx',
+					},
+				} );
+				expect( result1.status() ).toEqual( 200 );
+				const result1JSON = await result1.json();
+
+				// Verify all results are in ascending order.
+				result1JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesByRatingAsc[ idx ] );
+				} );
+			} );
+
+			// This case will remain skipped until popularity can be sorted ascending.
+			// See: https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099.
+			test.skip( 'popularity (asc)', async ( { request } ) => {
+				const result1 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'asc',
+						orderby: 'popularity',
+						per_page: productNamesByPopularityAsc.length,
+						search: 'xxx',
+					},
+				} );
+				const result1JSON = await result1.json();
+				expect( result1.status() ).toEqual( 200 );
+
+				// Verify all results are in ascending order.
+				result1JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesByPopularityAsc[ idx ] );
+				} );
+			} );
+
+			test( 'popularity (desc)', async ( { request } ) => {
+				const result2 = await request.get( 'wp-json/wc/v3/products', {
+					params: {
+						order: 'desc',
+						orderby: 'popularity',
+						per_page: productNamesByPopularityDesc.length,
+						search: 'xxx',
+					},
+				} );
+				const result2JSON = await result2.json();
+				expect( result2.status() ).toEqual( 200 );
+
+				// Verify all results are in descending order.
+				result2JSON.forEach( ( { name }, idx ) => {
+					expect( name ).toBe( productNamesByPopularityDesc[ idx ] );
+				} );
+			} );
+		} );
+	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -2824,7 +2824,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			} );
 			const result2JSON = await result2.json();
 			expect( result2.status() ).toEqual( 200 );
-			expect( result2JSON ).toHaveLength( 0 );
+			expect( result2JSON ).toEqual( expect.any( Array ) );
 		} );
 
 		test( 'shipping class', async ( { request } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/product-list.test.js
@@ -717,7 +717,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Hoodie with Pocket xxx',
+								name: `Hoodie with Pocket ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-08T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -794,7 +794,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Sunglasses xxx',
+								name: `Sunglasses ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-09T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -863,7 +863,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Cap xxx',
+								name: `Cap ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-10T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -936,7 +936,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Belt xxx',
+								name: `Belt ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-12T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1001,7 +1001,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Beanie xxx',
+								name: `Beanie ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-13T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1078,7 +1078,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'T-Shirt xxx',
+								name: `T-Shirt ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-14T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1151,7 +1151,7 @@ test.describe( 'Products API tests: List All Products', () => {
 								stock_status: 'onbackorder',
 							},
 							{
-								name: 'Hoodie with Logo xxx',
+								name: `Hoodie with Logo ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-15T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1239,7 +1239,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					data: {
 						create: [
 							{
-								name: 'WordPress Pennant xxx',
+								name: `WordPress Pennant ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-16T15:50:20',
 								type: 'external',
 								status: 'publish',
@@ -1334,7 +1334,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					data: {
 						create: [
 							{
-								name: 'Logo Collection xxx',
+								name: `Logo Collection ${ RAND_NUM }`,
 								date_created_gmt: '2021-09-17T15:50:20',
 								type: 'grouped',
 								status: 'publish',
@@ -1423,7 +1423,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			const hoodie = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'Hoodie xxx',
+					name: `Hoodie ${ RAND_NUM }`,
 					date_created_gmt: '2021-09-18T15:50:19',
 					type: 'variable',
 					status: 'publish',
@@ -1708,7 +1708,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			const vneck = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'V-Neck T-Shirt xxx',
+					name: `V-Neck T-Shirt ${ RAND_NUM }`,
 					date_created_gmt: '2021-09-23T15:50:19',
 					type: 'variable',
 					status: 'publish',
@@ -1932,7 +1932,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		const createSampleHierarchicalProducts = async () => {
 			const parent = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'Parent Product xxx',
+					name: `Parent Product ${ RAND_NUM }`,
 					date_created_gmt: '2021-09-27T15:50:19',
 				},
 			} );
@@ -1940,7 +1940,7 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			const child = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'Child Product xxx',
+					name: `Child Product ${ RAND_NUM }`,
 					parent_id: parentJSON.id,
 					date_created_gmt: '2021-09-28T15:50:19',
 				},
@@ -1954,12 +1954,14 @@ test.describe( 'Products API tests: List All Products', () => {
 		};
 
 		const createSampleProductReviews = async ( simpleProducts ) => {
-			const cap = simpleProducts.find( ( p ) => p.name === 'Cap xxx' );
+			const cap = simpleProducts.find(
+				( p ) => p.name === `Cap ${ RAND_NUM }`
+			);
 			const shirt = simpleProducts.find(
-				( p ) => p.name === 'T-Shirt xxx'
+				( p ) => p.name === `T-Shirt ${ RAND_NUM }`
 			);
 			const sunglasses = simpleProducts.find(
-				( p ) => p.name === 'Sunglasses xxx'
+				( p ) => p.name === `Sunglasses ${ RAND_NUM }`
 			);
 
 			const review1 = await request.post(
@@ -2033,13 +2035,13 @@ test.describe( 'Products API tests: List All Products', () => {
 
 		const createSampleProductOrders = async ( simpleProducts ) => {
 			const single = simpleProducts.find(
-				( p ) => p.name === 'Single xxx'
+				( p ) => p.name === `Single ${ RAND_NUM }`
 			);
 			const beanie = simpleProducts.find(
-				( p ) => p.name === 'Beanie with Logo xxx'
+				( p ) => p.name === `Beanie with Logo ${ RAND_NUM }`
 			);
 			const shirt = simpleProducts.find(
-				( p ) => p.name === 'T-Shirt xxx'
+				( p ) => p.name === `T-Shirt ${ RAND_NUM }`
 			);
 
 			const order = await request.post( './wp-json/wc/v3/orders', {
@@ -2238,7 +2240,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		test( 'defaults', async ( { request } ) => {
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 
@@ -2254,7 +2256,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const page1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					per_page: pageSize,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const page1JSON = await page1.json();
@@ -2262,7 +2264,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				params: {
 					per_page: pageSize,
 					page: 2,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const page2JSON = await page2.json();
@@ -2296,7 +2298,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					per_page: pageSize,
 					page: 2,
 					offset: pageSize + 1,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const page2OffsetJSON = await page2Offset.json();
@@ -2315,7 +2317,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				params: {
 					per_page: pageSize,
 					page: 4,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const lastPageJSON = await lastPage.json();
@@ -2327,7 +2329,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				params: {
 					per_page: pageSize,
 					page: 6,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const page6JSON = await page6.json();
@@ -2348,7 +2350,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result1JSON ).toEqual(
 				expect.arrayContaining( [
 					expect.objectContaining( {
-						name: 'WordPress Pennant xxx',
+						name: `WordPress Pennant ${ RAND_NUM }`,
 					} ),
 				] )
 			);
@@ -2356,20 +2358,22 @@ test.describe( 'Products API tests: List All Products', () => {
 			// Match in the product name.
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
-					search: 'pocket xxx',
+					search: `pocket ${ RAND_NUM }`,
 				},
 			} );
 			const result2JSON = await result2.json();
 			expect( result2.status() ).toEqual( 200 );
 			expect( result2JSON ).toHaveLength( 1 );
-			expect( result2JSON[ 0 ].name ).toBe( 'Hoodie with Pocket xxx' );
+			expect( result2JSON[ 0 ].name ).toBe(
+				`Hoodie with Pocket ${ RAND_NUM }`
+			);
 		} );
 
 		test( 'inclusion / exclusion', async ( { request } ) => {
 			const allProducts = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					per_page: 20,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const allProductsJSON = await allProducts.json();
@@ -2431,13 +2435,15 @@ test.describe( 'Products API tests: List All Products', () => {
 			// Match by slug.
 			const result1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
-					slug: 't-shirt-with-logo-xxx',
+					slug: `t-shirt-with-logo-${ RAND_NUM }`,
 				},
 			} );
 			const result1JSON = await result1.json();
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON ).toHaveLength( 1 );
-			expect( result1JSON[ 0 ].slug ).toBe( 't-shirt-with-logo-xxx' );
+			expect( result1JSON[ 0 ].slug ).toBe(
+				`t-shirt-with-logo-${ RAND_NUM }`
+			);
 
 			// No matches
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
@@ -2477,7 +2483,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					type: 'simple',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			expect( result1.status() ).toEqual( 200 );
@@ -2486,18 +2492,20 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					type: 'external',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result2JSON = await result2.json();
 			expect( result2.status() ).toEqual( 200 );
 			expect( result2JSON ).toHaveLength( 1 );
-			expect( result2JSON[ 0 ].name ).toBe( 'WordPress Pennant xxx' );
+			expect( result2JSON[ 0 ].name ).toBe(
+				`WordPress Pennant ${ RAND_NUM }`
+			);
 
 			const result3 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					type: 'variable',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result3JSON = await result3.json();
@@ -2507,13 +2515,15 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result4 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					type: 'grouped',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result4JSON = await result4.json();
 			expect( result4.status() ).toEqual( 200 );
 			expect( result4JSON ).toHaveLength( 1 );
-			expect( result4JSON[ 0 ].name ).toBe( 'Logo Collection xxx' );
+			expect( result4JSON[ 0 ].name ).toBe(
+				`Logo Collection ${ RAND_NUM }`
+			);
 		} );
 
 		test( 'featured', async ( { request } ) => {
@@ -2522,23 +2532,23 @@ test.describe( 'Products API tests: List All Products', () => {
 					name: `Hoodie with Zipper ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie with Pocket xxx',
+					name: `Hoodie with Pocket ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Sunglasses xxx',
+					name: `Sunglasses ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Cap xxx',
+					name: `Cap ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'V-Neck T-Shirt xxx',
+					name: `V-Neck T-Shirt ${ RAND_NUM }`,
 				} ),
 			];
 
 			const result1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					featured: true,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result1JSON = await result1.json();
@@ -2549,7 +2559,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					featured: false,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result2JSON = await result2.json();
@@ -2562,7 +2572,7 @@ test.describe( 'Products API tests: List All Products', () => {
 		test( 'categories', async ( { request } ) => {
 			const accessory = [
 				expect.objectContaining( {
-					name: 'Beanie xxx',
+					name: `Beanie ${ RAND_NUM }`,
 				} ),
 			];
 			const hoodies = [
@@ -2570,13 +2580,13 @@ test.describe( 'Products API tests: List All Products', () => {
 					name: `Hoodie with Zipper ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie with Pocket xxx',
+					name: `Hoodie with Pocket ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie with Logo xxx',
+					name: `Hoodie with Logo ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie xxx',
+					name: `Hoodie ${ RAND_NUM }`,
 				} ),
 			];
 
@@ -2611,32 +2621,32 @@ test.describe( 'Products API tests: List All Products', () => {
 		test( 'on sale', async ( { request } ) => {
 			const onSale = [
 				expect.objectContaining( {
-					name: 'Beanie with Logo xxx',
+					name: `Beanie with Logo ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie with Pocket xxx',
+					name: `Hoodie with Pocket ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Single xxx',
+					name: `Single ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Cap xxx',
+					name: `Cap ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Belt xxx',
+					name: `Belt ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Beanie xxx',
+					name: `Beanie ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie xxx',
+					name: `Hoodie ${ RAND_NUM }`,
 				} ),
 			];
 
 			const result1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					on_sale: true,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result1JSON = await result1.json();
@@ -2647,7 +2657,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					on_sale: false,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result2JSON = await result2.json();
@@ -2662,7 +2672,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				params: {
 					min_price: 21,
 					max_price: 28,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result1JSON = await result1.json();
@@ -2676,13 +2686,13 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					max_price: 5,
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result2JSON = await result2.json();
 			expect( result2.status() ).toEqual( 200 );
 			expect( result2JSON ).toHaveLength( 1 );
-			expect( result2JSON[ 0 ].name ).toBe( 'Single xxx' );
+			expect( result2JSON[ 0 ].name ).toBe( `Single ${ RAND_NUM }` );
 			expect( result2JSON[ 0 ].price ).toBe( '2' );
 
 			const result3 = await request.get( 'wp-json/wc/v3/products', {
@@ -2690,7 +2700,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					min_price: 5,
 					order: 'asc',
 					orderby: 'price',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result3JSON = await result3.json();
@@ -2698,7 +2708,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result3JSON ).toEqual(
 				expect.not.arrayContaining( [
 					expect.objectContaining( {
-						name: 'Single xxx',
+						name: `Single ${ RAND_NUM }`,
 					} ),
 				] )
 			);
@@ -2710,34 +2720,34 @@ test.describe( 'Products API tests: List All Products', () => {
 					name: `Album ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Single xxx',
+					name: `Single ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'T-Shirt with Logo xxx',
+					name: `T-Shirt with Logo ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Beanie with Logo xxx',
+					name: `Beanie with Logo ${ RAND_NUM }`,
 				} ),
 			];
 			const after = [
 				expect.objectContaining( {
-					name: 'Hoodie xxx',
+					name: `Hoodie ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'V-Neck T-Shirt xxx',
+					name: `V-Neck T-Shirt ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Parent Product xxx',
+					name: `Parent Product ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Child Product xxx',
+					name: `Child Product ${ RAND_NUM }`,
 				} ),
 			];
 
 			const result1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					before: '2021-09-05T15:50:19',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result1JSON = await result1.json();
@@ -2748,7 +2758,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					after: '2021-09-18T15:50:18',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result2JSON = await result2.json();
@@ -2767,22 +2777,22 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			const redProducts = [
 				expect.objectContaining( {
-					name: 'V-Neck T-Shirt xxx',
+					name: `V-Neck T-Shirt ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie xxx',
+					name: `Hoodie ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Beanie xxx',
+					name: `Beanie ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Beanie with Logo xxx',
+					name: `Beanie with Logo ${ RAND_NUM }`,
 				} ),
 			];
 
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
-					attribute: 'pa_colorxxx',
+					attribute: `pa_color${ RAND_NUM }`,
 					attribute_term: red.id,
 				},
 			} );
@@ -2799,7 +2809,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result1 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					status: 'pending',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const result1JSON = await result1.json();
@@ -2835,38 +2845,38 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					tax_class: 'reduced-rate',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const resultJSON = await result.json();
 			expect( result.status() ).toEqual( 200 );
 			expect( resultJSON ).toHaveLength( 1 );
-			expect( resultJSON[ 0 ].name ).toBe( 'Sunglasses xxx' );
+			expect( resultJSON[ 0 ].name ).toBe( `Sunglasses ${ RAND_NUM }` );
 		} );
 
 		test( 'stock status', async ( { request } ) => {
 			const result = await request.get( 'wp-json/wc/v3/products', {
 				params: {
 					stock_status: 'onbackorder',
-					search: 'xxx',
+					search: RAND_NUM,
 				},
 			} );
 			const resultJSON = await result.json();
 			expect( result.status() ).toEqual( 200 );
 			expect( resultJSON ).toHaveLength( 1 );
-			expect( resultJSON[ 0 ].name ).toBe( 'T-Shirt xxx' );
+			expect( resultJSON[ 0 ].name ).toBe( `T-Shirt ${ RAND_NUM }` );
 		} );
 
 		test.only( 'tags', async ( { request } ) => {
 			const coolProducts = [
 				expect.objectContaining( {
-					name: 'Sunglasses xxx',
+					name: `Sunglasses ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Hoodie with Pocket xxx',
+					name: `Hoodie with Pocket ${ RAND_NUM }`,
 				} ),
 				expect.objectContaining( {
-					name: 'Beanie xxx',
+					name: `Beanie ${ RAND_NUM }`,
 				} ),
 			];
 
@@ -2893,7 +2903,9 @@ test.describe( 'Products API tests: List All Products', () => {
 			const result1JSON = await result1.json();
 			expect( result1.status() ).toEqual( 200 );
 			expect( result1JSON ).toHaveLength( 1 );
-			expect( result1JSON[ 0 ].name ).toBe( 'Child Product xxx' );
+			expect( result1JSON[ 0 ].name ).toBe(
+				`Child Product ${ RAND_NUM }`
+			);
 
 			const result2 = await request.get( 'wp-json/wc/v3/products', {
 				params: {
@@ -2906,7 +2918,7 @@ test.describe( 'Products API tests: List All Products', () => {
 			expect( result2JSON ).toEqual(
 				expect.not.arrayContaining( [
 					expect.objectContaining( {
-						name: 'Child Product xxx',
+						name: `Child Product ${ RAND_NUM }`,
 					} ),
 				] )
 			);
@@ -2915,39 +2927,39 @@ test.describe( 'Products API tests: List All Products', () => {
 		test.describe( 'orderby', () => {
 			const productNamesAsc = [
 				`Album ${ RAND_NUM }`,
-				'Beanie with Logo xxx',
-				'Beanie xxx',
-				'Belt xxx',
-				'Cap xxx',
-				'Child Product xxx',
-				'Hoodie with Logo xxx',
-				'Hoodie with Pocket xxx',
+				`Beanie with Logo ${ RAND_NUM }`,
+				`Beanie ${ RAND_NUM }`,
+				`Belt ${ RAND_NUM }`,
+				`Cap ${ RAND_NUM }`,
+				`Child Product ${ RAND_NUM }`,
+				`Hoodie with Logo ${ RAND_NUM }`,
+				`Hoodie with Pocket ${ RAND_NUM }`,
 				`Hoodie with Zipper ${ RAND_NUM }`,
-				'Hoodie xxx',
-				'Logo Collection xxx',
+				`Hoodie ${ RAND_NUM }`,
+				`Logo Collection ${ RAND_NUM }`,
 				`Long Sleeve Tee ${ RAND_NUM }`,
-				'Parent Product xxx',
+				`Parent Product ${ RAND_NUM }`,
 				`Polo ${ RAND_NUM }`,
-				'Single xxx',
-				'Sunglasses xxx',
-				'T-Shirt with Logo xxx',
-				'T-Shirt xxx',
-				'V-Neck T-Shirt xxx',
-				'WordPress Pennant xxx',
+				`Single ${ RAND_NUM }`,
+				`Sunglasses ${ RAND_NUM }`,
+				`T-Shirt with Logo ${ RAND_NUM }`,
+				`T-Shirt ${ RAND_NUM }`,
+				`V-Neck T-Shirt ${ RAND_NUM }`,
+				`WordPress Pennant ${ RAND_NUM }`,
 			];
 			const productNamesDesc = [ ...productNamesAsc ].reverse();
 			const productNamesByRatingAsc = [
-				'Sunglasses xxx',
-				'Cap xxx',
-				'T-Shirt xxx',
+				`Sunglasses ${ RAND_NUM }`,
+				`Cap ${ RAND_NUM }`,
+				`T-Shirt ${ RAND_NUM }`,
 			];
 			const productNamesByRatingDesc = [
 				...productNamesByRatingAsc,
 			].reverse();
 			const productNamesByPopularityDesc = [
-				'Beanie with Logo xxx',
-				'Single xxx',
-				'T-Shirt xxx',
+				`Beanie with Logo ${ RAND_NUM }`,
+				`Single ${ RAND_NUM }`,
+				`T-Shirt ${ RAND_NUM }`,
 			];
 			const productNamesByPopularityAsc = [
 				...productNamesByPopularityDesc,
@@ -2957,7 +2969,7 @@ test.describe( 'Products API tests: List All Products', () => {
 				// Default = date desc.
 				const result = await request.get( 'wp-json/wc/v3/products', {
 					params: {
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const resultJSON = await result.json();
@@ -2977,7 +2989,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					params: {
 						order: 'asc',
 						orderby: 'date',
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const resultJSON = await result.json();
@@ -2997,7 +3009,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					params: {
 						order: 'asc',
 						orderby: 'id',
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result1JSON = await result1.json();
@@ -3014,7 +3026,7 @@ test.describe( 'Products API tests: List All Products', () => {
 					params: {
 						order: 'desc',
 						orderby: 'id',
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result2JSON = await result2.json();
@@ -3034,7 +3046,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'asc',
 						orderby: 'title',
 						per_page: productNamesAsc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result1JSON = await result1.json();
@@ -3050,7 +3062,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'desc',
 						orderby: 'title',
 						per_page: productNamesDesc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result2JSON = await result2.json();
@@ -3078,7 +3090,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'asc',
 						orderby: 'slug',
 						per_page: productNamesBySlugAsc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result1JSON = await result1.json();
@@ -3094,7 +3106,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'desc',
 						orderby: 'slug',
 						per_page: productNamesBySlugDesc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result2JSON = await result2.json();
@@ -3108,33 +3120,33 @@ test.describe( 'Products API tests: List All Products', () => {
 
 			test( 'price orderby', async ( { request } ) => {
 				const productNamesMinPriceAsc = [
-					'Parent Product xxx',
-					'Child Product xxx',
-					'Single xxx',
-					'WordPress Pennant xxx',
+					`Parent Product ${ RAND_NUM }`,
+					`Child Product ${ RAND_NUM }`,
+					`Single ${ RAND_NUM }`,
+					`WordPress Pennant ${ RAND_NUM }`,
 					`Album ${ RAND_NUM }`,
-					'V-Neck T-Shirt xxx',
-					'Cap xxx',
-					'Beanie with Logo xxx',
-					'T-Shirt with Logo xxx',
-					'Beanie xxx',
-					'T-Shirt xxx',
-					'Logo Collection xxx',
+					`V-Neck T-Shirt ${ RAND_NUM }`,
+					`Cap ${ RAND_NUM }`,
+					`Beanie with Logo ${ RAND_NUM }`,
+					`T-Shirt with Logo ${ RAND_NUM }`,
+					`Beanie ${ RAND_NUM }`,
+					`T-Shirt ${ RAND_NUM }`,
+					`Logo Collection ${ RAND_NUM }`,
 					`Polo ${ RAND_NUM }`,
 					`Long Sleeve Tee ${ RAND_NUM }`,
-					'Hoodie with Pocket xxx',
-					'Hoodie xxx',
+					`Hoodie with Pocket ${ RAND_NUM }`,
+					`Hoodie ${ RAND_NUM }`,
 					`Hoodie with Zipper ${ RAND_NUM }`,
-					'Hoodie with Logo xxx',
-					'Belt xxx',
-					'Sunglasses xxx',
+					`Hoodie with Logo ${ RAND_NUM }`,
+					`Belt ${ RAND_NUM }`,
+					`Sunglasses ${ RAND_NUM }`,
 				];
 				const result1 = await request.get( 'wp-json/wc/v3/products', {
 					params: {
 						order: 'asc',
 						orderby: 'price',
 						per_page: productNamesMinPriceAsc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result1JSON = await result1.json();
@@ -3151,26 +3163,26 @@ test.describe( 'Products API tests: List All Products', () => {
 				} );
 
 				const productNamesMaxPriceDesc = [
-					'Sunglasses xxx',
-					'Belt xxx',
-					'Hoodie xxx',
-					'Logo Collection xxx',
-					'Hoodie with Logo xxx',
+					`Sunglasses ${ RAND_NUM }`,
+					`Belt ${ RAND_NUM }`,
+					`Hoodie ${ RAND_NUM }`,
+					`Logo Collection ${ RAND_NUM }`,
+					`Hoodie with Logo ${ RAND_NUM }`,
 					`Hoodie with Zipper ${ RAND_NUM }`,
-					'Hoodie with Pocket xxx',
+					`Hoodie with Pocket ${ RAND_NUM }`,
 					`Long Sleeve Tee ${ RAND_NUM }`,
-					'V-Neck T-Shirt xxx',
+					`V-Neck T-Shirt ${ RAND_NUM }`,
 					`Polo ${ RAND_NUM }`,
-					'T-Shirt xxx',
-					'Beanie xxx',
-					'T-Shirt with Logo xxx',
-					'Beanie with Logo xxx',
-					'Cap xxx',
+					`T-Shirt ${ RAND_NUM }`,
+					`Beanie ${ RAND_NUM }`,
+					`T-Shirt with Logo ${ RAND_NUM }`,
+					`Beanie with Logo ${ RAND_NUM }`,
+					`Cap ${ RAND_NUM }`,
 					`Album ${ RAND_NUM }`,
-					'WordPress Pennant xxx',
-					'Single xxx',
-					'Child Product xxx',
-					'Parent Product xxx',
+					`WordPress Pennant ${ RAND_NUM }`,
+					`Single ${ RAND_NUM }`,
+					`Child Product ${ RAND_NUM }`,
+					`Parent Product ${ RAND_NUM }`,
 				];
 
 				const result2 = await request.get( 'wp-json/wc/v3/products', {
@@ -3178,7 +3190,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'desc',
 						orderby: 'price',
 						per_page: productNamesMaxPriceDesc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result2JSON = await result2.json();
@@ -3242,7 +3254,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'desc',
 						orderby: 'rating',
 						per_page: productNamesByRatingDesc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result2JSON = await result2.json();
@@ -3262,7 +3274,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'asc',
 						orderby: 'rating',
 						per_page: productNamesByRatingAsc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				expect( result1.status() ).toEqual( 200 );
@@ -3282,7 +3294,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'asc',
 						orderby: 'popularity',
 						per_page: productNamesByPopularityAsc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result1JSON = await result1.json();
@@ -3300,7 +3312,7 @@ test.describe( 'Products API tests: List All Products', () => {
 						order: 'desc',
 						orderby: 'popularity',
 						per_page: productNamesByPopularityDesc.length,
-						search: 'xxx',
+						search: RAND_NUM,
 					},
 				} );
 				const result2JSON = await result2.json();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

- Randomized hard-coded values using faker-js. The test was trying to create products that were duplicates of previous failed runs, that's why it's been failing on WPCOM and Pressable.
- Fixed steps involved in creating the `reduced-rate` tax class if it doesn't exist. In `trunk` this test fails when the reduced-rate tax class doesn't exist or was deleted, as is sometimes the case in WPCOM and Pressable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure CI checks pass.
2. Run on WPCOM and Pressable and make sure it passes:
```bash
export E2E_ENV_KEY="..."
pnpm test:e2e:wpcom product-list.test.js
pnpm test:e2e:pressable product-list.test.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Unskip product-list.test.js on WPCOM and Pressable

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
