### PR TITLE
Ensure the category slug comparison is URL decoded in both ends for canonical redirect

### DIFF
--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -311,6 +311,8 @@ function wc_product_canonical_redirect(): void {
 		return;
 	}
 
+	$specified_category_slug = urldecode( $specified_category_slug );
+
 	// What category slug did we expect? Normally this maps back to the first assigned product_cat
 	// term. However, this is filterable so we use the relevant helper function to figure this out.
 	$expected_category_slug = wc_product_post_type_link( '%product_cat%', get_post( get_the_ID() ) );


### PR DESCRIPTION
This is a defect of 55027 introduced in WC 9.7 RC1.

https://github.com/woocommerce/woocommerce/issues/55414

Closes #55414.


### How to test the changes in this Pull Request:

1. Create a brand new WP site in Greek (or another language with encoded slugs)
2. Install and setup WooCommerce
3. Go to Settings > Permalinks
4. Set the following custom product base: `/shop/%product_cat%/`
5. Create a product and assign it to the default product category "Χωρίς κατηγορία" (with the slug `χωρίς-κατηγορία`)
6. Visit the product page (should be like http://test.loc/shop/%cf%87%cf%89%cf%81%ce%af%cf%82-%ce%ba%ce%b1%cf%84%ce%b7%ce%b3%ce%bf%cf%81%ce%af%ce%b1/some-product/)

=> The product page should be displayed without any infinite redirection.

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

This was detected in the RC version, I presume it does not need a changelog.
