### PR TITLE
Fixed - Order Emails Empty Spaces Caused by Missing First Name

### DIFF
--- a/plugins/woocommerce/changelog/55516-fix-Order-Emails-Fix-Empty-Spaces-Caused-by-Missing-First-Name
+++ b/plugins/woocommerce/changelog/55516-fix-Order-Emails-Fix-Empty-Spaces-Caused-by-Missing-First-Name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Order Emails Empty Spaces Caused by Missing First Name Fixed.

--- a/plugins/woocommerce/templates/emails/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-completed-order.php
@@ -29,8 +29,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 <?php if ( $email_improvements_enabled ) : ?>
 	<p><?php esc_html_e( 'We’ve successfully processed your order, and it’s on its way to you.', 'woocommerce' ); ?></p>
 	<p><?php esc_html_e( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ); ?></p>

--- a/plugins/woocommerce/templates/emails/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-failed-order.php
@@ -32,8 +32,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 <p><?php esc_html_e( "Unfortunately, we couldn't complete your order due to an issue with your payment method.", 'woocommerce' ); ?></p>
 <?php /* translators: %s: Site title */ ?>
 <p><?php printf( esc_html__( "If you'd like to continue with your purchase, please return to %s and try a different method of payment.", 'woocommerce' ), esc_html( $blogname ) ); ?></p>

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -32,9 +32,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
-
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 <?php if ( $order->needs_payment() ) { ?>
 	<p>
 	<?php

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -29,8 +29,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 <p><?php esc_html_e( 'The following note has been added to your order:', 'woocommerce' ); ?></p>
 
 <blockquote><?php echo wpautop( wptexturize( make_clickable( $customer_note ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></blockquote>

--- a/plugins/woocommerce/templates/emails/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/customer-on-hold-order.php
@@ -27,8 +27,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 <?php if ( $email_improvements_enabled ) : ?>
 	<p><?php esc_html_e( 'We’ve received your order and it’s currently on hold until we can confirm your payment has been processed.', 'woocommerce' ); ?></p>
 	<p><?php esc_html_e( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ); ?></p>

--- a/plugins/woocommerce/templates/emails/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/customer-processing-order.php
@@ -29,8 +29,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 <?php if ( $email_improvements_enabled ) : ?>
 	<p><?php esc_html_e( 'We’ve received your order and will let you know when it’s on its way to you!', 'woocommerce' ); ?></p>
 	<p><?php esc_html_e( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ); ?></p>

--- a/plugins/woocommerce/templates/emails/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-refunded-order.php
@@ -27,8 +27,16 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php echo $email_improvements_enabled ? '<div class="email-introduction">' : ''; ?>
-<?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p>
+<?php 
+if( !empty($order->get_billing_first_name()) ) {
+	/* translators: %s: Customer first name */
+	printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); 
+} else {
+	printf('Hi,');
+}
+?>
+</p>
 
 <p>
 <?php

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -36,7 +36,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 			<?php } ?>
 
 			<address class="address">
-				<?php echo wp_kses_post( $address ? $address : esc_html__( 'N/A', 'woocommerce' ) ); ?>
+				<?php echo wp_kses_post( $address ? $address : esc_html__( 'N/bmA', 'woocommerce' ) ); ?>
 				<?php if ( $order->get_billing_phone() ) : ?>
 					<br/><?php echo wc_make_phone_clickable( $order->get_billing_phone() ); ?>
 				<?php endif; ?>


### PR DESCRIPTION
Order Emails Empty Spaces Caused by Missing First Name Fixed.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Create new order (WooCommerce -> Orders -> Add Order)
2. Add product
3. Add customer with email
4. Remove first and last name if necessary
5. Save order
6. In order actions select "Send order details to customer"
7. Tap Update
8. Check email
9. Notice that now there is no empty space in "Hi,"

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Order Emails Empty Spaces Caused by Missing First Name Fixed.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
