### PR TITLE
Prevent data stores being registered more than once due to circular dependency

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/utils.ts
@@ -10,18 +10,22 @@ import {
 	Cart,
 	CartResponse,
 } from '@woocommerce/types';
+import { CurriedSelectorsOf } from '@wordpress/data/build-types/types';
 
 /**
  * Internal dependencies
  */
-import { store as validationStoreDescriptor } from '../validation';
+import type { ValidationStoreDescriptor } from '../validation';
+import { STORE_KEY as VALIDATION_STORE_KEY } from '../validation/constants';
 
 export const mapCartResponseToCart = ( responseCart: CartResponse ): Cart => {
 	return camelCaseKeys( responseCart ) as unknown as Cart;
 };
 
 export const shippingAddressHasValidationErrors = () => {
-	const validationStore = select( validationStoreDescriptor );
+	const validationStore = select(
+		VALIDATION_STORE_KEY
+	) as CurriedSelectorsOf< ValidationStoreDescriptor >;
 	// Check if the shipping address form has validation errors - if not then we know the full required
 	// address has been pushed to the server.
 	const stateValidationErrors =
@@ -97,7 +101,9 @@ export const validateDirtyProps = ( dirtyProps: {
 	billingAddress: BaseAddressKey[];
 	shippingAddress: BaseAddressKey[];
 } ): boolean => {
-	const validationStore = select( validationStoreDescriptor );
+	const validationStore = select(
+		VALIDATION_STORE_KEY
+	) as CurriedSelectorsOf< ValidationStoreDescriptor >;
 
 	const invalidProps = [
 		...dirtyProps.billingAddress.filter( ( key ) => {

--- a/plugins/woocommerce-blocks/assets/js/data/payment/utils/check-payment-methods.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/payment/utils/check-payment-methods.ts
@@ -18,12 +18,18 @@ import {
 	getPaymentMethods,
 } from '@woocommerce/blocks-registry';
 import { previewCart } from '@woocommerce/resource-previews';
+import {
+	ActionCreatorsOf,
+	ConfigOf,
+	CurriedSelectorsOf,
+} from '@wordpress/data/build-types/types';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY as CART_STORE_KEY } from '../../cart/constants';
-import { store as paymentStore } from '../index';
+import { STORE_KEY as PAYMENT_STORE_KEY } from '../constants';
+import type { PaymentStoreDescriptor } from '../index';
 import { noticeContexts } from '../../../base/context/event-emit';
 import {
 	EMPTY_CART_ERRORS,
@@ -236,10 +242,14 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 		}
 	}
 
+	const paymentSelectors = select(
+		PAYMENT_STORE_KEY
+	) as CurriedSelectorsOf< PaymentStoreDescriptor >;
+
 	const availablePaymentMethodNames = Object.keys( availablePaymentMethods );
 	const currentlyAvailablePaymentMethods = express
-		? select( paymentStore ).getAvailableExpressPaymentMethods()
-		: select( paymentStore ).getAvailablePaymentMethods();
+		? paymentSelectors.getAvailableExpressPaymentMethods()
+		: paymentSelectors.getAvailablePaymentMethods();
 
 	if (
 		Object.keys( currentlyAvailablePaymentMethods ).length ===
@@ -255,7 +265,9 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 	const {
 		__internalSetAvailablePaymentMethods,
 		__internalSetAvailableExpressPaymentMethods,
-	} = dispatch( paymentStore );
+	} = dispatch( PAYMENT_STORE_KEY ) as ActionCreatorsOf<
+		ConfigOf< PaymentStoreDescriptor >
+	>;
 
 	const setCallback = express
 		? __internalSetAvailableExpressPaymentMethods

--- a/plugins/woocommerce-blocks/assets/js/data/validation/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/validation/index.ts
@@ -19,5 +19,6 @@ export const config = {
 
 export const store = createReduxStore( STORE_KEY, config );
 register( store );
+export type ValidationStoreDescriptor = typeof store;
 
 export const VALIDATION_STORE_KEY = STORE_KEY;

--- a/plugins/woocommerce/changelog/fix-duplicate-store-imports
+++ b/plugins/woocommerce/changelog/fix-duplicate-store-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent data stores being imported twice when there are circular dependencies


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Reverts a couple of changes we made to use `StoreDescriptor` when accessing data stores where importing that store descriptor would lead to a "circular dependency" (not a true circular dependency, as there's no script with a dependency on a script that depends on it, this issue is caused by File A loading File B which loads File A.)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you can place an order with a couple of different payment methods, there should be no console errors and the order should place fine.
2. Check the console for any messages like `Store "wc/store/validation" is already registered`. You should not see any.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
