### PR TITLE
[API tests] Unskip `orders.test.js` on WPCOM and Pressable.

### DIFF
--- a/plugins/woocommerce/changelog/55430-dev-test-api-orders
+++ b/plugins/woocommerce/changelog/55430-dev-test-api-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unskip orders.test.js on WPCOM and Pressable.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -3132,8 +3132,8 @@ test.describe.serial( 'Orders API tests', () => {
 			const result2JSON = await result2.json();
 
 			expect( result2.status() ).toEqual( 200 );
-			expect( result2JSON ).toHaveLength( 1 );
-			expect( result2JSON[ 0 ].id ).toEqual(
+			expect( result2JSON.length ).toBeGreaterThanOrEqual( 1 );
+			expect( result2JSON.map( ( { id } ) => id ) ).toContain(
 				sampleData.guestOrderJSON.id
 			);
 
@@ -3146,8 +3146,8 @@ test.describe.serial( 'Orders API tests', () => {
 			const result3JSON = await result3.json();
 
 			expect( result3.status() ).toEqual( 200 );
-			expect( result3JSON ).toHaveLength( 1 );
-			expect( result3JSON[ 0 ].id ).toEqual(
+			expect( result3JSON.length ).toBeGreaterThanOrEqual( 1 );
+			expect( result3JSON.map( ( { id } ) => id ) ).toContain(
 				sampleData.guestOrderJSON.id
 			);
 
@@ -3174,7 +3174,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const result5JSON = await result5.json();
 
 			expect( result5.status() ).toEqual( 200 );
-			expect( result5JSON ).toHaveLength( 2 );
+			expect( result5JSON.length ).toBeGreaterThanOrEqual( 2 );
 			result5JSON.forEach( ( _order ) =>
 				expect( _order ).toEqual(
 					expect.objectContaining( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -117,28 +117,31 @@ test.describe.serial( 'Orders API tests', () => {
 		};
 
 		const createSampleAttributes = async () => {
-			const color = await request.post(
-				'./wp-json/wc/v3/products/attributes',
+			// Create attributes
+			const color = {
+				name: `Color ${ RAND_STRING }`,
+			};
+			const size = {
+				name: `Size ${ RAND_STRING }`,
+			};
+			const attributes = await request.post(
+				'./wp-json/wc/v3/products/attributes/batch',
 				{
 					data: {
-						name: `Color ${ RAND_STRING }`,
+						create: [ color, size ],
 					},
 					failOnStatusCode: true,
 				}
 			);
-			const colorJSON = await color.json();
-
-			const size = await request.post(
-				'./wp-json/wc/v3/products/attributes',
-				{
-					data: {
-						name: `Size ${ RAND_STRING }`,
-					},
-					failOnStatusCode: true,
-				}
+			const attributesJSON = await attributes.json();
+			const colorJSON = attributesJSON.create.find(
+				( { name } ) => name === color.name
 			);
-			const sizeJSON = await size.json();
+			const sizeJSON = attributesJSON.create.find(
+				( { name } ) => name === size.name
+			);
 
+			// Create attribute terms
 			const colorNames = [ 'Blue', 'Gray', 'Green', 'Red', 'Yellow' ];
 
 			const colorNamesObjectArray = colorNames.map( ( name ) => ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -39,7 +39,7 @@ const updatedCustomerShipping = {
 };
 
 test.describe.serial( 'Orders API tests', () => {
-	let orderId, sampleData, reducedRatePreexists;
+	let orderId, sampleData;
 
 	test.beforeAll( async ( { request } ) => {
 		const createSampleCategories = async () => {
@@ -214,29 +214,6 @@ test.describe.serial( 'Orders API tests', () => {
 			return {
 				freightJSON,
 			};
-		};
-
-		const createSampleTaxClasses = async () => {
-			//check to see if Reduced Rate tax class exists - if not, create it
-			const response_getReducedRate = await request.get(
-				'./wp-json/wc/v3/taxes/classes/reduced-rate'
-			);
-			reducedRatePreexists = response_getReducedRate.ok();
-
-			//if tax class does not exist then create it
-			if ( ! reducedRatePreexists ) {
-				const reducedRate = await request.post(
-					'./wp-json/wc/v3/taxes/classes',
-					{
-						data: {
-							name: 'Reduced rate',
-						},
-						failOnStatusCode: true,
-					}
-				);
-				const reducedRateJSON = await reducedRate.json();
-				return { reducedRateJSON };
-			}
 		};
 
 		const createSampleSimpleProducts = async (
@@ -860,7 +837,7 @@ test.describe.serial( 'Orders API tests', () => {
 								external_url: '',
 								button_text: '',
 								tax_status: 'taxable',
-								tax_class: 'reduced-rate',
+								tax_class: '',
 								manage_stock: false,
 								stock_quantity: null,
 								backorders: 'no',
@@ -2138,8 +2115,6 @@ test.describe.serial( 'Orders API tests', () => {
 
 			const shippingClasses = await createSampleShippingClasses();
 
-			await createSampleTaxClasses();
-
 			const simpleProducts = await createSampleSimpleProducts(
 				categories,
 				attributes,
@@ -2592,19 +2567,6 @@ test.describe.serial( 'Orders API tests', () => {
 					failOnStatusCode: true,
 				}
 			);
-
-			// Delete Reduced rate tax class if it didn't exist.
-			if ( ! reducedRatePreexists ) {
-				await request.delete(
-					'./wp-json/wc/v3/taxes/classes/reduced-rate',
-					{
-						data: {
-							force: true,
-						},
-						failOnStatusCode: true,
-					}
-				);
-			}
 		};
 
 		const deleteSampleData = async ( _sampleData ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -3,6 +3,7 @@ const { order } = require( '../../../data' );
 const { faker } = require( '@faker-js/faker' );
 
 const RAND_STRING = faker.string.alphanumeric( 8 ).toLowerCase();
+const COUPON_CODE = `coupon-${ faker.string.alphanumeric( 4 ).toLowerCase() }`;
 
 /**
  * Billing properties to update.
@@ -2426,7 +2427,7 @@ test.describe.serial( 'Orders API tests', () => {
 
 			const coupon = await request.post( './wp-json/wc/v3/coupons', {
 				data: {
-					code: 'save5',
+					code: COUPON_CODE,
 					amount: '5',
 				},
 			} );
@@ -2443,7 +2444,7 @@ test.describe.serial( 'Orders API tests', () => {
 					],
 					coupon_lines: [
 						{
-							code: 'save5',
+							code: COUPON_CODE,
 						},
 					],
 					shipping_lines: [

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -2084,6 +2084,7 @@ test.describe.serial( 'Orders API tests', () => {
 						reviewer: 'Tim Frugalman',
 						reviewer_email: 'timmyfrufru@example.com',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const review3JSON = await review3.json();
@@ -2275,6 +2276,7 @@ test.describe.serial( 'Orders API tests', () => {
 					},
 					shipping: johnAddress,
 				},
+				failOnStatusCode: true,
 			} );
 
 			expect( john.status() ).toEqual( 201 );
@@ -2295,6 +2297,7 @@ test.describe.serial( 'Orders API tests', () => {
 					},
 					shipping: tinaAddress,
 				},
+				failOnStatusCode: true,
 			} );
 
 			expect( tina.status() ).toEqual( 201 );
@@ -2329,6 +2332,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				} );
 				const orderJSON = await order2.json();
 
@@ -2355,6 +2359,7 @@ test.describe.serial( 'Orders API tests', () => {
 						},
 					],
 				},
+				failOnStatusCode: true,
 			} );
 			const order2JSON = await order2.json();
 
@@ -2378,6 +2383,7 @@ test.describe.serial( 'Orders API tests', () => {
 						},
 					],
 				},
+				failOnStatusCode: true,
 			} );
 			const order3JSON = await order3.json();
 
@@ -2400,6 +2406,7 @@ test.describe.serial( 'Orders API tests', () => {
 						},
 					],
 				},
+				failOnStatusCode: true,
 			} );
 			const guestOrderJSON = await guestOrder.json();
 
@@ -2410,6 +2417,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						value: 'yes',
 					},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -2423,6 +2431,7 @@ test.describe.serial( 'Orders API tests', () => {
 					rate: '5.5',
 					shipping: true,
 				},
+				failOnStatusCode: true,
 			} );
 
 			const coupon = await request.post( './wp-json/wc/v3/coupons', {
@@ -2430,6 +2439,7 @@ test.describe.serial( 'Orders API tests', () => {
 					code: COUPON_CODE,
 					amount: '5',
 				},
+				failOnStatusCode: true,
 			} );
 			const couponJSON = await coupon.json();
 
@@ -2460,6 +2470,7 @@ test.describe.serial( 'Orders API tests', () => {
 						},
 					],
 				},
+				failOnStatusCode: true,
 			} );
 			const order4JSON = await order4.json();
 
@@ -2485,6 +2496,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				}
 			);
 			orders.push( order4JSON );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -1,5 +1,8 @@
 const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { order } = require( '../../../data' );
+const { faker } = require( '@faker-js/faker' );
+
+const RAND_STRING = faker.number.int( { min: 1000, max: 9999 } );
 
 /**
  * Billing properties to update.
@@ -45,6 +48,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						name: 'Clothing',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const clothingJSON = await clothing.json();
@@ -56,6 +60,7 @@ test.describe.serial( 'Orders API tests', () => {
 						name: 'Accessories',
 						parent: clothingJSON.id,
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const accessoriesJSON = await accessories.json();
@@ -67,6 +72,7 @@ test.describe.serial( 'Orders API tests', () => {
 						name: 'Hoodies',
 						parent: clothingJSON.id,
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const hoodiesJSON = await hoodies.json();
@@ -78,6 +84,7 @@ test.describe.serial( 'Orders API tests', () => {
 						name: 'Tshirts',
 						parent: clothingJSON.id,
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const tshirtsJSON = await tshirts.json();
@@ -88,6 +95,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						name: 'Decor',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const decorJSON = await decor.json();
@@ -98,6 +106,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						name: 'Music',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const musicJSON = await music.json();
@@ -119,6 +128,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						name: 'Color',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const colorJSON = await color.json();
@@ -129,6 +139,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						name: 'Size',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const sizeJSON = await size.json();
@@ -145,6 +156,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						create: colorNamesObjectArray,
 					},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -162,6 +174,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						create: sizeNamesObjectArray,
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const sizesJSON = await sizes.json();
@@ -179,6 +192,7 @@ test.describe.serial( 'Orders API tests', () => {
 				data: {
 					name: 'Cool',
 				},
+				failOnStatusCode: true,
 			} );
 			const coolJSON = await cool.json();
 
@@ -194,6 +208,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						name: 'Freight',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const freightJSON = await freight.json();
@@ -219,6 +234,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							name: 'Reduced Rate',
 						},
+						failOnStatusCode: true,
 					}
 				);
 				reducedRateJSON = await reducedRate.json();
@@ -1258,6 +1274,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const simpleProductsJSON = await simpleProducts.json();
@@ -1342,6 +1359,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const externalProductsJSON = await externalProducts.json();
@@ -1438,6 +1456,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const groupedProductsJSON = await groupedProducts.json();
@@ -1533,6 +1552,7 @@ test.describe.serial( 'Orders API tests', () => {
 					menu_order: 0,
 					stock_status: 'instock',
 				},
+				failOnStatusCode: true,
 			} );
 			const hoodieJSON = await hoodie.json();
 
@@ -1735,6 +1755,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const hoodieVariationsJSON = await hoodieVariations.json();
@@ -1817,6 +1838,7 @@ test.describe.serial( 'Orders API tests', () => {
 					menu_order: 0,
 					stock_status: 'instock',
 				},
+				failOnStatusCode: true,
 			} );
 			const vneckJSON = await vneck.json();
 
@@ -1950,6 +1972,7 @@ test.describe.serial( 'Orders API tests', () => {
 							},
 						],
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const vneckVariationsJSON = await vneckVariations.json();
@@ -1968,6 +1991,7 @@ test.describe.serial( 'Orders API tests', () => {
 					name: 'Parent Product oxo',
 					date_created_gmt: '2021-09-27T15:50:19',
 				},
+				failOnStatusCode: true,
 			} );
 			const parentJSON = await parent.json();
 
@@ -1977,6 +2001,7 @@ test.describe.serial( 'Orders API tests', () => {
 					parent_id: parentJSON.id,
 					date_created_gmt: '2021-09-28T15:50:19',
 				},
+				failOnStatusCode: true,
 			} );
 			const childJSON = await child.json();
 
@@ -2007,6 +2032,7 @@ test.describe.serial( 'Orders API tests', () => {
 						reviewer: 'John Doe',
 						reviewer_email: 'john.doe@example.com',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const review1JSON = await review1.json();
@@ -2019,6 +2045,7 @@ test.describe.serial( 'Orders API tests', () => {
 				`./wp-json/wc/v3/products/reviews/${ review1JSON.id }`,
 				{
 					data: {},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -2032,6 +2059,7 @@ test.describe.serial( 'Orders API tests', () => {
 						reviewer: 'Shannon Smith',
 						reviewer_email: 'shannon.smith@example.com',
 					},
+					failOnStatusCode: true,
 				}
 			);
 			const review2JSON = await review2.json();
@@ -2041,6 +2069,7 @@ test.describe.serial( 'Orders API tests', () => {
 				`./wp-json/wc/v3/products/reviews/${ review2JSON.id }`,
 				{
 					data: {},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -2062,6 +2091,7 @@ test.describe.serial( 'Orders API tests', () => {
 				`./wp-json/wc/v3/products/reviews/${ review3JSON.id }`,
 				{
 					data: {},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -2098,6 +2128,7 @@ test.describe.serial( 'Orders API tests', () => {
 						},
 					],
 				},
+				failOnStatusCode: true,
 			} );
 			const orderJSON = await order1.json();
 
@@ -2511,6 +2542,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						force: true,
 					},
+					failOnStatusCode: true,
 				} );
 			}
 
@@ -2521,6 +2553,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							force: true,
 						},
+						failOnStatusCode: true,
 					}
 				);
 			}
@@ -2531,6 +2564,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						force: true,
 					},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -2540,6 +2574,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						force: true,
 					},
+					failOnStatusCode: true,
 				}
 			);
 
@@ -2550,6 +2585,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							force: true,
 						},
+						failOnStatusCode: true,
 					}
 				);
 			}
@@ -2561,6 +2597,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							force: true,
 						},
+						failOnStatusCode: true,
 					}
 				);
 			}
@@ -2572,6 +2609,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							force: true,
 						},
+						failOnStatusCode: true,
 					}
 				);
 			}
@@ -2583,6 +2621,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							force: true,
 						},
+						failOnStatusCode: true,
 					}
 				);
 			}
@@ -2600,6 +2639,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						force: true,
 					},
+					failOnStatusCode: true,
 				} );
 			}
 
@@ -2610,6 +2650,7 @@ test.describe.serial( 'Orders API tests', () => {
 						data: {
 							force: true,
 						},
+						failOnStatusCode: true,
 					}
 				);
 			}

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -385,7 +385,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple, virtual product.</p>\n',
-
 								price: '2',
 								regular_price: '3',
 								sale_price: '2',
@@ -456,7 +455,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple, virtual product.</p>\n',
-
 								price: '15',
 								regular_price: '15',
 								sale_price: '',
@@ -532,7 +530,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '20',
 								regular_price: '20',
 								sale_price: '',
@@ -605,7 +602,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '25',
 								regular_price: '25',
 								sale_price: '',
@@ -678,7 +674,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -743,7 +738,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '35',
 								regular_price: '45',
 								sale_price: '35',
@@ -820,7 +814,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '90',
 								regular_price: '90',
 								sale_price: '',
@@ -889,7 +882,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '16',
 								regular_price: '18',
 								sale_price: '16',
@@ -962,7 +954,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '55',
 								regular_price: '65',
 								sale_price: '55',
@@ -1027,7 +1018,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '18',
 								regular_price: '20',
 								sale_price: '18',
@@ -1104,7 +1094,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '18',
 								regular_price: '18',
 								sale_price: '',
@@ -1177,7 +1166,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -1269,7 +1257,6 @@ test.describe.serial( 'Orders API tests', () => {
 									'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
 								short_description:
 									'<p>This is an external product.</p>\n',
-
 								price: '11.05',
 								regular_price: '11.05',
 								sale_price: '',
@@ -1365,7 +1352,6 @@ test.describe.serial( 'Orders API tests', () => {
 									'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
 								short_description:
 									'<p>This is a grouped product.</p>\n',
-
 								price: '18',
 								regular_price: '',
 								sale_price: '',
@@ -1451,7 +1437,6 @@ test.describe.serial( 'Orders API tests', () => {
 					catalog_visibility: 'visible',
 					description,
 					short_description: '<p>This is a variable product.</p>\n',
-
 					price: '42',
 					regular_price: '',
 					sale_price: '',
@@ -1738,7 +1723,6 @@ test.describe.serial( 'Orders API tests', () => {
 					catalog_visibility: 'visible',
 					description,
 					short_description: '<p>This is a variable product.</p>\n',
-
 					price: '15',
 					regular_price: '',
 					sale_price: '',

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -43,74 +43,68 @@ test.describe.serial( 'Orders API tests', () => {
 
 	test.beforeAll( async ( { request } ) => {
 		const createSampleCategories = async () => {
-			const clothing = await request.post(
-				'./wp-json/wc/v3/products/categories',
+			// Create main categories
+			const clothing = {
+				name: `Clothing ${ RAND_STRING }`,
+			};
+			const decor = {
+				name: `Decor ${ RAND_STRING }`,
+			};
+			const music = {
+				name: `Music ${ RAND_STRING }`,
+			};
+			const categories = await request.post(
+				'./wp-json/wc/v3/products/categories/batch',
 				{
 					data: {
-						name: `Clothing ${ RAND_STRING }`,
+						create: [ clothing, decor, music ],
 					},
 					failOnStatusCode: true,
 				}
 			);
-			const clothingJSON = await clothing.json();
+			const categoriesJSON = await categories.json();
+			const clothingJSON = categoriesJSON.create.find(
+				( { name } ) => name === clothing.name
+			);
+			const decorJSON = categoriesJSON.create.find(
+				( { name } ) => name === decor.name
+			);
+			const musicJSON = categoriesJSON.create.find(
+				( { name } ) => name === music.name
+			);
 
-			const accessories = await request.post(
-				'./wp-json/wc/v3/products/categories',
+			// Create sub-categories
+			const accessories = {
+				name: `Accessories ${ RAND_STRING }`,
+				parent: clothingJSON.id,
+			};
+			const hoodies = {
+				name: `Hoodies ${ RAND_STRING }`,
+				parent: clothingJSON.id,
+			};
+			const tshirts = {
+				name: `Tshirts ${ RAND_STRING }`,
+				parent: clothingJSON.id,
+			};
+			const subCategories = await request.post(
+				'./wp-json/wc/v3/products/categories/batch',
 				{
 					data: {
-						name: `Accessories ${ RAND_STRING }`,
-						parent: clothingJSON.id,
+						create: [ accessories, hoodies, tshirts ],
 					},
 					failOnStatusCode: true,
 				}
 			);
-			const accessoriesJSON = await accessories.json();
-
-			const hoodies = await request.post(
-				'./wp-json/wc/v3/products/categories',
-				{
-					data: {
-						name: `Hoodies ${ RAND_STRING }`,
-						parent: clothingJSON.id,
-					},
-					failOnStatusCode: true,
-				}
+			const subCategoriesJSON = await subCategories.json();
+			const accessoriesJSON = subCategoriesJSON.create.find(
+				( { name } ) => name === accessories.name
 			);
-			const hoodiesJSON = await hoodies.json();
-
-			const tshirts = await request.post(
-				'./wp-json/wc/v3/products/categories',
-				{
-					data: {
-						name: `Tshirts ${ RAND_STRING }`,
-						parent: clothingJSON.id,
-					},
-					failOnStatusCode: true,
-				}
+			const hoodiesJSON = subCategoriesJSON.create.find(
+				( { name } ) => name === hoodies.name
 			);
-			const tshirtsJSON = await tshirts.json();
-
-			const decor = await request.post(
-				'./wp-json/wc/v3/products/categories',
-				{
-					data: {
-						name: `Decor ${ RAND_STRING }`,
-					},
-					failOnStatusCode: true,
-				}
+			const tshirtsJSON = subCategoriesJSON.create.find(
+				( { name } ) => name === tshirts.name
 			);
-			const decorJSON = await decor.json();
-
-			const music = await request.post(
-				'./wp-json/wc/v3/products/categories',
-				{
-					data: {
-						name: `Music ${ RAND_STRING }`,
-					},
-					failOnStatusCode: true,
-				}
-			);
-			const musicJSON = await music.json();
 
 			return {
 				clothingJSON,

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -2536,87 +2536,66 @@ test.describe.serial( 'Orders API tests', () => {
 					hierarchicalProducts.parentJSON.id,
 					hierarchicalProducts.childJSON.id,
 				] );
+			const orderIds = orders.map( ( { id } ) => id );
+			const categoryIds = Object.values( categories ).map(
+				( { id } ) => id
+			);
+			const tagIds = Object.values( productTags ).map( ( { id } ) => id );
+			const shippingClassIds = Object.values( shippingClasses ).map(
+				( { id } ) => id
+			);
+			const taxClassSlugs = Object.values( taxClasses ).map(
+				( { slug } ) => slug
+			);
 
-			for ( const _order of orders ) {
-				await request.delete( `./wp-json/wc/v3/orders/${ _order.id }`, {
-					data: {
-						force: true,
-					},
-					failOnStatusCode: true,
-				} );
-			}
+			await request.post( './wp-json/wc/v3/orders/batch', {
+				data: {
+					delete: orderIds,
+				},
+				failOnStatusCode: true,
+			} );
 
-			for ( const productId of productIds ) {
-				await request.delete(
-					`./wp-json/wc/v3/products/${ productId }`,
-					{
-						data: {
-							force: true,
-						},
-						failOnStatusCode: true,
-					}
-				);
-			}
+			await request.post( `./wp-json/wc/v3/products/batch`, {
+				data: {
+					delete: productIds,
+				},
+				failOnStatusCode: true,
+			} );
 
-			await request.delete(
-				`./wp-json/wc/v3/products/attributes/${ attributes.colorJSON.id }`,
+			await request.post( `./wp-json/wc/v3/products/attributes/batch`, {
+				data: {
+					delete: [ attributes.colorJSON.id, attributes.sizeJSON.id ],
+				},
+				failOnStatusCode: true,
+			} );
+
+			await request.post( `./wp-json/wc/v3/products/categories/batch`, {
+				data: {
+					delete: categoryIds,
+				},
+				failOnStatusCode: true,
+			} );
+
+			await request.post( `./wp-json/wc/v3/products/tags/batch`, {
+				data: {
+					delete: tagIds,
+				},
+				failOnStatusCode: true,
+			} );
+
+			await request.post(
+				`./wp-json/wc/v3/products/shipping_classes/batch`,
 				{
 					data: {
-						force: true,
+						delete: shippingClassIds,
 					},
 					failOnStatusCode: true,
 				}
 			);
 
-			await request.delete(
-				`./wp-json/wc/v3/products/attributes/${ attributes.sizeJSON.id }`,
-				{
-					data: {
-						force: true,
-					},
-					failOnStatusCode: true,
-				}
-			);
-
-			for ( const category of Object.values( categories ) ) {
+			for ( const slug of taxClassSlugs ) {
 				await request.delete(
-					`./wp-json/wc/v3/products/categories/${ category.id }`,
-					{
-						data: {
-							force: true,
-						},
-						failOnStatusCode: true,
-					}
-				);
-			}
-
-			for ( const tag of Object.values( productTags ) ) {
-				await request.delete(
-					`./wp-json/wc/v3/products/tags/${ tag.id }`,
-					{
-						data: {
-							force: true,
-						},
-						failOnStatusCode: true,
-					}
-				);
-			}
-
-			for ( const shippingClass of Object.values( shippingClasses ) ) {
-				await request.delete(
-					`./wp-json/wc/v3/products/shipping_classes/${ shippingClass.id }`,
-					{
-						data: {
-							force: true,
-						},
-						failOnStatusCode: true,
-					}
-				);
-			}
-
-			for ( const taxClass of Object.values( taxClasses ) ) {
-				await request.delete(
-					`./wp-json/wc/v3/taxes/classes/${ taxClass.slug }`,
+					`./wp-json/wc/v3/taxes/classes/${ slug }`,
 					{
 						data: {
 							force: true,
@@ -2632,28 +2611,25 @@ test.describe.serial( 'Orders API tests', () => {
 				_sampleData.testProductData
 			);
 
-			for ( const _order of _sampleData.orders.concat( [
-				_sampleData.guestOrderJSON,
-			] ) ) {
-				await request.delete( `./wp-json/wc/v3/orders/${ _order.id }`, {
-					data: {
-						force: true,
-					},
-					failOnStatusCode: true,
-				} );
-			}
+			const orderIds = _sampleData.orders
+				.concat( [ _sampleData.guestOrderJSON ] )
+				.map( ( { id } ) => id );
+			await request.post( './wp-json/wc/v3/orders/batch', {
+				data: {
+					delete: orderIds,
+				},
+				failOnStatusCode: true,
+			} );
 
-			for ( const customer of Object.values( _sampleData.customers ) ) {
-				await request.delete(
-					`./wp-json/wc/v3/customers/${ customer.id }`,
-					{
-						data: {
-							force: true,
-						},
-						failOnStatusCode: true,
-					}
-				);
-			}
+			const customerIds = Object.values( _sampleData.customers ).map(
+				( { id } ) => id
+			);
+			await request.post( `./wp-json/wc/v3/customers/batch`, {
+				data: {
+					delete: customerIds,
+				},
+				failOnStatusCode: true,
+			} );
 		};
 
 		await deleteSampleData( sampleData );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -2631,6 +2631,14 @@ test.describe.serial( 'Orders API tests', () => {
 				},
 				failOnStatusCode: true,
 			} );
+
+			const couponIds = [ _sampleData.couponJSON.id ];
+			await request.post( `./wp-json/wc/v3/coupons/batch`, {
+				data: {
+					delete: couponIds,
+				},
+				failOnStatusCode: true,
+			} );
 		};
 
 		await deleteSampleData( sampleData );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -343,7 +343,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'Woo-tshirt-logo',
 								price: '18',
 								regular_price: '18',
 								sale_price: '',
@@ -416,7 +415,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple, virtual product.</p>\n',
-								sku: 'woo-single',
+
 								price: '2',
 								regular_price: '3',
 								sale_price: '2',
@@ -487,7 +486,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple, virtual product.</p>\n',
-								sku: 'woo-album',
+
 								price: '15',
 								regular_price: '15',
 								sale_price: '',
@@ -563,7 +562,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-polo',
+
 								price: '20',
 								regular_price: '20',
 								sale_price: '',
@@ -636,7 +635,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-long-sleeve-tee',
+
 								price: '25',
 								regular_price: '25',
 								sale_price: '',
@@ -709,7 +708,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-hoodie-with-zipper',
+
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -774,7 +773,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-hoodie-with-pocket',
+
 								price: '35',
 								regular_price: '45',
 								sale_price: '35',
@@ -851,7 +850,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-sunglasses',
+
 								price: '90',
 								regular_price: '90',
 								sale_price: '',
@@ -920,7 +919,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-cap',
+
 								price: '16',
 								regular_price: '18',
 								sale_price: '16',
@@ -993,7 +992,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-belt',
+
 								price: '55',
 								regular_price: '65',
 								sale_price: '55',
@@ -1058,7 +1057,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-beanie',
+
 								price: '18',
 								regular_price: '20',
 								sale_price: '18',
@@ -1135,7 +1134,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-tshirt',
+
 								price: '18',
 								regular_price: '18',
 								sale_price: '',
@@ -1208,7 +1207,7 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'woo-hoodie-with-logo',
+
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -1300,7 +1299,7 @@ test.describe.serial( 'Orders API tests', () => {
 									'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
 								short_description:
 									'<p>This is an external product.</p>\n',
-								sku: 'wp-pennant',
+
 								price: '11.05',
 								regular_price: '11.05',
 								sale_price: '',
@@ -1396,7 +1395,7 @@ test.describe.serial( 'Orders API tests', () => {
 									'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
 								short_description:
 									'<p>This is a grouped product.</p>\n',
-								sku: 'logo-collection',
+
 								price: '18',
 								regular_price: '',
 								sale_price: '',
@@ -1482,7 +1481,7 @@ test.describe.serial( 'Orders API tests', () => {
 					catalog_visibility: 'visible',
 					description,
 					short_description: '<p>This is a variable product.</p>\n',
-					sku: 'woo-hoodie',
+
 					price: '42',
 					regular_price: '',
 					sale_price: '',
@@ -1571,7 +1570,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-19T15:50:20',
 								description: variationDescription,
-								sku: 'woo-hoodie-blue-logo',
+
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -1617,7 +1616,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-20T15:50:20',
 								description: variationDescription,
-								sku: 'woo-hoodie-blue',
+
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -1663,7 +1662,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-21T15:50:20',
 								description: variationDescription,
-								sku: 'woo-hoodie-green',
+
 								price: '45',
 								regular_price: '45',
 								sale_price: '',
@@ -1709,7 +1708,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-22T15:50:19',
 								description: variationDescription,
-								sku: 'woo-hoodie-red',
+
 								price: '42',
 								regular_price: '45',
 								sale_price: '42',
@@ -1769,7 +1768,7 @@ test.describe.serial( 'Orders API tests', () => {
 					catalog_visibility: 'visible',
 					description,
 					short_description: '<p>This is a variable product.</p>\n',
-					sku: 'woo-vneck-tee',
+
 					price: '15',
 					regular_price: '',
 					sale_price: '',
@@ -1890,7 +1889,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-25T15:50:19',
 								description: variationDescription,
-								sku: 'woo-vneck-tee-green',
+
 								price: '20',
 								regular_price: '20',
 								sale_price: '',
@@ -1931,7 +1930,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-26T15:50:19',
 								description: variationDescription,
-								sku: 'woo-vneck-tee-red',
+
 								price: '20',
 								regular_price: '20',
 								sale_price: '',

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -1849,7 +1849,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-24T15:50:19',
 								description: variationDescription,
-								sku: 'woo-vneck-tee-blue',
+								sku: `woo-vneck-tee-blue-${ RAND_NUM }`,
 								price: '15',
 								regular_price: '15',
 								sale_price: '',
@@ -2206,7 +2206,7 @@ test.describe.serial( 'Orders API tests', () => {
 				),
 				blueVneck:
 					testProductData.variableProducts.vneckVariations.find(
-						( p ) => p.sku === 'woo-vneck-tee-blue'
+						( p ) => p.sku === `woo-vneck-tee-blue-${ RAND_NUM }`
 					),
 				pennant: testProductData.externalProducts[ 0 ],
 			};

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -1848,7 +1848,7 @@ test.describe.serial( 'Orders API tests', () => {
 							{
 								date_created_gmt: '2021-09-24T15:50:19',
 								description: variationDescription,
-								sku: `woo-vneck-tee-blue-${ RAND_NUM }`,
+								sku: `woo-vneck-tee-blue-${ RAND_STRING }`,
 								price: '15',
 								regular_price: '15',
 								sale_price: '',
@@ -2205,7 +2205,7 @@ test.describe.serial( 'Orders API tests', () => {
 				),
 				blueVneck:
 					testProductData.variableProducts.vneckVariations.find(
-						( p ) => p.sku === `woo-vneck-tee-blue-${ RAND_NUM }`
+						( p ) => p.sku === `woo-vneck-tee-blue-${ RAND_STRING }`
 					),
 				pennant: testProductData.externalProducts[ 0 ],
 			};

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -1,8 +1,4 @@
-const {
-	test,
-	expect,
-	tags,
-} = require( '../../../fixtures/api-tests-fixtures' );
+const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { order } = require( '../../../data' );
 
 /**
@@ -38,3286 +34,3244 @@ const updatedCustomerShipping = {
 	phone: '123456789',
 };
 
-test.describe.serial(
-	'Orders API tests',
-	{ tag: [ tags.SKIP_ON_PRESSABLE, tags.SKIP_ON_WPCOM ] },
-	() => {
-		let orderId, sampleData;
+test.describe.serial( 'Orders API tests', () => {
+	let orderId, sampleData;
 
-		test.beforeAll( async ( { request } ) => {
-			const createSampleCategories = async () => {
-				const clothing = await request.post(
-					'./wp-json/wc/v3/products/categories',
-					{
-						data: {
-							name: 'Clothing',
-						},
-					}
-				);
-				const clothingJSON = await clothing.json();
-
-				const accessories = await request.post(
-					'./wp-json/wc/v3/products/categories',
-					{
-						data: {
-							name: 'Accessories',
-							parent: clothingJSON.id,
-						},
-					}
-				);
-				const accessoriesJSON = await accessories.json();
-
-				const hoodies = await request.post(
-					'./wp-json/wc/v3/products/categories',
-					{
-						data: {
-							name: 'Hoodies',
-							parent: clothingJSON.id,
-						},
-					}
-				);
-				const hoodiesJSON = await hoodies.json();
-
-				const tshirts = await request.post(
-					'./wp-json/wc/v3/products/categories',
-					{
-						data: {
-							name: 'Tshirts',
-							parent: clothingJSON.id,
-						},
-					}
-				);
-				const tshirtsJSON = await tshirts.json();
-
-				const decor = await request.post(
-					'./wp-json/wc/v3/products/categories',
-					{
-						data: {
-							name: 'Decor',
-						},
-					}
-				);
-				const decorJSON = await decor.json();
-
-				const music = await request.post(
-					'./wp-json/wc/v3/products/categories',
-					{
-						data: {
-							name: 'Music',
-						},
-					}
-				);
-				const musicJSON = await music.json();
-
-				return {
-					clothingJSON,
-					accessoriesJSON,
-					hoodiesJSON,
-					tshirtsJSON,
-					decorJSON,
-					musicJSON,
-				};
-			};
-
-			const createSampleAttributes = async () => {
-				const color = await request.post(
-					'./wp-json/wc/v3/products/attributes',
-					{
-						data: {
-							name: 'Color',
-						},
-					}
-				);
-				const colorJSON = await color.json();
-
-				const size = await request.post(
-					'./wp-json/wc/v3/products/attributes',
-					{
-						data: {
-							name: 'Size',
-						},
-					}
-				);
-				const sizeJSON = await size.json();
-
-				const colorNames = [ 'Blue', 'Gray', 'Green', 'Red', 'Yellow' ];
-
-				const colorNamesObjectArray = colorNames.map( ( name ) => ( {
-					name,
-				} ) );
-
-				const colors = await request.post(
-					`./wp-json/wc/v3/products/attributes/${ colorJSON.id }/terms/batch`,
-					{
-						data: {
-							create: colorNamesObjectArray,
-						},
-					}
-				);
-
-				const colorsJSON = await colors.json();
-
-				const sizeNames = [ 'Large', 'Medium', 'Small' ];
-
-				const sizeNamesObjectArray = sizeNames.map( ( name ) => ( {
-					name,
-				} ) );
-
-				const sizes = await request.post(
-					`./wp-json/wc/v3/products/attributes/${ sizeJSON.id }/terms/batch`,
-					{
-						data: {
-							create: sizeNamesObjectArray,
-						},
-					}
-				);
-				const sizesJSON = await sizes.json();
-
-				return {
-					colorJSON,
-					colors: colorsJSON.create,
-					sizeJSON,
-					sizes: sizesJSON.create,
-				};
-			};
-
-			const createSampleTags = async () => {
-				const cool = await request.post(
-					'./wp-json/wc/v3/products/tags',
-					{
-						data: {
-							name: 'Cool',
-						},
-					}
-				);
-				const coolJSON = await cool.json();
-
-				return {
-					coolJSON,
-				};
-			};
-
-			const createSampleShippingClasses = async () => {
-				const freight = await request.post(
-					'./wp-json/wc/v3/products/shipping_classes',
-					{
-						data: {
-							name: 'Freight',
-						},
-					}
-				);
-				const freightJSON = await freight.json();
-
-				return {
-					freightJSON,
-				};
-			};
-
-			const createSampleTaxClasses = async () => {
-				//check to see if Reduced Rate tax class exists - if not, create it
-				let reducedRate = await request.get(
-					'./wp-json/wc/v3/taxes/classes/reduced-rate'
-				);
-				let reducedRateJSON = await reducedRate.json();
-				expect( Array.isArray( reducedRateJSON ) ).toBe( true );
-
-				//if tax class does not exist then create it
-				if ( reducedRateJSON.length < 1 ) {
-					reducedRate = await request.post(
-						'./wp-json/wc/v3/taxes/classes',
-						{
-							data: {
-								name: 'Reduced Rate',
-							},
-						}
-					);
-					reducedRateJSON = await reducedRate.json();
-					return { reducedRateJSON };
+	test.beforeAll( async ( { request } ) => {
+		const createSampleCategories = async () => {
+			const clothing = await request.post(
+				'./wp-json/wc/v3/products/categories',
+				{
+					data: {
+						name: 'Clothing',
+					},
 				}
+			);
+			const clothingJSON = await clothing.json();
 
-				// return an empty object as nothing new was created so nothing will
-				// need deleted during cleanup
-				return {};
+			const accessories = await request.post(
+				'./wp-json/wc/v3/products/categories',
+				{
+					data: {
+						name: 'Accessories',
+						parent: clothingJSON.id,
+					},
+				}
+			);
+			const accessoriesJSON = await accessories.json();
+
+			const hoodies = await request.post(
+				'./wp-json/wc/v3/products/categories',
+				{
+					data: {
+						name: 'Hoodies',
+						parent: clothingJSON.id,
+					},
+				}
+			);
+			const hoodiesJSON = await hoodies.json();
+
+			const tshirts = await request.post(
+				'./wp-json/wc/v3/products/categories',
+				{
+					data: {
+						name: 'Tshirts',
+						parent: clothingJSON.id,
+					},
+				}
+			);
+			const tshirtsJSON = await tshirts.json();
+
+			const decor = await request.post(
+				'./wp-json/wc/v3/products/categories',
+				{
+					data: {
+						name: 'Decor',
+					},
+				}
+			);
+			const decorJSON = await decor.json();
+
+			const music = await request.post(
+				'./wp-json/wc/v3/products/categories',
+				{
+					data: {
+						name: 'Music',
+					},
+				}
+			);
+			const musicJSON = await music.json();
+
+			return {
+				clothingJSON,
+				accessoriesJSON,
+				hoodiesJSON,
+				tshirtsJSON,
+				decorJSON,
+				musicJSON,
 			};
+		};
 
-			const createSampleSimpleProducts = async (
+		const createSampleAttributes = async () => {
+			const color = await request.post(
+				'./wp-json/wc/v3/products/attributes',
+				{
+					data: {
+						name: 'Color',
+					},
+				}
+			);
+			const colorJSON = await color.json();
+
+			const size = await request.post(
+				'./wp-json/wc/v3/products/attributes',
+				{
+					data: {
+						name: 'Size',
+					},
+				}
+			);
+			const sizeJSON = await size.json();
+
+			const colorNames = [ 'Blue', 'Gray', 'Green', 'Red', 'Yellow' ];
+
+			const colorNamesObjectArray = colorNames.map( ( name ) => ( {
+				name,
+			} ) );
+
+			const colors = await request.post(
+				`./wp-json/wc/v3/products/attributes/${ colorJSON.id }/terms/batch`,
+				{
+					data: {
+						create: colorNamesObjectArray,
+					},
+				}
+			);
+
+			const colorsJSON = await colors.json();
+
+			const sizeNames = [ 'Large', 'Medium', 'Small' ];
+
+			const sizeNamesObjectArray = sizeNames.map( ( name ) => ( {
+				name,
+			} ) );
+
+			const sizes = await request.post(
+				`./wp-json/wc/v3/products/attributes/${ sizeJSON.id }/terms/batch`,
+				{
+					data: {
+						create: sizeNamesObjectArray,
+					},
+				}
+			);
+			const sizesJSON = await sizes.json();
+
+			return {
+				colorJSON,
+				colors: colorsJSON.create,
+				sizeJSON,
+				sizes: sizesJSON.create,
+			};
+		};
+
+		const createSampleTags = async () => {
+			const cool = await request.post( './wp-json/wc/v3/products/tags', {
+				data: {
+					name: 'Cool',
+				},
+			} );
+			const coolJSON = await cool.json();
+
+			return {
+				coolJSON,
+			};
+		};
+
+		const createSampleShippingClasses = async () => {
+			const freight = await request.post(
+				'./wp-json/wc/v3/products/shipping_classes',
+				{
+					data: {
+						name: 'Freight',
+					},
+				}
+			);
+			const freightJSON = await freight.json();
+
+			return {
+				freightJSON,
+			};
+		};
+
+		const createSampleTaxClasses = async () => {
+			//check to see if Reduced Rate tax class exists - if not, create it
+			let reducedRate = await request.get(
+				'./wp-json/wc/v3/taxes/classes/reduced-rate'
+			);
+			let reducedRateJSON = await reducedRate.json();
+			expect( Array.isArray( reducedRateJSON ) ).toBe( true );
+
+			//if tax class does not exist then create it
+			if ( reducedRateJSON.length < 1 ) {
+				reducedRate = await request.post(
+					'./wp-json/wc/v3/taxes/classes',
+					{
+						data: {
+							name: 'Reduced Rate',
+						},
+					}
+				);
+				reducedRateJSON = await reducedRate.json();
+				return { reducedRateJSON };
+			}
+
+			// return an empty object as nothing new was created so nothing will
+			// need deleted during cleanup
+			return {};
+		};
+
+		const createSampleSimpleProducts = async (
+			categories,
+			attributes,
+			productTags
+		) => {
+			const description =
+				'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
+				'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. ' +
+				'Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n';
+
+			const simpleProducts = await request.post(
+				'./wp-json/wc/v3/products/batch',
+				{
+					data: {
+						create: [
+							{
+								name: 'Beanie with Logo oxo',
+								date_created_gmt: '2021-09-01T15:50:20',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'Woo-beanie-logo',
+								price: '18',
+								regular_price: '20',
+								sale_price: '18',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.2',
+								dimensions: {
+									length: '6',
+									width: '4',
+									height: '1',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.accessoriesJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Red' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 62, 63, 61, 60 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'T-Shirt with Logo oxo',
+								date_created_gmt: '2021-09-02T15:50:20',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'Woo-tshirt-logo',
+								price: '18',
+								regular_price: '18',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.5',
+								dimensions: {
+									length: '10',
+									width: '12',
+									height: '0.5',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.tshirtsJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Gray' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 59, 67, 66, 56 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Single oxo',
+								date_created_gmt: '2021-09-03T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple, virtual product.</p>\n',
+								sku: 'woo-single',
+								price: '2',
+								regular_price: '3',
+								sale_price: '2',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: true,
+								total_sales: 0,
+								virtual: true,
+								downloadable: true,
+								downloads: [
+									{
+										id: '2579cf07-8b08-4c25-888a-b6258dd1f035',
+										name: 'Single',
+										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+									},
+								],
+								download_limit: 1,
+								download_expiry: 1,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '',
+								dimensions: {
+									length: '',
+									width: '',
+									height: '',
+								},
+								shipping_required: false,
+								shipping_taxable: false,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.musicJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 68 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Album oxo',
+								date_created_gmt: '2021-09-04T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple, virtual product.</p>\n',
+								sku: 'woo-album',
+								price: '15',
+								regular_price: '15',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: true,
+								downloadable: true,
+								downloads: [
+									{
+										id: 'cc10249f-1de2-44d4-93d3-9f88ae629f76',
+										name: 'Single 1',
+										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+									},
+									{
+										id: 'aea8ef69-ccdc-4d83-8e21-3c395ebb9411',
+										name: 'Single 2',
+										file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/album.jpg',
+									},
+								],
+								download_limit: 1,
+								download_expiry: 1,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '',
+								dimensions: {
+									length: '',
+									width: '',
+									height: '',
+								},
+								shipping_required: false,
+								shipping_taxable: false,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.musicJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 69 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Polo oxo',
+								date_created_gmt: '2021-09-05T15:50:19',
+								type: 'simple',
+								status: 'pending',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-polo',
+								price: '20',
+								regular_price: '20',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.8',
+								dimensions: {
+									length: '6',
+									width: '5',
+									height: '1',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.tshirtsJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Blue' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 59, 56, 66, 76 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Long Sleeve Tee oxo',
+								date_created_gmt: '2021-09-06T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-long-sleeve-tee',
+								price: '25',
+								regular_price: '25',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '1',
+								dimensions: {
+									length: '7',
+									width: '5',
+									height: '1',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: 'freight',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.tshirtsJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Green' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 59, 56, 76, 67 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Hoodie with Zipper oxo',
+								date_created_gmt: '2021-09-07T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: true,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-hoodie-with-zipper',
+								price: '45',
+								regular_price: '45',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '2',
+								dimensions: {
+									length: '8',
+									width: '6',
+									height: '2',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.hoodiesJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 57, 58 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Hoodie with Pocket oxo',
+								date_created_gmt: '2021-09-08T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: true,
+								catalog_visibility: 'hidden',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-hoodie-with-pocket',
+								price: '35',
+								regular_price: '45',
+								sale_price: '35',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '3',
+								dimensions: {
+									length: '10',
+									width: '8',
+									height: '2',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.hoodiesJSON.id,
+									},
+								],
+								tags: [
+									{
+										id: productTags.coolJSON.id,
+									},
+								],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Gray' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 65, 57, 58 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Sunglasses oxo',
+								date_created_gmt: '2021-09-09T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: true,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-sunglasses',
+								price: '90',
+								regular_price: '90',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: 'reduced-rate',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.2',
+								dimensions: {
+									length: '4',
+									width: '1.4',
+									height: '1',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.accessoriesJSON.id,
+									},
+								],
+								tags: [
+									{
+										id: productTags.coolJSON.id,
+									},
+								],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 60, 62, 77, 61 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Cap oxo',
+								date_created_gmt: '2021-09-10T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: true,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-cap',
+								price: '16',
+								regular_price: '18',
+								sale_price: '16',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.6',
+								dimensions: {
+									length: '8',
+									width: '6.5',
+									height: '4',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.accessoriesJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Yellow' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 60, 77, 61, 63 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Belt oxo',
+								date_created_gmt: '2021-09-12T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-belt',
+								price: '55',
+								regular_price: '65',
+								sale_price: '55',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '1.2',
+								dimensions: {
+									length: '12',
+									width: '2',
+									height: '1.5',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.accessoriesJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 63, 77, 62, 60 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'Beanie oxo',
+								date_created_gmt: '2021-09-13T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-beanie',
+								price: '18',
+								regular_price: '20',
+								sale_price: '18',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.2',
+								dimensions: {
+									length: '4',
+									width: '5',
+									height: '0.5',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.accessoriesJSON.id,
+									},
+								],
+								tags: [
+									{
+										id: productTags.coolJSON.id,
+									},
+								],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Red' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 63, 62, 61, 77 ],
+								stock_status: 'instock',
+							},
+							{
+								name: 'T-Shirt oxo',
+								date_created_gmt: '2021-09-14T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-tshirt',
+								price: '18',
+								regular_price: '18',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '0.8',
+								dimensions: {
+									length: '8',
+									width: '6',
+									height: '1',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.tshirtsJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Gray' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 67, 76, 56, 66 ],
+								stock_status: 'onbackorder',
+							},
+							{
+								name: 'Hoodie with Logo oxo',
+								date_created_gmt: '2021-09-15T15:50:19',
+								type: 'simple',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description,
+								short_description:
+									'<p>This is a simple product.</p>\n',
+								sku: 'woo-hoodie-with-logo',
+								price: '45',
+								regular_price: '45',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: true,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '2',
+								dimensions: {
+									length: '10',
+									width: '6',
+									height: '3',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.hoodiesJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										position: 0,
+										visible: true,
+										variation: false,
+										options: [ 'Blue' ],
+									},
+								],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [ 57, 65 ],
+								stock_status: 'instock',
+							},
+						],
+					},
+				}
+			);
+			const simpleProductsJSON = await simpleProducts.json();
+
+			return simpleProductsJSON.create;
+		};
+
+		const createSampleExternalProducts = async ( categories ) => {
+			const externalProducts = await request.post(
+				'./wp-json/wc/v3/products/batch',
+				{
+					data: {
+						create: [
+							{
+								name: 'WordPress Pennant oxo',
+								date_created_gmt: '2021-09-16T15:50:20',
+								type: 'external',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description:
+									'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
+									'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. ' +
+									'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
+								short_description:
+									'<p>This is an external product.</p>\n',
+								sku: 'wp-pennant',
+								price: '11.05',
+								regular_price: '11.05',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								purchasable: false,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url:
+									'https://mercantile.wordpress.org/product/wordpress-pennant/',
+								button_text: 'Buy on the WordPress swag store!',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '',
+								dimensions: {
+									length: '',
+									width: '',
+									height: '',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.decorJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: [],
+								menu_order: 0,
+								related_ids: [],
+								stock_status: 'instock',
+							},
+						],
+					},
+				}
+			);
+			const externalProductsJSON = await externalProducts.json();
+
+			return externalProductsJSON.create;
+		};
+
+		const createSampleGroupedProduct = async ( categories ) => {
+			const logoProducts = await request.get(
+				'./wp-json/wc/v3/products',
+				{
+					params: {
+						search: 'logo',
+						_fields: [ 'id' ],
+					},
+				}
+			);
+			const logoProductsJSON = await logoProducts.json();
+
+			const groupedProducts = await request.post(
+				'./wp-json/wc/v3/products/batch',
+				{
+					data: {
+						create: [
+							{
+								name: 'Logo Collection oxo',
+								date_created_gmt: '2021-09-17T15:50:20',
+								type: 'grouped',
+								status: 'publish',
+								featured: false,
+								catalog_visibility: 'visible',
+								description:
+									'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
+									'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. ' +
+									'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
+								short_description:
+									'<p>This is a grouped product.</p>\n',
+								sku: 'logo-collection',
+								price: '18',
+								regular_price: '',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								purchasable: false,
+								total_sales: 0,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								external_url: '',
+								button_text: '',
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								sold_individually: false,
+								weight: '',
+								dimensions: {
+									length: '',
+									width: '',
+									height: '',
+								},
+								shipping_required: true,
+								shipping_taxable: true,
+								shipping_class: '',
+								reviews_allowed: true,
+								average_rating: '0.00',
+								rating_count: 0,
+								upsell_ids: [],
+								cross_sell_ids: [],
+								parent_id: 0,
+								purchase_note: '',
+								categories: [
+									{
+										id: categories.clothingJSON.id,
+									},
+								],
+								tags: [],
+								attributes: [],
+								default_attributes: [],
+								variations: [],
+								grouped_products: logoProductsJSON.map(
+									( p ) => p.id
+								),
+								menu_order: 0,
+								related_ids: [],
+								stock_status: 'instock',
+							},
+						],
+					},
+				}
+			);
+			const groupedProductsJSON = await groupedProducts.json();
+
+			return groupedProductsJSON.create;
+		};
+
+		const createSampleVariableProducts = async (
+			categories,
+			attributes
+		) => {
+			const description =
+				'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
+				'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. ' +
+				'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n';
+
+			const hoodie = await request.post( './wp-json/wc/v3/products', {
+				data: {
+					name: 'Hoodie oxo',
+					date_created_gmt: '2021-09-18T15:50:19',
+					type: 'variable',
+					status: 'publish',
+					featured: false,
+					catalog_visibility: 'visible',
+					description,
+					short_description: '<p>This is a variable product.</p>\n',
+					sku: 'woo-hoodie',
+					price: '42',
+					regular_price: '',
+					sale_price: '',
+					date_on_sale_from_gmt: null,
+					date_on_sale_to_gmt: null,
+					on_sale: true,
+					purchasable: true,
+					total_sales: 0,
+					virtual: false,
+					downloadable: false,
+					downloads: [],
+					download_limit: 0,
+					download_expiry: 0,
+					external_url: '',
+					button_text: '',
+					tax_status: 'taxable',
+					tax_class: '',
+					manage_stock: false,
+					stock_quantity: null,
+					backorders: 'no',
+					backorders_allowed: false,
+					backordered: false,
+					low_stock_amount: null,
+					sold_individually: false,
+					weight: '1.5',
+					dimensions: {
+						length: '10',
+						width: '8',
+						height: '3',
+					},
+					shipping_required: true,
+					shipping_taxable: true,
+					shipping_class: '',
+					reviews_allowed: true,
+					average_rating: '0.00',
+					rating_count: 0,
+					upsell_ids: [],
+					cross_sell_ids: [],
+					parent_id: 0,
+					purchase_note: '',
+					categories: [
+						{
+							id: categories.hoodiesJSON.id,
+						},
+					],
+					tags: [],
+					attributes: [
+						{
+							id: attributes.colorJSON.id,
+							position: 0,
+							visible: true,
+							variation: true,
+							options: [ 'Blue', 'Green', 'Red' ],
+						},
+						{
+							id: 0,
+							name: 'Logo',
+							position: 1,
+							visible: true,
+							variation: true,
+							options: [ 'Yes', 'No' ],
+						},
+					],
+					default_attributes: [],
+					grouped_products: [],
+					menu_order: 0,
+					stock_status: 'instock',
+				},
+			} );
+			const hoodieJSON = await hoodie.json();
+
+			const variationDescription =
+				'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sagittis orci ac odio dictum tincidunt. ' +
+				'Donec ut metus leo. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. ' +
+				'Sed luctus, dui eu sagittis sodales, nulla nibh sagittis augue, vel porttitor diam enim non metus. ' +
+				'Vestibulum aliquam augue neque. Phasellus tincidunt odio eget ullamcorper efficitur. ' +
+				'Cras placerat ut turpis pellentesque vulputate. Nam sed consequat tortor. Curabitur finibus sapien dolor. ' +
+				'Ut eleifend tellus nec erat pulvinar dignissim. Nam non arcu purus. Vivamus et massa massa.</p>\n';
+
+			const hoodieVariations = await request.post(
+				`./wp-json/wc/v3/products/${ hoodieJSON.id }/variations/batch`,
+				{
+					data: {
+						create: [
+							{
+								date_created_gmt: '2021-09-19T15:50:20',
+								description: variationDescription,
+								sku: 'woo-hoodie-blue-logo',
+								price: '45',
+								regular_price: '45',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '1.5',
+								dimensions: {
+									length: '10',
+									width: '8',
+									height: '3',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Blue',
+									},
+									{
+										id: 0,
+										name: 'Logo',
+										option: 'Yes',
+									},
+								],
+								menu_order: 0,
+							},
+							{
+								date_created_gmt: '2021-09-20T15:50:20',
+								description: variationDescription,
+								sku: 'woo-hoodie-blue',
+								price: '45',
+								regular_price: '45',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '1.5',
+								dimensions: {
+									length: '10',
+									width: '8',
+									height: '3',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Blue',
+									},
+									{
+										id: 0,
+										name: 'Logo',
+										option: 'No',
+									},
+								],
+								menu_order: 3,
+							},
+							{
+								date_created_gmt: '2021-09-21T15:50:20',
+								description: variationDescription,
+								sku: 'woo-hoodie-green',
+								price: '45',
+								regular_price: '45',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '1.5',
+								dimensions: {
+									length: '10',
+									width: '8',
+									height: '3',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Green',
+									},
+									{
+										id: 0,
+										name: 'Logo',
+										option: 'No',
+									},
+								],
+								menu_order: 2,
+							},
+							{
+								date_created_gmt: '2021-09-22T15:50:19',
+								description: variationDescription,
+								sku: 'woo-hoodie-red',
+								price: '42',
+								regular_price: '45',
+								sale_price: '42',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: true,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '1.5',
+								dimensions: {
+									length: '10',
+									width: '8',
+									height: '3',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Red',
+									},
+									{
+										id: 0,
+										name: 'Logo',
+										option: 'No',
+									},
+								],
+								menu_order: 1,
+							},
+						],
+					},
+				}
+			);
+			const hoodieVariationsJSON = await hoodieVariations.json();
+
+			const vneck = await request.post( './wp-json/wc/v3/products', {
+				data: {
+					name: 'V-Neck T-Shirt oxo',
+					date_created_gmt: '2021-09-23T15:50:19',
+					type: 'variable',
+					status: 'publish',
+					featured: true,
+					catalog_visibility: 'visible',
+					description,
+					short_description: '<p>This is a variable product.</p>\n',
+					sku: 'woo-vneck-tee',
+					price: '15',
+					regular_price: '',
+					sale_price: '',
+					date_on_sale_from_gmt: null,
+					date_on_sale_to_gmt: null,
+					on_sale: false,
+					purchasable: true,
+					total_sales: 0,
+					virtual: false,
+					downloadable: false,
+					downloads: [],
+					download_limit: 0,
+					download_expiry: 0,
+					external_url: '',
+					button_text: '',
+					tax_status: 'taxable',
+					tax_class: '',
+					manage_stock: false,
+					stock_quantity: null,
+					backorders: 'no',
+					backorders_allowed: false,
+					backordered: false,
+					low_stock_amount: null,
+					sold_individually: false,
+					weight: '0.5',
+					dimensions: {
+						length: '24',
+						width: '1',
+						height: '2',
+					},
+					shipping_required: true,
+					shipping_taxable: true,
+					shipping_class: '',
+					reviews_allowed: true,
+					average_rating: '0.00',
+					rating_count: 0,
+					upsell_ids: [],
+					cross_sell_ids: [],
+					parent_id: 0,
+					purchase_note: '',
+					categories: [
+						{
+							id: categories.tshirtsJSON.id,
+						},
+					],
+					tags: [],
+					attributes: [
+						{
+							id: attributes.colorJSON.id,
+							position: 0,
+							visible: true,
+							variation: true,
+							options: [ 'Blue', 'Green', 'Red' ],
+						},
+						{
+							id: attributes.sizeJSON.id,
+							position: 1,
+							visible: true,
+							variation: true,
+							options: [ 'Large', 'Medium', 'Small' ],
+						},
+					],
+					default_attributes: [],
+					grouped_products: [],
+					menu_order: 0,
+					stock_status: 'instock',
+				},
+			} );
+			const vneckJSON = await vneck.json();
+
+			const vneckVariations = await request.post(
+				`./wp-json/wc/v3/products/${ vneckJSON.id }/variations/batch`,
+				{
+					data: {
+						create: [
+							{
+								date_created_gmt: '2021-09-24T15:50:19',
+								description: variationDescription,
+								sku: 'woo-vneck-tee-blue',
+								price: '15',
+								regular_price: '15',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '0.5',
+								dimensions: {
+									length: '24',
+									width: '1',
+									height: '2',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Blue',
+									},
+								],
+								menu_order: 0,
+							},
+							{
+								date_created_gmt: '2021-09-25T15:50:19',
+								description: variationDescription,
+								sku: 'woo-vneck-tee-green',
+								price: '20',
+								regular_price: '20',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '0.5',
+								dimensions: {
+									length: '24',
+									width: '1',
+									height: '2',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Green',
+									},
+								],
+								menu_order: 0,
+							},
+							{
+								date_created_gmt: '2021-09-26T15:50:19',
+								description: variationDescription,
+								sku: 'woo-vneck-tee-red',
+								price: '20',
+								regular_price: '20',
+								sale_price: '',
+								date_on_sale_from_gmt: null,
+								date_on_sale_to_gmt: null,
+								on_sale: false,
+								status: 'publish',
+								purchasable: true,
+								virtual: false,
+								downloadable: false,
+								downloads: [],
+								download_limit: 0,
+								download_expiry: 0,
+								tax_status: 'taxable',
+								tax_class: '',
+								manage_stock: false,
+								stock_quantity: null,
+								stock_status: 'instock',
+								backorders: 'no',
+								backorders_allowed: false,
+								backordered: false,
+								low_stock_amount: null,
+								weight: '0.5',
+								dimensions: {
+									length: '24',
+									width: '1',
+									height: '2',
+								},
+								shipping_class: '',
+								attributes: [
+									{
+										id: attributes.colorJSON.id,
+										option: 'Red',
+									},
+								],
+								menu_order: 0,
+							},
+						],
+					},
+				}
+			);
+			const vneckVariationsJSON = await vneckVariations.json();
+
+			return {
+				hoodieJSON,
+				hoodieVariations: hoodieVariationsJSON.create,
+				vneckJSON,
+				vneckVariations: vneckVariationsJSON.create,
+			};
+		};
+
+		const createSampleHierarchicalProducts = async () => {
+			const parent = await request.post( './wp-json/wc/v3/products', {
+				data: {
+					name: 'Parent Product oxo',
+					date_created_gmt: '2021-09-27T15:50:19',
+				},
+			} );
+			const parentJSON = await parent.json();
+
+			const child = await request.post( './wp-json/wc/v3/products', {
+				data: {
+					name: 'Child Product oxo',
+					parent_id: parentJSON.id,
+					date_created_gmt: '2021-09-28T15:50:19',
+				},
+			} );
+			const childJSON = await child.json();
+
+			return {
+				parentJSON,
+				childJSON,
+			};
+		};
+
+		const createSampleProductReviews = async ( simpleProducts ) => {
+			const cap = simpleProducts.find( ( p ) => p.name === 'Cap oxo' );
+
+			const shirt = simpleProducts.find(
+				( p ) => p.name === 'T-Shirt oxo'
+			);
+
+			const sunglasses = simpleProducts.find(
+				( p ) => p.name === 'Sunglasses oxo'
+			);
+
+			const review1 = await request.post(
+				'./wp-json/wc/v3/products/reviews',
+				{
+					data: {
+						product_id: cap.id,
+						rating: 3,
+						review: 'Decent cap.',
+						reviewer: 'John Doe',
+						reviewer_email: 'john.doe@example.com',
+					},
+				}
+			);
+			const review1JSON = await review1.json();
+
+			// We need to update the review in order for the product's
+			// average_rating to be recalculated.
+			// See: https://github.com/woocommerce/woocommerce/issues/29906.
+			//await updateProductReview(review1.id);
+			await request.post(
+				`./wp-json/wc/v3/products/reviews/${ review1JSON.id }`,
+				{
+					data: {},
+				}
+			);
+
+			const review2 = await request.post(
+				'./wp-json/wc/v3/products/reviews',
+				{
+					data: {
+						product_id: shirt.id,
+						rating: 5,
+						review: 'The BEST shirt ever!!',
+						reviewer: 'Shannon Smith',
+						reviewer_email: 'shannon.smith@example.com',
+					},
+				}
+			);
+			const review2JSON = await review2.json();
+
+			//await updateProductReview(review2.id);
+			await request.post(
+				`./wp-json/wc/v3/products/reviews/${ review2JSON.id }`,
+				{
+					data: {},
+				}
+			);
+
+			const review3 = await request.post(
+				'./wp-json/wc/v3/products/reviews',
+				{
+					data: {
+						product_id: sunglasses.id,
+						rating: 1,
+						review: 'These are way too expensive.',
+						reviewer: 'Tim Frugalman',
+						reviewer_email: 'timmyfrufru@example.com',
+					},
+				}
+			);
+			const review3JSON = await review3.json();
+
+			await request.post(
+				`./wp-json/wc/v3/products/reviews/${ review3JSON.id }`,
+				{
+					data: {},
+				}
+			);
+
+			return [ review1JSON.id, review2JSON.id, review3JSON.id ];
+		};
+
+		const createSampleProductOrders = async ( simpleProducts ) => {
+			const single = simpleProducts.find(
+				( p ) => p.name === 'Single oxo'
+			);
+			const beanie = simpleProducts.find(
+				( p ) => p.name === 'Beanie with Logo oxo'
+			);
+			const shirt = simpleProducts.find(
+				( p ) => p.name === 'T-Shirt oxo'
+			);
+
+			const order1 = await request.post( './wp-json/wc/v3/orders', {
+				data: {
+					set_paid: true,
+					status: 'completed',
+					line_items: [
+						{
+							product_id: single.id,
+							quantity: 2,
+						},
+						{
+							product_id: beanie.id,
+							quantity: 3,
+						},
+						{
+							product_id: shirt.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const orderJSON = await order1.json();
+
+			return [ orderJSON ];
+		};
+
+		const productsTestSetupCreateSampleData = async () => {
+			const categories = await createSampleCategories();
+
+			const attributes = await createSampleAttributes();
+
+			const productTags = await createSampleTags();
+
+			const shippingClasses = await createSampleShippingClasses();
+
+			const taxClasses = await createSampleTaxClasses();
+
+			const simpleProducts = await createSampleSimpleProducts(
 				categories,
 				attributes,
 				productTags
-			) => {
-				const description =
-					'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
-					'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. ' +
-					'Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n';
+			);
 
-				const simpleProducts = await request.post(
-					'./wp-json/wc/v3/products/batch',
-					{
-						data: {
-							create: [
-								{
-									name: 'Beanie with Logo oxo',
-									date_created_gmt: '2021-09-01T15:50:20',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'Woo-beanie-logo',
-									price: '18',
-									regular_price: '20',
-									sale_price: '18',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.2',
-									dimensions: {
-										length: '6',
-										width: '4',
-										height: '1',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.accessoriesJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Red' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 62, 63, 61, 60 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'T-Shirt with Logo oxo',
-									date_created_gmt: '2021-09-02T15:50:20',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'Woo-tshirt-logo',
-									price: '18',
-									regular_price: '18',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.5',
-									dimensions: {
-										length: '10',
-										width: '12',
-										height: '0.5',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.tshirtsJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Gray' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 59, 67, 66, 56 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Single oxo',
-									date_created_gmt: '2021-09-03T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple, virtual product.</p>\n',
-									sku: 'woo-single',
-									price: '2',
-									regular_price: '3',
-									sale_price: '2',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: true,
-									total_sales: 0,
-									virtual: true,
-									downloadable: true,
-									downloads: [
-										{
-											id: '2579cf07-8b08-4c25-888a-b6258dd1f035',
-											name: 'Single',
-											file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
-										},
-									],
-									download_limit: 1,
-									download_expiry: 1,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '',
-									dimensions: {
-										length: '',
-										width: '',
-										height: '',
-									},
-									shipping_required: false,
-									shipping_taxable: false,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.musicJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 68 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Album oxo',
-									date_created_gmt: '2021-09-04T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple, virtual product.</p>\n',
-									sku: 'woo-album',
-									price: '15',
-									regular_price: '15',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: true,
-									downloadable: true,
-									downloads: [
-										{
-											id: 'cc10249f-1de2-44d4-93d3-9f88ae629f76',
-											name: 'Single 1',
-											file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
-										},
-										{
-											id: 'aea8ef69-ccdc-4d83-8e21-3c395ebb9411',
-											name: 'Single 2',
-											file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/album.jpg',
-										},
-									],
-									download_limit: 1,
-									download_expiry: 1,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '',
-									dimensions: {
-										length: '',
-										width: '',
-										height: '',
-									},
-									shipping_required: false,
-									shipping_taxable: false,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.musicJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 69 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Polo oxo',
-									date_created_gmt: '2021-09-05T15:50:19',
-									type: 'simple',
-									status: 'pending',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-polo',
-									price: '20',
-									regular_price: '20',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.8',
-									dimensions: {
-										length: '6',
-										width: '5',
-										height: '1',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.tshirtsJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Blue' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 59, 56, 66, 76 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Long Sleeve Tee oxo',
-									date_created_gmt: '2021-09-06T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-long-sleeve-tee',
-									price: '25',
-									regular_price: '25',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '1',
-									dimensions: {
-										length: '7',
-										width: '5',
-										height: '1',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: 'freight',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.tshirtsJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Green' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 59, 56, 76, 67 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Hoodie with Zipper oxo',
-									date_created_gmt: '2021-09-07T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: true,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-hoodie-with-zipper',
-									price: '45',
-									regular_price: '45',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '2',
-									dimensions: {
-										length: '8',
-										width: '6',
-										height: '2',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.hoodiesJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 57, 58 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Hoodie with Pocket oxo',
-									date_created_gmt: '2021-09-08T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: true,
-									catalog_visibility: 'hidden',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-hoodie-with-pocket',
-									price: '35',
-									regular_price: '45',
-									sale_price: '35',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '3',
-									dimensions: {
-										length: '10',
-										width: '8',
-										height: '2',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.hoodiesJSON.id,
-										},
-									],
-									tags: [
-										{
-											id: productTags.coolJSON.id,
-										},
-									],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Gray' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 65, 57, 58 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Sunglasses oxo',
-									date_created_gmt: '2021-09-09T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: true,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-sunglasses',
-									price: '90',
-									regular_price: '90',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: 'reduced-rate',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.2',
-									dimensions: {
-										length: '4',
-										width: '1.4',
-										height: '1',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.accessoriesJSON.id,
-										},
-									],
-									tags: [
-										{
-											id: productTags.coolJSON.id,
-										},
-									],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 60, 62, 77, 61 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Cap oxo',
-									date_created_gmt: '2021-09-10T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: true,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-cap',
-									price: '16',
-									regular_price: '18',
-									sale_price: '16',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.6',
-									dimensions: {
-										length: '8',
-										width: '6.5',
-										height: '4',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.accessoriesJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Yellow' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 60, 77, 61, 63 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Belt oxo',
-									date_created_gmt: '2021-09-12T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-belt',
-									price: '55',
-									regular_price: '65',
-									sale_price: '55',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '1.2',
-									dimensions: {
-										length: '12',
-										width: '2',
-										height: '1.5',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.accessoriesJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 63, 77, 62, 60 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'Beanie oxo',
-									date_created_gmt: '2021-09-13T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-beanie',
-									price: '18',
-									regular_price: '20',
-									sale_price: '18',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.2',
-									dimensions: {
-										length: '4',
-										width: '5',
-										height: '0.5',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.accessoriesJSON.id,
-										},
-									],
-									tags: [
-										{
-											id: productTags.coolJSON.id,
-										},
-									],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Red' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 63, 62, 61, 77 ],
-									stock_status: 'instock',
-								},
-								{
-									name: 'T-Shirt oxo',
-									date_created_gmt: '2021-09-14T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-tshirt',
-									price: '18',
-									regular_price: '18',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '0.8',
-									dimensions: {
-										length: '8',
-										width: '6',
-										height: '1',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.tshirtsJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Gray' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 67, 76, 56, 66 ],
-									stock_status: 'onbackorder',
-								},
-								{
-									name: 'Hoodie with Logo oxo',
-									date_created_gmt: '2021-09-15T15:50:19',
-									type: 'simple',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description,
-									short_description:
-										'<p>This is a simple product.</p>\n',
-									sku: 'woo-hoodie-with-logo',
-									price: '45',
-									regular_price: '45',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: true,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '2',
-									dimensions: {
-										length: '10',
-										width: '6',
-										height: '3',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.hoodiesJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											position: 0,
-											visible: true,
-											variation: false,
-											options: [ 'Blue' ],
-										},
-									],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [ 57, 65 ],
-									stock_status: 'instock',
-								},
-							],
-						},
-					}
-				);
-				const simpleProductsJSON = await simpleProducts.json();
+			const externalProducts = await createSampleExternalProducts(
+				categories
+			);
 
-				return simpleProductsJSON.create;
-			};
+			const groupedProducts = await createSampleGroupedProduct(
+				categories
+			);
 
-			const createSampleExternalProducts = async ( categories ) => {
-				const externalProducts = await request.post(
-					'./wp-json/wc/v3/products/batch',
-					{
-						data: {
-							create: [
-								{
-									name: 'WordPress Pennant oxo',
-									date_created_gmt: '2021-09-16T15:50:20',
-									type: 'external',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description:
-										'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
-										'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. ' +
-										'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
-									short_description:
-										'<p>This is an external product.</p>\n',
-									sku: 'wp-pennant',
-									price: '11.05',
-									regular_price: '11.05',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									purchasable: false,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url:
-										'https://mercantile.wordpress.org/product/wordpress-pennant/',
-									button_text:
-										'Buy on the WordPress swag store!',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '',
-									dimensions: {
-										length: '',
-										width: '',
-										height: '',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.decorJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: [],
-									menu_order: 0,
-									related_ids: [],
-									stock_status: 'instock',
-								},
-							],
-						},
-					}
-				);
-				const externalProductsJSON = await externalProducts.json();
-
-				return externalProductsJSON.create;
-			};
-
-			const createSampleGroupedProduct = async ( categories ) => {
-				const logoProducts = await request.get(
-					'./wp-json/wc/v3/products',
-					{
-						params: {
-							search: 'logo',
-							_fields: [ 'id' ],
-						},
-					}
-				);
-				const logoProductsJSON = await logoProducts.json();
-
-				const groupedProducts = await request.post(
-					'./wp-json/wc/v3/products/batch',
-					{
-						data: {
-							create: [
-								{
-									name: 'Logo Collection oxo',
-									date_created_gmt: '2021-09-17T15:50:20',
-									type: 'grouped',
-									status: 'publish',
-									featured: false,
-									catalog_visibility: 'visible',
-									description:
-										'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
-										'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. ' +
-										'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n',
-									short_description:
-										'<p>This is a grouped product.</p>\n',
-									sku: 'logo-collection',
-									price: '18',
-									regular_price: '',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									purchasable: false,
-									total_sales: 0,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									external_url: '',
-									button_text: '',
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									sold_individually: false,
-									weight: '',
-									dimensions: {
-										length: '',
-										width: '',
-										height: '',
-									},
-									shipping_required: true,
-									shipping_taxable: true,
-									shipping_class: '',
-									reviews_allowed: true,
-									average_rating: '0.00',
-									rating_count: 0,
-									upsell_ids: [],
-									cross_sell_ids: [],
-									parent_id: 0,
-									purchase_note: '',
-									categories: [
-										{
-											id: categories.clothingJSON.id,
-										},
-									],
-									tags: [],
-									attributes: [],
-									default_attributes: [],
-									variations: [],
-									grouped_products: logoProductsJSON.map(
-										( p ) => p.id
-									),
-									menu_order: 0,
-									related_ids: [],
-									stock_status: 'instock',
-								},
-							],
-						},
-					}
-				);
-				const groupedProductsJSON = await groupedProducts.json();
-
-				return groupedProductsJSON.create;
-			};
-
-			const createSampleVariableProducts = async (
+			const variableProducts = await createSampleVariableProducts(
 				categories,
 				attributes
-			) => {
-				const description =
-					'<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. ' +
-					'Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. ' +
-					'Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n';
+			);
 
-				const hoodie = await request.post( './wp-json/wc/v3/products', {
-					data: {
-						name: 'Hoodie oxo',
-						date_created_gmt: '2021-09-18T15:50:19',
-						type: 'variable',
-						status: 'publish',
-						featured: false,
-						catalog_visibility: 'visible',
-						description,
-						short_description:
-							'<p>This is a variable product.</p>\n',
-						sku: 'woo-hoodie',
-						price: '42',
-						regular_price: '',
-						sale_price: '',
-						date_on_sale_from_gmt: null,
-						date_on_sale_to_gmt: null,
-						on_sale: true,
-						purchasable: true,
-						total_sales: 0,
-						virtual: false,
-						downloadable: false,
-						downloads: [],
-						download_limit: 0,
-						download_expiry: 0,
-						external_url: '',
-						button_text: '',
-						tax_status: 'taxable',
-						tax_class: '',
-						manage_stock: false,
-						stock_quantity: null,
-						backorders: 'no',
-						backorders_allowed: false,
-						backordered: false,
-						low_stock_amount: null,
-						sold_individually: false,
-						weight: '1.5',
-						dimensions: {
-							length: '10',
-							width: '8',
-							height: '3',
-						},
-						shipping_required: true,
-						shipping_taxable: true,
-						shipping_class: '',
-						reviews_allowed: true,
-						average_rating: '0.00',
-						rating_count: 0,
-						upsell_ids: [],
-						cross_sell_ids: [],
-						parent_id: 0,
-						purchase_note: '',
-						categories: [
-							{
-								id: categories.hoodiesJSON.id,
-							},
-						],
-						tags: [],
-						attributes: [
-							{
-								id: attributes.colorJSON.id,
-								position: 0,
-								visible: true,
-								variation: true,
-								options: [ 'Blue', 'Green', 'Red' ],
-							},
-							{
-								id: 0,
-								name: 'Logo',
-								position: 1,
-								visible: true,
-								variation: true,
-								options: [ 'Yes', 'No' ],
-							},
-						],
-						default_attributes: [],
-						grouped_products: [],
-						menu_order: 0,
-						stock_status: 'instock',
-					},
-				} );
-				const hoodieJSON = await hoodie.json();
+			const hierarchicalProducts =
+				await createSampleHierarchicalProducts();
 
-				const variationDescription =
-					'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sagittis orci ac odio dictum tincidunt. ' +
-					'Donec ut metus leo. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. ' +
-					'Sed luctus, dui eu sagittis sodales, nulla nibh sagittis augue, vel porttitor diam enim non metus. ' +
-					'Vestibulum aliquam augue neque. Phasellus tincidunt odio eget ullamcorper efficitur. ' +
-					'Cras placerat ut turpis pellentesque vulputate. Nam sed consequat tortor. Curabitur finibus sapien dolor. ' +
-					'Ut eleifend tellus nec erat pulvinar dignissim. Nam non arcu purus. Vivamus et massa massa.</p>\n';
+			const reviewIds = await createSampleProductReviews(
+				simpleProducts
+			);
 
-				const hoodieVariations = await request.post(
-					`./wp-json/wc/v3/products/${ hoodieJSON.id }/variations/batch`,
-					{
-						data: {
-							create: [
-								{
-									date_created_gmt: '2021-09-19T15:50:20',
-									description: variationDescription,
-									sku: 'woo-hoodie-blue-logo',
-									price: '45',
-									regular_price: '45',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '1.5',
-									dimensions: {
-										length: '10',
-										width: '8',
-										height: '3',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Blue',
-										},
-										{
-											id: 0,
-											name: 'Logo',
-											option: 'Yes',
-										},
-									],
-									menu_order: 0,
-								},
-								{
-									date_created_gmt: '2021-09-20T15:50:20',
-									description: variationDescription,
-									sku: 'woo-hoodie-blue',
-									price: '45',
-									regular_price: '45',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '1.5',
-									dimensions: {
-										length: '10',
-										width: '8',
-										height: '3',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Blue',
-										},
-										{
-											id: 0,
-											name: 'Logo',
-											option: 'No',
-										},
-									],
-									menu_order: 3,
-								},
-								{
-									date_created_gmt: '2021-09-21T15:50:20',
-									description: variationDescription,
-									sku: 'woo-hoodie-green',
-									price: '45',
-									regular_price: '45',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '1.5',
-									dimensions: {
-										length: '10',
-										width: '8',
-										height: '3',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Green',
-										},
-										{
-											id: 0,
-											name: 'Logo',
-											option: 'No',
-										},
-									],
-									menu_order: 2,
-								},
-								{
-									date_created_gmt: '2021-09-22T15:50:19',
-									description: variationDescription,
-									sku: 'woo-hoodie-red',
-									price: '42',
-									regular_price: '45',
-									sale_price: '42',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: true,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '1.5',
-									dimensions: {
-										length: '10',
-										width: '8',
-										height: '3',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Red',
-										},
-										{
-											id: 0,
-											name: 'Logo',
-											option: 'No',
-										},
-									],
-									menu_order: 1,
-								},
-							],
-						},
-					}
-				);
-				const hoodieVariationsJSON = await hoodieVariations.json();
+			const orders = await createSampleProductOrders( simpleProducts );
 
-				const vneck = await request.post( './wp-json/wc/v3/products', {
-					data: {
-						name: 'V-Neck T-Shirt oxo',
-						date_created_gmt: '2021-09-23T15:50:19',
-						type: 'variable',
-						status: 'publish',
-						featured: true,
-						catalog_visibility: 'visible',
-						description,
-						short_description:
-							'<p>This is a variable product.</p>\n',
-						sku: 'woo-vneck-tee',
-						price: '15',
-						regular_price: '',
-						sale_price: '',
-						date_on_sale_from_gmt: null,
-						date_on_sale_to_gmt: null,
-						on_sale: false,
-						purchasable: true,
-						total_sales: 0,
-						virtual: false,
-						downloadable: false,
-						downloads: [],
-						download_limit: 0,
-						download_expiry: 0,
-						external_url: '',
-						button_text: '',
-						tax_status: 'taxable',
-						tax_class: '',
-						manage_stock: false,
-						stock_quantity: null,
-						backorders: 'no',
-						backorders_allowed: false,
-						backordered: false,
-						low_stock_amount: null,
-						sold_individually: false,
-						weight: '0.5',
-						dimensions: {
-							length: '24',
-							width: '1',
-							height: '2',
-						},
-						shipping_required: true,
-						shipping_taxable: true,
-						shipping_class: '',
-						reviews_allowed: true,
-						average_rating: '0.00',
-						rating_count: 0,
-						upsell_ids: [],
-						cross_sell_ids: [],
-						parent_id: 0,
-						purchase_note: '',
-						categories: [
-							{
-								id: categories.tshirtsJSON.id,
-							},
-						],
-						tags: [],
-						attributes: [
-							{
-								id: attributes.colorJSON.id,
-								position: 0,
-								visible: true,
-								variation: true,
-								options: [ 'Blue', 'Green', 'Red' ],
-							},
-							{
-								id: attributes.sizeJSON.id,
-								position: 1,
-								visible: true,
-								variation: true,
-								options: [ 'Large', 'Medium', 'Small' ],
-							},
-						],
-						default_attributes: [],
-						grouped_products: [],
-						menu_order: 0,
-						stock_status: 'instock',
-					},
-				} );
-				const vneckJSON = await vneck.json();
-
-				const vneckVariations = await request.post(
-					`./wp-json/wc/v3/products/${ vneckJSON.id }/variations/batch`,
-					{
-						data: {
-							create: [
-								{
-									date_created_gmt: '2021-09-24T15:50:19',
-									description: variationDescription,
-									sku: 'woo-vneck-tee-blue',
-									price: '15',
-									regular_price: '15',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '0.5',
-									dimensions: {
-										length: '24',
-										width: '1',
-										height: '2',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Blue',
-										},
-									],
-									menu_order: 0,
-								},
-								{
-									date_created_gmt: '2021-09-25T15:50:19',
-									description: variationDescription,
-									sku: 'woo-vneck-tee-green',
-									price: '20',
-									regular_price: '20',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '0.5',
-									dimensions: {
-										length: '24',
-										width: '1',
-										height: '2',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Green',
-										},
-									],
-									menu_order: 0,
-								},
-								{
-									date_created_gmt: '2021-09-26T15:50:19',
-									description: variationDescription,
-									sku: 'woo-vneck-tee-red',
-									price: '20',
-									regular_price: '20',
-									sale_price: '',
-									date_on_sale_from_gmt: null,
-									date_on_sale_to_gmt: null,
-									on_sale: false,
-									status: 'publish',
-									purchasable: true,
-									virtual: false,
-									downloadable: false,
-									downloads: [],
-									download_limit: 0,
-									download_expiry: 0,
-									tax_status: 'taxable',
-									tax_class: '',
-									manage_stock: false,
-									stock_quantity: null,
-									stock_status: 'instock',
-									backorders: 'no',
-									backorders_allowed: false,
-									backordered: false,
-									low_stock_amount: null,
-									weight: '0.5',
-									dimensions: {
-										length: '24',
-										width: '1',
-										height: '2',
-									},
-									shipping_class: '',
-									attributes: [
-										{
-											id: attributes.colorJSON.id,
-											option: 'Red',
-										},
-									],
-									menu_order: 0,
-								},
-							],
-						},
-					}
-				);
-				const vneckVariationsJSON = await vneckVariations.json();
-
-				return {
-					hoodieJSON,
-					hoodieVariations: hoodieVariationsJSON.create,
-					vneckJSON,
-					vneckVariations: vneckVariationsJSON.create,
-				};
+			return {
+				categories,
+				attributes,
+				productTags,
+				shippingClasses,
+				taxClasses,
+				simpleProducts,
+				externalProducts,
+				groupedProducts,
+				variableProducts,
+				hierarchicalProducts,
+				reviewIds,
+				orders,
 			};
+		};
 
-			const createSampleHierarchicalProducts = async () => {
-				const parent = await request.post( './wp-json/wc/v3/products', {
-					data: {
-						name: 'Parent Product oxo',
-						date_created_gmt: '2021-09-27T15:50:19',
-					},
-				} );
-				const parentJSON = await parent.json();
-
-				const child = await request.post( './wp-json/wc/v3/products', {
-					data: {
-						name: 'Child Product oxo',
-						parent_id: parentJSON.id,
-						date_created_gmt: '2021-09-28T15:50:19',
-					},
-				} );
-				const childJSON = await child.json();
-
-				return {
-					parentJSON,
-					childJSON,
-				};
-			};
-
-			const createSampleProductReviews = async ( simpleProducts ) => {
-				const cap = simpleProducts.find(
-					( p ) => p.name === 'Cap oxo'
-				);
-
-				const shirt = simpleProducts.find(
-					( p ) => p.name === 'T-Shirt oxo'
-				);
-
-				const sunglasses = simpleProducts.find(
+		// create Sample Data function
+		const createSampleData = async () => {
+			const testProductData = await productsTestSetupCreateSampleData();
+			const orderedProducts = {
+				pocketHoodie: testProductData.simpleProducts.find(
+					( p ) => p.name === 'Hoodie with Pocket oxo'
+				),
+				sunglasses: testProductData.simpleProducts.find(
 					( p ) => p.name === 'Sunglasses oxo'
-				);
-
-				const review1 = await request.post(
-					'./wp-json/wc/v3/products/reviews',
-					{
-						data: {
-							product_id: cap.id,
-							rating: 3,
-							review: 'Decent cap.',
-							reviewer: 'John Doe',
-							reviewer_email: 'john.doe@example.com',
-						},
-					}
-				);
-				const review1JSON = await review1.json();
-
-				// We need to update the review in order for the product's
-				// average_rating to be recalculated.
-				// See: https://github.com/woocommerce/woocommerce/issues/29906.
-				//await updateProductReview(review1.id);
-				await request.post(
-					`./wp-json/wc/v3/products/reviews/${ review1JSON.id }`,
-					{
-						data: {},
-					}
-				);
-
-				const review2 = await request.post(
-					'./wp-json/wc/v3/products/reviews',
-					{
-						data: {
-							product_id: shirt.id,
-							rating: 5,
-							review: 'The BEST shirt ever!!',
-							reviewer: 'Shannon Smith',
-							reviewer_email: 'shannon.smith@example.com',
-						},
-					}
-				);
-				const review2JSON = await review2.json();
-
-				//await updateProductReview(review2.id);
-				await request.post(
-					`./wp-json/wc/v3/products/reviews/${ review2JSON.id }`,
-					{
-						data: {},
-					}
-				);
-
-				const review3 = await request.post(
-					'./wp-json/wc/v3/products/reviews',
-					{
-						data: {
-							product_id: sunglasses.id,
-							rating: 1,
-							review: 'These are way too expensive.',
-							reviewer: 'Tim Frugalman',
-							reviewer_email: 'timmyfrufru@example.com',
-						},
-					}
-				);
-				const review3JSON = await review3.json();
-
-				await request.post(
-					`./wp-json/wc/v3/products/reviews/${ review3JSON.id }`,
-					{
-						data: {},
-					}
-				);
-
-				return [ review1JSON.id, review2JSON.id, review3JSON.id ];
+				),
+				beanie: testProductData.simpleProducts.find(
+					( p ) => p.name === 'Beanie oxo'
+				),
+				blueVneck:
+					testProductData.variableProducts.vneckVariations.find(
+						( p ) => p.sku === 'woo-vneck-tee-blue'
+					),
+				pennant: testProductData.externalProducts[ 0 ],
 			};
 
-			const createSampleProductOrders = async ( simpleProducts ) => {
-				const single = simpleProducts.find(
-					( p ) => p.name === 'Single oxo'
-				);
-				const beanie = simpleProducts.find(
-					( p ) => p.name === 'Beanie with Logo oxo'
-				);
-				const shirt = simpleProducts.find(
-					( p ) => p.name === 'T-Shirt oxo'
-				);
-
-				const order1 = await request.post( './wp-json/wc/v3/orders', {
-					data: {
-						set_paid: true,
-						status: 'completed',
-						line_items: [
-							{
-								product_id: single.id,
-								quantity: 2,
-							},
-							{
-								product_id: beanie.id,
-								quantity: 3,
-							},
-							{
-								product_id: shirt.id,
-								quantity: 1,
-							},
-						],
-					},
-				} );
-				const orderJSON = await order1.json();
-
-				return [ orderJSON ];
+			const johnAddress = {
+				first_name: 'John',
+				last_name: 'Doe',
+				company: 'Automattic',
+				country: 'US',
+				address_1: '60 29th Street',
+				address_2: '#343',
+				city: 'San Francisco',
+				state: 'CA',
+				postcode: '94110',
+				phone: '123456789',
+			};
+			const tinaAddress = {
+				first_name: 'Tina',
+				last_name: 'Clark',
+				company: 'Automattic',
+				country: 'US',
+				address_1: 'Oxford Ave',
+				address_2: '',
+				city: 'Buffalo',
+				state: 'NY',
+				postcode: '14201',
+				phone: '123456789',
+			};
+			const guestShippingAddress = {
+				first_name: 'Ano',
+				last_name: 'Nymous',
+				company: '',
+				country: 'US',
+				address_1: '0 Incognito St',
+				address_2: '',
+				city: 'Erie',
+				state: 'PA',
+				postcode: '16515',
+				phone: '123456789',
+			};
+			const guestBillingAddress = {
+				first_name: 'Ben',
+				last_name: 'Efactor',
+				company: '',
+				country: 'US',
+				address_1: '200 W University Avenue',
+				address_2: '',
+				city: 'Gainesville',
+				state: 'FL',
+				postcode: '32601',
+				phone: '123456789',
+				email: 'ben.efactor@email.net',
 			};
 
-			const productsTestSetupCreateSampleData = async () => {
-				const categories = await createSampleCategories();
-
-				const attributes = await createSampleAttributes();
-
-				const productTags = await createSampleTags();
-
-				const shippingClasses = await createSampleShippingClasses();
-
-				const taxClasses = await createSampleTaxClasses();
-
-				const simpleProducts = await createSampleSimpleProducts(
-					categories,
-					attributes,
-					productTags
-				);
-
-				const externalProducts = await createSampleExternalProducts(
-					categories
-				);
-
-				const groupedProducts = await createSampleGroupedProduct(
-					categories
-				);
-
-				const variableProducts = await createSampleVariableProducts(
-					categories,
-					attributes
-				);
-
-				const hierarchicalProducts =
-					await createSampleHierarchicalProducts();
-
-				const reviewIds = await createSampleProductReviews(
-					simpleProducts
-				);
-
-				const orders = await createSampleProductOrders(
-					simpleProducts
-				);
-
-				return {
-					categories,
-					attributes,
-					productTags,
-					shippingClasses,
-					taxClasses,
-					simpleProducts,
-					externalProducts,
-					groupedProducts,
-					variableProducts,
-					hierarchicalProducts,
-					reviewIds,
-					orders,
-				};
-			};
-
-			// create Sample Data function
-			const createSampleData = async () => {
-				const testProductData =
-					await productsTestSetupCreateSampleData();
-				const orderedProducts = {
-					pocketHoodie: testProductData.simpleProducts.find(
-						( p ) => p.name === 'Hoodie with Pocket oxo'
-					),
-					sunglasses: testProductData.simpleProducts.find(
-						( p ) => p.name === 'Sunglasses oxo'
-					),
-					beanie: testProductData.simpleProducts.find(
-						( p ) => p.name === 'Beanie oxo'
-					),
-					blueVneck:
-						testProductData.variableProducts.vneckVariations.find(
-							( p ) => p.sku === 'woo-vneck-tee-blue'
-						),
-					pennant: testProductData.externalProducts[ 0 ],
-				};
-
-				const johnAddress = {
+			const usernameJohn = `john.doe.${ Date.now() }`;
+			const emailJohn = `${ usernameJohn }@example.com`;
+			const john = await request.post( './wp-json/wc/v3/customers', {
+				data: {
 					first_name: 'John',
 					last_name: 'Doe',
-					company: 'Automattic',
-					country: 'US',
-					address_1: '60 29th Street',
-					address_2: '#343',
-					city: 'San Francisco',
-					state: 'CA',
-					postcode: '94110',
-					phone: '123456789',
-				};
-				const tinaAddress = {
+					username: usernameJohn,
+					email: emailJohn,
+					billing: {
+						...johnAddress,
+						email: emailJohn,
+					},
+					shipping: johnAddress,
+				},
+			} );
+
+			expect( john.status() ).toEqual( 201 );
+			const johnJSON = await john.json();
+			expect( johnJSON.id ).toBeDefined();
+
+			const usernameTina = `tina.clark.${ Date.now() }`;
+			const emailTina = `${ usernameTina }@example.com`;
+			const tina = await request.post( './wp-json/wc/v3/customers', {
+				data: {
 					first_name: 'Tina',
 					last_name: 'Clark',
-					company: 'Automattic',
-					country: 'US',
-					address_1: 'Oxford Ave',
-					address_2: '',
-					city: 'Buffalo',
-					state: 'NY',
-					postcode: '14201',
-					phone: '123456789',
-				};
-				const guestShippingAddress = {
-					first_name: 'Ano',
-					last_name: 'Nymous',
-					company: '',
-					country: 'US',
-					address_1: '0 Incognito St',
-					address_2: '',
-					city: 'Erie',
-					state: 'PA',
-					postcode: '16515',
-					phone: '123456789',
-				};
-				const guestBillingAddress = {
-					first_name: 'Ben',
-					last_name: 'Efactor',
-					company: '',
-					country: 'US',
-					address_1: '200 W University Avenue',
-					address_2: '',
-					city: 'Gainesville',
-					state: 'FL',
-					postcode: '32601',
-					phone: '123456789',
-					email: 'ben.efactor@email.net',
-				};
-
-				const usernameJohn = `john.doe.${ Date.now() }`;
-				const emailJohn = `${ usernameJohn }@example.com`;
-				const john = await request.post( './wp-json/wc/v3/customers', {
-					data: {
-						first_name: 'John',
-						last_name: 'Doe',
-						username: usernameJohn,
-						email: emailJohn,
-						billing: {
-							...johnAddress,
-							email: emailJohn,
-						},
-						shipping: johnAddress,
-					},
-				} );
-
-				expect( john.status() ).toEqual( 201 );
-				const johnJSON = await john.json();
-				expect( johnJSON.id ).toBeDefined();
-
-				const usernameTina = `tina.clark.${ Date.now() }`;
-				const emailTina = `${ usernameTina }@example.com`;
-				const tina = await request.post( './wp-json/wc/v3/customers', {
-					data: {
-						first_name: 'Tina',
-						last_name: 'Clark',
-						username: usernameTina,
+					username: usernameTina,
+					email: emailTina,
+					billing: {
+						...tinaAddress,
 						email: emailTina,
-						billing: {
-							...tinaAddress,
-							email: emailTina,
-						},
-						shipping: tinaAddress,
 					},
-				} );
+					shipping: tinaAddress,
+				},
+			} );
 
-				expect( tina.status() ).toEqual( 201 );
-				const tinaJSON = await tina.json();
-				expect( tinaJSON.id ).toBeDefined();
+			expect( tina.status() ).toEqual( 201 );
+			const tinaJSON = await tina.json();
+			expect( tinaJSON.id ).toBeDefined();
 
-				const orderBaseData = {
-					payment_method: 'cod',
-					payment_method_title: 'Cash on Delivery',
-					status: 'processing',
-					set_paid: false,
-					currency: 'USD',
-					customer_id: 0,
-				};
+			const orderBaseData = {
+				payment_method: 'cod',
+				payment_method_title: 'Cash on Delivery',
+				status: 'processing',
+				set_paid: false,
+				currency: 'USD',
+				customer_id: 0,
+			};
 
-				const orders = [];
-				// Have "John" order all products.
-				Object.values( orderedProducts ).forEach( async ( product ) => {
-					const order2 = await request.post(
-						'./wp-json/wc/v3/orders',
-						{
-							data: {
-								...orderBaseData,
-								customer_id: johnJSON.id,
-								billing: {
-									...johnAddress,
-									email: 'john.doe@example.com',
-								},
-								shipping: johnAddress,
-								line_items: [
-									{
-										product_id: product.id,
-										quantity: 1,
-									},
-								],
-							},
-						}
-					);
-					const orderJSON = await order2.json();
-
-					orders.push( orderJSON );
-				} );
-
-				// Have "Tina" order some sunglasses and make a child order.
-				// This somewhat resembles a subscription renewal, but we're just testing the `parent` field.
+			const orders = [];
+			// Have "John" order all products.
+			Object.values( orderedProducts ).forEach( async ( product ) => {
 				const order2 = await request.post( './wp-json/wc/v3/orders', {
 					data: {
 						...orderBaseData,
-						status: 'completed',
-						set_paid: true,
-						customer_id: tinaJSON.id,
+						customer_id: johnJSON.id,
 						billing: {
-							...tinaAddress,
-							email: 'tina.clark@example.com',
+							...johnAddress,
+							email: 'john.doe@example.com',
 						},
-						shipping: tinaAddress,
+						shipping: johnAddress,
 						line_items: [
 							{
-								product_id: orderedProducts.sunglasses.id,
+								product_id: product.id,
 								quantity: 1,
 							},
 						],
 					},
 				} );
-				const order2JSON = await order2.json();
+				const orderJSON = await order2.json();
 
-				orders.push( order2JSON );
-
-				// create child order by referencing a parent_id
-				const order3 = await request.post( './wp-json/wc/v3/orders', {
-					data: {
-						...orderBaseData,
-						parent_id: order2JSON.id,
-						customer_id: tinaJSON.id,
-						billing: {
-							...tinaAddress,
-							email: 'tina.clark@example.com',
-						},
-						shipping: tinaAddress,
-						line_items: [
-							{
-								product_id: orderedProducts.sunglasses.id,
-								quantity: 1,
-							},
-						],
-					},
-				} );
-				const order3JSON = await order3.json();
-
-				orders.push( order3JSON );
-
-				// Guest order.
-				const guestOrder = await request.post(
-					'./wp-json/wc/v3/orders',
-					{
-						data: {
-							...orderBaseData,
-							billing: guestBillingAddress,
-							shipping: guestShippingAddress,
-							line_items: [
-								{
-									product_id: orderedProducts.pennant.id,
-									quantity: 2,
-								},
-								{
-									product_id: orderedProducts.beanie.id,
-									quantity: 1,
-								},
-							],
-						},
-					}
-				);
-				const guestOrderJSON = await guestOrder.json();
-
-				// Create an order with all possible numerical fields (taxes, fees, refunds, etc).
-				await request.put(
-					'./wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
-					{
-						data: {
-							value: 'yes',
-						},
-					}
-				);
-
-				await request.post( './wp-json/wc/v3/taxes', {
-					data: {
-						country: '*',
-						state: '*',
-						postcode: '*',
-						city: '*',
-						name: 'Tax',
-						rate: '5.5',
-						shipping: true,
-					},
-				} );
-
-				const coupon = await request.post( './wp-json/wc/v3/coupons', {
-					data: {
-						code: 'save5',
-						amount: '5',
-					},
-				} );
-				const couponJSON = await coupon.json();
-
-				const order4 = await request.post( './wp-json/wc/v3/orders', {
-					data: {
-						...orderBaseData,
-						line_items: [
-							{
-								product_id: orderedProducts.blueVneck.id,
-								quantity: 1,
-							},
-						],
-						coupon_lines: [
-							{
-								code: 'save5',
-							},
-						],
-						shipping_lines: [
-							{
-								method_id: 'flat_rate',
-								total: '5.00',
-							},
-						],
-						fee_lines: [
-							{
-								total: '1.00',
-								name: 'Test Fee',
-							},
-						],
-					},
-				} );
-				const order4JSON = await order4.json();
-
-				await request.post(
-					`./wp-json/wc/v3/orders/${ order4JSON.id }/refunds`,
-					{
-						data: {
-							api_refund: false, // Prevent an actual refund request (fails with CoD),
-							line_items: [
-								{
-									id: order4JSON.line_items[ 0 ].id,
-									quantity: 1,
-									refund_total:
-										order4JSON.line_items[ 0 ].total,
-									refund_tax: [
-										{
-											id: order4JSON.line_items[ 0 ]
-												.taxes[ 0 ].id,
-											refund_total:
-												order4JSON.line_items[ 0 ]
-													.total_tax,
-										},
-									],
-								},
-							],
-						},
-					}
-				);
-				orders.push( order4JSON );
-
-				return {
-					customers: {
-						johnJSON,
-						tinaJSON,
-					},
-					orders,
-					precisionOrder: order4JSON,
-					hierarchicalOrders: {
-						parent: order2JSON,
-						child: order3JSON,
-					},
-					guestOrderJSON,
-					testProductData,
-					couponJSON,
-				};
-			};
-
-			sampleData = await createSampleData();
-		}, 100000 );
-
-		test.afterAll( async ( { request } ) => {
-			const productsTestSetupDeleteSampleData = async ( _sampleData ) => {
-				const {
-					categories,
-					attributes,
-					productTags,
-					shippingClasses,
-					taxClasses,
-					simpleProducts,
-					externalProducts,
-					groupedProducts,
-					variableProducts,
-					hierarchicalProducts,
-					orders,
-				} = _sampleData;
-
-				const productIds = []
-					.concat( simpleProducts.map( ( p ) => p.id ) )
-					.concat( externalProducts.map( ( p ) => p.id ) )
-					.concat( groupedProducts.map( ( p ) => p.id ) )
-					.concat( [
-						variableProducts.hoodieJSON.id,
-						variableProducts.vneckJSON.id,
-					] )
-					.concat( [
-						hierarchicalProducts.parentJSON.id,
-						hierarchicalProducts.childJSON.id,
-					] );
-
-				for ( const _order of orders ) {
-					await request.delete(
-						`./wp-json/wc/v3/orders/${ _order.id }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-
-				for ( const productId of productIds ) {
-					await request.delete(
-						`./wp-json/wc/v3/products/${ productId }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-
-				await request.delete(
-					`./wp-json/wc/v3/products/attributes/${ attributes.colorJSON.id }`,
-					{
-						data: {
-							force: true,
-						},
-					}
-				);
-
-				await request.delete(
-					`./wp-json/wc/v3/products/attributes/${ attributes.sizeJSON.id }`,
-					{
-						data: {
-							force: true,
-						},
-					}
-				);
-
-				for ( const category of Object.values( categories ) ) {
-					await request.delete(
-						`./wp-json/wc/v3/products/categories/${ category.id }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-
-				for ( const tag of Object.values( productTags ) ) {
-					await request.delete(
-						`./wp-json/wc/v3/products/tags/${ tag.id }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-
-				for ( const shippingClass of Object.values(
-					shippingClasses
-				) ) {
-					await request.delete(
-						`./wp-json/wc/v3/products/shipping_classes/${ shippingClass.id }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-
-				for ( const taxClass of Object.values( taxClasses ) ) {
-					await request.delete(
-						`./wp-json/wc/v3/taxes/classes/${ taxClass.slug }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-			};
-
-			const deleteSampleData = async ( _sampleData ) => {
-				await productsTestSetupDeleteSampleData(
-					_sampleData.testProductData
-				);
-
-				for ( const _order of _sampleData.orders.concat( [
-					_sampleData.guestOrderJSON,
-				] ) ) {
-					await request.delete(
-						`./wp-json/wc/v3/orders/${ _order.id }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-
-				for ( const customer of Object.values(
-					_sampleData.customers
-				) ) {
-					await request.delete(
-						`./wp-json/wc/v3/customers/${ customer.id }`,
-						{
-							data: {
-								force: true,
-							},
-						}
-					);
-				}
-			};
-
-			await deleteSampleData( sampleData );
-		}, 10000 );
-
-		test( 'can create an order', async ( { request } ) => {
-			const response = await request.post( './wp-json/wc/v3/orders', {
-				data: order,
+				orders.push( orderJSON );
 			} );
-			const responseJSON = await response.json();
 
-			expect( response.status() ).toEqual( 201 );
-			expect( responseJSON.id ).toBeDefined();
-			orderId = responseJSON.id;
+			// Have "Tina" order some sunglasses and make a child order.
+			// This somewhat resembles a subscription renewal, but we're just testing the `parent` field.
+			const order2 = await request.post( './wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					status: 'completed',
+					set_paid: true,
+					customer_id: tinaJSON.id,
+					billing: {
+						...tinaAddress,
+						email: 'tina.clark@example.com',
+					},
+					shipping: tinaAddress,
+					line_items: [
+						{
+							product_id: orderedProducts.sunglasses.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const order2JSON = await order2.json();
 
-			// Validate the data type and verify the order is in a pending state
-			expect( typeof responseJSON.status ).toBe( 'string' );
-			expect( responseJSON.status ).toEqual( 'pending' );
-		} );
+			orders.push( order2JSON );
 
-		test( 'can retrieve an order', async ( { request } ) => {
-			const response = await request.get(
-				`./wp-json/wc/v3/orders/${ orderId }`
-			);
-			const responseJSON = await response.json();
+			// create child order by referencing a parent_id
+			const order3 = await request.post( './wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					parent_id: order2JSON.id,
+					customer_id: tinaJSON.id,
+					billing: {
+						...tinaAddress,
+						email: 'tina.clark@example.com',
+					},
+					shipping: tinaAddress,
+					line_items: [
+						{
+							product_id: orderedProducts.sunglasses.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const order3JSON = await order3.json();
 
-			expect( response.status() ).toEqual( 200 );
-			expect( responseJSON.id ).toEqual( orderId );
-		} );
+			orders.push( order3JSON );
 
-		test( 'can add shipping and billing contacts to an order', async ( {
-			request,
-		} ) => {
-			// Update the billing and shipping fields on the order
-			order.billing = updatedCustomerBilling;
-			order.shipping = updatedCustomerShipping;
+			// Guest order.
+			const guestOrder = await request.post( './wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					billing: guestBillingAddress,
+					shipping: guestShippingAddress,
+					line_items: [
+						{
+							product_id: orderedProducts.pennant.id,
+							quantity: 2,
+						},
+						{
+							product_id: orderedProducts.beanie.id,
+							quantity: 1,
+						},
+					],
+				},
+			} );
+			const guestOrderJSON = await guestOrder.json();
 
-			const response = await request.put(
-				`./wp-json/wc/v3/orders/${ orderId }`,
+			// Create an order with all possible numerical fields (taxes, fees, refunds, etc).
+			await request.put(
+				'./wp-json/wc/v3/settings/general/woocommerce_calc_taxes',
 				{
-					data: order,
+					data: {
+						value: 'yes',
+					},
 				}
 			);
-			const responseJSON = await response.json();
-			expect( response.status() ).toEqual( 200 );
 
-			expect( responseJSON.billing ).toEqual( updatedCustomerBilling );
-			expect( responseJSON.shipping ).toEqual( updatedCustomerShipping );
-		} );
+			await request.post( './wp-json/wc/v3/taxes', {
+				data: {
+					country: '*',
+					state: '*',
+					postcode: '*',
+					city: '*',
+					name: 'Tax',
+					rate: '5.5',
+					shipping: true,
+				},
+			} );
 
-		test( 'can permanently delete an order', async ( { request } ) => {
-			const response = await request.delete(
-				`./wp-json/wc/v3/orders/${ orderId }`,
+			const coupon = await request.post( './wp-json/wc/v3/coupons', {
+				data: {
+					code: 'save5',
+					amount: '5',
+				},
+			} );
+			const couponJSON = await coupon.json();
+
+			const order4 = await request.post( './wp-json/wc/v3/orders', {
+				data: {
+					...orderBaseData,
+					line_items: [
+						{
+							product_id: orderedProducts.blueVneck.id,
+							quantity: 1,
+						},
+					],
+					coupon_lines: [
+						{
+							code: 'save5',
+						},
+					],
+					shipping_lines: [
+						{
+							method_id: 'flat_rate',
+							total: '5.00',
+						},
+					],
+					fee_lines: [
+						{
+							total: '1.00',
+							name: 'Test Fee',
+						},
+					],
+				},
+			} );
+			const order4JSON = await order4.json();
+
+			await request.post(
+				`./wp-json/wc/v3/orders/${ order4JSON.id }/refunds`,
+				{
+					data: {
+						api_refund: false, // Prevent an actual refund request (fails with CoD),
+						line_items: [
+							{
+								id: order4JSON.line_items[ 0 ].id,
+								quantity: 1,
+								refund_total: order4JSON.line_items[ 0 ].total,
+								refund_tax: [
+									{
+										id: order4JSON.line_items[ 0 ]
+											.taxes[ 0 ].id,
+										refund_total:
+											order4JSON.line_items[ 0 ]
+												.total_tax,
+									},
+								],
+							},
+						],
+					},
+				}
+			);
+			orders.push( order4JSON );
+
+			return {
+				customers: {
+					johnJSON,
+					tinaJSON,
+				},
+				orders,
+				precisionOrder: order4JSON,
+				hierarchicalOrders: {
+					parent: order2JSON,
+					child: order3JSON,
+				},
+				guestOrderJSON,
+				testProductData,
+				couponJSON,
+			};
+		};
+
+		sampleData = await createSampleData();
+	}, 100000 );
+
+	test.afterAll( async ( { request } ) => {
+		const productsTestSetupDeleteSampleData = async ( _sampleData ) => {
+			const {
+				categories,
+				attributes,
+				productTags,
+				shippingClasses,
+				taxClasses,
+				simpleProducts,
+				externalProducts,
+				groupedProducts,
+				variableProducts,
+				hierarchicalProducts,
+				orders,
+			} = _sampleData;
+
+			const productIds = []
+				.concat( simpleProducts.map( ( p ) => p.id ) )
+				.concat( externalProducts.map( ( p ) => p.id ) )
+				.concat( groupedProducts.map( ( p ) => p.id ) )
+				.concat( [
+					variableProducts.hoodieJSON.id,
+					variableProducts.vneckJSON.id,
+				] )
+				.concat( [
+					hierarchicalProducts.parentJSON.id,
+					hierarchicalProducts.childJSON.id,
+				] );
+
+			for ( const _order of orders ) {
+				await request.delete( `./wp-json/wc/v3/orders/${ _order.id }`, {
+					data: {
+						force: true,
+					},
+				} );
+			}
+
+			for ( const productId of productIds ) {
+				await request.delete(
+					`./wp-json/wc/v3/products/${ productId }`,
+					{
+						data: {
+							force: true,
+						},
+					}
+				);
+			}
+
+			await request.delete(
+				`./wp-json/wc/v3/products/attributes/${ attributes.colorJSON.id }`,
 				{
 					data: {
 						force: true,
 					},
 				}
 			);
-			expect( response.status() ).toEqual( 200 );
 
-			const getOrderResponse = await request.get(
-				`./wp-json/wc/v3/orders/${ orderId }`
+			await request.delete(
+				`./wp-json/wc/v3/products/attributes/${ attributes.sizeJSON.id }`,
+				{
+					data: {
+						force: true,
+					},
+				}
 			);
-			expect( getOrderResponse.status() ).toEqual( 404 );
-		} );
 
-		test.describe( 'List all orders', () => {
-			const ORDERS_COUNT = 10;
-
-			test( 'pagination', async ( { request } ) => {
-				const pageSize = 4;
-				const page1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						per_page: pageSize,
-						search: 'oxo',
-					},
-				} );
-				const page1JSON = await page1.json();
-
-				const page2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						per_page: pageSize,
-						page: 2,
-						search: 'oxo',
-					},
-				} );
-				const page2JSON = await page2.json();
-
-				expect( page1.status() ).toEqual( 200 );
-				expect( page2.status() ).toEqual( 200 );
-
-				// Verify total page count.
-				expect( page1.headers()[ 'x-wp-total' ] ).toEqual(
-					ORDERS_COUNT.toString()
-				);
-				expect( page1.headers()[ 'x-wp-totalpages' ] ).toEqual( '3' );
-
-				// Verify we get pageSize'd arrays.
-				expect( Array.isArray( page1JSON ) ).toBe( true );
-				expect( Array.isArray( page2JSON ) ).toBe( true );
-				expect( page1JSON ).toHaveLength( pageSize );
-				expect( page2JSON ).toHaveLength( pageSize );
-
-				// Ensure all of the order IDs are unique (no page overlap).
-				const allOrderIds = page1JSON
-					.concat( page2JSON )
-					.reduce( ( acc, { id } ) => {
-						acc[ id ] = 1;
-						return acc;
-					}, {} );
-				expect( Object.keys( allOrderIds ) ).toHaveLength(
-					pageSize * 2
-				);
-
-				// Verify that offset takes precedent over page number.
-				const page2Offset = await request.get(
-					'./wp-json/wc/v3/orders',
+			for ( const category of Object.values( categories ) ) {
+				await request.delete(
+					`./wp-json/wc/v3/products/categories/${ category.id }`,
 					{
-						params: {
-							per_page: pageSize,
-							page: 2,
-							offset: pageSize + 1,
-							search: 'oxo',
+						data: {
+							force: true,
 						},
 					}
 				);
-				const page2OffsetJSON = await page2Offset.json();
+			}
 
-				// The offset pushes the result set 1 order past the start of page 2.
-				expect( page2OffsetJSON ).toEqual(
-					expect.not.arrayContaining( [
+			for ( const tag of Object.values( productTags ) ) {
+				await request.delete(
+					`./wp-json/wc/v3/products/tags/${ tag.id }`,
+					{
+						data: {
+							force: true,
+						},
+					}
+				);
+			}
+
+			for ( const shippingClass of Object.values( shippingClasses ) ) {
+				await request.delete(
+					`./wp-json/wc/v3/products/shipping_classes/${ shippingClass.id }`,
+					{
+						data: {
+							force: true,
+						},
+					}
+				);
+			}
+
+			for ( const taxClass of Object.values( taxClasses ) ) {
+				await request.delete(
+					`./wp-json/wc/v3/taxes/classes/${ taxClass.slug }`,
+					{
+						data: {
+							force: true,
+						},
+					}
+				);
+			}
+		};
+
+		const deleteSampleData = async ( _sampleData ) => {
+			await productsTestSetupDeleteSampleData(
+				_sampleData.testProductData
+			);
+
+			for ( const _order of _sampleData.orders.concat( [
+				_sampleData.guestOrderJSON,
+			] ) ) {
+				await request.delete( `./wp-json/wc/v3/orders/${ _order.id }`, {
+					data: {
+						force: true,
+					},
+				} );
+			}
+
+			for ( const customer of Object.values( _sampleData.customers ) ) {
+				await request.delete(
+					`./wp-json/wc/v3/customers/${ customer.id }`,
+					{
+						data: {
+							force: true,
+						},
+					}
+				);
+			}
+		};
+
+		await deleteSampleData( sampleData );
+	}, 10000 );
+
+	test( 'can create an order', async ( { request } ) => {
+		const response = await request.post( './wp-json/wc/v3/orders', {
+			data: order,
+		} );
+		const responseJSON = await response.json();
+
+		expect( response.status() ).toEqual( 201 );
+		expect( responseJSON.id ).toBeDefined();
+		orderId = responseJSON.id;
+
+		// Validate the data type and verify the order is in a pending state
+		expect( typeof responseJSON.status ).toBe( 'string' );
+		expect( responseJSON.status ).toEqual( 'pending' );
+	} );
+
+	test( 'can retrieve an order', async ( { request } ) => {
+		const response = await request.get(
+			`./wp-json/wc/v3/orders/${ orderId }`
+		);
+		const responseJSON = await response.json();
+
+		expect( response.status() ).toEqual( 200 );
+		expect( responseJSON.id ).toEqual( orderId );
+	} );
+
+	test( 'can add shipping and billing contacts to an order', async ( {
+		request,
+	} ) => {
+		// Update the billing and shipping fields on the order
+		order.billing = updatedCustomerBilling;
+		order.shipping = updatedCustomerShipping;
+
+		const response = await request.put(
+			`./wp-json/wc/v3/orders/${ orderId }`,
+			{
+				data: order,
+			}
+		);
+		const responseJSON = await response.json();
+		expect( response.status() ).toEqual( 200 );
+
+		expect( responseJSON.billing ).toEqual( updatedCustomerBilling );
+		expect( responseJSON.shipping ).toEqual( updatedCustomerShipping );
+	} );
+
+	test( 'can permanently delete an order', async ( { request } ) => {
+		const response = await request.delete(
+			`./wp-json/wc/v3/orders/${ orderId }`,
+			{
+				data: {
+					force: true,
+				},
+			}
+		);
+		expect( response.status() ).toEqual( 200 );
+
+		const getOrderResponse = await request.get(
+			`./wp-json/wc/v3/orders/${ orderId }`
+		);
+		expect( getOrderResponse.status() ).toEqual( 404 );
+	} );
+
+	test.describe( 'List all orders', () => {
+		const ORDERS_COUNT = 10;
+
+		test( 'pagination', async ( { request } ) => {
+			const pageSize = 4;
+			const page1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: pageSize,
+					search: 'oxo',
+				},
+			} );
+			const page1JSON = await page1.json();
+
+			const page2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: pageSize,
+					page: 2,
+					search: 'oxo',
+				},
+			} );
+			const page2JSON = await page2.json();
+
+			expect( page1.status() ).toEqual( 200 );
+			expect( page2.status() ).toEqual( 200 );
+
+			// Verify total page count.
+			expect( page1.headers()[ 'x-wp-total' ] ).toEqual(
+				ORDERS_COUNT.toString()
+			);
+			expect( page1.headers()[ 'x-wp-totalpages' ] ).toEqual( '3' );
+
+			// Verify we get pageSize'd arrays.
+			expect( Array.isArray( page1JSON ) ).toBe( true );
+			expect( Array.isArray( page2JSON ) ).toBe( true );
+			expect( page1JSON ).toHaveLength( pageSize );
+			expect( page2JSON ).toHaveLength( pageSize );
+
+			// Ensure all of the order IDs are unique (no page overlap).
+			const allOrderIds = page1JSON
+				.concat( page2JSON )
+				.reduce( ( acc, { id } ) => {
+					acc[ id ] = 1;
+					return acc;
+				}, {} );
+			expect( Object.keys( allOrderIds ) ).toHaveLength( pageSize * 2 );
+
+			// Verify that offset takes precedent over page number.
+			const page2Offset = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: pageSize,
+					page: 2,
+					offset: pageSize + 1,
+					search: 'oxo',
+				},
+			} );
+			const page2OffsetJSON = await page2Offset.json();
+
+			// The offset pushes the result set 1 order past the start of page 2.
+			expect( page2OffsetJSON ).toEqual(
+				expect.not.arrayContaining( [
+					expect.objectContaining( {
+						id: page2JSON[ 0 ].id,
+					} ),
+				] )
+			);
+			expect( page2OffsetJSON[ 0 ].id ).toEqual( page2JSON[ 1 ].id );
+
+			// Verify the last page only has 1 order as we expect.
+			const lastPage = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: pageSize,
+					page: 3,
+					search: 'oxo',
+				},
+			} );
+			const lastPageJSON = await lastPage.json();
+
+			expect( Array.isArray( lastPageJSON ) ).toBe( true );
+			expect( lastPageJSON ).toHaveLength( 2 );
+
+			// Verify a page outside the total page count is empty.
+			const page6 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					page: 6,
+					search: 'oxo',
+				},
+			} );
+			const page6JSON = await page6.json();
+
+			expect( Array.isArray( page6JSON ) ).toBe( true );
+			expect( page6JSON ).toHaveLength( 0 );
+		} );
+
+		test( 'inclusion / exclusion', async ( { request } ) => {
+			const allOrders = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: 10,
+					search: 'oxo',
+				},
+			} );
+			const allOrdersJSON = await allOrders.json();
+
+			expect( allOrders.status() ).toEqual( 200 );
+			const allOrdersIds = allOrdersJSON.map( ( _order ) => _order.id );
+			expect( allOrdersIds ).toHaveLength( ORDERS_COUNT );
+
+			const ordersToFilter = [
+				allOrdersIds[ 0 ],
+				allOrdersIds[ 2 ],
+				allOrdersIds[ 4 ],
+				allOrdersIds[ 7 ],
+			];
+
+			const included = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: 20,
+					include: ordersToFilter.join( ',' ),
+				},
+			} );
+			const includedJSON = await included.json();
+
+			expect( included.status() ).toEqual( 200 );
+			expect( includedJSON ).toHaveLength( ordersToFilter.length );
+			expect( includedJSON ).toEqual(
+				expect.arrayContaining(
+					ordersToFilter.map( ( id ) =>
 						expect.objectContaining( {
-							id: page2JSON[ 0 ].id,
-						} ),
-					] )
-				);
-				expect( page2OffsetJSON[ 0 ].id ).toEqual( page2JSON[ 1 ].id );
-
-				// Verify the last page only has 1 order as we expect.
-				const lastPage = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						per_page: pageSize,
-						page: 3,
-						search: 'oxo',
-					},
-				} );
-				const lastPageJSON = await lastPage.json();
-
-				expect( Array.isArray( lastPageJSON ) ).toBe( true );
-				expect( lastPageJSON ).toHaveLength( 2 );
-
-				// Verify a page outside the total page count is empty.
-				const page6 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						page: 6,
-						search: 'oxo',
-					},
-				} );
-				const page6JSON = await page6.json();
-
-				expect( Array.isArray( page6JSON ) ).toBe( true );
-				expect( page6JSON ).toHaveLength( 0 );
-			} );
-
-			test( 'inclusion / exclusion', async ( { request } ) => {
-				const allOrders = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						per_page: 10,
-						search: 'oxo',
-					},
-				} );
-				const allOrdersJSON = await allOrders.json();
-
-				expect( allOrders.status() ).toEqual( 200 );
-				const allOrdersIds = allOrdersJSON.map(
-					( _order ) => _order.id
-				);
-				expect( allOrdersIds ).toHaveLength( ORDERS_COUNT );
-
-				const ordersToFilter = [
-					allOrdersIds[ 0 ],
-					allOrdersIds[ 2 ],
-					allOrdersIds[ 4 ],
-					allOrdersIds[ 7 ],
-				];
-
-				const included = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						per_page: 20,
-						include: ordersToFilter.join( ',' ),
-					},
-				} );
-				const includedJSON = await included.json();
-
-				expect( included.status() ).toEqual( 200 );
-				expect( includedJSON ).toHaveLength( ordersToFilter.length );
-				expect( includedJSON ).toEqual(
-					expect.arrayContaining(
-						ordersToFilter.map( ( id ) =>
-							expect.objectContaining( {
-								id,
-							} )
-						)
+							id,
+						} )
 					)
-				);
+				)
+			);
 
-				const excluded = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						per_page: 20,
-						exclude: ordersToFilter.join( ',' ),
-					},
-				} );
-				const excludedJSON = await excluded.json();
-
-				expect( excluded.status() ).toEqual( 200 );
-				expect( excludedJSON.length ).toBeGreaterThanOrEqual(
-					Number( ORDERS_COUNT - ordersToFilter.length )
-				);
-				expect( excludedJSON ).toEqual(
-					expect.not.arrayContaining(
-						ordersToFilter.map( ( id ) =>
-							expect.objectContaining( {
-								id,
-							} )
-						)
-					)
-				);
+			const excluded = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					per_page: 20,
+					exclude: ordersToFilter.join( ',' ),
+				},
 			} );
+			const excludedJSON = await excluded.json();
 
-			test( 'parent', async ( { request } ) => {
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						parent: sampleData.hierarchicalOrders.parent.id,
-					},
-				} );
-				const result1JSON = await result1.json();
-
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 1 );
-				expect( result1JSON[ 0 ].id ).toBe(
-					sampleData.hierarchicalOrders.child.id
-				);
-
-				const result2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						parent_exclude: sampleData.hierarchicalOrders.parent.id,
-					},
-				} );
-				const result2JSON = await result2.json();
-
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toEqual(
-					expect.not.arrayContaining( [
+			expect( excluded.status() ).toEqual( 200 );
+			expect( excludedJSON.length ).toBeGreaterThanOrEqual(
+				Number( ORDERS_COUNT - ordersToFilter.length )
+			);
+			expect( excludedJSON ).toEqual(
+				expect.not.arrayContaining(
+					ordersToFilter.map( ( id ) =>
 						expect.objectContaining( {
-							id: sampleData.hierarchicalOrders.child.id,
-						} ),
-					] )
-				);
-			} );
+							id,
+						} )
+					)
+				)
+			);
+		} );
 
-			test( 'status', async ( { request } ) => {
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
+		test( 'parent', async ( { request } ) => {
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					parent: sampleData.hierarchicalOrders.parent.id,
+				},
+			} );
+			const result1JSON = await result1.json();
+
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 1 );
+			expect( result1JSON[ 0 ].id ).toBe(
+				sampleData.hierarchicalOrders.child.id
+			);
+
+			const result2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					parent_exclude: sampleData.hierarchicalOrders.parent.id,
+				},
+			} );
+			const result2JSON = await result2.json();
+
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining( [
+					expect.objectContaining( {
+						id: sampleData.hierarchicalOrders.child.id,
+					} ),
+				] )
+			);
+		} );
+
+		test( 'status', async ( { request } ) => {
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					status: 'completed',
+					search: 'oxo',
+				},
+			} );
+			const result1JSON = await result1.json();
+
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 2 );
+			expect( result1JSON ).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
 						status: 'completed',
-						search: 'oxo',
-					},
-				} );
-				const result1JSON = await result1.json();
-
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 2 );
-				expect( result1JSON ).toEqual(
-					expect.arrayContaining( [
-						expect.objectContaining( {
-							status: 'completed',
-							line_items: expect.arrayContaining( [
-								expect.objectContaining( {
-									name: 'Single oxo',
-									quantity: 2,
-								} ),
-								expect.objectContaining( {
-									name: 'Beanie with Logo oxo',
-									quantity: 3,
-								} ),
-								expect.objectContaining( {
-									name: 'T-Shirt oxo',
-									quantity: 1,
-								} ),
-							] ),
-						} ),
-						expect.objectContaining( {
-							status: 'completed',
-							customer_id: sampleData.customers.tinaJSON.id,
-							line_items: expect.arrayContaining( [
-								expect.objectContaining( {
-									name: 'Sunglasses oxo',
-									quantity: 1,
-								} ),
-							] ),
-						} ),
-					] )
-				);
-
-				const result2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						status: 'processing',
-						search: 'oxo',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 8 );
-				expect( result2JSON ).toEqual(
-					expect.not.arrayContaining(
-						result1JSON.map( ( { id } ) =>
+						line_items: expect.arrayContaining( [
 							expect.objectContaining( {
-								id,
-							} )
-						)
-					)
-				);
+								name: 'Single oxo',
+								quantity: 2,
+							} ),
+							expect.objectContaining( {
+								name: 'Beanie with Logo oxo',
+								quantity: 3,
+							} ),
+							expect.objectContaining( {
+								name: 'T-Shirt oxo',
+								quantity: 1,
+							} ),
+						] ),
+					} ),
+					expect.objectContaining( {
+						status: 'completed',
+						customer_id: sampleData.customers.tinaJSON.id,
+						line_items: expect.arrayContaining( [
+							expect.objectContaining( {
+								name: 'Sunglasses oxo',
+								quantity: 1,
+							} ),
+						] ),
+					} ),
+				] )
+			);
+
+			const result2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					status: 'processing',
+					search: 'oxo',
+				},
 			} );
-
-			test( 'customer', async ( { request } ) => {
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						customer: sampleData.customers.johnJSON.id,
-					},
-				} );
-				const result1JSON = await result1.json();
-
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 5 );
-				result1JSON.forEach( ( _order ) =>
-					expect( _order ).toEqual(
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 8 );
+			expect( result2JSON ).toEqual(
+				expect.not.arrayContaining(
+					result1JSON.map( ( { id } ) =>
 						expect.objectContaining( {
-							customer_id: sampleData.customers.johnJSON.id,
+							id,
 						} )
 					)
-				);
+				)
+			);
+		} );
 
-				const result2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						customer: 0,
-						search: 'oxo',
-					},
-				} );
-				const result2JSON = await result2.json();
-
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 3 );
-				result2JSON.forEach( ( _order ) =>
-					expect( _order ).toEqual(
-						expect.objectContaining( {
-							customer_id: 0,
-						} )
-					)
-				);
+		test( 'customer', async ( { request } ) => {
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					customer: sampleData.customers.johnJSON.id,
+				},
 			} );
+			const result1JSON = await result1.json();
 
-			test( 'product', async ( { request } ) => {
-				const beanie = sampleData.testProductData.simpleProducts.find(
-					( p ) => p.name === 'Beanie oxo'
-				);
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						product: beanie.id,
-					},
-				} );
-				const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 5 );
+			result1JSON.forEach( ( _order ) =>
+				expect( _order ).toEqual(
+					expect.objectContaining( {
+						customer_id: sampleData.customers.johnJSON.id,
+					} )
+				)
+			);
 
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( 2 );
-				result1JSON.forEach( ( _order ) =>
-					expect( _order ).toEqual(
-						expect.objectContaining( {
-							line_items: expect.arrayContaining( [
-								expect.objectContaining( {
-									name: 'Beanie oxo',
-								} ),
-							] ),
-						} )
-					)
-				);
+			const result2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					customer: 0,
+					search: 'oxo',
+				},
 			} );
+			const result2JSON = await result2.json();
 
-			// NOTE: This does not verify the `taxes` array nested in line items.
-			// While the precision parameter doesn't affect those values, after some
-			// discussion it seems `dp` may not be supported in v4 of the API.
-			test( 'dp (precision)', async ( { request } ) => {
-				const expectPrecisionToMatch = ( value, dp ) => {
-					expect( value ).toEqual(
-						Number.parseFloat( value ).toFixed( dp )
-					);
-				};
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 3 );
+			result2JSON.forEach( ( _order ) =>
+				expect( _order ).toEqual(
+					expect.objectContaining( {
+						customer_id: 0,
+					} )
+				)
+			);
+		} );
 
-				const verifyOrderPrecision = ( _order, dp ) => {
-					expectPrecisionToMatch( _order.discount_total, dp );
-					expectPrecisionToMatch( _order.discount_tax, dp );
-					expectPrecisionToMatch( _order.shipping_total, dp );
-					expectPrecisionToMatch( _order.shipping_tax, dp );
-					expectPrecisionToMatch( _order.cart_tax, dp );
-					expectPrecisionToMatch( _order.total, dp );
-					expectPrecisionToMatch( _order.total_tax, dp );
-
-					_order.line_items.forEach( ( lineItem ) => {
-						expectPrecisionToMatch( lineItem.total, dp );
-						expectPrecisionToMatch( lineItem.total_tax, dp );
-					} );
-
-					_order.tax_lines.forEach( ( taxLine ) => {
-						expectPrecisionToMatch( taxLine.tax_total, dp );
-						expectPrecisionToMatch(
-							taxLine.shipping_tax_total,
-							dp
-						);
-					} );
-
-					_order.shipping_lines.forEach( ( shippingLine ) => {
-						expectPrecisionToMatch( shippingLine.total, dp );
-						expectPrecisionToMatch( shippingLine.total_tax, dp );
-					} );
-
-					_order.fee_lines.forEach( ( feeLine ) => {
-						expectPrecisionToMatch( feeLine.total, dp );
-						expectPrecisionToMatch( feeLine.total_tax, dp );
-					} );
-
-					_order.refunds.forEach( ( refund ) => {
-						expectPrecisionToMatch( refund.total, dp );
-					} );
-				};
-
-				const result1 = await request.get(
-					`wp-json/wc/v3/orders/${ sampleData.precisionOrder.id }`,
-					{
-						params: {
-							dp: 1,
-						},
-					}
-				);
-				const result1JSON = await result1.json();
-
-				expect( result1.status() ).toEqual( 200 );
-				verifyOrderPrecision( result1JSON, 1 );
-
-				const result2 = await request.get(
-					`wp-json/wc/v3/orders/${ sampleData.precisionOrder.id }`,
-					{
-						params: {
-							dp: 3,
-						},
-					}
-				);
-				const result2JSON = await result2.json();
-
-				expect( result2.status() ).toEqual( 200 );
-				verifyOrderPrecision( result2JSON, 3 );
-
-				const result3 = await request.get(
-					`wp-json/wc/v3/orders/${ sampleData.precisionOrder.id }`
-				);
-				const result3JSON = await result3.json();
-
-				expect( result3.status() ).toEqual( 200 );
-				verifyOrderPrecision( result3JSON, 2 ); // The default value for 'dp' is 2.
+		test( 'product', async ( { request } ) => {
+			const beanie = sampleData.testProductData.simpleProducts.find(
+				( p ) => p.name === 'Beanie oxo'
+			);
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					product: beanie.id,
+				},
 			} );
+			const result1JSON = await result1.json();
 
-			test( 'search', async ( { request } ) => {
-				// By default, 'search' looks in:
-				// - _billing_address_index
-				// - _shipping_address_index
-				// - _billing_last_name
-				// - _billing_email
-				// - order_item_name
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( 2 );
+			result1JSON.forEach( ( _order ) =>
+				expect( _order ).toEqual(
+					expect.objectContaining( {
+						line_items: expect.arrayContaining( [
+							expect.objectContaining( {
+								name: 'Beanie oxo',
+							} ),
+						] ),
+					} )
+				)
+			);
+		} );
 
-				// Test billing email.
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						search: 'example.com',
-					},
-				} );
-				const result1JSON = await result1.json();
-
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON.length ).toBeGreaterThanOrEqual( 1 );
-				result1JSON.forEach( ( _order ) =>
-					expect( _order.billing.email ).toContain( 'example.com' )
+		// NOTE: This does not verify the `taxes` array nested in line items.
+		// While the precision parameter doesn't affect those values, after some
+		// discussion it seems `dp` may not be supported in v4 of the API.
+		test( 'dp (precision)', async ( { request } ) => {
+			const expectPrecisionToMatch = ( value, dp ) => {
+				expect( value ).toEqual(
+					Number.parseFloat( value ).toFixed( dp )
 				);
+			};
 
-				// Test billing address.
-				const result2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						search: 'gainesville',
-					},
+			const verifyOrderPrecision = ( _order, dp ) => {
+				expectPrecisionToMatch( _order.discount_total, dp );
+				expectPrecisionToMatch( _order.discount_tax, dp );
+				expectPrecisionToMatch( _order.shipping_total, dp );
+				expectPrecisionToMatch( _order.shipping_tax, dp );
+				expectPrecisionToMatch( _order.cart_tax, dp );
+				expectPrecisionToMatch( _order.total, dp );
+				expectPrecisionToMatch( _order.total_tax, dp );
+
+				_order.line_items.forEach( ( lineItem ) => {
+					expectPrecisionToMatch( lineItem.total, dp );
+					expectPrecisionToMatch( lineItem.total_tax, dp );
 				} );
-				const result2JSON = await result2.json();
 
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( 1 );
-				expect( result2JSON[ 0 ].id ).toEqual(
-					sampleData.guestOrderJSON.id
-				);
-
-				// Test shipping address.
-				const result3 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						search: 'Incognito',
-					},
+				_order.tax_lines.forEach( ( taxLine ) => {
+					expectPrecisionToMatch( taxLine.tax_total, dp );
+					expectPrecisionToMatch( taxLine.shipping_tax_total, dp );
 				} );
-				const result3JSON = await result3.json();
 
-				expect( result3.status() ).toEqual( 200 );
-				expect( result3JSON ).toHaveLength( 1 );
-				expect( result3JSON[ 0 ].id ).toEqual(
-					sampleData.guestOrderJSON.id
-				);
-
-				// Test billing last name.
-				const result4 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						search: 'Doe',
-					},
+				_order.shipping_lines.forEach( ( shippingLine ) => {
+					expectPrecisionToMatch( shippingLine.total, dp );
+					expectPrecisionToMatch( shippingLine.total_tax, dp );
 				} );
-				const result4JSON = await result4.json();
 
-				expect( result4.status() ).toEqual( 200 );
-				expect( result4JSON.length ).toBeGreaterThanOrEqual( 1 );
-				result4JSON.forEach( ( _order ) =>
-					expect( _order.billing.last_name ).toEqual( 'Doe' )
-				);
-
-				// Test order item name.
-				const result5 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						search: 'Pennant oxo',
-					},
+				_order.fee_lines.forEach( ( feeLine ) => {
+					expectPrecisionToMatch( feeLine.total, dp );
+					expectPrecisionToMatch( feeLine.total_tax, dp );
 				} );
-				const result5JSON = await result5.json();
 
-				expect( result5.status() ).toEqual( 200 );
-				expect( result5JSON ).toHaveLength( 2 );
-				result5JSON.forEach( ( _order ) =>
-					expect( _order ).toEqual(
-						expect.objectContaining( {
-							line_items: expect.arrayContaining( [
-								expect.objectContaining( {
-									name: 'WordPress Pennant oxo',
-								} ),
-							] ),
-						} )
-					)
-				);
+				_order.refunds.forEach( ( refund ) => {
+					expectPrecisionToMatch( refund.total, dp );
+				} );
+			};
+
+			const result1 = await request.get(
+				`wp-json/wc/v3/orders/${ sampleData.precisionOrder.id }`,
+				{
+					params: {
+						dp: 1,
+					},
+				}
+			);
+			const result1JSON = await result1.json();
+
+			expect( result1.status() ).toEqual( 200 );
+			verifyOrderPrecision( result1JSON, 1 );
+
+			const result2 = await request.get(
+				`wp-json/wc/v3/orders/${ sampleData.precisionOrder.id }`,
+				{
+					params: {
+						dp: 3,
+					},
+				}
+			);
+			const result2JSON = await result2.json();
+
+			expect( result2.status() ).toEqual( 200 );
+			verifyOrderPrecision( result2JSON, 3 );
+
+			const result3 = await request.get(
+				`wp-json/wc/v3/orders/${ sampleData.precisionOrder.id }`
+			);
+			const result3JSON = await result3.json();
+
+			expect( result3.status() ).toEqual( 200 );
+			verifyOrderPrecision( result3JSON, 2 ); // The default value for 'dp' is 2.
+		} );
+
+		test( 'search', async ( { request } ) => {
+			// By default, 'search' looks in:
+			// - _billing_address_index
+			// - _shipping_address_index
+			// - _billing_last_name
+			// - _billing_email
+			// - order_item_name
+
+			// Test billing email.
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					search: 'example.com',
+				},
+			} );
+			const result1JSON = await result1.json();
+
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON.length ).toBeGreaterThanOrEqual( 1 );
+			result1JSON.forEach( ( _order ) =>
+				expect( _order.billing.email ).toContain( 'example.com' )
+			);
+
+			// Test billing address.
+			const result2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					search: 'gainesville',
+				},
+			} );
+			const result2JSON = await result2.json();
+
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( 1 );
+			expect( result2JSON[ 0 ].id ).toEqual(
+				sampleData.guestOrderJSON.id
+			);
+
+			// Test shipping address.
+			const result3 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					search: 'Incognito',
+				},
+			} );
+			const result3JSON = await result3.json();
+
+			expect( result3.status() ).toEqual( 200 );
+			expect( result3JSON ).toHaveLength( 1 );
+			expect( result3JSON[ 0 ].id ).toEqual(
+				sampleData.guestOrderJSON.id
+			);
+
+			// Test billing last name.
+			const result4 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					search: 'Doe',
+				},
+			} );
+			const result4JSON = await result4.json();
+
+			expect( result4.status() ).toEqual( 200 );
+			expect( result4JSON.length ).toBeGreaterThanOrEqual( 1 );
+			result4JSON.forEach( ( _order ) =>
+				expect( _order.billing.last_name ).toEqual( 'Doe' )
+			);
+
+			// Test order item name.
+			const result5 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					search: 'Pennant oxo',
+				},
+			} );
+			const result5JSON = await result5.json();
+
+			expect( result5.status() ).toEqual( 200 );
+			expect( result5JSON ).toHaveLength( 2 );
+			result5JSON.forEach( ( _order ) =>
+				expect( _order ).toEqual(
+					expect.objectContaining( {
+						line_items: expect.arrayContaining( [
+							expect.objectContaining( {
+								name: 'WordPress Pennant oxo',
+							} ),
+						] ),
+					} )
+				)
+			);
+		} );
+	} );
+
+	test.describe( 'orderby', () => {
+		// The orders endpoint `orderby` parameter uses WP_Query, so our tests won't
+		// include slug and title, since they are programmatically generated.
+		test( 'default', async ( { request } ) => {
+			// Default = date desc.
+			const result = await request.get( './wp-json/wc/v3/orders' );
+			const resultJSON = await result.json();
+			expect( result.status() ).toEqual( 200 );
+
+			// Verify all dates are in descending order.
+			let lastDate = Date.now();
+			resultJSON.forEach( ( { date_created } ) => {
+				const created = Date.parse( date_created + '.000Z' );
+				expect( lastDate ).toBeGreaterThanOrEqual( created );
+				lastDate = created;
 			} );
 		} );
 
-		test.describe( 'orderby', () => {
-			// The orders endpoint `orderby` parameter uses WP_Query, so our tests won't
-			// include slug and title, since they are programmatically generated.
-			test( 'default', async ( { request } ) => {
-				// Default = date desc.
-				const result = await request.get( './wp-json/wc/v3/orders' );
-				const resultJSON = await result.json();
-				expect( result.status() ).toEqual( 200 );
-
-				// Verify all dates are in descending order.
-				let lastDate = Date.now();
-				resultJSON.forEach( ( { date_created } ) => {
-					const created = Date.parse( date_created + '.000Z' );
-					expect( lastDate ).toBeGreaterThanOrEqual( created );
-					lastDate = created;
-				} );
+		test( 'date', async ( { request } ) => {
+			const result = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					order: 'asc',
+					orderby: 'date',
+				},
 			} );
+			const resultJSON = await result.json();
 
-			test( 'date', async ( { request } ) => {
-				const result = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						order: 'asc',
-						orderby: 'date',
-					},
-				} );
-				const resultJSON = await result.json();
+			expect( result.status() ).toEqual( 200 );
 
-				expect( result.status() ).toEqual( 200 );
-
-				// Verify all dates are in ascending order.
-				let lastDate = 0;
-				resultJSON.forEach( ( { date_created } ) => {
-					const created = Date.parse( date_created + '.000Z' );
-					expect( created ).toBeGreaterThanOrEqual( lastDate );
-					lastDate = created;
-				} );
-			} );
-
-			test( 'id', async ( { request } ) => {
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						order: 'asc',
-						orderby: 'id',
-					},
-				} );
-				const result1JSON = await result1.json();
-				expect( result1.status() ).toEqual( 200 );
-
-				// Verify all results are in ascending order.
-				let lastId = 0;
-				result1JSON.forEach( ( { id } ) => {
-					expect( id ).toBeGreaterThan( lastId );
-					lastId = id;
-				} );
-
-				const result2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						order: 'desc',
-						orderby: 'id',
-					},
-				} );
-				const result2JSON = await result2.json();
-				expect( result2.status() ).toEqual( 200 );
-
-				// Verify all results are in descending order.
-				lastId = Number.MAX_SAFE_INTEGER;
-				result2JSON.forEach( ( { id } ) => {
-					expect( lastId ).toBeGreaterThan( id );
-					lastId = id;
-				} );
-			} );
-
-			test( 'include', async ( { request } ) => {
-				const includeIds = [
-					sampleData.precisionOrder.id,
-					sampleData.hierarchicalOrders.parent.id,
-					sampleData.guestOrderJSON.id,
-				];
-
-				const result1 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						order: 'asc',
-						orderby: 'include',
-						include: includeIds.join( ',' ),
-					},
-				} );
-				const result1JSON = await result1.json();
-
-				expect( result1.status() ).toEqual( 200 );
-				expect( result1JSON ).toHaveLength( includeIds.length );
-
-				// Verify all results are in proper order.
-				result1JSON.forEach( ( { id }, idx ) => {
-					expect( id ).toBe( includeIds[ idx ] );
-				} );
-
-				const result2 = await request.get( './wp-json/wc/v3/orders', {
-					params: {
-						order: 'desc',
-						orderby: 'include',
-						include: includeIds.join( ',' ),
-					},
-				} );
-				const result2JSON = await result2.json();
-
-				expect( result2.status() ).toEqual( 200 );
-				expect( result2JSON ).toHaveLength( includeIds.length );
-
-				// Verify all results are in proper order.
-				result2JSON.forEach( ( { id }, idx ) => {
-					expect( id ).toBe( includeIds[ idx ] );
-				} );
+			// Verify all dates are in ascending order.
+			let lastDate = 0;
+			resultJSON.forEach( ( { date_created } ) => {
+				const created = Date.parse( date_created + '.000Z' );
+				expect( created ).toBeGreaterThanOrEqual( lastDate );
+				lastDate = created;
 			} );
 		} );
-	}
-);
+
+		test( 'id', async ( { request } ) => {
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					order: 'asc',
+					orderby: 'id',
+				},
+			} );
+			const result1JSON = await result1.json();
+			expect( result1.status() ).toEqual( 200 );
+
+			// Verify all results are in ascending order.
+			let lastId = 0;
+			result1JSON.forEach( ( { id } ) => {
+				expect( id ).toBeGreaterThan( lastId );
+				lastId = id;
+			} );
+
+			const result2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					order: 'desc',
+					orderby: 'id',
+				},
+			} );
+			const result2JSON = await result2.json();
+			expect( result2.status() ).toEqual( 200 );
+
+			// Verify all results are in descending order.
+			lastId = Number.MAX_SAFE_INTEGER;
+			result2JSON.forEach( ( { id } ) => {
+				expect( lastId ).toBeGreaterThan( id );
+				lastId = id;
+			} );
+		} );
+
+		test( 'include', async ( { request } ) => {
+			const includeIds = [
+				sampleData.precisionOrder.id,
+				sampleData.hierarchicalOrders.parent.id,
+				sampleData.guestOrderJSON.id,
+			];
+
+			const result1 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					order: 'asc',
+					orderby: 'include',
+					include: includeIds.join( ',' ),
+				},
+			} );
+			const result1JSON = await result1.json();
+
+			expect( result1.status() ).toEqual( 200 );
+			expect( result1JSON ).toHaveLength( includeIds.length );
+
+			// Verify all results are in proper order.
+			result1JSON.forEach( ( { id }, idx ) => {
+				expect( id ).toBe( includeIds[ idx ] );
+			} );
+
+			const result2 = await request.get( './wp-json/wc/v3/orders', {
+				params: {
+					order: 'desc',
+					orderby: 'include',
+					include: includeIds.join( ',' ),
+				},
+			} );
+			const result2JSON = await result2.json();
+
+			expect( result2.status() ).toEqual( 200 );
+			expect( result2JSON ).toHaveLength( includeIds.length );
+
+			// Verify all results are in proper order.
+			result2JSON.forEach( ( { id }, idx ) => {
+				expect( id ).toBe( includeIds[ idx ] );
+			} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -2513,7 +2513,7 @@ test.describe.serial( 'Orders API tests', () => {
 		};
 
 		sampleData = await createSampleData();
-	}, 100000 );
+	} );
 
 	test.afterAll( async ( { request } ) => {
 		const productsTestSetupDeleteSampleData = async ( _sampleData ) => {
@@ -2645,7 +2645,7 @@ test.describe.serial( 'Orders API tests', () => {
 		};
 
 		await deleteSampleData( sampleData );
-	}, 10000 );
+	} );
 
 	test( 'can create an order', async ( { request } ) => {
 		const response = await request.post( './wp-json/wc/v3/orders', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/orders/orders.test.js
@@ -2,7 +2,7 @@ const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { order } = require( '../../../data' );
 const { faker } = require( '@faker-js/faker' );
 
-const RAND_STRING = faker.number.int( { min: 1000, max: 9999 } );
+const RAND_STRING = faker.string.alphanumeric( 8 ).toLowerCase();
 
 /**
  * Billing properties to update.
@@ -46,7 +46,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Clothing',
+						name: `Clothing ${ RAND_STRING }`,
 					},
 					failOnStatusCode: true,
 				}
@@ -57,7 +57,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Accessories',
+						name: `Accessories ${ RAND_STRING }`,
 						parent: clothingJSON.id,
 					},
 					failOnStatusCode: true,
@@ -69,7 +69,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Hoodies',
+						name: `Hoodies ${ RAND_STRING }`,
 						parent: clothingJSON.id,
 					},
 					failOnStatusCode: true,
@@ -81,7 +81,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Tshirts',
+						name: `Tshirts ${ RAND_STRING }`,
 						parent: clothingJSON.id,
 					},
 					failOnStatusCode: true,
@@ -93,7 +93,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Decor',
+						name: `Decor ${ RAND_STRING }`,
 					},
 					failOnStatusCode: true,
 				}
@@ -104,7 +104,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/categories',
 				{
 					data: {
-						name: 'Music',
+						name: `Music ${ RAND_STRING }`,
 					},
 					failOnStatusCode: true,
 				}
@@ -126,7 +126,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/attributes',
 				{
 					data: {
-						name: 'Color',
+						name: `Color ${ RAND_STRING }`,
 					},
 					failOnStatusCode: true,
 				}
@@ -137,7 +137,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/attributes',
 				{
 					data: {
-						name: 'Size',
+						name: `Size ${ RAND_STRING }`,
 					},
 					failOnStatusCode: true,
 				}
@@ -190,7 +190,7 @@ test.describe.serial( 'Orders API tests', () => {
 		const createSampleTags = async () => {
 			const cool = await request.post( './wp-json/wc/v3/products/tags', {
 				data: {
-					name: 'Cool',
+					name: `Cool ${ RAND_STRING }`,
 				},
 				failOnStatusCode: true,
 			} );
@@ -206,7 +206,7 @@ test.describe.serial( 'Orders API tests', () => {
 				'./wp-json/wc/v3/products/shipping_classes',
 				{
 					data: {
-						name: 'Freight',
+						name: `Freight ${ RAND_STRING }`,
 					},
 					failOnStatusCode: true,
 				}
@@ -262,7 +262,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						create: [
 							{
-								name: 'Beanie with Logo oxo',
+								name: `Beanie with Logo ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-01T15:50:20',
 								type: 'simple',
 								status: 'publish',
@@ -271,7 +271,6 @@ test.describe.serial( 'Orders API tests', () => {
 								description,
 								short_description:
 									'<p>This is a simple product.</p>\n',
-								sku: 'Woo-beanie-logo',
 								price: '18',
 								regular_price: '20',
 								sale_price: '18',
@@ -335,7 +334,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'T-Shirt with Logo oxo',
+								name: `T-Shirt with Logo ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-02T15:50:20',
 								type: 'simple',
 								status: 'publish',
@@ -408,7 +407,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Single oxo',
+								name: `Single ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-03T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -479,7 +478,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Album oxo',
+								name: `Album ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-04T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -555,7 +554,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Polo oxo',
+								name: `Polo ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-05T15:50:19',
 								type: 'simple',
 								status: 'pending',
@@ -628,7 +627,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Long Sleeve Tee oxo',
+								name: `Long Sleeve Tee ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-06T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -701,7 +700,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Hoodie with Zipper oxo',
+								name: `Hoodie with Zipper ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-07T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -766,7 +765,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Hoodie with Pocket oxo',
+								name: `Hoodie with Pocket ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-08T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -843,7 +842,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Sunglasses oxo',
+								name: `Sunglasses ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-09T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -912,7 +911,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Cap oxo',
+								name: `Cap ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-10T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -985,7 +984,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Belt oxo',
+								name: `Belt ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-12T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1050,7 +1049,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'Beanie oxo',
+								name: `Beanie ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-13T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1127,7 +1126,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'instock',
 							},
 							{
-								name: 'T-Shirt oxo',
+								name: `T-Shirt ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-14T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1200,7 +1199,7 @@ test.describe.serial( 'Orders API tests', () => {
 								stock_status: 'onbackorder',
 							},
 							{
-								name: 'Hoodie with Logo oxo',
+								name: `Hoodie with Logo ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-15T15:50:19',
 								type: 'simple',
 								status: 'publish',
@@ -1289,7 +1288,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						create: [
 							{
-								name: 'WordPress Pennant oxo',
+								name: `WordPress Pennant ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-16T15:50:20',
 								type: 'external',
 								status: 'publish',
@@ -1385,7 +1384,7 @@ test.describe.serial( 'Orders API tests', () => {
 					data: {
 						create: [
 							{
-								name: 'Logo Collection oxo',
+								name: `Logo Collection ${ RAND_STRING }`,
 								date_created_gmt: '2021-09-17T15:50:20',
 								type: 'grouped',
 								status: 'publish',
@@ -1475,7 +1474,7 @@ test.describe.serial( 'Orders API tests', () => {
 
 			const hoodie = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'Hoodie oxo',
+					name: `Hoodie ${ RAND_STRING }`,
 					date_created_gmt: '2021-09-18T15:50:19',
 					type: 'variable',
 					status: 'publish',
@@ -1762,7 +1761,7 @@ test.describe.serial( 'Orders API tests', () => {
 
 			const vneck = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'V-Neck T-Shirt oxo',
+					name: `V-Neck T-Shirt ${ RAND_STRING }`,
 					date_created_gmt: '2021-09-23T15:50:19',
 					type: 'variable',
 					status: 'publish',
@@ -1988,7 +1987,7 @@ test.describe.serial( 'Orders API tests', () => {
 		const createSampleHierarchicalProducts = async () => {
 			const parent = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'Parent Product oxo',
+					name: `Parent Product ${ RAND_STRING }`,
 					date_created_gmt: '2021-09-27T15:50:19',
 				},
 				failOnStatusCode: true,
@@ -1997,7 +1996,7 @@ test.describe.serial( 'Orders API tests', () => {
 
 			const child = await request.post( './wp-json/wc/v3/products', {
 				data: {
-					name: 'Child Product oxo',
+					name: `Child Product ${ RAND_STRING }`,
 					parent_id: parentJSON.id,
 					date_created_gmt: '2021-09-28T15:50:19',
 				},
@@ -2012,14 +2011,16 @@ test.describe.serial( 'Orders API tests', () => {
 		};
 
 		const createSampleProductReviews = async ( simpleProducts ) => {
-			const cap = simpleProducts.find( ( p ) => p.name === 'Cap oxo' );
+			const cap = simpleProducts.find(
+				( p ) => p.name === `Cap ${ RAND_STRING }`
+			);
 
 			const shirt = simpleProducts.find(
-				( p ) => p.name === 'T-Shirt oxo'
+				( p ) => p.name === `T-Shirt ${ RAND_STRING }`
 			);
 
 			const sunglasses = simpleProducts.find(
-				( p ) => p.name === 'Sunglasses oxo'
+				( p ) => p.name === `Sunglasses ${ RAND_STRING }`
 			);
 
 			const review1 = await request.post(
@@ -2100,13 +2101,13 @@ test.describe.serial( 'Orders API tests', () => {
 
 		const createSampleProductOrders = async ( simpleProducts ) => {
 			const single = simpleProducts.find(
-				( p ) => p.name === 'Single oxo'
+				( p ) => p.name === `Single ${ RAND_STRING }`
 			);
 			const beanie = simpleProducts.find(
-				( p ) => p.name === 'Beanie with Logo oxo'
+				( p ) => p.name === `Beanie with Logo ${ RAND_STRING }`
 			);
 			const shirt = simpleProducts.find(
-				( p ) => p.name === 'T-Shirt oxo'
+				( p ) => p.name === `T-Shirt ${ RAND_STRING }`
 			);
 
 			const order1 = await request.post( './wp-json/wc/v3/orders', {
@@ -2195,13 +2196,13 @@ test.describe.serial( 'Orders API tests', () => {
 			const testProductData = await productsTestSetupCreateSampleData();
 			const orderedProducts = {
 				pocketHoodie: testProductData.simpleProducts.find(
-					( p ) => p.name === 'Hoodie with Pocket oxo'
+					( p ) => p.name === `Hoodie with Pocket ${ RAND_STRING }`
 				),
 				sunglasses: testProductData.simpleProducts.find(
-					( p ) => p.name === 'Sunglasses oxo'
+					( p ) => p.name === `Sunglasses ${ RAND_STRING }`
 				),
 				beanie: testProductData.simpleProducts.find(
-					( p ) => p.name === 'Beanie oxo'
+					( p ) => p.name === `Beanie ${ RAND_STRING }`
 				),
 				blueVneck:
 					testProductData.variableProducts.vneckVariations.find(
@@ -2729,7 +2730,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const page1 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
 					per_page: pageSize,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const page1JSON = await page1.json();
@@ -2738,7 +2739,7 @@ test.describe.serial( 'Orders API tests', () => {
 				params: {
 					per_page: pageSize,
 					page: 2,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const page2JSON = await page2.json();
@@ -2773,7 +2774,7 @@ test.describe.serial( 'Orders API tests', () => {
 					per_page: pageSize,
 					page: 2,
 					offset: pageSize + 1,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const page2OffsetJSON = await page2Offset.json();
@@ -2793,7 +2794,7 @@ test.describe.serial( 'Orders API tests', () => {
 				params: {
 					per_page: pageSize,
 					page: 3,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const lastPageJSON = await lastPage.json();
@@ -2805,7 +2806,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const page6 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
 					page: 6,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const page6JSON = await page6.json();
@@ -2818,7 +2819,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const allOrders = await request.get( './wp-json/wc/v3/orders', {
 				params: {
 					per_page: 10,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const allOrdersJSON = await allOrders.json();
@@ -2912,7 +2913,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const result1 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
 					status: 'completed',
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const result1JSON = await result1.json();
@@ -2925,15 +2926,15 @@ test.describe.serial( 'Orders API tests', () => {
 						status: 'completed',
 						line_items: expect.arrayContaining( [
 							expect.objectContaining( {
-								name: 'Single oxo',
+								name: `Single ${ RAND_STRING }`,
 								quantity: 2,
 							} ),
 							expect.objectContaining( {
-								name: 'Beanie with Logo oxo',
+								name: `Beanie with Logo ${ RAND_STRING }`,
 								quantity: 3,
 							} ),
 							expect.objectContaining( {
-								name: 'T-Shirt oxo',
+								name: `T-Shirt ${ RAND_STRING }`,
 								quantity: 1,
 							} ),
 						] ),
@@ -2943,7 +2944,7 @@ test.describe.serial( 'Orders API tests', () => {
 						customer_id: sampleData.customers.tinaJSON.id,
 						line_items: expect.arrayContaining( [
 							expect.objectContaining( {
-								name: 'Sunglasses oxo',
+								name: `Sunglasses ${ RAND_STRING }`,
 								quantity: 1,
 							} ),
 						] ),
@@ -2954,7 +2955,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const result2 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
 					status: 'processing',
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const result2JSON = await result2.json();
@@ -2992,7 +2993,7 @@ test.describe.serial( 'Orders API tests', () => {
 			const result2 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
 					customer: 0,
-					search: 'oxo',
+					search: RAND_STRING,
 				},
 			} );
 			const result2JSON = await result2.json();
@@ -3010,7 +3011,7 @@ test.describe.serial( 'Orders API tests', () => {
 
 		test( 'product', async ( { request } ) => {
 			const beanie = sampleData.testProductData.simpleProducts.find(
-				( p ) => p.name === 'Beanie oxo'
+				( p ) => p.name === `Beanie ${ RAND_STRING }`
 			);
 			const result1 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
@@ -3026,7 +3027,7 @@ test.describe.serial( 'Orders API tests', () => {
 					expect.objectContaining( {
 						line_items: expect.arrayContaining( [
 							expect.objectContaining( {
-								name: 'Beanie oxo',
+								name: `Beanie ${ RAND_STRING }`,
 							} ),
 						] ),
 					} )
@@ -3180,7 +3181,7 @@ test.describe.serial( 'Orders API tests', () => {
 			// Test order item name.
 			const result5 = await request.get( './wp-json/wc/v3/orders', {
 				params: {
-					search: 'Pennant oxo',
+					search: `Pennant ${ RAND_STRING }`,
 				},
 			} );
 			const result5JSON = await result5.json();
@@ -3192,7 +3193,7 @@ test.describe.serial( 'Orders API tests', () => {
 					expect.objectContaining( {
 						line_items: expect.arrayContaining( [
 							expect.objectContaining( {
-								name: 'WordPress Pennant oxo',
+								name: `WordPress Pennant ${ RAND_STRING }`,
 							} ),
 						] ),
 					} )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #54662.

This PR addresses the following reasons why it's been failing in WPCOM and Pressable:
- Hard-coded, non-unique values of products, categories, etc. Addressed by suffixing them with a short random string.
- Brittle or very strict assertions. Addressed by making them more stable and relaxed.
- incomplete cleanup steps, leaving coupons undeleted and affecting the succeeding runs. In trunk, the afterAll hook doesn't have a step to delete the created coupon. I added that step here in this PR.
- The test still runs even when the beforeAll got errors. The fact that this test is lengthy and slow, it would be good to fail it as early as possible in such cases. Addressed this by adding `failOnStatusCode` on a lot of the api calls in beforeAll and afterAll for easier debugging and fast-failing.

These optimizations were also done:
- Used batch endpoints when creating and deleting test data. It should greatly reduce the duration of beforeAll and afterAll. In beforeAll for example, 10 `POST` calls were reduced to just 4 batch calls.
- Originally, the test creates a tax class, but upon analyzing the test, it seems it wasn't relevant at all. The only reason the tax class was created was just for the sake of 1 test product to have a tax class. Tax calculations are already handled in `order-complex.test.js` anyway. So I removed the parts of the code in this test that's related to taxes.

I created task https://github.com/woocommerce/woocommerce/issues/55432 to optimize this test further in the future.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On WPCOM and Pressable, manually clean up the test data using WC Cleanup plugin. You might need to manually delete the items mentioned [here](https://github.com/woocommerce/woocommerce/issues/55434) since WC Cleanup doesn't seem to clear them automatically.
2. Run on WPCOM and Pressable and make sure it passes in both envs.
```bash
export E2E_ENV_KEY="..."
pnpm test:e2e:wpcom orders.test.js
pnpm test:e2e:pressable orders.test.js
```
3. Run each test at least twice per environment to ensure repeatability, and that succeeding runs aren't affected by previous ones.
4. After the test run, inspect the environment for any leftover test data. There shouldn't be any:
    - products,
    - categories and sub-categories
    - orders,
    - coupons,
    - global attributes (Products > Attributes)
    - tags
    - reviews

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Unskip orders.test.js on WPCOM and Pressable.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
