### PR TITLE
Fixed - Long local pickup details text truncate issue

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -30,15 +30,32 @@
 				font-style: inherit;
 			}
 		}
+		.wc-block-components-radio-control__option-checked {
+			.wc-block-components-radio-control__description-group {
+				.read-more-content {
+					margin-left: em($gap-small * 0.25);
+					position: initial;
+					visibility: visible;
+					z-index: initial;
+					hyphens: auto;
+					word-break: normal;
+				}
+			}
+		}
 		.wc-block-components-radio-control__description-group {
 			display: block;
 			width: calc(100% + em($gap-huge / 0.875));
 			box-sizing: border-box;
 			border-radius: $universal-border-radius;
-			padding: 0 em($gap);
+			padding: 1px em($gap-small);
 			margin-left: -(em($gap-huge));
 			margin-top: em($gap);
 			@include font-size(regular);
+			.read-more-content {
+				position: absolute;
+				visibility: hidden;
+				z-index: -1;
+			}
 		}
 		.wc-block-components-radio-control__description,
 		.wc-block-components-radio-control__secondary-description {
@@ -62,18 +79,6 @@
 				vertical-align: middle;
 				margin-top: -4px;
 				fill: currentColor;
-			}
-		}
-		.wc-block-components-radio-control__description-group {
-			.wc-block-components-radio-control__secondary-description {
-				display: none;
-			}
-		}
-		.wc-block-components-radio-control__option-checked {
-			.wc-block-components-radio-control__description-group {
-				.wc-block-components-radio-control__secondary-description {
-					display: block;
-				}
 			}
 		}
 	}

--- a/plugins/woocommerce/changelog/55502-fix-Long-local-pickup-details-truncate-issue
+++ b/plugins/woocommerce/changelog/55502-fix-Long-local-pickup-details-truncate-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Long local pickup details text will truncate on all options after selecting.

--- a/plugins/woocommerce/changelog/fix-Long-local-pickup-details-truncate-issue
+++ b/plugins/woocommerce/changelog/fix-Long-local-pickup-details-truncate-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Long local pickup details text will truncate on all options after selecting.

--- a/plugins/woocommerce/changelog/fix-Long-local-pickup-details-truncate-issue
+++ b/plugins/woocommerce/changelog/fix-Long-local-pickup-details-truncate-issue
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Long local pickup details text will truncate on all options after selecting.


### PR DESCRIPTION
Long local pickup details text will truncate on all options after selecting.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55410 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to /wp-admin/admin.php?page=wc-settings&tab=shipping&section=pickup_location.

2. Enable local pickups.

3. Create at least two pickup locations.

4. For both locations, add long pickup details, e.g. the following text:

"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

5. Go to the frontend.

6. Add a product to the cart.

7. Go to the checkout page.

8. Select Pickup, if not selected yet.

9. See that the pickup details of the select pickup location are truncated and a read more button is visible.

10. Select the other pickup location.

11. Check that the pickup details are truncated properly and read more button is visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Long local pickup details text will truncate on all options after selecting.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
