### PR TITLE
[Experimental] Fix missing stylesheets in several experimental blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-missing-stylesheets
+++ b/plugins/woocommerce/changelog/fix-missing-stylesheets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix missing stylesheets in several experimental blocks
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelector.php
@@ -18,6 +18,15 @@ class AddToCartWithOptionsGroupedProductSelector extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-grouped-product-selector';
 
 	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelectorItemTemplate.php
@@ -20,6 +20,15 @@ class AddToCartWithOptionsGroupedProductSelectorItemTemplate extends AbstractBlo
 	protected $block_name = 'add-to-cart-with-options-grouped-product-selector-item';
 
 	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
 	 * Get product row HTML.
 	 *
 	 * @param string   $product_id Product ID.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -13,6 +13,14 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 */
 	protected $block_name = 'blockified-product-details';
 
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
 
 	/**
 	 * Render the block.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates three blocks that didn't have a stylesheet but were still causing a request.

cc @gigitux and @louwie17 for awareness on the _Product Details_ block change.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Verify you don't see 404 errors related to _Add to Cart with Options Grouped Selector_ and _Product Details_ blocks.