### PR TITLE
Migrate to register(storeDescriptor) for settings data store

### DIFF
--- a/packages/js/data/README.md
+++ b/packages/js/data/README.md
@@ -15,12 +15,12 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ## Usage
 
 ```JS
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 
 function MySettings() {
 	const settings = useSelect( select => {
-		return select( SETTINGS_STORE_NAME ).getSettings();
+		return select( settingsStore ).getSettings();
 	} );
 	return (
 		<ul>

--- a/packages/js/data/changelog/fix-migrate-settings-store
+++ b/packages/js/data/changelog/fix-migrate-settings-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Migrate to register(storeDescriptor) for settings data store

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -51,6 +51,7 @@ export { ShippingMethod } from './shipping-methods/types';
 // Export stores
 export { store as onboardingStore } from './onboarding';
 export { store as reviewsStore } from './reviews';
+export { store as settingsStore } from './settings';
 
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';

--- a/packages/js/data/src/settings/index.ts
+++ b/packages/js/data/src/settings/index.ts
@@ -1,27 +1,24 @@
 /**
  * External dependencies
  */
-
-import { registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import { Reducer } from 'redux';
-import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+import type { Reducer } from 'redux';
 
 /**
  * Internal dependencies
  */
-import { WPDataSelectors, WPDataActions } from '../types';
 import { STORE_NAME } from './constants';
 import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { SettingsState } from './types';
-import { PromiseifySelectors } from '../types/promiseify-selectors';
+
 export * from './types';
 export type { State };
 
-registerStore< State >( STORE_NAME, {
+export const store = createReduxStore( STORE_NAME, {
 	reducer: reducer as Reducer< SettingsState >,
 	actions,
 	controls,
@@ -29,16 +26,6 @@ registerStore< State >( STORE_NAME, {
 	resolvers,
 } );
 
-export const SETTINGS_STORE_NAME = STORE_NAME;
+register( store );
 
-declare module '@wordpress/data' {
-	function dispatch(
-		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions > & WPDataActions;
-	function select(
-		key: typeof STORE_NAME
-	): SelectFromMap< typeof selectors > & WPDataSelectors;
-	function resolveSelect(
-		key: typeof STORE_NAME
-	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
-}
+export const SETTINGS_STORE_NAME = STORE_NAME;

--- a/packages/js/data/src/settings/use-settings.ts
+++ b/packages/js/data/src/settings/use-settings.ts
@@ -7,7 +7,8 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
+import { store } from './';
+import type { Settings } from './types';
 
 export const useSettings = ( group: string, settingsKeys: string[] = [] ) => {
 	const { requestedSettings, settingsError, isRequesting, isDirty } =
@@ -18,7 +19,7 @@ export const useSettings = ( group: string, settingsKeys: string[] = [] ) => {
 					getSettingsForGroup,
 					getIsDirty,
 					isUpdateSettingsRequesting,
-				} = select( STORE_NAME );
+				} = select( store );
 				return {
 					requestedSettings: getSettingsForGroup(
 						group,
@@ -37,9 +38,9 @@ export const useSettings = ( group: string, settingsKeys: string[] = [] ) => {
 		persistSettingsForGroup,
 		updateAndPersistSettingsForGroup,
 		updateSettingsForGroup,
-	} = useDispatch( STORE_NAME );
+	} = useDispatch( store );
 	const updateSettings = useCallback(
-		( name, data ) => {
+		( name: string, data: Settings ) => {
 			updateSettingsForGroup( group, { [ name ]: data } );
 		},
 		[ group ]
@@ -50,7 +51,7 @@ export const useSettings = ( group: string, settingsKeys: string[] = [] ) => {
 		persistSettingsForGroup( group );
 	}, [ group ] );
 	const updateAndPersistSettings = useCallback(
-		( name, data ) => {
+		( name: string, data: Settings ) => {
 			updateAndPersistSettingsForGroup( group, { [ name ]: data } );
 		},
 		[ group ]

--- a/packages/js/data/src/settings/with-settings-hydration.tsx
+++ b/packages/js/data/src/settings/with-settings-hydration.tsx
@@ -8,7 +8,7 @@ import { createElement, useRef, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
+import { store } from './';
 import { Settings } from './types';
 
 export const withSettingsHydration = ( group: string, settings: Settings ) =>
@@ -24,11 +24,11 @@ export const withSettingsHydration = ( group: string, settings: Settings ) =>
 				finishResolution,
 				updateSettingsForGroup,
 				clearIsDirty,
-			} = useDispatch( STORE_NAME );
+			} = useDispatch( store );
 			const { isResolvingGroup, hasFinishedResolutionGroup } = useSelect(
 				( select ) => {
 					const { isResolving, hasFinishedResolution } =
-						select( STORE_NAME );
+						select( store );
 					return {
 						isResolvingGroup: isResolving( 'getSettings', [
 							group,

--- a/plugins/woocommerce/changelog/fix-migrate-settings-store
+++ b/plugins/woocommerce/changelog/fix-migrate-settings-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update settings store import to use settingsStore from @woocommerce/data

--- a/plugins/woocommerce/client/admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/panels/help.js
@@ -12,7 +12,7 @@ import { List, Section } from '@woocommerce/components';
 import {
 	onboardingStore,
 	PLUGINS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 } from '@woocommerce/data';
 import { compose } from 'redux';
 import { recordEvent as fallbackRecordEvent } from '@woocommerce/tracks';
@@ -387,7 +387,7 @@ export const HelpPanel = ( {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { getSettings } = select( settingsStore );
 		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 		const { general: generalSettings = {} } = getSettings( 'general' );
 		const activePlugins = getActivePlugins();

--- a/plugins/woocommerce/client/admin/client/analytics/components/leaderboard/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/leaderboard/index.js
@@ -12,7 +12,7 @@ import { getPersistedQuery } from '@woocommerce/navigation';
 import {
 	getFilterQuery,
 	getLeaderboard,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 } from '@woocommerce/data';
 import { CurrencyContext } from '@woocommerce/currency';
 import { formatValue } from '@woocommerce/number';
@@ -186,7 +186,7 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { id, query, totalRows, filters } = props;
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 		const filterQuery = getFilterQuery( { filters, query } );
 

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-chart/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-chart/index.js
@@ -12,7 +12,7 @@ import { Chart, AnalyticsError } from '@woocommerce/components';
 import {
 	getReportChartData,
 	getTooltipValueFormat,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	REPORTS_STORE_NAME,
 } from '@woocommerce/data';
 import {
@@ -345,7 +345,7 @@ export default compose(
 			getChartMode( selectedFilter, query ) ||
 			'time-comparison';
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
 		/* eslint @wordpress/no-unused-vars-before-return: "off" */

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-filters/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-filters/index.js
@@ -8,7 +8,7 @@ import { omitBy, isUndefined, snakeCase } from 'lodash';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 import { ReportFilters as Filters } from '@woocommerce/components';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import {
 	getCurrentDates,
 	getDateParamsFromQuery,
@@ -162,7 +162,7 @@ ReportFilters.contextType = CurrencyContext;
 export default compose(
 	withSelect( ( select ) => {
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 		return { defaultDateRange };
 	} ),

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-summary/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-summary/index.js
@@ -14,7 +14,7 @@ import {
 	SummaryNumber,
 } from '@woocommerce/components';
 import { calculateDelta, formatValue } from '@woocommerce/number';
-import { getSummaryNumbers, SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { getSummaryNumbers, settingsStore } from '@woocommerce/data';
 import { getDateParamsFromQuery } from '@woocommerce/date';
 import { recordEvent } from '@woocommerce/tracks';
 import { CurrencyContext } from '@woocommerce/currency';
@@ -222,7 +222,7 @@ export default compose(
 		const fields = charts && charts.map( ( chart ) => chart.key );
 
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
 		const summaryData = getSummaryNumbers( {

--- a/plugins/woocommerce/client/admin/client/analytics/components/report-table/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/components/report-table/index.js
@@ -32,7 +32,7 @@ import {
 	getReportChartData,
 	getReportTableData,
 	EXPORT_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	REPORTS_STORE_NAME,
 	useUserPreferences,
 	QUERY_DEFAULTS,
@@ -590,7 +590,7 @@ export default compose(
 			: null;
 
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
 		const noSearchResultsFound =

--- a/plugins/woocommerce/client/admin/client/analytics/report/downloads/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/downloads/table.js
@@ -10,7 +10,7 @@ import { Date, Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { formatValue } from '@woocommerce/number';
 import { getAdminLink } from '@woocommerce/settings';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import { getCurrentDates, defaultTableDateFormat } from '@woocommerce/date';
 import { CurrencyContext } from '@woocommerce/currency';
 
@@ -209,7 +209,7 @@ DownloadsReportTable.contextType = CurrencyContext;
 
 export default withSelect( ( select ) => {
 	const { woocommerce_default_date_range: defaultDateRange } = select(
-		SETTINGS_STORE_NAME
+		settingsStore
 	).getSetting( 'wc_admin', 'wcAdminSettings' );
 	return { defaultDateRange };
 } )( DownloadsReportTable );

--- a/plugins/woocommerce/client/admin/client/analytics/report/revenue/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/revenue/table.js
@@ -12,7 +12,7 @@ import { formatValue } from '@woocommerce/number';
 import {
 	getReportTableQuery,
 	REPORTS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	QUERY_DEFAULTS,
 	OPTIONS_STORE_NAME,
 } from '@woocommerce/data';
@@ -353,7 +353,7 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { query, filters, advancedFilters } = props;
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 		const { getOption } = select( OPTIONS_STORE_NAME );
 		const dateType = getOption( 'woocommerce_date_type' ) || 'date_paid';

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -30,7 +30,7 @@ import {
 	Extension,
 	GeolocationResponse,
 	PLUGINS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	USER_STORE_NAME,
 	WCUser,
 	ProfileItems,
@@ -449,7 +449,7 @@ const updateBusinessLocation = ( countryAndState: string ) => {
 
 const updateStoreCurrency = async ( countryAndState: string ) => {
 	const { general: settings = {} } = await resolveSelect(
-		SETTINGS_STORE_NAME
+		settingsStore
 	).getSettings( 'general' );
 
 	const countryCode = getCountryCode( countryAndState ) as string;
@@ -473,7 +473,7 @@ const updateStoreCurrency = async ( countryAndState: string ) => {
 		return;
 	}
 
-	return dispatch( SETTINGS_STORE_NAME ).updateAndPersistSettingsForGroup(
+	return dispatch( settingsStore ).updateAndPersistSettingsForGroup(
 		'general',
 		{
 			general: {
@@ -517,7 +517,7 @@ const updateStoreMeasurements = async ( countryAndState: string ) => {
 
 	const { weight_unit, dimension_unit } = countryInfo;
 
-	return dispatch( SETTINGS_STORE_NAME ).updateAndPersistSettingsForGroup(
+	return dispatch( settingsStore ).updateAndPersistSettingsForGroup(
 		'products',
 		{
 			products: {

--- a/plugins/woocommerce/client/admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/customizable.js
@@ -10,7 +10,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { Icon, plusCircleFilled } from '@wordpress/icons';
 import { withSelect } from '@wordpress/data';
 import { H } from '@woocommerce/components';
-import { SETTINGS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
+import { settingsStore, useUserPreferences } from '@woocommerce/data';
 import { getQuery } from '@woocommerce/navigation';
 import {
 	getCurrentDates,
@@ -329,7 +329,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 export default compose(
 	withSelect( ( select ) => {
 		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
+			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
 		return {

--- a/plugins/woocommerce/client/admin/client/dashboard/store-performance/utils.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/store-performance/utils.js
@@ -6,7 +6,7 @@ import { find } from 'lodash';
 import { getCurrentDates, appendTimestamp } from '@woocommerce/date';
 import {
 	getFilterQuery,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	REPORTS_STORE_NAME,
 } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
@@ -77,7 +77,7 @@ export const getIndicatorData = ( select, indicators, query, filters ) => {
 	const { getReportItems, getReportItemsError, isResolving } =
 		select( REPORTS_STORE_NAME );
 	const { woocommerce_default_date_range: defaultDateRange } = select(
-		SETTINGS_STORE_NAME
+		settingsStore
 	).getSetting( 'wc_admin', 'wcAdminSettings' );
 	const datesFromQuery = getCurrentDates( query, defaultDateRange );
 	const endPrimary = datesFromQuery.primary.before;

--- a/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/utils.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/activity-panel/orders/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME, ITEMS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore, ITEMS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ export function getUnreadOrders( select, orderStatuses ) {
 }
 
 export function getOrderStatuses( select ) {
-	const { getSetting: getMutableSetting } = select( SETTINGS_STORE_NAME );
+	const { getSetting: getMutableSetting } = select( settingsStore );
 	const {
 		woocommerce_actionable_order_statuses:
 			orderStatuses = DEFAULT_ACTIONABLE_STATUSES,

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -17,7 +17,7 @@ import { getQuery, navigateTo } from '@woocommerce/navigation';
 import {
 	OPTIONS_STORE_NAME,
 	PAYMENT_GATEWAYS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	TaskListType,
 	TaskType,
 	PaymentGateway,
@@ -151,7 +151,7 @@ export const getWooPaymentsStatus = async () => {
 };
 
 export const getSiteCachedStatus = async () => {
-	const settings = await resolveSelect( SETTINGS_STORE_NAME ).getSettings(
+	const settings = await resolveSelect( settingsStore ).getSettings(
 		'wc_admin'
 	);
 

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
 
 import {
 	PLUGINS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	onboardingStore,
 } from '@woocommerce/data';
 
@@ -26,8 +26,7 @@ const ShippingRecommendations: React.FC = () => {
 		isJetpackConnected,
 		isSellingDigitalProductsOnly,
 	} = useSelect( ( select ) => {
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-		const settings = select( SETTINGS_STORE_NAME ).getSettings( 'general' );
+		const settings = select( settingsStore ).getSettings( 'general' );
 
 		const {
 			getActivePlugins,

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
@@ -7,7 +7,7 @@ import {
 	OPTIONS_STORE_NAME,
 	onboardingStore,
 	PAYMENT_GATEWAYS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useMemo, useCallback, useEffect } from '@wordpress/element';
@@ -45,7 +45,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		isResolving,
 		countryCode,
 	} = useSelect( ( select ) => {
-		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { getSettings } = select( settingsStore );
 		const { general: settings = {} } = getSettings( 'general' );
 		return {
 			getPaymentGateway: select( PAYMENT_GATEWAYS_STORE_NAME )

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/components/store-location.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/components/store-location.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -21,16 +21,12 @@ export const StoreLocation = ( {
 	onLocationComplete: () => void;
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateAndPersistSettingsForGroup } =
-		useDispatch( SETTINGS_STORE_NAME );
+	const { updateAndPersistSettingsForGroup } = useDispatch( settingsStore );
 	const { generalSettings, isResolving } = useSelect( ( select ) => {
-		const { getSettings, hasFinishedResolution } =
-			select( SETTINGS_STORE_NAME );
+		const { getSettings, hasFinishedResolution } = select( settingsStore );
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			generalSettings: getSettings( 'general' )?.general,
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			isResolving: ! hasFinishedResolution( 'getSettings', [
 				'general',
 			] ),

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/index.tsx
@@ -4,14 +4,13 @@
 import {
 	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 } from '@woocommerce/data';
-import type * as controls from '@wordpress/data-controls';
 import { withSelect } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { compose } from '@wordpress/compose';
-
+import type { SelectFunction } from '@wordpress/data/build-types/types';
 /**
  * Internal dependencies
  */
@@ -19,24 +18,24 @@ import { ShippingRecommendation } from './shipping-recommendation';
 import { TaskProps } from './types';
 
 const ShippingRecommendationWrapper = compose(
-	withSelect( ( select: typeof controls.select ) => {
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-		const { getSettings } = select( SETTINGS_STORE_NAME );
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
+	withSelect( ( select: SelectFunction ) => {
+		const { getSettings } = select( settingsStore );
 		const { hasFinishedResolution } = select( OPTIONS_STORE_NAME );
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 
 		return {
+			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			activePlugins: getActivePlugins(),
 			generalSettings: getSettings( 'general' )?.general,
 			isJetpackConnected:
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				select( PLUGINS_STORE_NAME ).isJetpackConnected(),
 			isResolving:
+				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_setup_jetpack_opted_in',
 				] ) ||
+				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'wc_connect_options',
 				] ) ||

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -13,7 +13,7 @@ import { Link, Stepper, Plugins } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import {
-	SETTINGS_STORE_NAME,
+	settingsStore,
 	onboardingStore,
 	PLUGINS_STORE_NAME,
 	COUNTRIES_STORE_NAME,
@@ -660,7 +660,7 @@ export class Shipping extends Component {
 const ShippingWrapper = compose(
 	withSelect( ( select ) => {
 		const { getSettings, isUpdateSettingsRequesting } =
-			select( SETTINGS_STORE_NAME );
+			select( settingsStore );
 		const { getActivePlugins, isJetpackConnected } =
 			select( PLUGINS_STORE_NAME );
 		const { getCountry } = select( COUNTRIES_STORE_NAME );
@@ -690,8 +690,7 @@ const ShippingWrapper = compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
-		const { updateAndPersistSettingsForGroup } =
-			dispatch( SETTINGS_STORE_NAME );
+		const { updateAndPersistSettingsForGroup } = dispatch( settingsStore );
 		const {
 			invalidateResolutionForStoreSelector,
 			optimisticallyCompleteTask,

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/components/store-location.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/components/store-location.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -49,24 +49,20 @@ export const StoreLocation: React.FC< {
 	nextStep: () => void;
 } > = ( { nextStep } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateAndPersistSettingsForGroup } =
-		useDispatch( SETTINGS_STORE_NAME );
+	const { updateAndPersistSettingsForGroup } = useDispatch( settingsStore );
 	const { generalSettings, isResolving, isUpdating } = useSelect(
 		( select ) => {
 			const {
 				getSettings,
 				hasFinishedResolution,
 				isUpdateSettingsRequesting,
-			} = select( SETTINGS_STORE_NAME );
+			} = select( settingsStore );
 
 			return {
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				generalSettings: getSettings( 'general' )?.general,
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				isResolving: ! hasFinishedResolution( 'getSettings', [
 					'general',
 				] ),
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				isUpdating: isUpdateSettingsRequesting( 'general' ),
 			};
 		},

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/index.tsx
@@ -5,11 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Card, CardBody, Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getAdminLink } from '@woocommerce/settings';
-import {
-	OPTIONS_STORE_NAME,
-	SETTINGS_STORE_NAME,
-	TaskType,
-} from '@woocommerce/data';
+import { OPTIONS_STORE_NAME, settingsStore, TaskType } from '@woocommerce/data';
 import { queueRecordEvent, recordEvent } from '@woocommerce/tracks';
 import { registerPlugin } from '@wordpress/plugins';
 import {
@@ -51,20 +47,16 @@ export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 	const [ isPending, setIsPending ] = useState( false );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateAndPersistSettingsForGroup } =
-		useDispatch( SETTINGS_STORE_NAME );
+	const { updateAndPersistSettingsForGroup } = useDispatch( settingsStore );
 	const { generalSettings, isResolving, taxSettings } = useSelect(
 		( select ) => {
 			const { getSettings, hasFinishedResolution } =
-				select( SETTINGS_STORE_NAME );
+				select( settingsStore );
 			return {
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				generalSettings: getSettings( 'general' ).general,
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				isResolving: ! hasFinishedResolution( 'getSettings', [
 					'general',
 				] ),
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				taxSettings: getSettings( 'tax' ).tax || {},
 			};
 		},

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/manual-configuration/configure.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/manual-configuration/configure.tsx
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -18,10 +18,9 @@ export const Configure: React.FC<
 	Pick< TaxChildProps, 'isPending' | 'onManual' >
 > = ( { isPending, onManual } ) => {
 	const { generalSettings } = useSelect( ( select ) => {
-		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { getSettings } = select( settingsStore );
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			generalSettings: getSettings( 'general' )?.general,
 		};
 	}, [] );

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/stripe-tax/card.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/stripe-tax/card.tsx
@@ -6,7 +6,7 @@ import { getAdminLink } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
 import { Plugins } from '@woocommerce/components';
 import { dispatch, useDispatch } from '@wordpress/data';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { settingsStore } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 
 /**
@@ -76,7 +76,7 @@ export const Card: React.FC< TaxChildProps > = ( {
 							selected_option: STRIPE_TAX_PLUGIN_SLUG,
 						} );
 						const { updateAndPersistSettingsForGroup } =
-							dispatch( SETTINGS_STORE_NAME );
+							dispatch( settingsStore );
 						updateAndPersistSettingsForGroup( 'general', {
 							general: {
 								woocommerce_calc_taxes: 'yes', // Stripe tax requires tax calculation to be enabled so let's do it here to save the user from doing it manually

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/index.tsx
@@ -4,7 +4,7 @@
 import { difference } from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { Spinner } from '@woocommerce/components';
-import { PLUGINS_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { PLUGINS_STORE_NAME, settingsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -29,14 +29,13 @@ export const WooCommerceTax: React.FC< TaxChildProps > = ( {
 		isResolving,
 		pluginsToActivate,
 	} = useSelect( ( select ) => {
-		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { getSettings } = select( settingsStore );
 		const { getActivePlugins, hasFinishedResolution } =
 			select( PLUGINS_STORE_NAME );
 		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const activePlugins = getActivePlugins();
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			generalSettings: getSettings( 'general' ).general,
 			isJetpackConnected:
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
@@ -44,8 +43,7 @@ export const WooCommerceTax: React.FC< TaxChildProps > = ( {
 			isResolving:
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'isJetpackConnected' ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-				! select( SETTINGS_STORE_NAME ).hasFinishedResolution(
+				! select( settingsStore ).hasFinishedResolution(
 					'getSettings',
 					[ 'general' ]
 				) ||

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/setup.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/setup.tsx
@@ -8,7 +8,7 @@ import { Stepper } from '@woocommerce/components';
 import {
 	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,
-	SETTINGS_STORE_NAME,
+	settingsStore,
 } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 
@@ -48,14 +48,13 @@ export const Setup: React.FC< SetupProps > = ( {
 		[]
 	);
 	const { activePlugins, isResolving } = useSelect( ( select ) => {
-		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { getSettings } = select( settingsStore );
 		const { hasFinishedResolution } = select( OPTIONS_STORE_NAME );
 		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 
 		return {
 			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			activePlugins: getActivePlugins(),
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			generalSettings: getSettings( 'general' )?.general,
 			isResolving:
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/55373

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the **settings** store registration pattern in `@woocommerce/data` to use the modern WordPress data store API. 

Key changes include:

1. Migrated from deprecated `registerStore` to `createReduxStore` and `register` pattern
2. Updated store exports to match the modern pattern used across other stores:
    - Added `export { store as settingsStore }`
    - Maintained `SETTINGS_STORE_NAME` export for backward compatibility
3. Removed deprecated type definitions:
    - Removed custom @wordpress/data module declaration
    - Cleaned up unused type exports and imports
4. Update settings store import to use `settingsStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the settings store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/settings/**`
4. `window.wp.data.select( wc.data.settingsStore )` and `window.wp.data.dispatch( wc.data.settingsStore )` should return selectors and dispatchers

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
