### PR TITLE
Fix core interface already registered console warning

### DIFF
--- a/packages/js/product-editor/changelog/fix-46771_core_interface_already_registered
+++ b/packages/js/product-editor/changelog/fix-46771_core_interface_already_registered
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix duplicate interface store warning, by bundling in and lazy loading some @wordpress/interface dependencies.

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -15,6 +15,7 @@ import {
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 import { useSelect } from '@wordpress/data';
 import { Popover } from '@wordpress/components';
+import InterfaceSkeleton from '@wordpress/interface/build-module/components/interface-skeleton';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -23,7 +24,6 @@ import { EntityProvider } from '@wordpress/core-data';
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
-import InterfaceSkeleton from '@wordpress/interface/build-module/components/interface-skeleton';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -23,10 +23,7 @@ import { EntityProvider } from '@wordpress/core-data';
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { InterfaceSkeleton } from '@wordpress/interface';
+import InterfaceSkeleton from '@wordpress/interface/build-module/components/interface-skeleton';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -20,10 +20,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import classNames from 'classnames';
 import { Tag } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { PinnedItems } from '@wordpress/interface';
+import PinnedItems from '@wordpress/interface/build-module/components/pinned-items';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/header/plugin-header-items/plugin-header-item-modal.tsx
+++ b/packages/js/product-editor/src/components/header/plugin-header-items/plugin-header-item-modal.tsx
@@ -4,10 +4,7 @@
 import { createElement, Fragment, useState } from '@wordpress/element';
 import { Button, Modal } from '@wordpress/components';
 import { plugins } from '@wordpress/icons';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { PinnedItems } from '@wordpress/interface';
+import PinnedItems from '@wordpress/interface/build-module/components/pinned-items';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/header/plugin-header-items/plugin-header-item-popover.tsx
+++ b/packages/js/product-editor/src/components/header/plugin-header-items/plugin-header-item-popover.tsx
@@ -7,7 +7,7 @@ import { plugins } from '@wordpress/icons';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
-import { PinnedItems } from '@wordpress/interface';
+import PinnedItems from '@wordpress/interface/build-module/components/pinned-items';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -18,6 +18,7 @@ import { isWpVersion } from '@woocommerce/settings';
 import classnames from 'classnames';
 import { MouseEvent } from 'react';
 import { Button, Popover, ToolbarItem } from '@wordpress/components';
+import PinnedItems from '@wordpress/interface/build-module/components/pinned-items';
 // eslint-disable-next-line @woocommerce/dependency-group
 import {
 	store as preferencesStore,
@@ -31,7 +32,6 @@ import {
 	ToolSelector,
 	BlockToolbar,
 } from '@wordpress/block-editor';
-import PinnedItems from '@wordpress/interface/build-module/components/pinned-items';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -31,10 +31,7 @@ import {
 	ToolSelector,
 	BlockToolbar,
 } from '@wordpress/block-editor';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { PinnedItems } from '@wordpress/interface';
+import PinnedItems from '@wordpress/interface/build-module/components/pinned-items';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
@@ -5,10 +5,7 @@ import { MenuGroup } from '@wordpress/components';
 import { createElement, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { isWpVersion } from '@woocommerce/settings';
-import {
-	ActionItem,
-	// @ts-expect-error missing types.
-} from '@wordpress/interface';
+import ActionItem from '@wordpress/interface/build-module/components/action-item';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/plugin-more-menu-item.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/plugin-more-menu-item/plugin-more-menu-item.tsx
@@ -4,10 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { ActionItem } from '@wordpress/interface';
+import ActionItem from '@wordpress/interface/build-module/components/action-item';
 
 /**
  * Internal dependencies

--- a/packages/js/product-editor/src/components/iframe-editor/sidebar/plugin-sidebar/plugin-sidebar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/sidebar/plugin-sidebar/plugin-sidebar.tsx
@@ -1,16 +1,19 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { ComplementaryArea } from '@wordpress/interface';
+import { createElement, lazy } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { SIDEBAR_COMPLEMENTARY_AREA_SCOPE } from '../../constants';
+
+const ComplementaryArea = lazy( () =>
+	// @ts-expect-error No types for this exist yet
+	import( '@wordpress/interface' ).then( ( module ) => ( {
+		default: module.ComplementaryArea,
+	} ) )
+);
 
 type PluginSidebarProps = {
 	children: React.ReactNode;
@@ -28,6 +31,7 @@ type PluginSidebarProps = {
 export function PluginSidebar( { className, ...props }: PluginSidebarProps ) {
 	return (
 		<ComplementaryArea
+			// @ts-expect-error No types for this exist yet
 			panelClassName={ className }
 			className="woocommerce-iframe-editor__sidebar"
 			scope={ SIDEBAR_COMPLEMENTARY_AREA_SCOPE }

--- a/packages/js/product-editor/typings/index.d.ts
+++ b/packages/js/product-editor/typings/index.d.ts
@@ -65,3 +65,32 @@ declare module '@wordpress/edit-site/build-module/components/site-hub' {
 	} >;
 	export default SiteHub;
 }
+
+declare module '@wordpress/interface/build-module/components/pinned-items' {
+	const PinnedItems: React.FunctionComponent< {
+		scope: string;
+		children: React.ReactNode;
+	} > & {
+		Slot: React.FunctionComponent< {
+			children?: React.ReactNode;
+			scope: string;
+		} >;
+	};
+	export default PinnedItems;
+}
+
+declare module '@wordpress/interface/build-module/components/action-item' {
+	const ActionItem: React.FunctionComponent< {
+		children: React.ReactNode;
+		scope: string;
+	} > & {
+		Slot: React.FunctionComponent< {
+			children?: React.ReactNode;
+			name: string;
+			label: string;
+			as: React.ElementType;
+			fillProps: Record< string, unknown >;
+		} >;
+	};
+	export default ActionItem;
+}

--- a/packages/js/product-editor/typings/index.d.ts
+++ b/packages/js/product-editor/typings/index.d.ts
@@ -94,3 +94,13 @@ declare module '@wordpress/interface/build-module/components/action-item' {
 	};
 	export default ActionItem;
 }
+
+declare module '@wordpress/interface/build-module/components/interface-skeleton' {
+	const InterfaceSkeleton: React.FunctionComponent< {
+		children?: React.ReactNode;
+		header?: React.ReactNode;
+		content?: React.ReactNode;
+		actions?: React.ReactNode;
+	} >;
+	export default InterfaceSkeleton;
+}

--- a/plugins/woocommerce/changelog/fix-46771_core_interface_already_registered
+++ b/plugins/woocommerce/changelog/fix-46771_core_interface_already_registered
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Bundle in the @wordpress/interface/build-module dependencies.

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
@@ -36,6 +36,9 @@ jest.mock( '../../layout', () => ( {
 jest.mock( '../', () => ( {
 	EmbeddedBodyLayout: jest.fn( () => null ),
 } ) );
+jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
+	jest.fn()
+);
 
 describe( 'embedded-layout', () => {
 	let mockEmbeddedRoot: HTMLDivElement;

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/test/render-embedded-layout.test.tsx
@@ -36,9 +36,9 @@ jest.mock( '../../layout', () => ( {
 jest.mock( '../', () => ( {
 	EmbeddedBodyLayout: jest.fn( () => null ),
 } ) );
-jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
-	jest.fn()
-);
+jest.mock( '@woocommerce/product-editor', () => ( {
+	isValidEmail: jest.fn(),
+} ) );
 
 describe( 'embedded-layout', () => {
 	let mockEmbeddedRoot: HTMLDivElement;

--- a/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/test/delete-variation-menu-item.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/test/delete-variation-menu-item.test.tsx
@@ -27,9 +27,15 @@ jest.mock( '@wordpress/core-data', () => ( {
 		.mockImplementation( ( _1, _2, propType ) => [ propType ] ),
 } ) );
 
-jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
-	jest.fn()
-);
+jest.mock( '@woocommerce/product-editor', () => ( {
+	RemoveConfirmationModal: jest.fn(),
+	__experimentalUseVariationSwitcher: jest.fn().mockReturnValue( {
+		invalidateVariationList: jest.fn(),
+		goToNextVariation: jest.fn(),
+		goToPreviousVariation: jest.fn(),
+		numberOfVariations: 1,
+	} ),
+} ) );
 
 describe( 'DeleteVariationMenuItem', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/test/delete-variation-menu-item.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/fills/more-menu-items/test/delete-variation-menu-item.test.tsx
@@ -27,6 +27,10 @@ jest.mock( '@wordpress/core-data', () => ( {
 		.mockImplementation( ( _1, _2, propType ) => [ propType ] ),
 } ) );
 
+jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
+	jest.fn()
+);
+
 describe( 'DeleteVariationMenuItem', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();

--- a/plugins/woocommerce/client/admin/client/products/fills/test/product-block-editor-fills.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/fills/test/product-block-editor-fills.test.tsx
@@ -24,9 +24,9 @@ jest.mock( '../more-menu-items', () => ( {
 		</div>
 	) ),
 } ) );
-jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
-	jest.fn()
-);
+jest.mock( '@woocommerce/product-editor', () => ( {
+	isValidEmail: jest.fn(),
+} ) );
 
 describe( 'MoreMenuFill', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce/client/admin/client/products/fills/test/product-block-editor-fills.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/fills/test/product-block-editor-fills.test.tsx
@@ -24,6 +24,9 @@ jest.mock( '../more-menu-items', () => ( {
 		</div>
 	) ),
 } ) );
+jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
+	jest.fn()
+);
 
 describe( 'MoreMenuFill', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce/client/admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/test/product-page.test.tsx
@@ -3,7 +3,6 @@
  */
 import { render } from '@testing-library/react';
 import { recordEvent } from '@woocommerce/tracks';
-import { TRACKS_SOURCE } from '@woocommerce/product-editor';
 import { useParams } from 'react-router-dom';
 
 /**
@@ -40,6 +39,7 @@ jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
 	jest.fn()
 );
 
+const TRACKS_SOURCE = 'product-block-editor-v1';
 describe( 'ProductPage', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();

--- a/plugins/woocommerce/client/admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/test/product-page.test.tsx
@@ -36,6 +36,9 @@ jest.mock( '@woocommerce/product-editor', () => ( {
 	productApiFetchMiddleware: jest.fn(),
 	__experimentalInitBlocks: jest.fn().mockImplementation( () => () => {} ),
 } ) );
+jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
+	jest.fn()
+);
 
 describe( 'ProductPage', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce/client/admin/client/products/test/product-page.test.tsx
+++ b/plugins/woocommerce/client/admin/client/products/test/product-page.test.tsx
@@ -35,11 +35,19 @@ jest.mock( '@woocommerce/product-editor', () => ( {
 	productApiFetchMiddleware: jest.fn(),
 	__experimentalInitBlocks: jest.fn().mockImplementation( () => () => {} ),
 } ) );
-jest.mock( '@wordpress/interface/build-module/components/pinned-items', () =>
-	jest.fn()
-);
+jest.mock( '@woocommerce/product-editor', () => ( {
+	__experimentalEditor: jest.fn(),
+	__experimentalInitBlocks: jest.fn().mockImplementation( () => () => {} ),
+	__experimentalWooProductMoreMenuItem: jest.fn(),
+	productApiFetchMiddleware: jest.fn(),
+	productEditorHeaderApiFetchMiddleware: jest.fn(),
+	TRACKS_SOURCE: 'test-source',
+	__experimentalProductMVPCESFooter: jest.fn(),
+	__experimentalEditorLoadingContext: jest.fn(),
+	__experimentalProductMVPFeedbackModalContainer: jest.fn(),
+} ) );
 
-const TRACKS_SOURCE = 'product-block-editor-v1';
+const TRACKS_SOURCE = 'test-source';
 describe( 'ProductPage', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();

--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -234,6 +234,14 @@ const webpackConfig = {
 						return null;
 					}
 
+					if (
+						request.startsWith(
+							'@wordpress/interface/build-module'
+						)
+					) {
+						return null;
+					}
+
 					if ( request.startsWith( '@wordpress/edit-site' ) ) {
 						// The external wp.editSite does not include edit-site components, so we need to skip requesting to external here. We can remove this once the edit-site components are exported in the external wp.editSite.
 						// We use the edit-site components in the customize store.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This addresses the console warning shown on any WooCommerce JS page that `core/interface` was already registered.
This is due the fact that the `wordpress/block-editor` package is already loaded and registers the above.
Given the `@wordpress/interface` package is not available on `window.wp`, the import gets triggered again when the product editor JS gets loaded ( as it depends on it ).

To fix this I did two things:
- For components that didn't depend on the interface store, I bundled them in directly using `build-module` folder.
- For components that did depend on the interface store, I wrapped them in the react `lazy` function, as they are only rendered when using the block editor within the product editor.

<img width="1510" alt="Screenshot 2025-02-14 at 2 22 47 PM" src="https://github.com/user-attachments/assets/c3a4c6ea-a691-49b0-b83c-6eb6070060f5" />

Closes #46771  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With the new product editor **disabled** ( **WooCommerce > Settings > Advanced > Features** )
2. Go to **WooCommerce > Home**
3. Open your console, it should **not** show this error: `Store "core/interface" is already registered`
4. Now enable the new product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **WooCommerce > Home**
3. Open your console, it should **not** show this error: `Store "core/interface" is already registered`
4. Go to **Products > Add new product**
5. It should render the new product editor correctly, still not showing the above error.
6. Scroll down to the description, focus on the description field and click **Full Editor**
7. A modal will open with the block editor
8. The `Store "core/interface" is already registered` error does show up now ( this is expected, and currently no easy way around this ).
9. Install and activate this plugin: 
[test-46597-modal-block-editor-sidebar.zip](https://github.com/user-attachments/files/18799617/test-46597-modal-block-editor-sidebar.1.zip)
10. Refresh the **Products > Add new product** page ( the new editor )
11. Open up the description block editor again click the 3-dot menu in the top right
12. Under the **Plugins** section it should correctly list **Product** and **Blocks** 
13. Click on each of them, they should correctly render something in the right side panel ( the product panel renders the product JSON object, and the blocks panel renders the block list of the description block ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
