### PR TITLE
[API tests] Unskip `order-complex.test.js` on WPCOM and Pressable.

### DIFF
--- a/plugins/woocommerce/changelog/55429-dev-test-api-order-complex
+++ b/plugins/woocommerce/changelog/55429-dev-test-api-order-complex
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip `order-complex.test.js` on WPCOM and Pressable.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
@@ -131,7 +131,7 @@ test.describe( 'Orders API test', () => {
 				expect( expectedMessages ).toContain( message );
 			}
 
-			if ( response.status() === 201 ) {
+			if ( response.ok() ) {
 				const { slug } = await response.json();
 				taxClassSlugsToTearDown.push( slug );
 			}

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
@@ -108,7 +108,7 @@ test.describe( 'Orders API test', () => {
 		 * If not, fail immediately.
 		 */
 		for ( const name of [ 'Reduced rate', 'Zero rate' ] ) {
-			const response_createTaxClasses = await request.post(
+			const responseCreateTaxClasses = await request.post(
 				'./wp-json/wc/v3/taxes/classes',
 				{
 					data: {
@@ -117,7 +117,7 @@ test.describe( 'Orders API test', () => {
 				}
 			);
 
-			if ( response_createTaxClasses.status() === 400 ) {
+			if ( responseCreateTaxClasses.status() === 400 ) {
 				const expectedCodes = [
 					'woocommerce_rest_tax_class_exists',
 					'woocommerce_rest_tax_class_slug_exists',
@@ -126,14 +126,13 @@ test.describe( 'Orders API test', () => {
 					'Tax class already exists',
 					'Tax class slug already exists',
 				];
-				const { code, message } =
-					await response_createTaxClasses.json();
+				const { code, message } = await responseCreateTaxClasses.json();
 				expect( expectedCodes ).toContain( code );
 				expect( expectedMessages ).toContain( message );
 			}
 
-			if ( response_createTaxClasses.ok() ) {
-				const { slug } = await response_createTaxClasses.json();
+			if ( responseCreateTaxClasses.ok() ) {
+				const { slug } = await responseCreateTaxClasses.json();
 				taxClassSlugsToTearDown.push( slug );
 			}
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
@@ -108,7 +108,7 @@ test.describe( 'Orders API test', () => {
 		 * If not, fail immediately.
 		 */
 		for ( const name of [ 'Reduced rate', 'Zero rate' ] ) {
-			const response = await request.post(
+			const response_createTaxClasses = await request.post(
 				'./wp-json/wc/v3/taxes/classes',
 				{
 					data: {
@@ -117,7 +117,7 @@ test.describe( 'Orders API test', () => {
 				}
 			);
 
-			if ( response.status() === 400 ) {
+			if ( response_createTaxClasses.status() === 400 ) {
 				const expectedCodes = [
 					'woocommerce_rest_tax_class_exists',
 					'woocommerce_rest_tax_class_slug_exists',
@@ -126,13 +126,14 @@ test.describe( 'Orders API test', () => {
 					'Tax class already exists',
 					'Tax class slug already exists',
 				];
-				const { code, message } = await response.json();
+				const { code, message } =
+					await response_createTaxClasses.json();
 				expect( expectedCodes ).toContain( code );
 				expect( expectedMessages ).toContain( message );
 			}
 
-			if ( response.ok() ) {
-				const { slug } = await response.json();
+			if ( response_createTaxClasses.ok() ) {
+				const { slug } = await response_createTaxClasses.json();
 				taxClassSlugsToTearDown.push( slug );
 			}
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
@@ -72,6 +72,11 @@ const expectedSimpleProductTaxTotal = '1.00';
 const expectedVariableProductTaxTotal = '0.20';
 const expectedExternalProductTaxTotal = '0.00';
 
+/**
+ * Slugs of tax classes to delete at tear down.
+ */
+const taxClassSlugsToTearDown = [];
+
 test.describe( 'Orders API test', () => {
 	test.beforeAll( async ( { request } ) => {
 		/**
@@ -91,17 +96,55 @@ test.describe( 'Orders API test', () => {
 				data: {
 					delete: ids,
 				},
+				failOnStatusCode: true,
 			} );
+		}
+
+		/**
+		 * Create the default "Reduced rate" and "Zero rate" tax classes if they're missing.
+		 * If successfully created, delete them at teardown to revert the list of tax classes.
+		 *
+		 * Allow 400 Bad Request as long as it's due to a duplicate tax class creation attempt.
+		 * If not, fail immediately.
+		 */
+		for ( const name of [ 'Reduced rate', 'Zero rate' ] ) {
+			const response = await request.post(
+				'./wp-json/wc/v3/taxes/classes',
+				{
+					data: {
+						name,
+					},
+				}
+			);
+
+			if ( response.status() === 400 ) {
+				const expectedCodes = [
+					'woocommerce_rest_tax_class_exists',
+					'woocommerce_rest_tax_class_slug_exists',
+				];
+				const expectedMessages = [
+					'Tax class already exists',
+					'Tax class slug already exists',
+				];
+				const { code, message } = await response.json();
+				expect( expectedCodes ).toContain( code );
+				expect( expectedMessages ).toContain( message );
+			}
+
+			if ( response.status() === 201 ) {
+				const { slug } = await response.json();
+				taxClassSlugsToTearDown.push( slug );
+			}
 		}
 
 		/**
 		 * Create a tax rate for each tax class, and save their ID's.
 		 */
 		const taxRates = [ standardTaxRate, reducedTaxRate, zeroTaxRate ];
-
 		for ( const taxRate of taxRates ) {
 			const taxResponse = await request.post( './wp-json/wc/v3/taxes', {
 				data: taxRate,
+				failOnStatusCode: true,
 			} );
 			const taxResponseJSON = await taxResponse.json();
 			taxRate.id = taxResponseJSON.id;
@@ -205,6 +248,16 @@ test.describe( 'Orders API test', () => {
 				],
 			},
 		} );
+
+		// Delete tax classes
+		for ( const slug of taxClassSlugsToTearDown ) {
+			await request.delete( `./wp-json/wc/v3/taxes/classes/${ slug }`, {
+				params: {
+					force: true,
+				},
+				failOnStatusCode: true,
+			} );
+		}
 	} );
 
 	test( 'can add complex order', async ( { request } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/order-complex.test.js
@@ -1,8 +1,4 @@
-const {
-	test,
-	expect,
-	tags,
-} = require( '../../../fixtures/api-tests-fixtures' );
+const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const {
 	getOrderExample,
 	getTaxRateExamples,
@@ -211,52 +207,48 @@ test.describe( 'Orders API test', () => {
 		} );
 	} );
 
-	test(
-		'can add complex order',
-		{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
-		async ( { request } ) => {
-			//ensure tax calculations are enabled
-			await request.put(
-				'./wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
-				{
-					data: {
-						value: 'yes',
-					},
-				}
-			);
-
-			// Create the complex order and save its ID.
-			const response = await request.post( './wp-json/wc/v3/orders', {
-				data: order,
-			} );
-			const responseJSON = await response.json();
-
-			order.id = responseJSON.id;
-
-			expect( response.status() ).toEqual( 201 );
-
-			// Verify order and tax totals
-			expect( responseJSON.total ).toEqual( expectedOrderTotal );
-			expect( responseJSON.total_tax ).toEqual( expectedTaxTotal );
-
-			// Verify total tax of each product line item
-			const expectedTaxTotalsPerLineItem = [
-				[ simpleProduct, expectedSimpleProductTaxTotal ],
-				[ variableProduct, expectedVariableProductTaxTotal ],
-				[ groupedProduct, expectedSimpleProductTaxTotal ],
-				[ externalProduct, expectedExternalProductTaxTotal ],
-			];
-			for ( const [
-				product,
-				expectedLineTaxTotal,
-			] of expectedTaxTotalsPerLineItem ) {
-				const { total_tax: actualLineTaxTotal } =
-					responseJSON.line_items.find(
-						( { product_id } ) => product_id === product.id
-					);
-
-				expect( actualLineTaxTotal ).toEqual( expectedLineTaxTotal );
+	test( 'can add complex order', async ( { request } ) => {
+		//ensure tax calculations are enabled
+		await request.put(
+			'./wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
+			{
+				data: {
+					value: 'yes',
+				},
 			}
+		);
+
+		// Create the complex order and save its ID.
+		const response = await request.post( './wp-json/wc/v3/orders', {
+			data: order,
+		} );
+		const responseJSON = await response.json();
+
+		order.id = responseJSON.id;
+
+		expect( response.status() ).toEqual( 201 );
+
+		// Verify order and tax totals
+		expect( responseJSON.total ).toEqual( expectedOrderTotal );
+		expect( responseJSON.total_tax ).toEqual( expectedTaxTotal );
+
+		// Verify total tax of each product line item
+		const expectedTaxTotalsPerLineItem = [
+			[ simpleProduct, expectedSimpleProductTaxTotal ],
+			[ variableProduct, expectedVariableProductTaxTotal ],
+			[ groupedProduct, expectedSimpleProductTaxTotal ],
+			[ externalProduct, expectedExternalProductTaxTotal ],
+		];
+		for ( const [
+			product,
+			expectedLineTaxTotal,
+		] of expectedTaxTotalsPerLineItem ) {
+			const { total_tax: actualLineTaxTotal } =
+				responseJSON.line_items.find(
+					( { product_id } ) => product_id === product.id
+				);
+
+			expect( actualLineTaxTotal ).toEqual( expectedLineTaxTotal );
 		}
-	);
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

- Makes sure that the default "Reduced rate" and "Zero rate" tax classes are present prior to running the test. The reason it previously fails on WPCOM and Pressable is that sometimes these tax classes get deleted, causing the test to fail
- Added `failOnStatusCode`  on a few key api calls in beforeAll and afterAll to avoid silent failures and help with debugging. In trunk, the beforeAll fails silently when it tries to create tax rates for non-existing tax classes as shown below, allowing the test to still run instead of failing early.

<img width="1363" alt="Screenshot 2025-02-12 at 9 58 54 PM" src="https://github.com/user-attachments/assets/751cd6f3-342c-4364-a95c-179cff49f940" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run on Pressable and WPCOM, make sure they pass.
```bash
export E2E_ENV_KEY="..."
pnpm test:e2e:pressable order-complex.test.js
pnpm test:e2e:wpcom order-complex.test.js
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
