### PR TITLE
[Experimental] Update Add to Cart with Options template part in tests

### DIFF
--- a/docs/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -575,7 +575,7 @@ Due to technical reasons, it's not yet possible to specify the meta key for fiel
 
 Assuming 2 fields, named `my-plugin-namespace/address-field` in the address step and `my-plugin-namespace/my-other-field` in the order step, you can:
 
-### React to to saving fields
+### React to saving fields
 
 You can react to those fields being saved by hooking into `woocommerce_set_additional_field_value` action.
 

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -196,7 +196,7 @@
           "menu_title": "Additional Checkout Fields",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/additional-checkout-fields.md",
-          "hash": "8336fc88a08df2b41ec20234f7475ddc94b8605fdd7db9577e96c93dad716fee",
+          "hash": "5b27bc3fa44a5c548a6cd1d1530f49108e960e858b607c69a981ccdd5ea9ab4e",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/additional-checkout-fields.md",
           "id": "cb5dd8d59043a4e53929121b45da7b33b1661ab8"
         }
@@ -1954,5 +1954,5 @@
       "categories": []
     }
   ],
-  "hash": "7a688f3ce563ed941994959844bdc4f90e8e7efb2ecefd4d121f264d947fcab0"
+  "hash": "fe9444e7bad4c3d1311becc4382f47065c79a7ecb526356ea3c79e5d13df149b"
 }

--- a/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce-blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -65,7 +65,7 @@ class AddToCartWithOptionsPage {
 		// Add to Cart is a dynamic block, so we need to wait for it to be
 		// ready. If we don't do that, it might clear the paragraph we're
 		// inserting below (depending on the test execution speed).
-		await parentBlock.getByText( 'Add to Cart' ).waitFor();
+		await parentBlock.getByText( 'Add to cart', { exact: true } ).waitFor();
 
 		await this.editor.insertBlock(
 			{

--- a/plugins/woocommerce-blocks/tests/e2e/themes/theme-with-woo-templates/block-template-parts/external-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce-blocks/tests/e2e/themes/theme-with-woo-templates/block-template-parts/external-product-add-to-cart-with-options.html
@@ -2,6 +2,4 @@
 <p>External Product Add to cart with Options template loaded from theme</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:woocommerce/product-button {"textAlign":"center","fontSize":"small"} -->
-<div class="wp-block-woocommerce-product-button is-loading has-small-font-size"></div>
-<!-- /wp:woocommerce/product-button -->
+<!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"small"} /-->

--- a/plugins/woocommerce/changelog/fix-update-tests-template-part
+++ b/plugins/woocommerce/changelog/fix-update-tests-template-part
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update Add to Cart with Options template part in tests
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/55205. In that PR we updated the layout of the WooCommerce template parts for the _Add to Cart with Options_ block, but I forgot to update the template part used in tests. This PR fixes that.

### How to test the changes in this Pull Request:

1. Make sure tests keep passing.