### PR TITLE
Redirect to add product task if no products created yet

### DIFF
--- a/plugins/woocommerce/changelog/add-54617_empty_all_product_screen_redirect
+++ b/plugins/woocommerce/changelog/add-54617_empty_all_product_screen_redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+When no products are created yet, redirect "All Products" page to "Add Product" task.

--- a/plugins/woocommerce/changelog/add-54617_empty_all_product_screen_redirect_2
+++ b/plugins/woocommerce/changelog/add-54617_empty_all_product_screen_redirect_2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add is_always_accessible method to Task class, to allow tasks to still be accessible when list is hidden.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -613,5 +613,4 @@ abstract class Task {
 		}
 		return $result;
 	}
-
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -463,6 +463,15 @@ abstract class Task {
 	}
 
 	/**
+	 * If a task is always accessible, relevant for when a task list is hidden but a task can still be viewed.
+	 *
+	 * @return bool
+	 */
+	public function is_always_accessible() {
+		return false;
+	}
+
+	/**
 	 * Check if the task has been visited.
 	 *
 	 * @return bool

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -415,10 +415,12 @@ class TaskList {
 		$this->possibly_track_completion();
 		$tasks_json = array();
 
-		// We have no use for hidden lists, it's expensive to compute individual tasks completion.
-		// Exception: Secret tasklist is always hidden.
-		if ( $this->is_visible() || 'secret_tasklist' === $this->id ) {
-			foreach ( $this->tasks as $task ) {
+		
+		foreach ( $this->tasks as $task ) {
+			// We have no use for hidden lists, it's expensive to compute individual tasks completion.
+			// Exception: Secret tasklist is always hidden, or a task is always accessible.
+			$list_is_visible = $this->is_visible() || 'secret_tasklist' === $this->id;
+			if ( $list_is_visible || ( method_exists( $task, 'is_always_accessible' ) && $task->is_always_accessible() ) ) {
 				$json = $task->get_json();
 				if ( $json['canView'] ) {
 					$tasks_json[] = $json;

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -187,7 +187,7 @@ class TaskList {
 		$viewable_tasks  = $this->get_viewable_tasks();
 		$completed_count = array_reduce(
 			$viewable_tasks,
-			function( $total, $task ) {
+			function ( $total, $task ) {
 				return $task->is_complete() ? $total + 1 : $total;
 			},
 			0
@@ -285,7 +285,7 @@ class TaskList {
 		return current(
 			array_filter(
 				$this->tasks,
-				function( $task ) use ( $task_id ) {
+				function ( $task ) use ( $task_id ) {
 					return $task->get_id() === $task_id;
 				}
 			)
@@ -301,7 +301,7 @@ class TaskList {
 		return array_values(
 			array_filter(
 				$this->tasks,
-				function( $task ) {
+				function ( $task ) {
 					return $task->can_view();
 				}
 			)
@@ -362,7 +362,7 @@ class TaskList {
 		if ( 0 !== count( $sort_by ) ) {
 			usort(
 				$this->tasks,
-				function( $a, $b ) use ( $sort_by ) {
+				function ( $a, $b ) use ( $sort_by ) {
 					return Task::sort( $a, $b, $sort_by );
 				}
 			);
@@ -415,7 +415,6 @@ class TaskList {
 		$this->possibly_track_completion();
 		$tasks_json = array();
 
-		
 		foreach ( $this->tasks as $task ) {
 			// We have no use for hidden lists, it's expensive to compute individual tasks completion.
 			// Exception: Secret tasklist is always hidden, or a task is always accessible.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -28,6 +28,7 @@ class Products extends Task {
 		add_action( 'woocommerce_new_product', array( $this, 'delete_product_count_cache' ) );
 		add_action( 'wp_trash_post', array( $this, 'delete_product_count_cache' ) );
 		add_action( 'untrashed_post', array( $this, 'delete_product_count_cache' ) );
+		add_action( 'current_screen', array( $this, 'maybe_redirect_to_add_product_tasklist' ), 30, 0 );
 	}
 
 	/**
@@ -95,6 +96,14 @@ class Products extends Task {
 		);
 	}
 
+	/**
+	 * If a task is always accessible, relevant for when a task list is hidden but a task can still be viewed.
+	 *
+	 * @return bool
+	 */
+	public function is_always_accessible() {
+		return true;
+	}
 
 	/**
 	 * Adds a return to task list notice when completing the manual product task.
@@ -215,5 +224,20 @@ class Products extends Task {
 		$products_query = new \WP_Query( $args );
 
 		return $products_query->found_posts;
+	}
+
+	public function maybe_redirect_to_add_product_tasklist() {
+		$screen = get_current_screen();
+		if ( 'edit' === $screen->base && 'product' === $screen->post_type ) {
+			// wp_count_posts is cached.
+			$counts = (array) wp_count_posts( $screen->post_type );
+			unset( $counts['auto-draft'] );
+			$count = array_sum( $counts );
+			if ( $count > 0 ) {
+				return;
+			}
+			wp_redirect( admin_url( 'admin.php?page=wc-admin&task=products' ) );
+			exit;
+		}
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -226,6 +226,11 @@ class Products extends Task {
 		return $products_query->found_posts;
 	}
 
+	/**
+	 * Redirect to the add product tasklist if there are no products.
+	 *
+	 * @return void
+	 */
 	public function maybe_redirect_to_add_product_tasklist() {
 		$screen = get_current_screen();
 		if ( 'edit' === $screen->base && 'product' === $screen->post_type ) {
@@ -236,7 +241,7 @@ class Products extends Task {
 			if ( $count > 0 ) {
 				return;
 			}
-			wp_redirect( admin_url( 'admin.php?page=wc-admin&task=products' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&task=products' ) );
 			exit;
 		}
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/onboarding/add-product-task.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/onboarding/add-product-task.spec.js
@@ -1,0 +1,146 @@
+const { test, expect } = require( '../../fixtures/fixtures' );
+const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
+
+const hide_task_list = async ( wcAdminApi, task_list_name ) => {
+	const {
+		statusText,
+		data: { isHidden },
+	} = await wcAdminApi.post( 'onboarding/tasks/' + task_list_name + '/hide' );
+
+	expect( statusText ).toEqual( 'OK' );
+
+	return isHidden === true;
+};
+
+const show_task_list = async ( wcAdminApi, task_list_name ) => {
+	const {
+		statusText,
+		data: { isHidden },
+	} = await wcAdminApi.post(
+		'onboarding/tasks/' + task_list_name + '/unhide'
+	);
+
+	expect( statusText ).toEqual( 'OK' );
+
+	return isHidden === false;
+};
+
+// TODO (E2E Audit): This test should be combined with other WC Homepage setup tests like the tests in activate-and-setup/stats-overview.spec.js into a single spec.
+test.describe( 'Add Product Task', () => {
+	test.use( { storageState: ADMIN_STATE_PATH } );
+
+	test.beforeAll( async ( { wcAdminApi, api } ) => {
+		await wcAdminApi.post( 'onboarding/profile', {
+			skipped: true,
+		} );
+		const products = await api.get( 'products?per_page=50' );
+		await api.post( 'products/batch', {
+			delete: products.data.map( ( product ) => product.id ),
+		} );
+	} );
+
+	test.afterAll( async ( { wcAdminApi } ) => {
+		await wcAdminApi.post( 'onboarding/profile', {
+			skipped: false,
+		} );
+	} );
+
+	test( 'Add product task displays options for different product types', async ( {
+		page,
+	} ) => {
+		// Navigate to the task list
+		await page.goto( 'wp-admin/admin.php?page=wc-admin&task=products' );
+
+		// Verify product type options are displayed
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Physical product' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Variable product' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Grouped product' } )
+		).toBeVisible();
+	} );
+
+	test( 'Products page redirects to add product task when no products exist', async ( {
+		page,
+	} ) => {
+		// Navigate to All Products page
+		await page.goto( 'wp-admin/edit.php?post_type=product' );
+
+		// Verify redirect to add product task
+		await expect( page ).toHaveURL( /.+task=products/ );
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Physical product' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Variable product' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Grouped product' } )
+		).toBeVisible();
+	} );
+
+	test( 'Products page shows products table when products exist', async ( {
+		page,
+		api,
+	} ) => {
+		// Create a test product
+		await api.post( 'products', {
+			name: 'Test Product',
+			type: 'simple',
+			regular_price: '10.00',
+		} );
+
+		// Navigate to All Products page
+		await page.goto( 'wp-admin/edit.php?post_type=product' );
+
+		// Verify products table is visible
+		await expect( page.locator( '.wp-list-table' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'columnheader', { name: 'Name' } )
+		).toHaveCount( 2 );
+		await expect(
+			page.getByRole( 'columnheader', { name: 'SKU' } )
+		).toHaveCount( 2 );
+		await expect(
+			page.getByRole( 'columnheader', { name: 'Price' } )
+		).toHaveCount( 2 );
+		await expect(
+			page.locator( '.wp-list-table > tbody > tr' )
+		).toHaveCount( 1 );
+
+		// Clean up - delete test product
+		const products = await api.get( 'products' );
+		for ( const product of products.data ) {
+			await api.delete( `products/${ product.id }`, { force: true } );
+		}
+	} );
+
+	test( 'Products page redirects to add product task when no products exist and task list is hidden', async ( {
+		page,
+		wcAdminApi,
+	} ) => {
+		// Hide the task list
+		expect( await hide_task_list( wcAdminApi, 'setup' ) ).toBe( true );
+
+		// Navigate to All Products page
+		await page.goto( 'wp-admin/edit.php?post_type=product' );
+
+		// Verify redirect to add product task
+		await expect( page ).toHaveURL( /.+task=products/ );
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Physical product' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Variable product' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Grouped product' } )
+		).toBeVisible();
+
+		// Reset task list to visible
+		expect( await show_task_list( wcAdminApi, 'setup' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR mainly updates the **All Products** page when no products are in the store, by redirecting to the **Add Product** task screen instead.
In order for this to still work when the task list is hidden, I added an `is_always_accessible` option to the `Task` class that defaults to `false`.
I set this to `true` for the **Add Product** task so it can still be accessed when the task list is hidden.

Closes #54617 

https://github.com/user-attachments/assets/b5399106-414b-45cb-a956-932535cf7242

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce site and go to **Products > All Products**
2. It should redirect to the **Add your products** task with several option to create a specific product type.
3. Create a product and safe it as draft or publish it.
4. Go to **Products > All Products** again
5. It should correctly render the products table and **not** redirect to the task
6. Now move the created product to trash, and than go to the **Trash** tab and click **Delete Permantly** on the product ( see video if you need help )
7. It should redirect to the **Add your products** task if you don't have any other products created.
8. Now go to **WooCommerce > Home**
9. The main task list should be shown, click the 3-dot menu beside **Follow these steps to start selling quickly. 3 out of 5 complete.** and click **Hide setup list**
10. Now go to **Products > All Products**
11. It should redirect to the **Add your products** task correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
