### PR TITLE
Improve secondary color explanatory text and use hardcoded colors

### DIFF
--- a/plugins/woocommerce/changelog/fix-secondary-color-comments
+++ b/plugins/woocommerce/changelog/fix-secondary-color-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve secondary color explanatory text and use hardcoded colors

--- a/plugins/woocommerce/client/legacy/css/_variables.scss
+++ b/plugins/woocommerce/client/legacy/css/_variables.scss
@@ -8,16 +8,18 @@ $red:           	#a00 !default;
 $orange:        	#ffba00 !default;
 $blue:          	#2ea2cc !default;
 
-$primary:           #720eec !default;                                    // Primary color for buttons (alt)
-$primarytext:       desaturate(lighten($primary, 50%), 18%) !default;    // Text on primary color bg
+$primary:           #720eec !default;                                  // Primary color for buttons (alt)
+$primarytext:       desaturate(lighten($primary, 50%), 18%) !default;    // Text on primary color background.
 
-// We use the old WooCommerce color as the base of the secondary color on purpose.
+// In the past, the secondary color was derived from the WooCommerce purple (the primary color).
+// However, since it was used in many places in the frontend, we decided not to modify it
+// after the WooCommerce rebranding.
 // See: https://github.com/woocommerce/woocommerce/issues/55165.
-$secondary:         desaturate(lighten(#7F54B3, 40%), 21%) !default;    // Secondary buttons
-$secondarytext:     desaturate(darken($secondary, 60%), 21%) !default;   // Text on secondary color bg
+$secondary:         #e9e6ed !default;                                  // Secondary color for buttons, backgrounds, etc.
+$secondarytext:     #515151 !default;                                  // Text on secondary color background.
 
 $highlight:         adjust-hue(darken($primary, 18%), 150deg) !default;  // Prices, In stock labels, sales flash
-$highlightext:      desaturate(lighten($highlight, 80%), 18%) !default;  // Text on highlight color bg
+$highlightext:      desaturate(lighten($highlight, 80%), 18%) !default;  // Text on highlight color background.
 
 $contentbg:         #fff !default;                                     // Content BG - Tabs (active state)
 $subtext:           #767676 !default;                                  // small, breadcrumbs etc


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the comment in https://github.com/woocommerce/woocommerce/pull/55366#discussion_r1952475542.

This PR makes two changes:

1. Updates the secondary color from being a calculation based on the primary color to being hardcoded. Making it clear it's now unrelated to the WooCommerce purple.
2. Updates the comment accordingly to make it clearer.

### How to test the changes in this Pull Request:

1. Install a theme that uses WooCommerce colors in visible parts of the UI, for example, [GeneratePress](https://wordpress.org/themes/generatepress/).
2. Go to the Shop page, Cart page and Checkout page (when using the shortcodes) and verify the colors look like in `cherry-pick/54802`, so backgrounds are not purple-ish.

Not expected | Expected
--- | ---
![imatge](https://github.com/user-attachments/assets/61ea9237-9d1e-4cec-88a6-6c5edf2a994c) | ![imatge](https://github.com/user-attachments/assets/4c8b57e5-c5ab-4c03-93c0-576e4f97aee2)

3. Check the CSS variables loaded in the page and verify the secondary color is `#e9e6ed` and the secondary text color is `#515151`.

Not expected | Expected
--- | ---
![imatge](https://github.com/user-attachments/assets/c323ab89-7a02-49ee-aefa-3e1e5f5f13ac) | ![imatge](https://github.com/user-attachments/assets/79b160f2-e083-4ed9-bc70-3db7e408eb58)