### PR TITLE
Accurate slug comparison by decoding both sides

### DIFF
--- a/plugins/woocommerce/changelog/copy-55415-9.7-2
+++ b/plugins/woocommerce/changelog/copy-55415-9.7-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This simply fixes an issue introduced earlier in the 9.7 release cycle, so no additional changelog entry is needed
+
+

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -304,6 +304,7 @@ function wc_product_canonical_redirect(): void {
 
 	// In the event we are dealing with ugly permalinks, this will be empty.
 	$specified_category_slug = get_query_var( 'product_cat' );
+	$specified_category_slug = urldecode( $specified_category_slug );
 
 	if ( ! is_string( $specified_category_slug ) || strlen( $specified_category_slug ) < 1 ) {
 		return;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes a regression caused by #54940, which was in turn fixing a regression caused by #51637. When comparing an expected and a specified product category slug, one or the other may be URL-encoded if it contains multibyte characters. This simply ensures that both sides have been decoded before the comparison is made, and avoiding potential infinite redirect loops.

Note: this is based on #55415 but targeted at the 9.7 release branch instead of trunk. Props @strategio 

Fixes #55414

### How to test the changes in this Pull Request:

1. Follow the testing instructions in #55415 and make sure everything works as described.
2. Follow the testing instructions in #54940 and make sure this isn't causing a regression from that change.
3. Do step 2 of the testing instructions in #51637 to make sure the canonical redirect is still working as expected.
