### PR TITLE
Fix email preview loaded twice on the manage email page

### DIFF
--- a/plugins/woocommerce/changelog/55483-email-preview-loaded-twice
+++ b/plugins/woocommerce/changelog/55483-email-preview-loaded-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email preview loaded twice on the manage email page

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -57,8 +57,15 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 			handlers[ id ] = debounce( handleFieldChange, 400 );
 			const field = jQuery( `#${ id }` );
 			if ( field.length ) {
-				// Using jQuery events due to select2 and iris (color picker) usage
-				field.on( 'change', handlers[ id ] );
+				if ( field.hasClass( 'wc-enhanced-select' ) ) {
+					// For select2 fields, only bind change event once initialized
+					field.one( 'select2:open', () => {
+						field.on( 'change', handlers[ id ] );
+					} );
+				} else {
+					// Using jQuery events due to select2 and iris (color picker) usage
+					field.on( 'change', handlers[ id ] );
+				}
 			}
 		} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When managing a specific email in settings, the email preview is loaded twice on the page load. This is caused by enhanced select boxes used in WooCommerce settings, which rely on the select2 library. The email preview is initialized before them, and once the select2 is initialized, it automatically triggers a `change` event, which reloads the email preview. 

The fix is to only listen to changes once the select2 is initialized. 

Closes #55483.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Email improvements` feature in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. Click `Manage` on any of the emails. 
4. Check that the email preview is only loaded once (there is no loading animation).
5. Check that it's reloaded when any select box changes (this also applies to the general **WooCommerce > Settings > Emails** page).

<!-- End testing instructions -->
