### PR TITLE
Migrate to register(storeDescriptor) for notes data store

### DIFF
--- a/packages/js/data/changelog/55440-fix-migrate-notes-store
+++ b/packages/js/data/changelog/55440-fix-migrate-notes-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrated notes data store to use register(storeDescriptor) pattern

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -50,7 +50,7 @@ export { ShippingMethod } from './shipping-methods/types';
 
 // Export stores
 export { store as onboardingStore } from './onboarding';
-
+export { store as notesStore } from './notes';
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';
 export { withOnboardingHydration } from './onboarding/with-onboarding-hydration';

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -53,6 +53,7 @@ export { store as onboardingStore } from './onboarding';
 export { store as notesStore } from './notes';
 export { store as reviewsStore } from './reviews';
 
+// Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';
 export { withOnboardingHydration } from './onboarding/with-onboarding-hydration';
 export { withCurrentUserHydration } from './user/with-current-user-hydration';

--- a/packages/js/data/src/notes/index.ts
+++ b/packages/js/data/src/notes/index.ts
@@ -1,26 +1,23 @@
 /**
  * External dependencies
  */
-import { registerStore } from '@wordpress/data';
-import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+import { createReduxStore, register } from '@wordpress/data';
 import { Reducer, AnyAction } from 'redux';
 import { controls } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
  */
-import { WPDataActions, WPDataSelectors } from '../types';
 import { STORE_NAME } from './constants';
 import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
-import { PromiseifySelectors } from '../types/promiseify-selectors';
 
 export * from './types';
 export type { State };
 
-registerStore( STORE_NAME, {
+export const store = createReduxStore( STORE_NAME, {
 	reducer: reducer as Reducer< State, AnyAction >,
 	actions,
 	controls,
@@ -28,16 +25,6 @@ registerStore( STORE_NAME, {
 	resolvers,
 } );
 
-export const NOTES_STORE_NAME = STORE_NAME;
+register( store );
 
-declare module '@wordpress/data' {
-	function dispatch(
-		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions & WPDataActions >;
-	function select(
-		key: typeof STORE_NAME
-	): SelectFromMap< typeof selectors > & WPDataSelectors;
-	function resolveSelect(
-		key: typeof STORE_NAME
-	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
-}
+export const NOTES_STORE_NAME = STORE_NAME;

--- a/packages/js/product-editor/changelog/55440-fix-migrate-notes-store
+++ b/packages/js/product-editor/changelog/55440-fix-migrate-notes-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrated notes data store to use register(storeDescriptor) pattern

--- a/packages/js/product-editor/changelog/55440-fix-migrate-notes-store
+++ b/packages/js/product-editor/changelog/55440-fix-migrate-notes-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrated notes data store to use register(storeDescriptor) pattern

--- a/plugins/woocommerce/changelog/55440-fix-migrate-notes-store
+++ b/plugins/woocommerce/changelog/55440-fix-migrate-notes-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrated notes data store to use register(storeDescriptor) pattern

--- a/plugins/woocommerce/client/admin/client/activity-panel/unread-indicators.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/unread-indicators.js
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	NOTES_STORE_NAME,
-	USER_STORE_NAME,
-	QUERY_DEFAULTS,
-} from '@woocommerce/data';
+import { notesStore, USER_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -23,7 +19,7 @@ const UNREAD_NOTES_QUERY = {
 };
 
 export function hasUnreadNotes( select ) {
-	const { getNotes, getNotesError, isResolving } = select( NOTES_STORE_NAME );
+	const { getNotes, getNotesError, isResolving } = select( notesStore );
 
 	const { getCurrentUser } = select( USER_STORE_NAME );
 	const userData = getCurrentUser();

--- a/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/index.js
+++ b/plugins/woocommerce/client/admin/client/analytics/settings/historical-data/index.js
@@ -6,7 +6,7 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
 	IMPORT_STORE_NAME,
-	NOTES_STORE_NAME,
+	notesStore,
 	QUERY_DEFAULTS,
 	SECOND,
 } from '@woocommerce/data';
@@ -140,7 +140,7 @@ class HistoricalData extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getNotes } = select( NOTES_STORE_NAME );
+		const { getNotes } = select( notesStore );
 		const { getImportStarted, getFormSettings } =
 			select( IMPORT_STORE_NAME );
 
@@ -164,7 +164,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { updateNote } = dispatch( NOTES_STORE_NAME );
+		const { updateNote } = dispatch( notesStore );
 		const { invalidateResolution, setImportStarted } =
 			dispatch( IMPORT_STORE_NAME );
 

--- a/plugins/woocommerce/client/admin/client/homescreen/layout.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/layout.js
@@ -14,7 +14,7 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import {
 	useUserPreferences,
-	NOTES_STORE_NAME,
+	notesStore,
 	onboardingStore,
 	OPTIONS_STORE_NAME,
 } from '@woocommerce/data';
@@ -192,7 +192,7 @@ Layout.propTypes = {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { isNotesRequesting } = select( NOTES_STORE_NAME );
+		const { isNotesRequesting } = select( notesStore );
 		const { getOption } = select( OPTIONS_STORE_NAME );
 		const defaultHomescreenLayout =
 			getOption( 'woocommerce_default_homepage_layout' ) ||

--- a/plugins/woocommerce/client/admin/client/inbox-panel/dismiss-all-modal.js
+++ b/plugins/woocommerce/client/admin/client/inbox-panel/dismiss-all-modal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NOTES_STORE_NAME } from '@woocommerce/data';
+import { notesStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
@@ -10,8 +10,7 @@ import { __ } from '@wordpress/i18n';
 const DismissAllModal = ( { onClose } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 
-	const { batchUpdateNotes, removeAllNotes } =
-		useDispatch( NOTES_STORE_NAME );
+	const { batchUpdateNotes, removeAllNotes } = useDispatch( notesStore );
 
 	const dismissAllNotes = async () => {
 		recordEvent( 'wcadmin_inbox_action_dismissall', {} );

--- a/plugins/woocommerce/client/admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce/client/admin/client/inbox-panel/index.js
@@ -10,7 +10,7 @@ import {
 	EllipsisMenu,
 } from '@woocommerce/components';
 import { Card, CardHeader, Button, CardFooter } from '@wordpress/components';
-import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
+import { notesStore, QUERY_DEFAULTS } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -214,7 +214,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 		updateNote,
 		triggerNoteAction,
 		invalidateResolutionForStoreSelector,
-	} = useDispatch( NOTES_STORE_NAME );
+	} = useDispatch( notesStore );
 	const screen = getScreenName();
 
 	const inboxQuery = useMemo( () => {
@@ -236,7 +236,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 			getNotesError,
 			isNotesRequesting,
 			hasFinishedResolution,
-		} = select( NOTES_STORE_NAME );
+		} = select( notesStore );
 
 		return {
 			notes: getNotes( inboxQuery ),

--- a/plugins/woocommerce/client/admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce/client/admin/client/layout/store-alerts/index.js
@@ -17,7 +17,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import moment from 'moment';
 import { Icon, chevronLeft, chevronRight, close } from '@wordpress/icons';
 import {
-	NOTES_STORE_NAME,
+	notesStore,
 	QUERY_DEFAULTS,
 	OPTIONS_STORE_NAME,
 	useUserPreferences,
@@ -63,7 +63,7 @@ export const StoreAlerts = () => {
 		isLoading,
 		defaultHomescreenLayout,
 	} = useSelect( ( select ) => {
-		const { getNotes, hasFinishedResolution } = select( NOTES_STORE_NAME );
+		const { getNotes, hasFinishedResolution } = select( notesStore );
 		const { getOption } = select( OPTIONS_STORE_NAME );
 
 		return {
@@ -76,7 +76,7 @@ export const StoreAlerts = () => {
 	} );
 
 	const { triggerNoteAction, updateNote, removeNote } =
-		useDispatch( NOTES_STORE_NAME );
+		useDispatch( notesStore );
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	const userPrefs = useUserPreferences();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55378 

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the **notes** store registration pattern in `@woocommerce/data` to use the modern WordPress data store API. 

Key changes include:

1. Migrated from deprecated `registerStore` to `createReduxStore` and `register` pattern
2. Updated store exports to match the modern pattern used across other stores:
    - Added `export { store as notesStore }`
    - Maintained `NOTES_STORE_NAME` export for backward compatibility
3. Removed deprecated type definitions:
    - Removed custom @wordpress/data module declaration
4. Update notes store import to use `notesStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the notes store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/notes/**`
4.`window.wp.data.select( wc.data.notesStore )` and `window.wp.data.dispatch( wc.data.notesStore )` should return selectors and dispatchers
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Migrated notes data store to use register(storeDescriptor) pattern

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
