### PR TITLE
Use old Woo `$primary` color for computed background colors

### DIFF
--- a/plugins/woocommerce/changelog/further-scss-fixes
+++ b/plugins/woocommerce/changelog/further-scss-fixes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is already covered in another changelog entry.
+
+

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -1589,7 +1589,8 @@ p.demo_store,
 			z-index: 2;
 			width: 1em;
 			height: 1em;
-			background-color: $primary;
+			// We use the old WooCommerce color on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+			background-color: #7F54B3;
 			border-radius: 1em;
 			cursor: ew-resize;
 			outline: none;
@@ -1606,7 +1607,8 @@ p.demo_store,
 			display: block;
 			border: 0;
 			border-radius: 1em;
-			background-color: $primary;
+			// We use the old WooCommerce color on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+			background-color: #7F54B3;
 		}
 
 		.price_slider_wrapper .ui-widget-content {
@@ -1739,13 +1741,15 @@ p.demo_store,
 		}
 
 		&.alt {
-			background-color: $primary;
-			color: $primarytext;
+			// We use the old WooCommerce colors on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+			background-color: #7F54B3;
+			color: desaturate(lighten(#7F54B3, 50%), 18%);
 			-webkit-font-smoothing: antialiased;
 
 			&:hover {
-				background-color: darken($primary, 5%);
-				color: $primarytext;
+				// We use the old WooCommerce colors on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+				background-color: darken(#7F54B3, 5%);
+				color: desaturate(lighten(#7F54B3, 50%), 18%);
 			}
 
 			&.disabled,
@@ -1754,8 +1758,9 @@ p.demo_store,
 			&.disabled:hover,
 			&:disabled:hover,
 			&:disabled[disabled]:hover {
-				background-color: $primary;
-				color: $primarytext;
+				// We use the old WooCommerce colors on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+				background-color: #7F54B3;
+				color: desaturate(lighten(#7F54B3, 50%), 18%);
 			}
 		}
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -1611,7 +1611,8 @@ p.demo_store,
 
 		.price_slider_wrapper .ui-widget-content {
 			border-radius: 1em;
-			background-color: darken($primary, 30%);
+			// We use the old WooCommerce color as the base on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+			background-color: darken(#7F54B3, 30%);
 			border: 0;
 		}
 
@@ -2119,15 +2120,17 @@ p.demo_store,
 	}
 
 	#payment {
-		background: desaturate(rgba($primary, 0.14), 21%);
+		// We use the old WooCommerce color as the base on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
+		background: desaturate(rgba(#7F54B3, 0.14), 21%);
 		border-radius: 5px;
 
 		ul.payment_methods {
 			@include clearfix();
 			text-align: left;
 			padding: 1em;
+			// We use the old WooCommerce color as the base on purpose. See https://github.com/woocommerce/woocommerce/issues/55165.
 			border-bottom: 1px solid
-				darken(desaturate(rgba($primary, 0.14), 21%), 10%);
+				darken(desaturate(rgba(#7F54B3, 0.14), 21%), 10%);
 			margin: 0;
 			list-style: none outside;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Continuation of #55366. This applies a similar fix for the legacy price filter widget and the payment section in the legacy checkout page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install theme [GeneratePress](https://wordpress.org/themes/generatepress/) and make sure it's enabled.
1. Create a new page on the admin that uses the **Classic Checkout** block.
1. Install plugin [Classic Widgets](https://wordpress.org/plugins/classic-widgets/) to enable access to legacy widgets and make sure to add the **Filter Products by Price** widget to one of the widget areas.
1. Go to the **Shop** page on your store and confirm that the price widget slider looks correct:
   |Before | After|
   |-------|------|
   |<img width="392" alt="Screenshot 2025-02-12 at 16 33 12" src="https://github.com/user-attachments/assets/3f1ee20a-121e-47e6-a7ee-7d09562f1706" /> | <img width="413" alt="Screenshot 2025-02-12 at 16 32 35" src="https://github.com/user-attachments/assets/504b2e79-91a1-4e6a-ae66-ec92e7879a62" /> |
1. Add a few products to your cart.
1. Visit the legacy checkout page you created in step 2 and confirm that things look right:
   |Before | After|
   |-------|------|
   |<img width="850" alt="before" src="https://github.com/user-attachments/assets/3742abac-c8bb-4172-b040-f4bb9d103d72" /> | <img width="837" alt="after" src="https://github.com/user-attachments/assets/8590ffb0-3d96-4458-94b2-56f2ddd2c48c" />|

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
