### PR TITLE
Migrate to register(storeDescriptor) for plugins data store

### DIFF
--- a/packages/js/components/changelog/55426-fix-migrate-plugin-store
+++ b/packages/js/components/changelog/55426-fix-migrate-plugin-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrate to register(storeDescriptor) for plugins data store

--- a/packages/js/components/src/plugins/index.tsx
+++ b/packages/js/components/src/plugins/index.tsx
@@ -12,11 +12,7 @@ import {
 import { SyntheticEvent, useCallback } from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { pluginsStore } from '@woocommerce/data';
-import type {
-	InstallPluginsResponse,
-	PluginSelectors,
-	PluginActions,
-} from '@woocommerce/data';
+import type { InstallPluginsResponse } from '@woocommerce/data';
 
 type ButtonProps = React.ComponentProps< typeof Button >;
 
@@ -102,6 +98,7 @@ export const Plugins = ( {
 
 			installAndActivatePlugins( pluginSlugs )
 				.then( ( response ) => {
+					// @ts-expect-error TODO react-18-upgrade: useDispatch does not return the correct type for installAndActivatePlugins.
 					handleSuccess( response.data.activated, response );
 				} )
 				.catch( ( response ) => {

--- a/packages/js/components/src/plugins/index.tsx
+++ b/packages/js/components/src/plugins/index.tsx
@@ -98,7 +98,6 @@ export const Plugins = ( {
 
 			installAndActivatePlugins( pluginSlugs )
 				.then( ( response ) => {
-					// @ts-expect-error TODO react-18-upgrade: useDispatch does not return the correct type for installAndActivatePlugins.
 					handleSuccess( response.data.activated, response );
 				} )
 				.catch( ( response ) => {

--- a/packages/js/components/src/plugins/index.tsx
+++ b/packages/js/components/src/plugins/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/element';
 import { SyntheticEvent, useCallback } from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 import type {
 	InstallPluginsResponse,
 	PluginSelectors,
@@ -59,14 +59,10 @@ export const Plugins = ( {
 	const [ hasErrors, setHasErrors ] = useState( false );
 	// Tracks action so that multiple instances of this button don't all light up when one is clicked
 	const [ hasBeenClicked, setHasBeenClicked ] = useState( false );
-	const { installAndActivatePlugins }: PluginActions =
-		useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const { isRequesting } = useSelect( ( select ) => {
-		const {
-			getActivePlugins,
-			getInstalledPlugins,
-			isPluginsRequesting,
-		}: PluginSelectors = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins, getInstalledPlugins, isPluginsRequesting } =
+			select( pluginsStore );
 
 		return {
 			isRequesting:

--- a/packages/js/data/changelog/55426-fix-migrate-plugin-store
+++ b/packages/js/data/changelog/55426-fix-migrate-plugin-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrate to register(storeDescriptor) for plugins data store

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -53,6 +53,7 @@ export { store as onboardingStore } from './onboarding';
 export { store as notesStore } from './notes';
 export { store as reviewsStore } from './reviews';
 export { store as settingsStore } from './settings';
+export { store as pluginsStore } from './plugins';
 
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';

--- a/packages/js/data/src/plugins/index.ts
+++ b/packages/js/data/src/plugins/index.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
-import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+
 /**
  * Internal dependencies
  */
@@ -12,12 +12,11 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
-import { WPDataActions, WPDataSelectors } from '../types';
-import { PromiseifySelectors } from '../types/promiseify-selectors';
+
 export * from './types';
 export type { State };
 
-registerStore< State >( STORE_NAME, {
+export const store = createReduxStore( STORE_NAME, {
 	reducer,
 	actions,
 	controls,
@@ -25,16 +24,6 @@ registerStore< State >( STORE_NAME, {
 	resolvers,
 } );
 
+register( store );
+
 export const PLUGINS_STORE_NAME = STORE_NAME;
-declare module '@wordpress/data' {
-	// TODO: convert action.js to TS
-	function dispatch(
-		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions & WPDataActions >;
-	function select(
-		key: typeof STORE_NAME
-	): SelectFromMap< typeof selectors > & WPDataSelectors;
-	function resolveSelect(
-		key: typeof STORE_NAME
-	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
-}

--- a/packages/js/data/src/plugins/resolvers.ts
+++ b/packages/js/data/src/plugins/resolvers.ts
@@ -10,7 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { WC_ADMIN_NAMESPACE, JETPACK_NAMESPACE } from '../constants';
 import { OPTIONS_STORE_NAME } from '../options';
-import { PAYPAL_NAMESPACE, STORE_NAME } from './constants';
+import { PAYPAL_NAMESPACE } from './constants';
 import {
 	setIsRequesting,
 	updateActivePlugins,
@@ -26,8 +26,10 @@ import {
 	PaypalOnboardingStatus,
 	RecommendedTypes,
 	JetpackConnectionDataResponse,
+	Plugin,
 } from './types';
 import { checkUserCapability } from '../utils';
+import { store } from './';
 
 // Can be removed in WP 5.9, wp.data is supported in >5.7.
 const resolveSelect =
@@ -115,8 +117,8 @@ export function* isJetpackConnected() {
 export function* getJetpackConnectionData() {
 	yield setIsRequesting( 'getJetpackConnectionData', true );
 	try {
-		const isConnected = yield resolveSelect(
-			STORE_NAME,
+		const isConnected: boolean = yield resolveSelect(
+			store,
 			'isJetpackConnected'
 		);
 		// See API side permission check here: https://github.com/Automattic/jetpack-connection/blob/trunk/src/class-manager.php#L1560-L1568.
@@ -190,7 +192,7 @@ export function* getPaypalOnboardingStatus() {
 	const errorData: {
 		data?: { status: number };
 	} = yield resolveSelect(
-		STORE_NAME,
+		store,
 		'getPluginsError',
 		'getPaypalOnboardingStatus'
 	);

--- a/packages/js/data/src/plugins/with-plugins-hydration.tsx
+++ b/packages/js/data/src/plugins/with-plugins-hydration.tsx
@@ -20,7 +20,10 @@ type PluginHydrationData = {
 	jetpackStatus?: { isActive: boolean };
 };
 export const withPluginsHydration = ( data: PluginHydrationData ) =>
-	createHigherOrderComponent< Record< string, unknown > >(
+	createHigherOrderComponent<
+		React.ComponentType< Record< string, unknown > >,
+		React.ComponentType< Record< string, unknown > >
+	>(
 		( OriginalComponent ) => ( props ) => {
 			const shouldHydrate = useSelect(
 				(

--- a/packages/js/data/typings/index.d.ts
+++ b/packages/js/data/typings/index.d.ts
@@ -2,18 +2,6 @@
  * External dependencies
  */
 import { Entity } from '@wordpress/core-data';
-import * as controls from '@wordpress/data-controls';
 
-
-declare module '@wordpress/data' {
-	// TODO: update @wordpress/data types to include this.
-	// Follow up note: we're adding these declares also to @woocommerce/admin-library as an interim solution
-	// until we bump the @wordpress/data version to wp-6.6 across the board in WC.
-	const controls: {
-		select: typeof controls.select;
-		resolveSelect: typeof controls.resolveSelect;
-		dispatch: typeof controls.dispatch;
-	};
-}
 
 declare module 'rememo';

--- a/plugins/woocommerce/changelog/55426-fix-migrate-plugin-store
+++ b/plugins/woocommerce/changelog/55426-fix-migrate-plugin-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrate to register(storeDescriptor) for plugins data store

--- a/plugins/woocommerce/client/admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/panels/help.js
@@ -11,7 +11,7 @@ import { partial } from 'lodash';
 import { List, Section } from '@woocommerce/components';
 import {
 	onboardingStore,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	settingsStore,
 } from '@woocommerce/data';
 import { compose } from 'redux';
@@ -388,7 +388,7 @@ export const HelpPanel = ( {
 export default compose(
 	withSelect( ( select ) => {
 		const { getSettings } = select( settingsStore );
-		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins } = select( pluginsStore );
 		const { general: generalSettings = {} } = getSettings( 'general' );
 		const activePlugins = getActivePlugins();
 		const paymentGatewaySuggestions = select( onboardingStore )

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -29,7 +29,7 @@ import {
 	onboardingStore,
 	Extension,
 	GeolocationResponse,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	settingsStore,
 	USER_STORE_NAME,
 	WCUser,
@@ -599,7 +599,7 @@ const preFetchIsJetpackConnected = assign( {
 	isJetpackConnectedRef: ( { spawn } ) =>
 		spawn(
 			fromPromise( async () =>
-				resolveSelect( PLUGINS_STORE_NAME ).isJetpackConnected()
+				resolveSelect( pluginsStore ).isJetpackConnected()
 			)
 		),
 } );
@@ -738,7 +738,7 @@ const skipFlowUpdateBusinessLocation = fromPromise(
 );
 
 export const getJetpackIsConnected = fromPromise( async () => {
-	return resolveSelect( PLUGINS_STORE_NAME ).isJetpackConnected();
+	return resolveSelect( pluginsStore ).isJetpackConnected();
 } );
 
 const reloadPage = () => {

--- a/plugins/woocommerce/client/admin/client/core-profiler/services/installAndActivatePlugins.ts
+++ b/plugins/woocommerce/client/admin/client/core-profiler/services/installAndActivatePlugins.ts
@@ -3,7 +3,7 @@
  */
 import {
 	ExtensionList,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	PluginNames,
 	onboardingStore,
 } from '@woocommerce/data';
@@ -315,9 +315,7 @@ export const pluginInstallerMachine = createMachine(
 				}: {
 					input: { pluginsInstallationQueue: PluginNames[] };
 				} ) => {
-					return dispatch(
-						PLUGINS_STORE_NAME
-					).installAndActivatePlugins( [
+					return dispatch( pluginsStore ).installAndActivatePlugins( [
 						getPluginSlug( pluginsInstallationQueue[ 0 ] ),
 					] );
 				}

--- a/plugins/woocommerce/client/admin/client/dashboard/components/cart-modal.js
+++ b/plugins/woocommerce/client/admin/client/dashboard/components/cart-modal.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect } from '@wordpress/data';
 import { List } from '@woocommerce/components';
-import { onboardingStore, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { onboardingStore, pluginsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -166,7 +166,7 @@ class CartModal extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getInstalledPlugins } = select( PLUGINS_STORE_NAME );
+		const { getInstalledPlugins } = select( pluginsStore );
 		const { getProductTypes, getProfileItems } = select( onboardingStore );
 		const profileItems = getProfileItems();
 		const installedPlugins = getInstalledPlugins();

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
@@ -3,7 +3,7 @@
  */
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PLUGINS_STORE_NAME, useUser } from '@woocommerce/data';
+import { pluginsStore, useUser } from '@woocommerce/data';
 import { createErrorNotice } from '@woocommerce/data/src/plugins/actions';
 
 export const JetpackPluginStates = {
@@ -40,12 +40,10 @@ export const useJetpackPluginState = () => {
 	} = useSelect(
 		( select ) => {
 			const { getPluginInstallState, getJetpackConnectionData } =
-				select( PLUGINS_STORE_NAME );
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
+				select( pluginsStore );
 			const installState = getPluginInstallState( 'jetpack' );
 
 			return {
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				jetpackConnectionData: getJetpackConnectionData(),
 				jetpackInstallState: installState,
 				canUserInstallPlugins: currentUserCan( 'install_plugins' ),
@@ -54,7 +52,7 @@ export const useJetpackPluginState = () => {
 		[ currentUserCan ]
 	);
 
-	const { installJetpackAndConnect } = useDispatch( PLUGINS_STORE_NAME );
+	const { installJetpackAndConnect } = useDispatch( pluginsStore );
 
 	const [ pluginState, setPluginState ] = useState< JetpackPluginStates >(
 		JetpackPluginStates.INITIALIZING

--- a/plugins/woocommerce/client/admin/client/homescreen/stats-overview/index.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/stats-overview/index.js
@@ -12,7 +12,7 @@ import {
 	MenuTitle,
 	Link,
 } from '@woocommerce/components';
-import { useUserPreferences, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { useUserPreferences, pluginsStore } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
@@ -49,7 +49,7 @@ export const StatsOverview = () => {
 	);
 
 	const jetPackIsConnectedAndActivated = useSelect( ( select ) => {
-		const store = select( PLUGINS_STORE_NAME );
+		const store = select( pluginsStore );
 		return (
 			store.isJetpackConnected() &&
 			store.getPluginInstallState( 'jetpack' ) === 'activated'

--- a/plugins/woocommerce/client/admin/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -4,11 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	PLUGINS_STORE_NAME,
-	useUser,
-	useUserPreferences,
-} from '@woocommerce/data';
+import { pluginsStore, useUser, useUserPreferences } from '@woocommerce/data';
 import { H } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { getAdminLink } from '@woocommerce/settings';
@@ -77,7 +73,7 @@ export const InstallJetpackCTA = () => {
 	const { canUserInstallPlugins, jetpackInstallState, isBusy } = useSelect(
 		( select ) => {
 			const { getPluginInstallState, isPluginsRequesting } =
-				select( PLUGINS_STORE_NAME );
+				select( pluginsStore );
 			const installState = getPluginInstallState( 'jetpack' );
 			const busyState =
 				isPluginsRequesting( 'getJetpackConnectUrl' ) ||
@@ -92,7 +88,7 @@ export const InstallJetpackCTA = () => {
 		}
 	);
 
-	const { installJetpackAndConnect } = useDispatch( PLUGINS_STORE_NAME );
+	const { installJetpackAndConnect } = useDispatch( pluginsStore );
 
 	if ( ! canUserInstallPlugins ) {
 		return null;

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/services.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/launch-store-success/services.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PLUGINS_STORE_NAME, onboardingStore } from '@woocommerce/data';
+import { pluginsStore, onboardingStore } from '@woocommerce/data';
 import { resolveSelect } from '@wordpress/data';
 import { fromPromise } from 'xstate5';
 import apiFetch from '@wordpress/api-fetch';
@@ -27,7 +27,7 @@ export const fetchCongratsData = fromPromise( async () => {
 			'setup',
 			'extended',
 		] ),
-		resolveSelect( PLUGINS_STORE_NAME ).getActivePlugins(),
+		resolveSelect( pluginsStore ).getActivePlugins(),
 	] );
 	return {
 		surveyCompleted: surveyCompleted as string | null,

--- a/plugins/woocommerce/client/admin/client/layout/index.js
+++ b/plugins/woocommerce/client/admin/client/layout/index.js
@@ -27,7 +27,7 @@ import {
 	navigateTo,
 } from '@woocommerce/navigation';
 import {
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	useUser,
 	withPluginsHydration,
 	withOptionsHydration,
@@ -288,7 +288,7 @@ const Layout = compose(
 		}
 
 		const { getActivePlugins, getInstalledPlugins, isJetpackConnected } =
-			select( PLUGINS_STORE_NAME );
+			select( pluginsStore );
 
 		return {
 			activePlugins: getActivePlugins(),

--- a/plugins/woocommerce/client/admin/client/marketing/components/PluginCardBody/SmartPluginCardBody.tsx
+++ b/plugins/woocommerce/client/admin/client/marketing/components/PluginCardBody/SmartPluginCardBody.tsx
@@ -7,7 +7,7 @@ import { Button } from '@wordpress/components';
 import { Pill } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
-import { PLUGINS_STORE_NAME, type PluginSelectors } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -38,12 +38,10 @@ export const SmartPluginCardBody = ( {
 	const [ currentPlugin, setCurrentPlugin ] = useState< string | null >(
 		null
 	);
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const { installState } = useSelect(
 		( select ) => {
-			const { getPluginInstallState } = select(
-				PLUGINS_STORE_NAME
-			) as PluginSelectors;
+			const { getPluginInstallState } = select( pluginsStore );
 
 			return {
 				installState: getPluginInstallState( plugin.product ),

--- a/plugins/woocommerce/client/admin/client/marketing/hooks/useRecommendedChannels.ts
+++ b/plugins/woocommerce/client/admin/client/marketing/hooks/useRecommendedChannels.ts
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
-import type { PluginSelectors } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 import { differenceWith } from 'lodash';
 
 /**
@@ -25,9 +24,7 @@ export const useRecommendedChannels = (): UseRecommendedChannels => {
 		) as Selectors;
 		const { data, error } = getRecommendedChannels();
 
-		const { getActivePlugins } = select(
-			PLUGINS_STORE_NAME
-		) as PluginSelectors;
+		const { getActivePlugins } = select( pluginsStore );
 		const activePlugins = getActivePlugins();
 
 		/**

--- a/plugins/woocommerce/client/admin/client/marketing/overview-multichannel/DiscoverTools/PluginsTabPanel.tsx
+++ b/plugins/woocommerce/client/admin/client/marketing/overview-multichannel/DiscoverTools/PluginsTabPanel.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { TabPanel, Button } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { Pill } from '@woocommerce/components';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 import { flatMapDeep, uniqBy } from 'lodash';
 
 /**
@@ -60,7 +60,7 @@ export const PluginsTabPanel = ( {
 	const [ currentPlugin, setCurrentPlugin ] = useState< string | null >(
 		null
 	);
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const { loadInstalledPluginsAfterActivation } =
 		useInstalledPluginsWithoutChannels();
 

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -3,11 +3,7 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
-import {
-	OPTIONS_STORE_NAME,
-	PLUGINS_STORE_NAME,
-	useUser,
-} from '@woocommerce/data';
+import { OPTIONS_STORE_NAME, pluginsStore, useUser } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { getPath } from '@woocommerce/navigation';
 import { isWcVersion } from '@woocommerce/settings';
@@ -88,7 +84,7 @@ export const useOrderAttributionInstallBanner = () => {
 
 	const { canUserInstallPlugins, orderAttributionInstallState } = useSelect(
 		( select ) => {
-			const { getPluginInstallState } = select( PLUGINS_STORE_NAME );
+			const { getPluginInstallState } = select( pluginsStore );
 			const installState = getPluginInstallState(
 				'woocommerce-analytics'
 			);

--- a/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
@@ -5,7 +5,7 @@ import { Notice } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME, type PluginSelectors } from '@woocommerce/data';
+import { OPTIONS_STORE_NAME, pluginsStore } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -24,17 +24,16 @@ interface activatePromoResponse {
 const ConnectAccountPage = () => {
 	const incentive = getAdminSetting( 'wcpayWelcomePageIncentive' );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const { installAndActivatePlugins } = useDispatch( 'wc/admin/plugins' );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const [ isSubmitted, setSubmitted ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const [ enabledApms, setEnabledApms ] = useState( new Set< Apm >() );
 
 	const { isJetpackConnected, connectUrl } = useSelect(
 		( select ) => {
+			const selectors = select( pluginsStore );
 			return {
-				isJetpackConnected: (
-					select( 'wc/admin/plugins' ) as PluginSelectors
-				 ).isJetpackConnected(),
+				isJetpackConnected: selectors.isJetpackConnected(),
 				connectUrl:
 					'admin.php?wcpay-connect=1&promo=' +
 					encodeURIComponent( incentive.id ) +

--- a/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
@@ -113,7 +113,6 @@ const ConnectAccountPage = () => {
 			const installAndActivateResponse = await installAndActivatePlugins(
 				[ 'woocommerce-payments' ].concat( pluginsToInstall )
 			);
-			// @ts-expect-error TODO react-18-upgrade: useDispatch does not return the correct type for installAndActivatePlugins.
 			if ( installAndActivateResponse?.success ) {
 				recordEvent( 'wcpay_extension_installed', {
 					extensions: [ ...enabledApms ]
@@ -123,7 +122,6 @@ const ConnectAccountPage = () => {
 				} );
 				await activatePromo();
 			} else {
-				// @ts-expect-error TODO react-18-upgrade: useDispatch does not return the correct type for installAndActivatePlugins.
 				throw new Error( installAndActivateResponse.message );
 			}
 		} catch ( e ) {

--- a/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
@@ -113,6 +113,7 @@ const ConnectAccountPage = () => {
 			const installAndActivateResponse = await installAndActivatePlugins(
 				[ 'woocommerce-payments' ].concat( pluginsToInstall )
 			);
+			// @ts-expect-error TODO react-18-upgrade: useDispatch does not return the correct type for installAndActivatePlugins.
 			if ( installAndActivateResponse?.success ) {
 				recordEvent( 'wcpay_extension_installed', {
 					extensions: [ ...enabledApms ]
@@ -122,6 +123,7 @@ const ConnectAccountPage = () => {
 				} );
 				await activatePromo();
 			} else {
+				// @ts-expect-error TODO react-18-upgrade: useDispatch does not return the correct type for installAndActivatePlugins.
 				throw new Error( installAndActivateResponse.message );
 			}
 		} catch ( e ) {

--- a/plugins/woocommerce/client/admin/client/payments/payment-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/payments/payment-recommendations.tsx
@@ -12,7 +12,7 @@ import { Text } from '@woocommerce/experimental';
 import {
 	onboardingStore,
 	PAYMENT_GATEWAYS_STORE_NAME,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	Plugin,
 	type PaymentSelectors,
 } from '@woocommerce/data';
@@ -41,7 +41,7 @@ const PaymentRecommendations: React.FC = () => {
 	const [ isDismissed, setIsDismissed ] = useState< boolean >( false );
 	const [ isInstalled, setIsInstalled ] = useState< boolean >( false );
 	const { installAndActivatePlugins, dismissRecommendedPlugins } =
-		useDispatch( PLUGINS_STORE_NAME );
+		useDispatch( pluginsStore );
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	const {

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Button, CardDivider } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	PAYMENT_SETTINGS_STORE_NAME,
 	PaymentGatewayLink,
 } from '@woocommerce/data';
@@ -72,7 +72,7 @@ export const EllipsisMenuContent = ( {
 	setResetAccountModalVisible = () => {},
 	isEnabled = false,
 }: EllipsisMenuContentProps ) => {
-	const { deactivatePlugin } = useDispatch( PLUGINS_STORE_NAME );
+	const { deactivatePlugin } = useDispatch( pluginsStore );
 	const [ isDeactivating, setIsDeactivating ] = useState( false );
 	const [ isDisabling, setIsDisabling ] = useState( false );
 	const [ isHidingSuggestion, setIsHidingSuggestion ] = useState( false );

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -4,11 +4,10 @@
 import { useCallback } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	PAYMENT_SETTINGS_STORE_NAME,
 	PaymentProvider,
 	type PaymentSettingsSelectors,
-	type PluginSelectors,
 } from '@woocommerce/data';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
@@ -48,7 +47,7 @@ export const SettingsPaymentsMain = () => {
 	const [ sortedProviders, setSortedProviders ] = useState<
 		PaymentProvider[] | null
 	>( null );
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const { updateProviderOrdering } = useDispatch(
 		PAYMENT_SETTINGS_STORE_NAME
 	);
@@ -107,9 +106,7 @@ export const SettingsPaymentsMain = () => {
 	}, [] );
 
 	const installedPluginSlugs = useSelect( ( select ) => {
-		return (
-			select( PLUGINS_STORE_NAME ) as PluginSelectors
-		 ).getInstalledPlugins();
+		return select( pluginsStore ).getInstalledPlugins();
 	}, [] );
 
 	// Make UI refresh when plugin is installed.
@@ -231,7 +228,7 @@ export const SettingsPaymentsMain = () => {
 
 			setInstallingPlugin( id );
 			installAndActivatePlugins( [ slug ] )
-				.then( async ( response: Response ) => {
+				.then( async ( response ) => {
 					createNoticesFromResponse( response );
 					invalidateResolutionForStoreSelector(
 						'getPaymentProviders'

--- a/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 
 import {
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	settingsStore,
 	onboardingStore,
 } from '@woocommerce/data';
@@ -32,20 +32,17 @@ const ShippingRecommendations: React.FC = () => {
 			getActivePlugins,
 			getInstalledPlugins,
 			isJetpackConnected: _isJetpackConnected,
-		} = select( PLUGINS_STORE_NAME );
+		} = select( pluginsStore );
 
 		const profileItems =
 			select( onboardingStore ).getProfileItems().product_types;
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			activePlugins: getActivePlugins(),
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			installedPlugins: getInstalledPlugins(),
 			countryCode: getCountryCode(
 				settings.general?.woocommerce_default_country
 			),
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			isJetpackConnected: _isJetpackConnected(),
 			isSellingDigitalProductsOnly:
 				profileItems?.length === 1 && profileItems[ 0 ] === 'downloads',

--- a/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, Children } from '@wordpress/element';
 import { Text } from '@woocommerce/experimental';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 import ExternalIcon from 'gridicons/dist/external';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore VisuallyHidden is present, it's just not typed
@@ -28,7 +28,7 @@ const useInstallPlugin = () => {
 		Array< string >
 	>( [] );
 
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 
 	const handleSetup = ( slugs: string[] ): PromiseLike< void > => {
 		if ( pluginsBeingSetup.length > 0 ) {
@@ -106,7 +106,7 @@ const ShippingRecommendations: React.FC = () => {
 	const activePlugins = useSelect(
 		( select ) =>
 			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( PLUGINS_STORE_NAME ).getActivePlugins(),
+			select( pluginsStore ).getActivePlugins(),
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/shipping-recommendations.tsx
@@ -104,9 +104,7 @@ const ShippingRecommendations: React.FC = () => {
 	const [ pluginsBeingSetup, setupPlugin ] = useInstallPlugin();
 
 	const activePlugins = useSelect(
-		( select ) =>
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( pluginsStore ).getActivePlugins(),
+		( select ) => select( pluginsStore ).getActivePlugins(),
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/shipping/woocommerce-services-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/woocommerce-services-item.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, ExternalLink } from '@wordpress/components';
 import { Pill } from '@woocommerce/components';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/settings';
 
 /**
@@ -23,7 +23,7 @@ const WooCommerceServicesItem: React.FC< {
 	const isSiteConnectedToJetpack = useSelect(
 		( select ) =>
 			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( PLUGINS_STORE_NAME ).isJetpackConnected(),
+			select( pluginsStore ).isJetpackConnected(),
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/shipping/woocommerce-services-item.tsx
+++ b/plugins/woocommerce/client/admin/client/shipping/woocommerce-services-item.tsx
@@ -21,9 +21,7 @@ const WooCommerceServicesItem: React.FC< {
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
 	const isSiteConnectedToJetpack = useSelect(
-		( select ) =>
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( pluginsStore ).isJetpackConnected(),
+		( select ) => select( pluginsStore ).isJetpackConnected(),
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/Marketing/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/Marketing/index.tsx
@@ -5,14 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { Card, CardHeader, Spinner } from '@wordpress/components';
 import {
 	onboardingStore,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	Extension,
 	ExtensionList,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
 import { useMemo, useState } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { getNewPath } from '@woocommerce/navigation';
@@ -106,19 +106,17 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 		null
 	);
 	const { actionTask } = useDispatch( onboardingStore );
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const { activePlugins, freeExtensions, installedPlugins, isResolving } =
 		useSelect( ( select ) => {
 			const { getActivePlugins, getInstalledPlugins } =
-				select( PLUGINS_STORE_NAME );
+				select( pluginsStore );
 			const { getFreeExtensions, hasFinishedResolution } =
 				select( onboardingStore );
 
 			return {
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				activePlugins: getActivePlugins(),
 				freeExtensions: getFreeExtensions(),
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				installedPlugins: getInstalledPlugins(),
 				isResolving: ! hasFinishedResolution( 'getFreeExtensions', [] ),
 			};

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/components/Setup/Setup.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/components/Setup/Setup.js
@@ -6,7 +6,7 @@ import { Card, CardBody } from '@wordpress/components';
 import {
 	OPTIONS_STORE_NAME,
 	PAYMENT_GATEWAYS_STORE_NAME,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 } from '@woocommerce/data';
 import { Plugins, Stepper } from '@woocommerce/components';
 import { WooPaymentGatewaySetup } from '@woocommerce/onboarding';
@@ -49,8 +49,7 @@ export const Setup = ( { markConfigured, paymentGateway } ) => {
 		useSelect( ( select ) => {
 			const { isOptionsUpdating } = select( OPTIONS_STORE_NAME );
 			const { isResolving } = select( PAYMENT_GATEWAYS_STORE_NAME );
-			const activePlugins =
-				select( PLUGINS_STORE_NAME ).getActivePlugins();
+			const activePlugins = select( pluginsStore ).getActivePlugins();
 			const pluginsToInstall = plugins.filter(
 				( m ) => ! activePlugins.includes( m )
 			);

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/index.tsx
@@ -3,7 +3,7 @@
  */
 import {
 	OPTIONS_STORE_NAME,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	settingsStore,
 } from '@woocommerce/data';
 import { withSelect } from '@wordpress/data';
@@ -21,15 +21,12 @@ const ShippingRecommendationWrapper = compose(
 	withSelect( ( select: SelectFunction ) => {
 		const { getSettings } = select( settingsStore );
 		const { hasFinishedResolution } = select( OPTIONS_STORE_NAME );
-		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins } = select( pluginsStore );
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			activePlugins: getActivePlugins(),
 			generalSettings: getSettings( 'general' )?.general,
-			isJetpackConnected:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-				select( PLUGINS_STORE_NAME ).isJetpackConnected(),
+			isJetpackConnected: select( pluginsStore ).isJetpackConnected(),
 			isResolving:
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
@@ -40,7 +37,7 @@ const ShippingRecommendationWrapper = compose(
 					'wc_connect_options',
 				] ) ||
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-				! select( PLUGINS_STORE_NAME ).hasFinishedResolution(
+				! select( pluginsStore ).hasFinishedResolution(
 					'isJetpackConnected'
 				),
 		};

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/purchase.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/purchase.tsx
@@ -7,7 +7,7 @@ import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
 import { useState, useCallback } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { useSelect } from '@wordpress/data';
-import { onboardingStore, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { onboardingStore, pluginsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -28,10 +28,9 @@ const PurchaseTaskItem = ( { defaultTaskItem }: PurchaseTaskItemProps ) => {
 		( select ) => {
 			const { getProductTypes, getProfileItems } =
 				select( onboardingStore );
-			const { getInstalledPlugins } = select( PLUGINS_STORE_NAME );
+			const { getInstalledPlugins } = select( pluginsStore );
 
 			return {
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				installedPlugins: getInstalledPlugins(),
 				productTypes: getProductTypes(),
 				profileItems: getProfileItems(),

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -15,7 +15,7 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 import {
 	settingsStore,
 	onboardingStore,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	COUNTRIES_STORE_NAME,
 	SHIPPING_METHODS_STORE_NAME,
 } from '@woocommerce/data';
@@ -661,8 +661,7 @@ const ShippingWrapper = compose(
 	withSelect( ( select ) => {
 		const { getSettings, isUpdateSettingsRequesting } =
 			select( settingsStore );
-		const { getActivePlugins, isJetpackConnected } =
-			select( PLUGINS_STORE_NAME );
+		const { getActivePlugins, isJetpackConnected } = select( pluginsStore );
 		const { getCountry } = select( COUNTRIES_STORE_NAME );
 
 		const { general: settings = {} } = getSettings( 'general' );

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/index.tsx
@@ -4,7 +4,7 @@
 import { difference } from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { Spinner } from '@woocommerce/components';
-import { PLUGINS_STORE_NAME, settingsStore } from '@woocommerce/data';
+import { pluginsStore, settingsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -31,15 +31,12 @@ export const WooCommerceTax: React.FC< TaxChildProps > = ( {
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( settingsStore );
 		const { getActivePlugins, hasFinishedResolution } =
-			select( PLUGINS_STORE_NAME );
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
+			select( pluginsStore );
 		const activePlugins = getActivePlugins();
 
 		return {
 			generalSettings: getSettings( 'general' ).general,
-			isJetpackConnected:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-				select( PLUGINS_STORE_NAME ).isJetpackConnected(),
+			isJetpackConnected: select( pluginsStore ).isJetpackConnected(),
 			isResolving:
 				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'isJetpackConnected' ) ||

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/setup.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/setup.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { Stepper } from '@woocommerce/components';
 import {
 	OPTIONS_STORE_NAME,
-	PLUGINS_STORE_NAME,
+	pluginsStore,
 	settingsStore,
 } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
@@ -50,10 +50,9 @@ export const Setup: React.FC< SetupProps > = ( {
 	const { activePlugins, isResolving } = useSelect( ( select ) => {
 		const { getSettings } = select( settingsStore );
 		const { hasFinishedResolution } = select( OPTIONS_STORE_NAME );
-		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins } = select( pluginsStore );
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			activePlugins: getActivePlugins(),
 			generalSettings: getSettings( 'general' )?.general,
 			isResolving:

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -4,10 +4,7 @@
 import { Button } from '@wordpress/components';
 import { EllipsisMenu, Link } from '@woocommerce/components';
 import { useState, useEffect } from '@wordpress/element';
-import {
-	PLUGINS_STORE_NAME,
-	PAYMENT_GATEWAYS_STORE_NAME,
-} from '@woocommerce/data';
+import { pluginsStore, PAYMENT_GATEWAYS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { sanitize } from 'dompurify';
@@ -53,14 +50,13 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 	const { gatewayId, pluginSlug, url } = paymentMethod;
 	const [ installing, setInstalling ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( true );
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
 	const { gatewayIsActive, paymentGateway } = useSelect( ( select ) => {
 		const { getPaymentGateway } = select( PAYMENT_GATEWAYS_STORE_NAME );
 		const activePlugins: string[] =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( PLUGINS_STORE_NAME ).getActivePlugins();
+			select( pluginsStore ).getActivePlugins();
 		const isActive = activePlugins && activePlugins.includes( pluginSlug );
 		let paymentGatewayData;
 		if ( isActive ) {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -7,7 +7,7 @@ import { Button, ExternalLink } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import interpolateComponents from '@automattic/interpolate-components';
 import PropTypes from 'prop-types';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { pluginsStore } from '@woocommerce/data';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { getSetting, getAdminLink } from '@woocommerce/settings';
@@ -497,7 +497,7 @@ ShippingBanner.propTypes = {
 export default compose(
 	withSelect( ( select ) => {
 		const { isPluginsRequesting, isJetpackConnected, getActivePlugins } =
-			select( PLUGINS_STORE_NAME );
+			select( pluginsStore );
 
 		const isRequesting =
 			isPluginsRequesting( 'activatePlugins' ) ||
@@ -531,8 +531,7 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { activatePlugins, installPlugins } =
-			dispatch( PLUGINS_STORE_NAME );
+		const { activatePlugins, installPlugins } = dispatch( pluginsStore );
 
 		return {
 			activatePlugins,

--- a/plugins/woocommerce/client/admin/docs/features/core-profiler.md
+++ b/plugins/woocommerce/client/admin/docs/features/core-profiler.md
@@ -112,7 +112,7 @@ This is used to retrieve the list of countries that will be shown in the Country
 
 This is used to retrieve the country that the store believes it is in. It makes an API call to the WordPress.com geolocation API, if permitted. Otherwise it will not be used.
 
-- `resolveSelect( PLUGINS_STORE_NAME ).isJetpackConnected()`
+- `resolveSelect( pluginsStore ).isJetpackConnected()`
 
 This is used to determine whether the store is connected to Jetpack.
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/55374

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the **plugins** store registration pattern in `@woocommerce/data` to use the modern WordPress data store API. 

Key changes include:

1. Migrated from deprecated `registerStore` to `createReduxStore` and `register` pattern
2. Updated store exports to match the modern pattern used across other stores:
    - Added `export { store as pluginsStore }`
    - Maintained `PLUGINS_STORE_NAME` export for backward compatibility
3. Removed deprecated type definitions:
    - Removed custom @wordpress/data module declaration
    - Cleaned up unused type exports and imports
4. Update plugins store import to use `pluginsStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the plugins store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/plugins/**`
4.`window.wp.data.select( wc.data.pluginsStore )` and `window.wp.data.dispatch( wc.data.pluginsStore )` should return selectors and dispatchers


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Migrate to register(storeDescriptor) for plugins data store

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
