### PR TITLE
Remove unused wp/editor enqueue

### DIFF
--- a/plugins/woocommerce/changelog/fix-46771_remove_unused_wp_editor_enqueue
+++ b/plugins/woocommerce/changelog/fix-46771_remove_unused_wp_editor_enqueue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Remove the unneeded wp-editor script dependency when the product editor feature is not enabled.

--- a/plugins/woocommerce/src/Admin/Features/ProductDataViews/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductDataViews/Init.php
@@ -38,7 +38,7 @@ class Init {
 	/**
 	 * Returns true if we are on a JS powered admin page.
 	 */
-	private static function is_product_data_view_page() {
+	public static function is_product_data_view_page() {
 		// phpcs:disable WordPress.Security.NonceVerification
 		return isset( $_GET['page'] ) && 'woocommerce-products-dashboard' === $_GET['page'];
 		// phpcs:enable WordPress.Security.NonceVerification

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -9,7 +9,7 @@ use _WP_Dependency;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Internal\Admin\Loader;
-
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 /**
  * WCAdminAssets Class.
  */
@@ -322,6 +322,12 @@ class WCAdminAssets {
 					str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store' )
 				);
 				if ( ! $is_customize_store_page && WC_ADMIN_APP === $script ) {
+					$script_assets['dependencies'] = array_diff( $script_assets['dependencies'], array( 'wp-editor' ) );
+				}
+
+				// Remove wp-editor dependency if the product editor feature is disabled as we don't need it.
+				$is_product_data_view_page = \Automattic\WooCommerce\Admin\Features\ProductDataViews\Init::is_product_data_view_page();
+				if ( 'wc-product-editor' === $script && ! ( FeaturesUtil::feature_is_enabled( 'product_block_editor' ) || $is_product_data_view_page ) ) {
 					$script_assets['dependencies'] = array_diff( $script_assets['dependencies'], array( 'wp-editor' ) );
 				}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is another fix for #46771 as the `wp-editor` package triggers the register call for the `core/interface` package. The thing is that when the product editor feature flag is not enabled we do not need this dependency at all.

We actually already had similar logic in place for the customize your store page: https://github.com/woocommerce/woocommerce/blob/c29b2e4c77c2797fc51141dc646bacc9508f0887/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php#L319-L326

Removing this dependency actually changes the enqueued scripts from 125 to 86.

Also addresses #46771 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With the new product editor **disabled** ( **WooCommerce > Settings > Advanced > Features** )
2. Go to **WooCommerce > Home**
3. Open your console, it should **not** show this error: `Store "core/interface" is already registered`
4. Now enable the new product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **WooCommerce > Home**
3. Open your console, it will show the error: `Store "core/interface" is already registered` ( this PR ( https://github.com/woocommerce/woocommerce/pull/55489 ) fixes the error in this use case )
4. Go to **Products > Add new product**
5. It should render the new product editor correctly

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
