### PR TITLE
[e2e tests] Fix IS_MULTISITE always being set

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-is-multisite-always-true
+++ b/plugins/woocommerce/changelog/e2e-fix-is-multisite-always-true
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fixed IS_MULTISITE always resolved to true

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/site.setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/site.setup.js
@@ -108,5 +108,11 @@ setup( 'disable coming soon', async ( { baseURL } ) => {
 setup( 'determine if multisite', async ( { api } ) => {
 	const response = await api.get( 'system_status' );
 	const { environment } = response.data;
-	process.env.IS_MULTISITE = environment.wp_multisite;
+
+	if ( environment.wp_multisite === false ) {
+		delete process.env.IS_MULTISITE;
+	} else {
+		process.env.IS_MULTISITE = environment.wp_multisite;
+		console.log( `IS_MULTISITE: ${ process.env.IS_MULTISITE }` );
+	}
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/55162 introduced the global setup step that checks the `environment.wp_multisite` value and sets the environment variable `IS_MULTISITE`. However, the value of `IS_MULTISITE` is not checked when evaluating the variable in  tests like:
test.skip( process.env.IS_MULTISITE, '');

Only the variable being set is checked, 
and because of this all tests that should be skipped for multisite are always being skipped, even for non-multisite setups.

The fix is to unset IS_MULTISITE if `environment.wp_multisite` is false.

### How to test the changes in this Pull Request:

Run tests that are skipped in multisite. Make sure they run.

```
pnpm test:e2e account-email-receiveing onboarding-wizard users-create users-manage 
```