### PR TITLE
Migrate to register(storeDescriptor) for shipping methods data store

### DIFF
--- a/packages/js/data/changelog/55443-fix-migrate-shipping-methods-store
+++ b/packages/js/data/changelog/55443-fix-migrate-shipping-methods-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated shipping methods store import to use the storeDescriptor instead of STORE_NAME_STRING

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -52,6 +52,7 @@ export { ShippingMethod } from './shipping-methods/types';
 export { store as onboardingStore } from './onboarding';
 export { store as notesStore } from './notes';
 export { store as reviewsStore } from './reviews';
+export { store as shippingMethodsStore } from './shipping-methods';
 
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';

--- a/packages/js/product-editor/changelog/55443-fix-migrate-shipping-methods-store
+++ b/packages/js/product-editor/changelog/55443-fix-migrate-shipping-methods-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated shipping methods store import to use the storeDescriptor instead of STORE_NAME_STRING

--- a/packages/js/product-editor/changelog/55443-fix-migrate-shipping-methods-store
+++ b/packages/js/product-editor/changelog/55443-fix-migrate-shipping-methods-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Updated shipping methods store import to use the storeDescriptor instead of STORE_NAME_STRING

--- a/plugins/woocommerce/changelog/55443-fix-migrate-shipping-methods-store
+++ b/plugins/woocommerce/changelog/55443-fix-migrate-shipping-methods-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated shipping methods store import to use the storeDescriptor instead of STORE_NAME_STRING

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/shipping/index.js
@@ -17,7 +17,7 @@ import {
 	onboardingStore,
 	PLUGINS_STORE_NAME,
 	COUNTRIES_STORE_NAME,
-	SHIPPING_METHODS_STORE_NAME,
+	shippingMethodsStore,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { registerPlugin } from '@wordpress/plugins';
@@ -670,9 +670,8 @@ const ShippingWrapper = compose(
 			settings.woocommerce_default_country
 		);
 
-		const shippingPartners = select(
-			SHIPPING_METHODS_STORE_NAME
-		).getShippingMethods();
+		const shippingPartners =
+			select( shippingMethodsStore ).getShippingMethods();
 
 		const country = countryCode ? getCountry( countryCode ) : null;
 		const countryName = country ? country.name : null;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55384

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the **shipping-methods** store registration pattern in `@woocommerce/data` to use the modern WordPress data store API. 

Key changes include:

1. Update shipping methods store import to use `shippingMethodsStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the plugins store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/shipping-methods/**`
4.`window.wp.data.select( wc.data.shippingMethodsStore )` and `window.wp.data.dispatch( wc.data.shippingMethodsStore )` should return selectors and dispatchers

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Updated shipping methods store import to use the storeDescriptor instead of STORE_NAME_STRING

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
