### PR TITLE
Migrate to register(storeDescriptor) for user data store

### DIFF
--- a/packages/js/data/changelog/fix-migrate-user-store
+++ b/packages/js/data/changelog/fix-migrate-user-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Migrate to register(storeDescriptor) for user data store

--- a/packages/js/data/src/export/test/reducer.ts
+++ b/packages/js/data/src/export/test/reducer.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment node
+ * @jest-environment jsdom
  */
 
 /**

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -54,7 +54,7 @@ export { store as reviewsStore } from './reviews';
 export { store as shippingMethodsStore } from './shipping-methods';
 export { store as settingsStore } from './settings';
 export { store as pluginsStore } from './plugins';
-
+export { store as userStore } from './user';
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';
 export { withOnboardingHydration } from './onboarding/with-onboarding-hydration';

--- a/packages/js/data/src/user/index.ts
+++ b/packages/js/data/src/user/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+export { store } from '@wordpress/core-data'; // User store is the same as core data store
+
+/**
  * Internal dependencies
  */
 import { STORE_NAME } from './constants';

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import schema from '@wordpress/core-data';
+import type { User, Context } from '@wordpress/core-data';
 
 export type UserPreferences = {
 	activity_panel_inbox_last_read?: string;
@@ -40,12 +40,7 @@ export type WoocommerceMeta = {
 	[ key in keyof UserPreferences ]: string;
 };
 
-export type WCUser<
-	T extends keyof schema.Schema.BaseUser< 'view' > = schema.Schema.ViewKeys.User
-> = Pick<
-	schema.Schema.BaseUser< 'view' >,
-	schema.Schema.ViewKeys.User | T
-> & {
+export type WCUser< T extends Context = 'edit' > = User< T > & {
 	// https://github.com/woocommerce/woocommerce/blob/3eb1938f4a0d0a93c9bcaf2a904f96bd501177fc/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php#L40-L58
 	woocommerce_meta: WoocommerceMeta;
 	is_super_admin: boolean;

--- a/packages/js/data/src/user/use-user-preferences.ts
+++ b/packages/js/data/src/user/use-user-preferences.ts
@@ -7,8 +7,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
 import { WCUser, UserPreferences } from './types';
+import { store } from './';
 
 /**
  * Retrieve and decode the user's WooCommerce meta values.
@@ -109,7 +109,7 @@ async function updateUserPrefs(
  */
 export const useUserPreferences = () => {
 	// Get our dispatch methods now - this can't happen inside the callback below.
-	const dispatch = useDispatch( STORE_NAME );
+	const dispatch = useDispatch( store );
 	const { addEntities, receiveCurrentUser, saveEntityRecord } = dispatch;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
@@ -129,19 +129,19 @@ export const useUserPreferences = () => {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
 			hasFinishedResolution,
-		} = select( STORE_NAME );
+		} = select( store );
 
 		return {
 			isRequesting:
-				hasStartedResolution( 'getCurrentUser' ) &&
-				! hasFinishedResolution( 'getCurrentUser' ),
-			user: getCurrentUser() as WCUser,
+				hasStartedResolution( 'getCurrentUser', [] ) &&
+				! hasFinishedResolution( 'getCurrentUser', [] ),
+			user: getCurrentUser() as unknown as WCUser,
 			getCurrentUser,
 			getEntity,
 			getEntityRecord,
 			getLastEntitySaveError,
 		};
-	} );
+	}, [] );
 
 	const updateUserPreferences = <
 		T extends Record< string, unknown > = UserPreferences
@@ -183,7 +183,7 @@ export const useUserPreferences = () => {
 			};
 		}
 		// Get most recent user before update.
-		const currentUser = userData.getCurrentUser() as WCUser;
+		const currentUser = userData.getCurrentUser() as unknown as WCUser;
 		return updateUserPrefs(
 			receiveCurrentUser,
 			currentUser,

--- a/packages/js/data/src/user/use-user-preferences.ts
+++ b/packages/js/data/src/user/use-user-preferences.ts
@@ -135,7 +135,7 @@ export const useUserPreferences = () => {
 			isRequesting:
 				hasStartedResolution( 'getCurrentUser', [] ) &&
 				! hasFinishedResolution( 'getCurrentUser', [] ),
-			user: getCurrentUser() as unknown as WCUser,
+			user: getCurrentUser() as WCUser,
 			getCurrentUser,
 			getEntity,
 			getEntityRecord,
@@ -183,7 +183,7 @@ export const useUserPreferences = () => {
 			};
 		}
 		// Get most recent user before update.
-		const currentUser = userData.getCurrentUser() as unknown as WCUser;
+		const currentUser = userData.getCurrentUser() as WCUser;
 		return updateUserPrefs(
 			receiveCurrentUser,
 			currentUser,

--- a/packages/js/data/src/user/use-user.ts
+++ b/packages/js/data/src/user/use-user.ts
@@ -26,7 +26,7 @@ export const useUser = () => {
 				hasStartedResolution( 'getCurrentUser', [] ) &&
 				! hasFinishedResolution( 'getCurrentUser', [] ),
 			// We register additional user data in backend so we need to use a type assertion here for WC user.
-			user: getCurrentUser() as unknown as WCUser,
+			user: getCurrentUser() as WCUser,
 			getCurrentUser,
 		};
 	}, [] );

--- a/packages/js/data/src/user/use-user.ts
+++ b/packages/js/data/src/user/use-user.ts
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
+import { store } from './';
 import { WCUser } from './types';
 
 /**
@@ -19,17 +19,17 @@ export const useUser = () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		const { getCurrentUser, hasStartedResolution, hasFinishedResolution } =
-			select( STORE_NAME );
+			select( store );
 
 		return {
 			isRequesting:
-				hasStartedResolution( 'getCurrentUser' ) &&
-				! hasFinishedResolution( 'getCurrentUser' ),
+				hasStartedResolution( 'getCurrentUser', [] ) &&
+				! hasFinishedResolution( 'getCurrentUser', [] ),
 			// We register additional user data in backend so we need to use a type assertion here for WC user.
-			user: getCurrentUser() as WCUser< 'capabilities' >,
+			user: getCurrentUser() as unknown as WCUser,
 			getCurrentUser,
 		};
-	} );
+	}, [] );
 
 	const currentUserCan = ( capability: string ) => {
 		if ( userData.user && userData.user.is_super_admin ) {

--- a/packages/js/data/src/user/with-current-user-hydration.tsx
+++ b/packages/js/data/src/user/with-current-user-hydration.tsx
@@ -28,8 +28,7 @@ export const withCurrentUserHydration = ( currentUser: WCUser ) =>
 				if ( ! currentUser ) {
 					return;
 				}
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
+
 				const { isResolving, hasFinishedResolution } = select( store );
 				return (
 					! isResolving( 'getCurrentUser', [] ) &&
@@ -37,10 +36,8 @@ export const withCurrentUserHydration = ( currentUser: WCUser ) =>
 				);
 			}, [] );
 
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
 			const { startResolution, finishResolution, receiveCurrentUser } =
-				useDispatch( STORE_NAME );
+				useDispatch( store );
 
 			if ( shouldHydrate ) {
 				startResolution( 'getCurrentUser', [] );

--- a/packages/js/data/src/user/with-current-user-hydration.tsx
+++ b/packages/js/data/src/user/with-current-user-hydration.tsx
@@ -8,7 +8,7 @@ import { createElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
+import { store } from './';
 import { WCUser } from './types';
 
 /**
@@ -30,13 +30,12 @@ export const withCurrentUserHydration = ( currentUser: WCUser ) =>
 				}
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
-				const { isResolving, hasFinishedResolution } =
-					select( STORE_NAME );
+				const { isResolving, hasFinishedResolution } = select( store );
 				return (
-					! isResolving( 'getCurrentUser' ) &&
-					! hasFinishedResolution( 'getCurrentUser' )
+					! isResolving( 'getCurrentUser', [] ) &&
+					! hasFinishedResolution( 'getCurrentUser', [] )
 				);
-			} );
+			}, [] );
 
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore

--- a/packages/js/data/src/utils.ts
+++ b/packages/js/data/src/utils.ts
@@ -9,8 +9,9 @@ import { apiFetch, select } from '@wordpress/data-controls';
  */
 import { BaseQueryParams } from './types/query-params';
 import { fetchWithHeaders } from './controls';
-import { USER_STORE_NAME } from './user';
+import { store as userStore } from './user';
 import { WCUser } from './user/types';
+
 function replacer( _: string, value: unknown ) {
 	if ( value ) {
 		if ( Array.isArray( value ) ) {
@@ -109,10 +110,7 @@ export function* request< Query extends BaseQueryParams, DataType >(
  * @throws {Error} If the user does not have the required capability.
  */
 export function* checkUserCapability( capability: string ) {
-	const currentUser: WCUser = yield select(
-		USER_STORE_NAME,
-		'getCurrentUser'
-	);
+	const currentUser: WCUser = yield select( userStore, 'getCurrentUser' );
 
 	if ( ! currentUser.capabilities[ capability ] ) {
 		throw new Error( `User does not have ${ capability } capability.` );

--- a/packages/js/data/src/utils.ts
+++ b/packages/js/data/src/utils.ts
@@ -109,7 +109,7 @@ export function* request< Query extends BaseQueryParams, DataType >(
  * @throws {Error} If the user does not have the required capability.
  */
 export function* checkUserCapability( capability: string ) {
-	const currentUser: WCUser< 'capabilities' > = yield select(
+	const currentUser: WCUser = yield select(
 		USER_STORE_NAME,
 		'getCurrentUser'
 	);

--- a/packages/js/product-editor/changelog/fix-migrate-user-store
+++ b/packages/js/product-editor/changelog/fix-migrate-user-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update user store imports and type references

--- a/packages/js/product-editor/src/hooks/use-metabox-hidden-product/use-metabox-hidden-product.ts
+++ b/packages/js/product-editor/src/hooks/use-metabox-hidden-product/use-metabox-hidden-product.ts
@@ -23,17 +23,20 @@ export function useMetaboxHiddenProduct() {
 
 	async function saveMetaboxhiddenProduct(
 		value: string[]
-	): Promise< WCUser< 'capabilities' > > {
+	): Promise< WCUser > {
 		try {
 			setIsSaving( true );
 
 			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			const { saveEntityRecord } = dispatch( coreStore );
-			const currentUser: WCUser< 'capabilities' > =
-				( await saveEntityRecord( 'root', 'user', {
+			const currentUser: WCUser = ( await saveEntityRecord(
+				'root',
+				'user',
+				{
 					id: user.id,
 					metaboxhidden_product: value,
-				} ) ) as never;
+				}
+			) ) as never;
 
 			return currentUser;
 		} finally {

--- a/plugins/woocommerce/changelog/fix-migrate-user-store
+++ b/plugins/woocommerce/changelog/fix-migrate-user-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update user store imports and type references

--- a/plugins/woocommerce/client/admin/client/activity-panel/unread-indicators.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/unread-indicators.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { notesStore, USER_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
+import { notesStore, userStore, QUERY_DEFAULTS } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ const UNREAD_NOTES_QUERY = {
 export function hasUnreadNotes( select ) {
 	const { getNotes, getNotesError, isResolving } = select( notesStore );
 
-	const { getCurrentUser } = select( USER_STORE_NAME );
+	const { getCurrentUser } = select( userStore );
 	const userData = getCurrentUser();
 	const lastRead = parseInt(
 		userData &&

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -31,7 +31,7 @@ import {
 	GeolocationResponse,
 	pluginsStore,
 	settingsStore,
-	USER_STORE_NAME,
+	userStore,
 	WCUser,
 	ProfileItems,
 	CoreProfilerStep,
@@ -133,7 +133,7 @@ export type CoreProfilerStateMachineContext = {
 	onboardingProfile: OnboardingProfile;
 	jetpackAuthUrl?: string;
 	currentUserEmail: string | undefined;
-	currentUser?: WCUser< 'capabilities' >;
+	currentUser?: WCUser;
 };
 
 const getAllowTrackingOption = fromPromise( async () =>
@@ -256,18 +256,12 @@ const handleCoreProfilerCompletedSteps = assign( {
 } );
 
 const getCurrentUserEmail = fromPromise( async () => {
-	// @ts-expect-error TODO react-18-upgrade: getCurrentUser type is not correctly typed and was surfaced by https://github.com/woocommerce/woocommerce/pull/54146
-	const currentUser: WCUser< 'email' > = await resolveSelect(
-		USER_STORE_NAME
-	).getCurrentUser();
+	const currentUser = await resolveSelect( userStore ).getCurrentUser();
 	return currentUser?.email;
 } );
 
 const getCurrentUser = fromPromise( async () => {
-	// @ts-expect-error TODO react-18-upgrade: getCurrentUser type is not correctly typed and was surfaced by https://github.com/woocommerce/woocommerce/pull/54146
-	const currentUser: WCUser< 'capabilities' > = await resolveSelect(
-		USER_STORE_NAME
-	).getCurrentUser();
+	const currentUser = await resolveSelect( userStore ).getCurrentUser();
 	return currentUser;
 } );
 
@@ -275,7 +269,7 @@ const assignCurrentUser = assign( {
 	currentUser: ( {
 		event,
 	}: {
-		event: DoneActorEvent< WCUser< 'capabilities' > | undefined >;
+		event: DoneActorEvent< WCUser | undefined >;
 	} ) => {
 		if ( event.output ) {
 			return event.output;
@@ -1878,6 +1872,7 @@ export const CoreProfilerController = ( {
 				},
 				userHasNoInstallPluginsPermission: ( { context } ) => {
 					return (
+						// @ts-expect-error TODO: react-18-upgrade: This comparison appears to be unintentional because the types 'string | undefined' and 'boolean' have no overlap.ts(2367). Need to check if this is a valid comparison.
 						context?.currentUser?.capabilities.install_plugins !==
 						true
 					);

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/NoPermissions.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/NoPermissions.test.tsx
@@ -37,7 +37,7 @@ describe( 'NoPermissions', () => {
 			],
 			currentUser: {
 				capabilities: {},
-			} as unknown as WCUser< 'capabilities' >,
+			} as unknown as WCUser,
 		},
 		sendEvent: mockSendEvent,
 		navigationProgress: 50,

--- a/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/NoPermissions.test.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/pages/Plugins/tests/NoPermissions.test.tsx
@@ -37,7 +37,7 @@ describe( 'NoPermissions', () => {
 			],
 			currentUser: {
 				capabilities: {},
-			} as unknown as WCUser,
+			} as WCUser,
 		},
 		sendEvent: mockSendEvent,
 		navigationProgress: 50,

--- a/plugins/woocommerce/client/admin/client/layout/transient-notices/index.js
+++ b/plugins/woocommerce/client/admin/client/layout/transient-notices/index.js
@@ -4,7 +4,7 @@
 import { applyFilters } from '@wordpress/hooks';
 import clsx from 'clsx';
 import { WooFooterItem } from '@woocommerce/admin-layout';
-import { OPTIONS_STORE_NAME, USER_STORE_NAME } from '@woocommerce/data';
+import { OPTIONS_STORE_NAME, userStore } from '@woocommerce/data';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -32,7 +32,7 @@ export function TransientNotices( props ) {
 		// NOTE: This uses core/notices2, if this file is copied back upstream
 		// to Gutenberg this needs to be changed back to just core/notices.
 		return {
-			currentUser: select( USER_STORE_NAME ).getCurrentUser(),
+			currentUser: select( userStore ).getCurrentUser(),
 			notices: select( 'core/notices' ).getNotices(),
 			notices2: select( 'core/notices2' ).getNotices(),
 			noticesQueue:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/55373

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the **user** store registration pattern in `@woocommerce/data` to use the modern WordPress data store API. 

Key changes include:

1. Migrated from deprecated `registerStore` to `createReduxStore` and `register` pattern
2. Updated store exports to match the modern pattern used across other stores:
    - Added `export { store as userStore }`
    - Maintained `USER_STORE_NAME` export for backward compatibility
3. Removed deprecated type definitions:
    - Removed custom @wordpress/data module declaration
    - Cleaned up unused type exports and imports
4. Update user store import to use `userStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the user store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/user/**`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
