### PR TITLE
Post 9.6.2 release tasks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 == Changelog ==
 
+= 9.6.2 2025-02-13 =
+
+**WooCommerce**
+
+* Fix - Return secondary color CSS variable to its original color [#55366](https://github.com/woocommerce/woocommerce/pull/55366)
+
+
 = 9.6.1 2025-02-04 =
 
 **WooCommerce**

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: online store, ecommerce, shop, shopping cart, sell online
 Requires at least: 6.6
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 9.6.1
+Stable tag: 9.6.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR includes 9.6.2's changelog in the global changelog and bumps the stable tag version to 9.6.2 as on wporg.