### PR TITLE
Migrate to register(storeDescriptor) for options store

### DIFF
--- a/packages/js/customer-effort-score/changelog/fix-migrate-option-store
+++ b/packages/js/customer-effort-score/changelog/fix-migrate-option-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update import of OPTIONS_STORE_NAME to optionsStore

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { createElement } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -23,8 +23,7 @@ export const CustomerEffortScoreModalContainer: React.FC = () => {
 		resolving: isLoading,
 		visibleCESModalData,
 	} = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 		const { getVisibleCESModalData } = select( STORE_KEY );
 
 		const adminInstallTimestamp =

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-tracks-container/index.js
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-tracks-container/index.js
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { createElement, Fragment } from '@wordpress/element';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -79,7 +79,7 @@ export const CustomerEffortScoreTracksContainer = compose(
 		return { queue, resolving };
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+		const { updateOptions } = dispatch( optionsStore );
 
 		return {
 			clearQueue: () => {

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-tracks/index.js
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-tracks/index.js
@@ -4,7 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { createElement, useState } from '@wordpress/element';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import apiFetch from '@wordpress/api-fetch';
@@ -184,8 +184,7 @@ function _CustomerEffortScoreTracks( {
  */
 export const CustomerEffortScoreTracks = compose(
 	withSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const cesShownForActions = getOption( SHOWN_FOR_ACTIONS_OPTION_NAME );
 

--- a/packages/js/customer-effort-score/src/hooks/use-customer-effort-score-modal/index.ts
+++ b/packages/js/customer-effort-score/src/hooks/use-customer-effort-score-modal/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -13,11 +13,10 @@ import { STORE_KEY } from '../../store';
 export const useCustomerEffortScoreModal = () => {
 	const { showCesModal: _showCesModal, showProductMVPFeedbackModal } =
 		useDispatch( STORE_KEY );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const { wasPreviouslyShown, isLoading } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const shownForActionsOption =
 			( getOption( SHOWN_FOR_ACTIONS_OPTION_NAME ) as string[] ) || [];
@@ -35,7 +34,7 @@ export const useCustomerEffortScoreModal = () => {
 	} );
 
 	const markCesAsShown = async ( action: string ) => {
-		const { getOption } = resolveSelect( OPTIONS_STORE_NAME );
+		const { getOption } = resolveSelect( optionsStore );
 
 		const shownForActionsOption =
 			( ( await getOption(

--- a/packages/js/customer-effort-score/src/utils/customer-effort-score-exit-page.ts
+++ b/packages/js/customer-effort-score/src/utils/customer-effort-score-exit-page.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { dispatch, resolveSelect } from '@wordpress/data';
 import { getQuery } from '@woocommerce/navigation';
 
@@ -42,7 +42,7 @@ export const getExitPageData = () => {
  * @return boolean
  */
 const isTrackingAllowed = async () => {
-	const trackingOption = await resolveSelect( OPTIONS_STORE_NAME ).getOption(
+	const trackingOption = await resolveSelect( optionsStore ).getOption(
 		ALLOW_TRACKING_OPTION_NAME
 	);
 

--- a/packages/js/customer-effort-score/src/utils/test/customer-effort-score-exit-page.test.ts
+++ b/packages/js/customer-effort-score/src/utils/test/customer-effort-score-exit-page.test.ts
@@ -9,7 +9,7 @@ import { dispatch } from '@wordpress/data';
 import { triggerExitPageCesSurvey } from '../customer-effort-score-exit-page';
 
 jest.mock( '@woocommerce/data', () => ( {
-	OPTIONS_STORE_NAME: 'options',
+	optionsStore: 'options',
 } ) );
 jest.mock( '@wordpress/data', () => ( {
 	...jest.requireActual( '@wordpress/data' ),

--- a/packages/js/data/changelog/fix-migrate-option-store
+++ b/packages/js/data/changelog/fix-migrate-option-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Migrate options data store to use createReduxStore and register

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -54,6 +54,7 @@ export { store as reviewsStore } from './reviews';
 export { store as shippingMethodsStore } from './shipping-methods';
 export { store as settingsStore } from './settings';
 export { store as pluginsStore } from './plugins';
+export { store as optionsStore } from './options';
 
 // Export hooks
 export { withSettingsHydration } from './settings/with-settings-hydration';

--- a/packages/js/data/src/options/controls.ts
+++ b/packages/js/data/src/options/controls.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { controls as dataControls } from '@wordpress/data-controls';
-import { Action } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -70,7 +69,7 @@ const debouncedFetch = async ( optionName: string ) => {
 
 export const controls = {
 	...dataControls,
-	async BATCH_FETCH( { optionName }: Action ) {
+	async BATCH_FETCH( { optionName }: { optionName: string } ) {
 		optionNames.push( optionName );
 
 		// Consolidate multiple fetches into a single fetch

--- a/packages/js/data/src/options/index.ts
+++ b/packages/js/data/src/options/index.ts
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { registerStore } from '@wordpress/data';
-import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
-import { Reducer, AnyAction } from 'redux';
+import { createReduxStore, register } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
@@ -13,29 +12,18 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { controls } from './controls';
-import { WPDataActions, WPDataSelectors } from '../types';
-import { PromiseifySelectors } from '../types/promiseify-selectors';
+
 export * from './types';
 export type { State };
 
-registerStore< State >( STORE_NAME, {
-	reducer: reducer as Reducer< State, AnyAction >,
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
 	actions,
 	controls,
 	selectors,
 	resolvers,
 } );
 
-export const OPTIONS_STORE_NAME = STORE_NAME;
+register( store );
 
-declare module '@wordpress/data' {
-	function dispatch(
-		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions & WPDataActions >;
-	function select(
-		key: typeof STORE_NAME
-	): SelectFromMap< typeof selectors > & WPDataSelectors;
-	function resolveSelect(
-		key: typeof STORE_NAME
-	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
-}
+export const OPTIONS_STORE_NAME = STORE_NAME;

--- a/packages/js/data/src/options/with-options-hydration.tsx
+++ b/packages/js/data/src/options/with-options-hydration.tsx
@@ -2,18 +2,19 @@
  * External dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useSelect, useDispatch, select as WPSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { createElement, useEffect } from '@wordpress/element';
+import type { ComponentType } from 'react';
 
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './constants';
+import { store } from './';
 import { Options } from './types';
 
 export const useOptionsHydration = ( data: Options ) => {
-	const shouldHydrate = useSelect( ( select: typeof WPSelect ) => {
-		const { isResolving, hasFinishedResolution } = select( STORE_NAME );
+	const shouldHydrate = useSelect( ( select ) => {
+		const { isResolving, hasFinishedResolution } = select( store );
 
 		if ( ! data ) {
 			return {};
@@ -30,7 +31,7 @@ export const useOptionsHydration = ( data: Options ) => {
 	}, [] );
 
 	const { startResolution, finishResolution, receiveOptions } =
-		useDispatch( STORE_NAME );
+		useDispatch( store );
 
 	useEffect( () => {
 		Object.entries( shouldHydrate ).forEach( ( [ name, hydrate ] ) => {
@@ -44,7 +45,10 @@ export const useOptionsHydration = ( data: Options ) => {
 };
 
 export const withOptionsHydration = ( data: Options ) =>
-	createHigherOrderComponent< Record< string, unknown > >(
+	createHigherOrderComponent<
+		ComponentType< Record< string, unknown > >,
+		ComponentType< Record< string, unknown > >
+	>(
 		( OriginalComponent ) => ( props ) => {
 			useOptionsHydration( data );
 

--- a/packages/js/data/tsconfig.json
+++ b/packages/js/data/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../tsconfig",
 	"compilerOptions": {
 		"rootDir": "src",
+		"noCheck": true,
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,

--- a/packages/js/data/tsconfig.json
+++ b/packages/js/data/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../tsconfig",
 	"compilerOptions": {
 		"rootDir": "src",
-		"noCheck": true,
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,

--- a/packages/js/product-editor/changelog/fix-migrate-option-store
+++ b/packages/js/product-editor/changelog/fix-migrate-option-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace OPTIONS_STORE_NAME with optionsStore

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import {
-	OPTIONS_STORE_NAME,
-	Product,
-	ProductDimensions,
-} from '@woocommerce/data';
+import { optionsStore, Product, ProductDimensions } from '@woocommerce/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import {
@@ -60,12 +56,10 @@ export function Edit( {
 	const [ highlightSide, setHighlightSide ] = useState< HighlightSides >();
 
 	const { dimensionUnit, weightUnit } = useSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			dimensionUnit: getOption( 'woocommerce_dimension_unit' ),
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			weightUnit: getOption( 'woocommerce_weight_unit' ),
+			dimensionUnit: getOption( 'woocommerce_dimension_unit' ) as string,
+			weightUnit: getOption( 'woocommerce_weight_unit' ) as string,
 		};
 	}, [] );
 

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/variable-product-tour.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/variable-product-tour.tsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { TourKit, TourKitTypes } from '@woocommerce/components';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	useUserPreferences,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -141,10 +141,9 @@ export const VariableProductTour: React.FC = () => {
 	}, [ totalCount ] );
 
 	const { hasShownProductEditorTour } = useSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 		return {
 			hasShownProductEditorTour:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				getOption( 'woocommerce_block_product_tour_shown' ) === 'yes',
 		};
 	}, [] );

--- a/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-stock-status-form/variation-stock-status-form.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { FormEvent } from 'react';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import {
@@ -55,12 +55,10 @@ export function VariationStockStatusForm( {
 
 	const { canManageStock, isLoadingManageStockOption } = useSelect(
 		( select ) => {
-			const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+			const { getOption, isResolving } = select( optionsStore );
 
 			return {
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				canManageStock: getOption( MANAGE_STOCK_OPTION ) === 'yes',
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				isLoadingManageStockOption: isResolving( 'getOption', [
 					MANAGE_STOCK_OPTION,
 				] ),

--- a/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
+++ b/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -10,18 +10,15 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME } from '../../constants';
 
 export const useFeedbackBar = () => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const { shouldShowFeedbackBar } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const showFeedbackBarOption = getOption(
 			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME
 		) as string;
 
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const resolving = ! hasFinishedResolution( 'getOption', [
 			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME,
 		] );
@@ -41,7 +38,7 @@ export const useFeedbackBar = () => {
 	};
 
 	const getOptions = async () => {
-		const { getOption } = resolveSelect( OPTIONS_STORE_NAME );
+		const { getOption } = resolveSelect( optionsStore );
 
 		const showFeedbackBarOption = ( await getOption(
 			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME

--- a/packages/js/product-editor/src/hooks/use-notice/use-notice.ts
+++ b/packages/js/product-editor/src/hooks/use-notice/use-notice.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -10,17 +10,14 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { SINGLE_VARIATION_NOTICE_DISMISSED_OPTION } from '../../constants';
 
 export function useNotice() {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const { dismissedNotices, isResolving } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const dismissedNoticesOption = getOption(
 			SINGLE_VARIATION_NOTICE_DISMISSED_OPTION
 		) as [ number ];
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const resolving = ! hasFinishedResolution( 'getOption', [
 			SINGLE_VARIATION_NOTICE_DISMISSED_OPTION,
 		] );
@@ -31,7 +28,7 @@ export function useNotice() {
 	}, [] );
 
 	const getOptions = async () => {
-		const { getOption } = resolveSelect( OPTIONS_STORE_NAME );
+		const { getOption } = resolveSelect( optionsStore );
 
 		const dismissedNoticesOption = ( await getOption(
 			SINGLE_VARIATION_NOTICE_DISMISSED_OPTION

--- a/packages/js/product-editor/src/hooks/use-show-prepublish-checks.ts
+++ b/packages/js/product-editor/src/hooks/use-show-prepublish-checks.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -10,17 +10,14 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME } from '../constants';
 
 export function useShowPrepublishChecks() {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const { isResolving, showPrepublishChecks } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const showPrepublishChecksOption =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			getOption( SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME ) || 'yes';
 
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const resolving = ! hasFinishedResolution( 'getOption', [
 			SHOW_PREPUBLISH_CHECKS_ENABLED_OPTION_NAME,
 		] );

--- a/plugins/woocommerce-beta-tester/changelog/fix-migrate-option-store
+++ b/plugins/woocommerce-beta-tester/changelog/fix-migrate-option-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update import of OPTIONS_STORE_NAME to optionsStore

--- a/plugins/woocommerce-beta-tester/src/experiments/index.js
+++ b/plugins/woocommerce-beta-tester/src/experiments/index.js
@@ -4,7 +4,7 @@
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
@@ -91,7 +91,7 @@ function Experiments( {
 export default compose(
 	withSelect( ( select ) => {
 		const { getExperiments } = select( STORE_KEY );
-		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+		const { getOption, isResolving } = select( optionsStore );
 
 		return {
 			experiments: getExperiments(),

--- a/plugins/woocommerce-beta-tester/src/remote-logging/index.tsx
+++ b/plugins/woocommerce-beta-tester/src/remote-logging/index.tsx
@@ -13,7 +13,7 @@ import { dispatch } from '@wordpress/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore no types
 // eslint-disable-next-line @woocommerce/dependency-group
-import { STORE_KEY as OPTIONS_STORE_NAME } from '../options/data/constants';
+import { STORE_KEY as optionsStore } from '../options/data/constants';
 
 export const API_NAMESPACE = '/wc-admin-test-helper';
 
@@ -81,7 +81,7 @@ function RemoteLogging() {
 
 	const simulatePhpException = async ( context: 'core' | 'beta-tester' ) => {
 		try {
-			await dispatch( OPTIONS_STORE_NAME ).saveOption(
+			await dispatch( optionsStore ).saveOption(
 				'wc_beta_tester_simulate_woocommerce_php_error',
 				context
 			);
@@ -139,7 +139,7 @@ function RemoteLogging() {
 
 	const simulateException = async ( context: 'core' | 'beta-tester' ) => {
 		try {
-			await dispatch( OPTIONS_STORE_NAME ).saveOption(
+			await dispatch( optionsStore ).saveOption(
 				'wc_beta_tester_simulate_woocommerce_js_error',
 				context
 			);

--- a/plugins/woocommerce-beta-tester/src/remote-logging/register-exception-filter.tsx
+++ b/plugins/woocommerce-beta-tester/src/remote-logging/register-exception-filter.tsx
@@ -14,7 +14,7 @@ import { dispatch } from '@wordpress/data';
  */
 import { API_NAMESPACE } from './';
 // @ts-ignore no types
-import { STORE_KEY as OPTIONS_STORE_NAME } from '../options/data/constants';
+import { STORE_KEY as optionsStore } from '../options/data/constants';
 
 /**
  * Retrieves the options for simulating a WooCommerce JavaScript error.
@@ -48,7 +48,7 @@ const getSimulateErrorOptions = async () => {
  * Deletes the option used for simulating WooCommerce JavaScript errors.
  */
 const deleteSimulateErrorOption = async () => {
-	await dispatch( OPTIONS_STORE_NAME ).deleteOption(
+	await dispatch( optionsStore ).deleteOption(
 		'wc_beta_tester_simulate_woocommerce_js_error'
 	);
 };

--- a/plugins/woocommerce/changelog/fix-migrate-option-store
+++ b/plugins/woocommerce/changelog/fix-migrate-option-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Migrate OPTIONS_STORE_NAME to optionsStore across multiple files

--- a/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/activity-panel.js
@@ -8,11 +8,7 @@ import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
 import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 import { H, Section } from '@woocommerce/components';
-import {
-	onboardingStore,
-	OPTIONS_STORE_NAME,
-	useUser,
-} from '@woocommerce/data';
+import { onboardingStore, optionsStore, useUser } from '@woocommerce/data';
 import { addHistoryListener } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useSlot } from '@woocommerce/experimental';
@@ -164,7 +160,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		previewSiteBtnTrackData,
 	} = useSelect(
 		( select ) => {
-			const { getOption } = select( OPTIONS_STORE_NAME );
+			const { getOption } = select( optionsStore );
 
 			return {
 				hasUnreadNotes: checkIfHasUnreadNotes( select ),

--- a/plugins/woocommerce/client/admin/client/activity-panel/display-options/index.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/display-options/index.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useUserPreferences, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useUserPreferences, optionsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -49,7 +49,7 @@ const LAYOUTS = [
 
 export const DisplayOptions = () => {
 	const { defaultHomescreenLayout } = useSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 
 		return {
 			defaultHomescreenLayout:

--- a/plugins/woocommerce/client/admin/client/analytics/report/revenue/table.js
+++ b/plugins/woocommerce/client/admin/client/analytics/report/revenue/table.js
@@ -14,7 +14,7 @@ import {
 	REPORTS_STORE_NAME,
 	settingsStore,
 	QUERY_DEFAULTS,
-	OPTIONS_STORE_NAME,
+	optionsStore,
 } from '@woocommerce/data';
 import {
 	appendTimestamp,
@@ -355,7 +355,7 @@ export default compose(
 		const { woocommerce_default_date_range: defaultDateRange } = select(
 			settingsStore
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 		const dateType = getOption( 'woocommerce_date_type' ) || 'date_paid';
 		const datesFromQuery = getCurrentDates( query, defaultDateRange );
 		const { getReportStats, getReportStatsError, isResolving } =

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@woocommerce/navigation';
 import {
 	ExtensionList,
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	COUNTRIES_STORE_NAME,
 	Country,
 	onboardingStore,
@@ -137,9 +137,7 @@ export type CoreProfilerStateMachineContext = {
 };
 
 const getAllowTrackingOption = fromPromise( async () =>
-	resolveSelect( OPTIONS_STORE_NAME ).getOption(
-		'woocommerce_allow_tracking'
-	)
+	resolveSelect( optionsStore ).getOption( 'woocommerce_allow_tracking' )
 );
 
 const handleTrackingOption = assign( {
@@ -151,7 +149,7 @@ const handleTrackingOption = assign( {
 } );
 
 const getStoreNameOption = fromPromise( async () =>
-	resolveSelect( OPTIONS_STORE_NAME ).getOption( 'blogname' )
+	resolveSelect( optionsStore ).getOption( 'blogname' )
 );
 
 const handleStoreNameOption = assign( {
@@ -172,9 +170,7 @@ const handleStoreNameOption = assign( {
 } );
 
 const getStoreCountryOption = fromPromise( async () =>
-	resolveSelect( OPTIONS_STORE_NAME ).getOption(
-		'woocommerce_default_country'
-	)
+	resolveSelect( optionsStore ).getOption( 'woocommerce_default_country' )
 );
 
 const handleStoreCountryOption = assign( {
@@ -195,7 +191,7 @@ const handleStoreCountryOption = assign( {
 const preFetchOptions = fromPromise( async ( { input }: { input: string[] } ) =>
 	Promise.all( [
 		input.map( ( optionName: string ) =>
-			resolveSelect( OPTIONS_STORE_NAME ).getOption( optionName )
+			resolveSelect( optionsStore ).getOption( optionName )
 		),
 	] )
 );
@@ -211,9 +207,7 @@ const handleCountries = assign( {
 } );
 
 const getOnboardingProfileOption = fromPromise( async () =>
-	resolveSelect( OPTIONS_STORE_NAME ).getOption(
-		'woocommerce_onboarding_profile'
-	)
+	resolveSelect( optionsStore ).getOption( 'woocommerce_onboarding_profile' )
 );
 
 const handleOnboardingProfileOption = assign( {
@@ -393,7 +387,7 @@ const recordUpdateTrackingOption = (
 const updateTrackingOption = fromPromise(
 	async ( { input }: { input: CoreProfilerStateMachineContext } ) => {
 		const prevValue =
-			( await resolveSelect( OPTIONS_STORE_NAME ).getOption(
+			( await resolveSelect( optionsStore ).getOption(
 				'woocommerce_allow_tracking'
 			) ) === 'yes'
 				? 'yes'
@@ -421,7 +415,7 @@ const updateTrackingOption = fromPromise(
 		} );
 
 		const trackingValue = input.optInDataSharing ? 'yes' : 'no';
-		dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		dispatch( optionsStore ).updateOptions( {
 			woocommerce_allow_tracking: trackingValue,
 		} );
 	}
@@ -442,7 +436,7 @@ const updateOnboardingProfileOption = fromPromise(
 );
 
 const updateBusinessLocation = ( countryAndState: string ) => {
-	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+	return dispatch( optionsStore ).updateOptions( {
 		woocommerce_default_country: countryAndState,
 	} );
 };
@@ -576,7 +570,7 @@ const updateBusinessInfo = fromPromise(
 					store_email: input.payload.storeEmailAddress,
 				} ),
 			} ),
-			dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+			dispatch( optionsStore ).updateOptions( {
 				blogname: input.payload.storeName,
 				woocommerce_default_country: input.payload.storeLocation,
 			} ),

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/onboarding-tour/use-onboarding-tour.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/onboarding-tour/use-onboarding-tour.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from 'react';
 
@@ -13,15 +13,12 @@ export const useOnboardingTour = () => {
 	const [ isResizeHandleVisible, setIsResizeHandleVisible ] =
 		useState( true );
 
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { shouldTourBeShown } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const wasTourShown =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			getOption( CUSTOMIZE_STORE_ONBOARDING_TOUR_HIDDEN ) === 'yes' ||
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			! hasFinishedResolution( 'getOption', [
 				CUSTOMIZE_STORE_ONBOARDING_TOUR_HIDDEN,
 			] );

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/opt-in/context.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/opt-in/context.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import React, { createContext, useState } from '@wordpress/element';
 import type { ReactNode } from 'react';
@@ -27,10 +27,8 @@ export const OptInContextProvider = ( {
 } ) => {
 	const isAllowTrackingEnabled = useSelect(
 		( select ) =>
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( OPTIONS_STORE_NAME ).getOption(
-				'woocommerce_allow_tracking'
-			) === 'yes',
+			select( optionsStore ).getOption( 'woocommerce_allow_tracking' ) ===
+			'yes',
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/opt-in/opt-in.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/opt-in/opt-in.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, resolveSelect, select, useSelect } from '@wordpress/data';
 import { useContext, useEffect } from '@wordpress/element';
@@ -124,11 +124,9 @@ export const OptInSubscribe = () => {
 	] = useGlobalSetting( 'typography.fontFamilies' );
 
 	const isOptedIn = useSelect( ( selectStore ) => {
-		const allowTracking =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			selectStore( OPTIONS_STORE_NAME ).getOption(
-				'woocommerce_allow_tracking'
-			);
+		const allowTracking = selectStore( optionsStore ).getOption(
+			'woocommerce_allow_tracking'
+		);
 		return allowTracking === 'yes';
 	}, [] );
 

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __experimentalGrid as Grid, Spinner } from '@wordpress/components';
@@ -18,14 +18,11 @@ import { ColorPaletteResponse } from '~/customize-store/design-with-ai/types';
 
 export const ColorPalette = () => {
 	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			aiSuggestions: getOption(
 				'woocommerce_customize_store_ai_suggestions'
 			) as { defaultColorPalette: ColorPaletteResponse },
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			isLoading: ! hasFinishedResolution( 'getOption', [
 				'woocommerce_customize_store_ai_suggestions',
 			] ),

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -5,7 +5,7 @@
  */
 // @ts-ignore No types for this exist yet.
 import { __experimentalGrid as Grid, Spinner } from '@wordpress/components';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useMemo } from '@wordpress/element';
 import {
@@ -37,14 +37,11 @@ import {
 
 export const FontPairing = () => {
 	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			aiSuggestions: getOption(
 				'woocommerce_customize_store_ai_suggestions'
 			) as { lookAndFeel: Look },
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			isLoading: ! hasFinishedResolution( 'getOption', [
 				'woocommerce_customize_store_ai_suggestions',
 			] ),
@@ -76,7 +73,7 @@ export const FontPairing = () => {
 			// Todo: awaiting more global fix, demo:
 			// https://github.com/woocommerce/woocommerce/pull/54146
 			(
-				select( OPTIONS_STORE_NAME ) as {
+				select( optionsStore ) as {
 					getOption: ( option: string ) => unknown;
 				}
 			 ).getOption( 'woocommerce_allow_tracking' ) === 'yes',

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography/sidebar-navigation-screen-typography.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography/sidebar-navigation-screen-typography.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { Link } from '@woocommerce/components';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { Button, Modal, CheckboxControl, Spinner } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 
@@ -50,10 +50,7 @@ export const SidebarNavigationScreenTypography = ( {
 
 	const trackingAllowed = useSelect(
 		( select ) =>
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( OPTIONS_STORE_NAME ).getOption(
-				'woocommerce_allow_tracking'
-			),
+			select( optionsStore ).getOption( 'woocommerce_allow_tracking' ),
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-with-ai/actions.ts
@@ -4,7 +4,7 @@
 import { assign, spawn } from 'xstate';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { dispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -191,7 +191,7 @@ const assignHomepageTemplate = assign<
 } );
 
 const updateWooAiStoreDescriptionOption = ( descriptionText: string ) => {
-	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+	return dispatch( optionsStore ).updateOptions( {
 		woo_ai_describe_store_description: descriptionText,
 	} );
 };

--- a/plugins/woocommerce/client/admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-with-ai/services.ts
@@ -5,7 +5,7 @@
  */
 import { __experimentalRequestJetpackToken as requestJetpackToken } from '@woocommerce/ai';
 import apiFetch from '@wordpress/api-fetch';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { Sender, assign, createMachine, actions } from 'xstate';
 import { dispatch, resolveSelect } from '@wordpress/data';
 // @ts-ignore No types for this exist yet.
@@ -199,7 +199,7 @@ export const queryAiEndpoint = createMachine(
 );
 
 const resetPatternsAndProducts = () => async () => {
-	await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+	await dispatch( optionsStore ).updateOptions( {
 		woocommerce_blocks_allow_ai_connection: 'yes',
 	} );
 
@@ -231,7 +231,7 @@ export const updateStorePatterns = async (
 ) => {
 	try {
 		// TODO: Probably move this to a more appropriate place with a check. We should set this when the user granted permissions during the onboarding phase.
-		await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		await dispatch( optionsStore ).updateOptions( {
 			woocommerce_blocks_allow_ai_connection: 'yes',
 		} );
 
@@ -448,7 +448,7 @@ const installAndActivateTheme = async () => {
 };
 
 const saveAiResponseToOption = ( context: designWithAiStateMachineContext ) => {
-	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+	return dispatch( optionsStore ).updateOptions( {
 		woocommerce_customize_store_ai_suggestions: {
 			...context.aiSuggestions,
 			lookAndFeel: context.lookAndFeel.choice,

--- a/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/services.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -83,7 +83,7 @@ const updateGlobalStylesWithDefaultValues = async (
 	const colorPalette = COLOR_PALETTES[ 0 ];
 
 	const allowTracking =
-		( await resolveSelect( OPTIONS_STORE_NAME ).getOption(
+		( await resolveSelect( optionsStore ).getOption(
 			'woocommerce_allow_tracking'
 		) ) === 'yes';
 
@@ -209,7 +209,7 @@ const createProducts = async () => {
 
 export const enableTracking = async () => {
 	try {
-		await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		await dispatch( optionsStore ).updateOptions( {
 			woocommerce_allow_tracking: 'yes',
 		} );
 		window.wcTracks.isEnabled = true;

--- a/plugins/woocommerce/client/admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/index.tsx
@@ -12,7 +12,7 @@ import {
 	getHistory,
 	getPersistedQuery,
 } from '@woocommerce/navigation';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { dispatch, resolveSelect } from '@wordpress/data';
 import { Spinner } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
@@ -134,7 +134,7 @@ const markTaskComplete = async () => {
 	const currentTemplateId: string | undefined = await resolveSelect(
 		coreStore
 	).getDefaultTemplateId( { slug: 'home' } );
-	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+	return dispatch( optionsStore ).updateOptions( {
 		woocommerce_admin_customize_store_completed: 'yes',
 		// We use this on the intro page to determine if this same theme was used in the last customization.
 		woocommerce_admin_customize_store_completed_theme_id: currentTemplateId,

--- a/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce/client/admin/client/customize-store/intro/services.ts
@@ -3,7 +3,7 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { onboardingStore, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { onboardingStore, optionsStore } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -45,7 +45,7 @@ export const fetchIntroData = async () => {
 	).getDefaultTemplateId( { slug: 'home' } );
 
 	const maybePreviousTemplatePromise = resolveSelect(
-		OPTIONS_STORE_NAME
+		optionsStore
 	).getOption( 'woocommerce_admin_customize_store_completed_theme_id' );
 
 	const getTaskPromise =

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/actions.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/actions.tsx
@@ -3,7 +3,7 @@
  */
 import { assign, DoneInvokeEvent } from 'xstate';
 import { dispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ export const completeSurvey = assign<
 	customizeStoreStateMachineEvents
 >( {
 	transitionalScreen: ( context: customizeStoreStateMachineContext ) => {
-		dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		dispatch( optionsStore ).updateOptions( {
 			woocommerce_admin_customize_store_survey_completed: 'yes',
 		} );
 

--- a/plugins/woocommerce/client/admin/client/customize-store/transitional/services.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/transitional/services.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { resolveSelect } from '@wordpress/data';
 
 export const fetchSurveyCompletedOption = async () =>
-	resolveSelect( OPTIONS_STORE_NAME ).getOption(
+	resolveSelect( optionsStore ).getOption(
 		'woocommerce_admin_customize_store_survey_completed'
 	);

--- a/plugins/woocommerce/client/admin/client/guided-tours/report-date-tour.tsx
+++ b/plugins/woocommerce/client/admin/client/guided-tours/report-date-tour.tsx
@@ -3,7 +3,7 @@
  */
 import { TourKit, TourKitTypes } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import {
 	createElement,
 	createInterpolateElement,
@@ -24,23 +24,18 @@ export const ReportDateTour: React.FC< {
 	headingText: string;
 } > = ( { optionName, headingText } ) => {
 	const [ isDismissed, setIsDismissed ] = useState( false );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const { shouldShowTour, isResolving } = useSelect(
 		( select ) => {
-			const { getOption, hasFinishedResolution } =
-				select( OPTIONS_STORE_NAME );
+			const { getOption, hasFinishedResolution } = select( optionsStore );
 
 			return {
 				shouldShowTour:
-					// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 					getOption( optionName ) !== 'yes' &&
-					// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 					getOption( DATE_TYPE_OPTION ) === false,
 				isResolving:
-					// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 					! hasFinishedResolution( 'getOption', [ optionName ] ) ||
-					// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 					! hasFinishedResolution( 'getOption', [
 						DATE_TYPE_OPTION,
 					] ),

--- a/plugins/woocommerce/client/admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce/client/admin/client/guided-tours/shipping-tour.tsx
@@ -11,7 +11,7 @@ import {
 	useRef,
 	createPortal,
 } from '@wordpress/element';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
@@ -44,31 +44,24 @@ const useShowShippingTour = () => {
 		businessCountry,
 		isLoading,
 	} = useSelect( ( select ) => {
-		const { hasFinishedResolution, getOption } =
-			select( OPTIONS_STORE_NAME );
+		const { hasFinishedResolution, getOption } = select( optionsStore );
 
 		return {
 			isLoading:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					CREATED_DEFAULTS_OPTION,
 				] ) &&
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					REVIEWED_DEFAULTS_OPTION,
 				] ) &&
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_default_country',
 				] ),
 			hasCreatedDefaultShippingZones:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				getOption( CREATED_DEFAULTS_OPTION ) === 'yes',
 			hasReviewedDefaultShippingOptions:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				getOption( REVIEWED_DEFAULTS_OPTION ) === 'yes',
 			businessCountry: getCountryCode(
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				getOption( 'woocommerce_default_country' ) as string
 			),
 		};
@@ -220,7 +213,7 @@ const TourFloaterWrapper = ( { step }: { step: number } ) => {
 export const ShippingTour: React.FC< {
 	showShippingRecommendationsStep: boolean;
 } > = ( { showShippingRecommendationsStep } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { show: showTour, isUspsDhlEligible } = useShowShippingTour();
 	const [ step, setStepNumber ] = useState( 0 );
 	const { createNotice } = useDispatch( 'core/notices' );

--- a/plugins/woocommerce/client/admin/client/guided-tours/wc-addons-tour/index.tsx
+++ b/plugins/woocommerce/client/admin/client/guided-tours/wc-addons-tour/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { TourKit, TourKitTypes } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import { getSteps } from './get-steps';
 const WCAddonsTour = () => {
 	const [ showTour, setShowTour ] = useState( true );
 
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const steps = getSteps();
 	const defaultAutoScrollBlock: ScrollLogicalPosition = 'center';

--- a/plugins/woocommerce/client/admin/client/homescreen/layout.js
+++ b/plugins/woocommerce/client/admin/client/homescreen/layout.js
@@ -16,7 +16,7 @@ import {
 	useUserPreferences,
 	notesStore,
 	onboardingStore,
-	OPTIONS_STORE_NAME,
+	optionsStore,
 } from '@woocommerce/data';
 import { __ } from '@wordpress/i18n';
 
@@ -193,7 +193,7 @@ Layout.propTypes = {
 export default compose(
 	withSelect( ( select ) => {
 		const { isNotesRequesting } = select( notesStore );
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 		const defaultHomescreenLayout =
 			getOption( 'woocommerce_default_homepage_layout' ) ||
 			'single_column';

--- a/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce/client/admin/client/homescreen/mobile-app-modal/index.tsx
@@ -10,7 +10,7 @@ import { addFilter, removeFilter } from '@wordpress/hooks';
 import { getAdminLink } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME, onboardingStore } from '@woocommerce/data';
+import { optionsStore, onboardingStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -34,7 +34,7 @@ export const MobileAppModal = () => {
 		useState( false );
 
 	const { state, jetpackConnectionData } = useJetpackPluginState();
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const [ pageContent, setPageContent ] = useState< React.ReactNode >();
 	const [ searchParams ] = useSearchParams();

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hooks/use-launch-your-store.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hooks/use-launch-your-store.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 type Props = {
 	/** Set to false to disable this query, defaults to true to query the data */
@@ -34,36 +34,27 @@ export const useLaunchYourStore = (
 				};
 			}
 
-			const { hasFinishedResolution, getOption } =
-				select( OPTIONS_STORE_NAME );
+			const { hasFinishedResolution, getOption } = select( optionsStore );
 
 			const allOptionResolutionsFinished =
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_coming_soon',
 				] ) &&
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_store_pages_only',
 				] ) &&
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_private_link',
 				] ) &&
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_share_key',
 				] );
 
 			return {
 				isLoading: allOptionResolutionsFinished,
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				comingSoon: getOption( 'woocommerce_coming_soon' ),
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				storePagesOnly: getOption( 'woocommerce_store_pages_only' ),
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				privateLink: getOption( 'woocommerce_private_link' ),
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				shareKey: getOption( 'woocommerce_share_key' ),
 				launchYourStoreEnabled:
 					window.wcAdminFeatures[ 'launch-your-store' ],

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/xstate.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/xstate.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { getQuery, navigateTo } from '@woocommerce/navigation';
 import {
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	PAYMENT_GATEWAYS_STORE_NAME,
 	settingsStore,
 	TaskListType,
@@ -78,7 +78,7 @@ const sidebarQueryParamListener = fromCallback( ( { sendBack } ) => {
 } );
 
 const launchStoreAction = async () => {
-	const results = await dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+	const results = await dispatch( optionsStore ).updateOptions( {
 		woocommerce_coming_soon: 'no',
 	} );
 	if ( results.success ) {

--- a/plugins/woocommerce/client/admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/tour/use-site-visibility-tour.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
+import { optionsStore, useUserPreferences } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import { useState } from 'react';
 
@@ -11,10 +11,8 @@ export const useSiteVisibilityTour = () => {
 	// Tour should only be shown if the user has not seen it before and the `woocommerce_show_lys_tour` option is "yes" (for sites upgrading from a previous WooCommerce version)
 	const shouldStoreShowLYSTour = useSelect(
 		( select ) =>
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			select( OPTIONS_STORE_NAME ).getOption(
-				'woocommerce_show_lys_tour'
-			) === 'yes',
+			select( optionsStore ).getOption( 'woocommerce_show_lys_tour' ) ===
+			'yes',
 		[]
 	);
 

--- a/plugins/woocommerce/client/admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce/client/admin/client/layout/store-alerts/index.js
@@ -19,7 +19,7 @@ import { Icon, chevronLeft, chevronRight, close } from '@wordpress/icons';
 import {
 	notesStore,
 	QUERY_DEFAULTS,
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	useUserPreferences,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -64,7 +64,7 @@ export const StoreAlerts = () => {
 		defaultHomescreenLayout,
 	} = useSelect( ( select ) => {
 		const { getNotes, hasFinishedResolution } = select( notesStore );
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 
 		return {
 			alerts: getUnactionedVisibleAlerts( getNotes( ALERTS_QUERY ) ),

--- a/plugins/woocommerce/client/admin/client/layout/transient-notices/index.js
+++ b/plugins/woocommerce/client/admin/client/layout/transient-notices/index.js
@@ -4,7 +4,7 @@
 import { applyFilters } from '@wordpress/hooks';
 import clsx from 'clsx';
 import { WooFooterItem } from '@woocommerce/admin-layout';
-import { OPTIONS_STORE_NAME, USER_STORE_NAME } from '@woocommerce/data';
+import { optionsStore, USER_STORE_NAME } from '@woocommerce/data';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -22,7 +22,7 @@ export function TransientNotices( props ) {
 	const { removeNotice: onRemove } = useDispatch( 'core/notices' );
 	const { createNotice: createNotice2, removeNotice: onRemove2 } =
 		useDispatch( 'core/notices2' );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const {
 		currentUser = {},
 		notices = [],
@@ -35,8 +35,7 @@ export function TransientNotices( props ) {
 			currentUser: select( USER_STORE_NAME ).getCurrentUser(),
 			notices: select( 'core/notices' ).getNotices(),
 			notices2: select( 'core/notices2' ).getNotices(),
-			noticesQueue:
-				select( OPTIONS_STORE_NAME ).getOption( QUEUE_OPTION ),
+			noticesQueue: select( optionsStore ).getOption( QUEUE_OPTION ),
 		};
 	} );
 

--- a/plugins/woocommerce/client/admin/client/marketing/hooks/useIntroductionBanner.ts
+++ b/plugins/woocommerce/client/admin/client/marketing/hooks/useIntroductionBanner.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 type UseIntroductionBanner = {
@@ -16,7 +16,7 @@ const OPTION_NAME_BANNER_DISMISSED =
 const OPTION_VALUE_YES = 'yes';
 
 export const useIntroductionBanner = (): UseIntroductionBanner => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const dismissIntroductionBanner = () => {
 		updateOptions( {
@@ -26,15 +26,12 @@ export const useIntroductionBanner = (): UseIntroductionBanner => {
 	};
 
 	const { loading, data } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		return {
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			loading: ! hasFinishedResolution( 'getOption', [
 				OPTION_NAME_BANNER_DISMISSED,
 			] ),
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			data: getOption( OPTION_NAME_BANNER_DISMISSED ),
 		};
 	}, [] );

--- a/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
+++ b/plugins/woocommerce/client/admin/client/order-attribution-install-banner/use-order-attribution-install-banner.js
@@ -3,7 +3,7 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
-import { OPTIONS_STORE_NAME, pluginsStore, useUser } from '@woocommerce/data';
+import { optionsStore, pluginsStore, useUser } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { getPath } from '@woocommerce/navigation';
 import { isWcVersion } from '@woocommerce/settings';
@@ -69,7 +69,7 @@ const shouldPromoteOrderAttribution = (
  * which determines if the banner should be displayed, checks if it has been dismissed, and provides a function to dismiss it.
  */
 export const useOrderAttributionInstallBanner = () => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { currentUserCan } = useUser();
 
 	const dismiss = ( eventContext = 'analytics-overview' ) => {
@@ -99,8 +99,7 @@ export const useOrderAttributionInstallBanner = () => {
 
 	const { loading, isBannerDismissed, remoteVariantAssignment } = useSelect(
 		( select ) => {
-			const { getOption, hasFinishedResolution } =
-				select( OPTIONS_STORE_NAME );
+			const { getOption, hasFinishedResolution } = select( optionsStore );
 
 			return {
 				loading: ! hasFinishedResolution( 'getOption', [

--- a/plugins/woocommerce/client/admin/client/payments-welcome/exit-survey-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/exit-survey-modal.tsx
@@ -9,7 +9,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -35,12 +35,11 @@ function ExitSurveyModal( {}: {
 	const [ isSomethingElseChecked, setSomethingElseChecked ] =
 		useState( false );
 	const [ comments, setComments ] = useState( '' );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const dismissedIncentives = useSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( optionsStore );
 		return (
-			// @ts-expect-error Awaiting for a broader global fix.
 			( getOption(
 				'wcpay_welcome_page_incentives_dismissed'
 			) as string[] ) || []

--- a/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce/client/admin/client/payments-welcome/index.tsx
@@ -5,7 +5,7 @@ import { Notice } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME, pluginsStore } from '@woocommerce/data';
+import { optionsStore, pluginsStore } from '@woocommerce/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -23,7 +23,7 @@ interface activatePromoResponse {
 
 const ConnectAccountPage = () => {
 	const incentive = getAdminSetting( 'wcpayWelcomePageIncentive' );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { installAndActivatePlugins } = useDispatch( pluginsStore );
 	const [ isSubmitted, setSubmitted ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( '' );

--- a/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
+++ b/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { getAdminLink } from '@woocommerce/settings';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { MenuItem } from '@wordpress/components';
 import {
 	ALLOW_TRACKING_OPTION_NAME,
@@ -26,14 +26,11 @@ export const ClassicEditorMenuItem = ( {
 	const { showProductMVPFeedbackModal } = useDispatch( CES_STORE_KEY );
 
 	const { allowTracking, resolving: isLoading } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const allowTrackingOption =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-			getOption( ALLOW_TRACKING_OPTION_NAME ) || 'no';
+			( getOption( ALLOW_TRACKING_OPTION_NAME ) as string ) || 'no';
 
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const resolving = ! hasFinishedResolution( 'getOption', [
 			ALLOW_TRACKING_OPTION_NAME,
 		] );

--- a/plugins/woocommerce/client/admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
+++ b/plugins/woocommerce/client/admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
@@ -1,22 +1,19 @@
 /**
  * External dependencies
  */
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 export const BLOCK_EDITOR_TOUR_SHOWN_OPTION =
 	'woocommerce_block_product_tour_shown';
 
 export const useBlockEditorTourOptions = () => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { shouldTourBeShown } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
 		const wasTourShown =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			getOption( BLOCK_EDITOR_TOUR_SHOWN_OPTION ) === 'yes' ||
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			! hasFinishedResolution( 'getOption', [
 				BLOCK_EDITOR_TOUR_SHOWN_OPTION,
 			] );

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/dismissable-list.tsx
@@ -3,7 +3,7 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Card, CardHeader } from '@wordpress/components';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { EllipsisMenu } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { createContext, useContext } from '@wordpress/element';
@@ -24,7 +24,7 @@ export const DismissableListHeading = ( {
 	children: React.ReactNode;
 	onDismiss?: () => void;
 } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const dismissOptionName = useContext( OptionNameContext );
 
 	const handleDismissClick = () => {
@@ -66,15 +66,12 @@ export const DismissableList = ( {
 } ) => {
 	const isVisible = useSelect(
 		( select ) => {
-			const { getOption, hasFinishedResolution } =
-				select( OPTIONS_STORE_NAME );
+			const { getOption, hasFinishedResolution } = select( optionsStore );
 
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			const hasFinishedResolving = hasFinishedResolution( 'getOption', [
 				dismissOptionName,
 			] );
 
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			const isDismissed = getOption( dismissOptionName ) === 'yes';
 
 			return hasFinishedResolving && ! isDismissed;

--- a/plugins/woocommerce/client/admin/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useUser, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useUser, optionsStore } from '@woocommerce/data';
 
 const SHOW_MARKETPLACE_SUGGESTION_OPTION =
 	'woocommerce_show_marketplace_suggestions';
@@ -15,15 +15,12 @@ const RecommendationsEligibilityWrapper = ( {
 	const { currentUserCan } = useUser();
 
 	const isMarketplaceSuggestionsEnabled = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 		const hasFinishedResolving = hasFinishedResolution( 'getOption', [
 			SHOW_MARKETPLACE_SUGGESTION_OPTION,
 		] );
 		const canShowMarketplaceSuggestions =
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			getOption( SHOW_MARKETPLACE_SUGGESTION_OPTION ) !== 'no';
 
 		return hasFinishedResolving && canShowMarketplaceSuggestions;

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/components/Setup/Setup.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/components/Setup/Setup.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody } from '@wordpress/components';
 import {
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	PAYMENT_GATEWAYS_STORE_NAME,
 	pluginsStore,
 } from '@woocommerce/data';
@@ -47,7 +47,7 @@ export const Setup = ( { markConfigured, paymentGateway } ) => {
 
 	const { isOptionUpdating, isPaymentGatewayResolving, needsPluginInstall } =
 		useSelect( ( select ) => {
-			const { isOptionsUpdating } = select( OPTIONS_STORE_NAME );
+			const { isOptionsUpdating } = select( optionsStore );
 			const { isResolving } = select( PAYMENT_GATEWAYS_STORE_NAME );
 			const activePlugins = select( pluginsStore ).getActivePlugins();
 			const pluginsToInstall = plugins.filter(

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	onboardingStore,
 	PAYMENT_GATEWAYS_STORE_NAME,
 	settingsStore,
@@ -50,7 +50,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		return {
 			getPaymentGateway: select( PAYMENT_GATEWAYS_STORE_NAME )
 				.getPaymentGateway,
-			getOption: select( OPTIONS_STORE_NAME ).getOption,
+			getOption: select( optionsStore ).getOption,
 			installedPaymentGateways: select(
 				PAYMENT_GATEWAYS_STORE_NAME
 			).getPaymentGateways(),

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/plugins/Bacs.js
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/PaymentGatewaySuggestions/plugins/Bacs.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Form, H, TextControl } from '@woocommerce/components';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { WooPaymentGatewaySetup } from '@woocommerce/onboarding';
@@ -20,10 +20,10 @@ const initialFormValues = {
 
 const BacsPaymentGatewaySetup = () => {
 	const isUpdating = useSelect( ( select ) => {
-		return select( OPTIONS_STORE_NAME ).isOptionsUpdating();
+		return select( optionsStore ).isOptionsUpdating();
 	} );
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 
 	const validate = ( values ) => {
 		const errors = {};

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/components/plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/components/plugins.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Plugins as PluginInstaller } from '@woocommerce/components';
-import { OPTIONS_STORE_NAME, InstallPluginsResponse } from '@woocommerce/data';
+import { optionsStore, InstallPluginsResponse } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -29,27 +29,22 @@ export const Plugins: React.FC< Props > = ( {
 	nextStep,
 	pluginsToActivate,
 } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { isResolving, tosAccepted } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 		const wcConnectOptions = getOption( 'wc_connect_options' );
 
 		return {
 			isResolving:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_setup_jetpack_opted_in',
 				] ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'wc_connect_options',
 				] ),
 			tosAccepted:
 				( isWcConnectOptions( wcConnectOptions ) &&
 					wcConnectOptions?.tos_accepted ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				getOption( 'woocommerce_setup_jetpack_opted_in' ) === '1',
 		};
 	}, [] );

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/index.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	OPTIONS_STORE_NAME,
-	pluginsStore,
-	settingsStore,
-} from '@woocommerce/data';
+import { optionsStore, pluginsStore, settingsStore } from '@woocommerce/data';
 import { withSelect } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
@@ -20,7 +16,7 @@ import { TaskProps } from './types';
 const ShippingRecommendationWrapper = compose(
 	withSelect( ( select: SelectFunction ) => {
 		const { getSettings } = select( settingsStore );
-		const { hasFinishedResolution } = select( OPTIONS_STORE_NAME );
+		const { hasFinishedResolution } = select( optionsStore );
 		const { getActivePlugins } = select( pluginsStore );
 
 		return {
@@ -28,17 +24,15 @@ const ShippingRecommendationWrapper = compose(
 			generalSettings: getSettings( 'general' )?.general,
 			isJetpackConnected: select( pluginsStore ).isJetpackConnected(),
 			isResolving:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_setup_jetpack_opted_in',
 				] ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'wc_connect_options',
 				] ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! select( pluginsStore ).hasFinishedResolution(
-					'isJetpackConnected'
+					'isJetpackConnected',
+					[]
 				),
 		};
 	} )

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/index.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Card, CardBody, Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getAdminLink } from '@woocommerce/settings';
-import { OPTIONS_STORE_NAME, settingsStore, TaskType } from '@woocommerce/data';
+import { optionsStore, settingsStore, TaskType } from '@woocommerce/data';
 import { queueRecordEvent, recordEvent } from '@woocommerce/tracks';
 import { registerPlugin } from '@wordpress/plugins';
 import {
@@ -45,7 +45,7 @@ export type TaxProps = {
 
 export const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 	const [ isPending, setIsPending ] = useState( false );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateAndPersistSettingsForGroup } = useDispatch( settingsStore );
 	const { generalSettings, isResolving, taxSettings } = useSelect(

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/plugins.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/plugins.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Plugins as PluginInstaller } from '@woocommerce/components';
-import { OPTIONS_STORE_NAME, InstallPluginsResponse } from '@woocommerce/data';
+import { optionsStore, InstallPluginsResponse } from '@woocommerce/data';
 import { recordEvent, queueRecordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -27,27 +27,22 @@ export const Plugins: React.FC< SetupStepProps > = ( {
 	onManual,
 	pluginsToActivate,
 } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const { isResolving, tosAccepted } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
-		// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
+		const { getOption, hasFinishedResolution } = select( optionsStore );
 		const wcConnectOptions = getOption( 'wc_connect_options' );
 
 		return {
 			isResolving:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_setup_jetpack_opted_in',
 				] ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'wc_connect_options',
 				] ),
 			tosAccepted:
 				( isWcConnectOptions( wcConnectOptions ) &&
 					wcConnectOptions?.tos_accepted ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				getOption( 'woocommerce_setup_jetpack_opted_in' ) === '1',
 		};
 	}, [] );

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/setup.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/tax/woocommerce-tax/setup.tsx
@@ -5,11 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { difference } from 'lodash';
 import { useEffect, useState } from '@wordpress/element';
 import { Stepper } from '@woocommerce/components';
-import {
-	OPTIONS_STORE_NAME,
-	pluginsStore,
-	settingsStore,
-} from '@woocommerce/data';
+import { optionsStore, pluginsStore, settingsStore } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -49,18 +45,16 @@ export const Setup: React.FC< SetupProps > = ( {
 	);
 	const { activePlugins, isResolving } = useSelect( ( select ) => {
 		const { getSettings } = select( settingsStore );
-		const { hasFinishedResolution } = select( OPTIONS_STORE_NAME );
+		const { hasFinishedResolution } = select( optionsStore );
 		const { getActivePlugins } = select( pluginsStore );
 
 		return {
 			activePlugins: getActivePlugins(),
 			generalSettings: getSettings( 'general' )?.general,
 			isResolving:
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'woocommerce_setup_jetpack_opted_in',
 				] ) ||
-				// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 				! hasFinishedResolution( 'getOption', [
 					'wc_connect_options',
 				] ),

--- a/plugins/woocommerce/client/admin/client/task-lists/reminder-bar/reminder-bar.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/reminder-bar/reminder-bar.tsx
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	OPTIONS_STORE_NAME,
+	optionsStore,
 	TaskType,
 	getVisibleTasks,
 	onboardingStore,
@@ -86,7 +86,7 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 	taskListId,
 	updateBodyMargin,
 } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const {
 		remainingCount,
 		loading,
@@ -103,8 +103,7 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 			const {
 				getOption,
 				hasFinishedResolution: optionHasFinishedResolution,
-			} = select( OPTIONS_STORE_NAME );
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
+			} = select( optionsStore );
 			const reminderBarHiddenOption = getOption(
 				REMINDER_BAR_HIDDEN_OPTION
 			);
@@ -113,7 +112,6 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 				'getTaskList',
 				[ taskListId ]
 			);
-			// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 			const optionIsResolved = optionHasFinishedResolution( 'getOption', [
 				REMINDER_BAR_HIDDEN_OPTION,
 			] );

--- a/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/components/task-list-completed-header.tsx
+++ b/plugins/woocommerce/client/admin/client/task-lists/setup-task-list/components/task-list-completed-header.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { EllipsisMenu } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { OPTIONS_STORE_NAME, WEEK } from '@woocommerce/data';
+import { optionsStore, WEEK } from '@woocommerce/data';
 import { Button, Card, CardHeader } from '@wordpress/components';
 import { Text } from '@woocommerce/experimental';
 import {
@@ -47,7 +47,7 @@ function getStoreAgeInWeeks( adminInstallTimestamp: number ) {
 export const TaskListCompletedHeader: React.FC<
 	TaskListCompletedHeaderProps
 > = ( { hideTasks, customerEffortScore } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateOptions } = useDispatch( optionsStore );
 	const [ showCesModal, setShowCesModal ] = useState( false );
 	const [ hasSubmittedScore, setHasSubmittedScore ] = useState( false );
 	const [ score, setScore ] = useState( NaN );
@@ -57,26 +57,23 @@ export const TaskListCompletedHeader: React.FC<
 		useSelect(
 			( select ) => {
 				const { getOption, hasFinishedResolution } =
-					select( OPTIONS_STORE_NAME );
+					select( optionsStore );
 
 				if ( customerEffortScore ) {
-					// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 					const allowTracking = getOption(
 						ALLOW_TRACKING_OPTION_NAME
-					);
+					) as string;
 					const adminInstallTimestamp: number =
-						// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-						getOption( ADMIN_INSTALL_TIMESTAMP_OPTION_NAME ) || 0;
-					// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
-					const cesActions = getOption< string[] >(
+						( getOption(
+							ADMIN_INSTALL_TIMESTAMP_OPTION_NAME
+						) as number ) || 0;
+					const cesActions = getOption(
 						SHOWN_FOR_ACTIONS_OPTION_NAME
-					);
+					) as string[];
 					const loadingOptions =
-						// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 						! hasFinishedResolution( 'getOption', [
 							SHOWN_FOR_ACTIONS_OPTION_NAME,
 						] ) ||
-						// @ts-expect-error Todo: awaiting more global fix, demo: https://github.com/woocommerce/woocommerce/pull/54146
 						! hasFinishedResolution( 'getOption', [
 							ADMIN_INSTALL_TIMESTAMP_OPTION_NAME,
 						] );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef } from '@wordpress/element';
 import { Button, Modal, CheckboxControl } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { initializeExPlat } from '@woocommerce/explat';
 
@@ -111,7 +111,7 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 
 export const BetaFeaturesTrackingContainer = compose(
 	withDispatch( ( dispatch ) => {
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+		const { updateOptions } = dispatch( optionsStore );
 		return { updateOptions };
 	} )
 )( BetaFeaturesTrackingModal );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
@@ -6,7 +6,7 @@ import { Component } from '@wordpress/element';
 import { Button, Modal } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { optionsStore } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -76,7 +76,7 @@ export class DismissModal extends Component {
 
 export default compose(
 	withDispatch( ( dispatch ) => {
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+		const { updateOptions } = dispatch( optionsStore );
 		return { updateOptions };
 	} )
 )( DismissModal );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/55376

As part of the React 18 upgrade and WordPress 6.6 compatibility changes, this PR updates the **options** store registration pattern in `@woocommerce/data` to use the modern WordPress data store API. 

Key changes include:

1. Migrated from deprecated `registerStore` to `createReduxStore` and `register` pattern
2. Updated store exports to match the modern pattern used across other stores:
    - Added `export { store as optionsStore }`
    - Maintained `OPTIONS_STORE_NAME` export for backward compatibility
3. Removed deprecated type definitions:
    - Removed custom @wordpress/data module declaration
    - Cleaned up unused type exports and imports
4. Update options store import to use `optionsStore` from `@woocommerce/data`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This PR doesn't change any functionality, so it's not necessary to test the changes.

For devs:

1. Review the @woocommerce/data changes for the options store migration
2. Delete the `noCheck: true` line in `./packages/js/data/tsconfig.json` and running `npx tsc` inside ./packages/js/data
3. Confirm that there are no TS errors in `./src/options/**`
4. `window.wp.data.select( wc.data.optionsStore )` and `window.wp.data.dispatch( wc.data.optionsStore )` should return selectors and dispatchers

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
