### PR TITLE
Migrate to register(storeDescriptor) for review data store

### DIFF
--- a/packages/js/data/changelog/fix-migrate-review-data
+++ b/packages/js/data/changelog/fix-migrate-review-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Migrate to register(storeDescriptor) for review data store

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -142,7 +142,6 @@ export { UserPreferences } from './user/types';
 /**
  * Internal dependencies
  */
-import type { REVIEWS_STORE_NAME } from './reviews';
 import type { SETTINGS_STORE_NAME } from './settings';
 import type { PLUGINS_STORE_NAME } from './plugins';
 import type { ONBOARDING_STORE_NAME } from './onboarding';

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -142,6 +142,7 @@ export { UserPreferences } from './user/types';
 /**
  * Internal dependencies
  */
+import type { REVIEWS_STORE_NAME } from './reviews';
 import type { SETTINGS_STORE_NAME } from './settings';
 import type { PLUGINS_STORE_NAME } from './plugins';
 import type { ONBOARDING_STORE_NAME } from './onboarding';
@@ -168,6 +169,7 @@ import type { EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME } from './product-varia
 import type { EXPERIMENTAL_TAX_CLASSES_STORE_NAME } from './tax-classes';
 
 export type WCDataStoreName =
+	| typeof REVIEWS_STORE_NAME
 	| typeof SETTINGS_STORE_NAME
 	| typeof PLUGINS_STORE_NAME
 	| typeof ONBOARDING_STORE_NAME
@@ -217,7 +219,9 @@ import { ProductFormSelectors } from './product-form/selectors';
 
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
-export type WCSelectorType< T > = T extends typeof SETTINGS_STORE_NAME
+export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME
+	? WPDataSelectors
+	: T extends typeof SETTINGS_STORE_NAME
 	? WPDataSelectors
 	: T extends typeof PLUGINS_STORE_NAME
 	? PluginSelectors

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -169,7 +169,6 @@ import type { EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME } from './product-varia
 import type { EXPERIMENTAL_TAX_CLASSES_STORE_NAME } from './tax-classes';
 
 export type WCDataStoreName =
-	| typeof REVIEWS_STORE_NAME
 	| typeof SETTINGS_STORE_NAME
 	| typeof PLUGINS_STORE_NAME
 	| typeof ONBOARDING_STORE_NAME

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -50,6 +50,7 @@ export { ShippingMethod } from './shipping-methods/types';
 
 // Export stores
 export { store as onboardingStore } from './onboarding';
+export { store as reviewsStore } from './reviews';
 
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';
@@ -218,9 +219,7 @@ import { ProductFormSelectors } from './product-form/selectors';
 
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
-export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME
-	? WPDataSelectors
-	: T extends typeof SETTINGS_STORE_NAME
+export type WCSelectorType< T > = T extends typeof SETTINGS_STORE_NAME
 	? WPDataSelectors
 	: T extends typeof PLUGINS_STORE_NAME
 	? PluginSelectors

--- a/packages/js/data/src/reviews/index.ts
+++ b/packages/js/data/src/reviews/index.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-
-import { registerStore } from '@wordpress/data';
-import { Reducer, AnyAction } from 'redux';
-import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+import { createReduxStore, register } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,32 +12,18 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import controls from '../controls';
 import reducer, { State } from './reducer';
-import { WPDataActions, WPDataSelectors } from '../types';
-import { PromiseifySelectors } from '../types/promiseify-selectors';
 
 export * from './types';
 export type { State };
 
-registerStore< State >( STORE_NAME, {
-	reducer: reducer as Reducer< State, AnyAction >,
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
 	actions,
 	controls,
 	selectors,
 	resolvers,
 } );
 
+register( store );
+
 export const REVIEWS_STORE_NAME = STORE_NAME;
-
-export type ReviewSelector = SelectFromMap< typeof selectors >;
-
-declare module '@wordpress/data' {
-	function dispatch(
-		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions & WPDataActions >;
-	function select(
-		key: typeof STORE_NAME
-	): SelectFromMap< typeof selectors > & WPDataSelectors;
-	function resolveSelect(
-		key: typeof STORE_NAME
-	): PromiseifySelectors< ReviewSelector >;
-}

--- a/plugins/woocommerce/changelog/fix-migrate-review-data
+++ b/plugins/woocommerce/changelog/fix-migrate-review-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update reviews store import to use reviewsStore from @woocommerce/data

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/reviews/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/reviews/index.js
@@ -19,7 +19,7 @@ import {
 } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { get, isNull } from 'lodash';
-import { REVIEWS_STORE_NAME } from '@woocommerce/data';
+import { reviewsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { CurrencyContext } from '@woocommerce/currency';
 
@@ -346,7 +346,7 @@ export default compose( [
 	withSelect( ( select, props ) => {
 		const { hasUnapprovedReviews } = props;
 		const { getReviews, getReviewsError, isResolving } =
-			select( REVIEWS_STORE_NAME );
+			select( reviewsStore );
 		let reviews = [];
 		let isError = false;
 		let isRequesting = false;
@@ -364,7 +364,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, props ) => {
 		const { deleteReview, updateReview, invalidateResolution } =
-			dispatch( REVIEWS_STORE_NAME );
+			dispatch( reviewsStore );
 		const { createNotice } = dispatch( 'core/notices' );
 
 		const clearReviewsCache = () => {

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/reviews/utils.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/reviews/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { REVIEWS_STORE_NAME } from '@woocommerce/data';
+import { reviewsStore } from '@woocommerce/data';
 
 export const REVIEW_PAGE_LIMIT = 5;
 
@@ -14,7 +14,7 @@ export const unapprovedReviewsQuery = {
 };
 export function getUnapprovedReviews( select ) {
 	const { getReviewsTotalCount, getReviewsError, isResolving } =
-		select( REVIEWS_STORE_NAME );
+		select( reviewsStore );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const totalReviews = getReviewsTotalCount( unapprovedReviewsQuery );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/55371

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the reviews store registration pattern in @woocommerce/data to use the modern WordPress data store API. 

Key changes include:

1. Migrated from deprecated `registerStore` to `createReduxStore` and `register` pattern
2. Updated store exports to match the modern pattern used across other stores:
    - Added `export { store as reviewsStore }`
    - Maintained `REVIEWS_STORE_NAME` export for backward compatibility
3. Removed deprecated type definitions:
    - Removed custom @wordpress/data module declaration
    - Cleaned up unused type exports and imports
4. Update reviews store import to use `reviewsStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the review store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/review/**`
4. `window.wp.data.select( wc.data.reviewsStore )` and `window.wp.data.dispatch( wc.data.reviewsStore )` should return selectors and dispatchers


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
