### PR TITLE
[e2e tests] Fix strict mode violation in customer list spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-customer-list-strict-mode-violation
+++ b/plugins/woocommerce/changelog/e2e-fix-customer-list-strict-mode-violation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixed strict mode violation error in customer-list spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/customer/customer-list.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customer/customer-list.spec.js
@@ -153,7 +153,9 @@ test.describe( 'Merchant > Customer List', () => {
 					page.getByRole( 'link', { name: customer.email } )
 				).toBeVisible();
 				await expect(
-					page.getByText( `${ x }customer` )
+					page
+						.getByRole( 'complementary' )
+						.getByText( `${ x }customer` )
 				).toBeVisible();
 				x++;
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Added a stricter locator to fix a strict mode violation when checking the label for number of displayed customers.

```
Error: expect.toBeVisible: Error: strict mode violation: getByText('1customer') resolved to 2 elements:
    1) <ul class="wp-submenu wp-submenu-wrap">…</ul> aka getByText('WooCommerceHome 3Orders')
    2) <li class="woocommerce-table__summary-item">…</li> aka getByText('1customer', { exact: true })
```

### How to test the changes in this Pull Request:


```
pnpm test:e2e customer
```
