### PR TITLE
Add Cursor AI Assistant Rules Configuration

### DIFF
--- a/.cursor/rules/git.mdc
+++ b/.cursor/rules/git.mdc
@@ -1,0 +1,28 @@
+---
+description: Rules for various git actions that happen with this project. 
+globs: 
+---
+
+# Creating Branches
+
+Branch names should go by the following structure (anything in "{}" brackets is a placeholder). "{short-slug}" should be replaced with a short name that best describes the changes - do ask for confirmation if needed.
+- `release/{version}` for release branches.
+- `refactor/{short-slug}` for refactors.
+- `test/{short-slug}` for changes that are only test updates or additions.
+- `fix/{short-slug}` for changes that fix a bug. Prompt the user for the issue number the fix is for and include that in the branch name.
+- `add/{short-slug}` for changes that are adding a new feature.
+
+# Commits
+
+Make sure each commit addresses an atomic unit of work that independently works.
+
+Make sure the commit message has a subject line which includes a brief description of the change and (if needed), why it was necessary. Write the subject in the imperative, start with a verb, and do not end with a period. The subject line should be no longer than 50 characters.
+
+There must be an empty line between the subject line and the rest of the commit message (if any). The commit body should be no longer than 72 characters.
+
+The commit message should explain what caused the problem and what its consequences are (if helpful for understanding the changes).
+
+The commit message should explain how the changes achieve the goal, but only if it isn't obvious.
+
+
+

--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -9,6 +9,7 @@ on:
             - 'tools/**'
             - '**/changelog/**'
             - 'changelog.txt'
+            - '.gitignore'
             - '**/tests/**'
             - '**/*.md'
             - '.husky/**'

--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -12,6 +12,7 @@ on:
             - '**/tests/**'
             - '**/*.md'
             - '.husky/**'
+            - '.cursor/**'
             - '.github/**'
             - '!.github/workflows/build-live-branch.yml'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - '**/changelog/**'
       - '.cursor/**'
       - '**/*.md'
+      - '.gitignore'
     branches:
       - 'trunk'
       - 'release/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(**/changelog/*)|(.cursor/**/*))'
+              - '!((**/*.md)|(**/*.mdc)|(**/changelog/*))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!(changelog/**)/**'
             needs-markdown-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(**/changelog/*)|(.cursor/**))'
+              - '!((**/*.md)|(**/changelog/*)|(.cursor/**)|(.gitignore))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!(changelog/**)/**'
             needs-markdown-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - '**/changelog/**'
       - '.cursor/**'
       - '**/*.md'
+      - 'changelog.txt'
       - '.gitignore'
     branches:
       - 'trunk'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/changelog/**'
+      - '.cursor/**'
       - '**/*.md'
     branches:
       - 'trunk'
@@ -43,7 +44,7 @@ jobs:
         with:
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(**/changelog/*)|(.cursor/**))'
+              - '!((**/*.md)|(**/changelog/*)|(.cursor/**/*))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!(changelog/**)/**'
             needs-markdown-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(**/*.mdc)|(**/changelog/*))'
+              - '!((**/*.md)|(**/changelog/*)|(.cursor/**))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!(changelog/**)/**'
             needs-markdown-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(**/changelog/*)|(**/.cursor/**))'
+              - '!((**/*.md)|(**/changelog/*)|(.cursor/**))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!(changelog/**)/**'
             needs-markdown-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           filters: |
             needs-code-validation:
-              - '!((**/*.md)|(**/changelog/*))'
+              - '!((**/*.md)|(**/changelog/*)|(**/.cursor/**))'
             needs-changelog-validation:
               - '{packages,plugins}/*/!(changelog/**)/**'
             needs-markdown-validation:

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -16,6 +16,7 @@ on:
             - '**/tests/**'
             - '**/*.md'
             - '.husky/**'
+            - '.cursor/**'
             - '.github/**'
             - '!.github/workflows/pr-build-live-branch.yml'
 

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -13,6 +13,7 @@ on:
             - 'tools/**'
             - '**/changelog/**'
             - 'changelog.txt'
+            - '.gitignore'
             - '**/tests/**'
             - '**/*.md'
             - '.husky/**'

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ changes.json
 /artifacts
 /plugins/*/artifacts
 /tools/*/artifacts
+
+# Cursor related files
+.cursorignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces Cursor AI assistant rules to enhance development workflow and maintain consistency for its usage across the WooCommerce codebase. 

Why Add Cursor Rules?
- **Consistent Development Practices**: By codifying our development guidelines into Cursor rules, we ensure that AI-assisted development follows our established best practices.
- **Improved Collaboration**: New contributors using Cursor will automatically receive guidance for various nuances of developing in the WooCommerce monorepo which in turn will improve the AI assisted development has more accurate initial output.
- **Scalable Documentation**: These rules serve as living documentation that's immediately accessible to developers in their IDE, making it easier to maintain and follow our conventions.

Initial Implementation:
- Added configuration for git-related practices, including:
  - Branch naming conventions for different types of changes (feature, fix, refactor, etc.)
  - Commit message formatting guidelines
  - Best practices for atomic commits
- Added `.cursorignore` to `.gitignore` to maintain clean git status

Future Potential:
This initial setup creates a foundation for adding more rules that could cover:
- Coding standards and style guides
- Testing requirements
- Documentation conventions
- Common architectural patterns
- Security best practices

The rules are stored in `.cursor/rules/` and can be iteratively expanded as we identify more areas where automated guidance would be valuable.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This has no user impact and is best tested in future development flows (however I did use this to create the branch and the commits for this PR. I plan on iterating on this after the initial merge but rules can also be iterated on and improved over time as we learn what is most effective for the AI assitance.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a developer workflow related update that has no relevance to consumers of the repository unless they are using Cursor. I don't think this needs to be included in a changelog.

</details>
