### PR TITLE
[NOX] Add more payment options click Tracks event

### DIFF
--- a/plugins/woocommerce/changelog/dev-more-implement-existing-tracks-events
+++ b/plugins/woocommerce/changelog/dev-more-implement-existing-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add missing legacy Tracks event for the Payments Settings page.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -15,11 +15,8 @@ import { useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { getAdminSetting } from '~/utils/admin-settings';
 import { GridItemPlaceholder } from '~/settings-payments/components/grid-item-placeholder';
 import { OfficialBadge } from '../official-badge';
-
-const assetUrl = getAdminSetting( 'wcAdminAssetUrl' );
 
 interface OtherPaymentGatewaysProps {
 	/**
@@ -46,6 +43,10 @@ interface OtherPaymentGatewaysProps {
 	 * Indicates whether the suggestions are still being fetched.
 	 */
 	isFetching: boolean;
+	/**
+	 * A link to view more payment options in the WooCommerce marketplace.
+	 */
+	morePaymentOptionsLink: JSX.Element;
 }
 
 /**
@@ -59,6 +60,7 @@ export const OtherPaymentGateways = ( {
 	installingPlugin,
 	setupPlugin,
 	isFetching,
+	morePaymentOptionsLink,
 }: OtherPaymentGatewaysProps ) => {
 	const urlParams = new URLSearchParams( window.location.search );
 
@@ -284,19 +286,9 @@ export const OtherPaymentGateways = ( {
 		categoryIdWithPopoverVisible,
 	] );
 
-	const morePaymentOptionsLink = (
-		<Button
-			variant={ 'link' }
-			target="_blank"
-			href="https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/"
-			className="more-payment-options-link"
-		>
-			<img src={ assetUrl + '/icons/external-link.svg' } alt="" />
-			{ __( 'More payment options', 'woocommerce' ) }
-		</Button>
-	);
 
-	// If no suggestions are available, return only a link to the WooCommerce.com payment marketplace page.
+
+
 	if ( ! isFetching && suggestions.length === 0 ) {
 		return (
 			<div className="more-payment-options">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We fire the current `wcadmin_settings_payments_recommendations_other_options` Tracks event when users click on the More payment options link in the NOX.

Related to https://github.com/woocommerce/woocommerce/issues/54672

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this PR on your local WC install
2. From the `plugins/woocommerce` directory build the admin assets by running `pnpm build:admin`
3. Make sure the `reactify-classic-payments-settings` feature flag is enabled
4. Install and activate the [Payment Plugins for Stripe WooCommerce](https://wordpress.org/plugins/woo-stripe-payment/) plugin
5. Make sure you have the Tracks Vigilante Chrome extension installed and enabled (Pe4Hk0-3f-p2)
6. Open the Tracks Vigilante standalone popup
7. Go to WooCommerce > Settings > Payments
8. Select "United States" from the top-right business location select
9. Install a couple of payment extension suggestions
10. Go to the "Other payment options" section at the bottom of the page and click on the "More payment options" link
![Screenshot 2025-02-13 at 17 28 45](https://github.com/user-attachments/assets/7e33c0d1-46d0-4dd5-8f5d-ad0a61122482)
11. Notice in the Tracks Vigilante popup that you have a `wcadmin_settings_payments_recommendations_other_options` Tracks event with the proper list in the `available_payment_methods` property (those are plugin slugs)
![Screenshot 2025-02-13 at 17 20 25](https://github.com/user-attachments/assets/079f5f7f-2a54-42da-ad38-97113fbf1227)
12. Select "Ukraine" from the business location select and you should not have a "Other payment options" section, only the the "More payment options" link.
![Screenshot 2025-02-13 at 17 29 10](https://github.com/user-attachments/assets/5117feb0-81b4-480f-821f-8178f874c3a8)
13. Click on it and you should again see a `wcadmin_settings_payments_recommendations_other_options` Tracks event with the proper list in the `available_payment_methods` property.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>