### PR TITLE
Add filter to customize of 'Your order' in form-checkout template

### DIFF
--- a/plugins/woocommerce/changelog/feature-form-checkout-header-filter
+++ b/plugins/woocommerce/changelog/feature-form-checkout-header-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added new filter `woocommerce_checkout_order_review_heading` to allow customizing the 'Your Order' text on the checkout form.

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -55,7 +55,6 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	/**
 	 * Filter to modify the output of the order review heading.
 	 *
-	 * @since x.x.x
 	 *
 	 * @param string $output The heading text.
 	 */

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -52,6 +52,13 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 
 	<?php
+	/**
+	 * Filter to modify the output of the order review heading.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $output The heading text.
+	 */
 	$order_review_heading = apply_filters( 'woocommerce_checkout_order_review_heading', __( 'Your order', 'woocommerce' ) );
 	if ( $order_review_heading ) :
 		?>

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -50,9 +50,14 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	<?php endif; ?>
 	
 	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
-	
-	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'woocommerce' ); ?></h3>
-	
+
+	<?php
+	$order_review_heading = apply_filters( 'woocommerce_checkout_order_review_heading', __( 'Your order', 'woocommerce' ) );
+	if ( $order_review_heading ) :
+		?>
+		<h3 id="order_review_heading"><?php esc_html( $order_review_heading ); ?></h3>
+	<?php endif; ?>
+
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 
 	<div id="order_review" class="woocommerce-checkout-review-order">

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -62,7 +62,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	$order_review_heading = apply_filters( 'woocommerce_checkout_order_review_heading', __( 'Your order', 'woocommerce' ) );
 	if ( $order_review_heading ) :
 		?>
-		<h3 id="order_review_heading"><?php esc_html_e( $order_review_heading ); ?></h3>
+		<h3 id="order_review_heading"><?php echo esc_html( $order_review_heading ); ?></h3>
 	<?php endif; ?>
 
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -62,7 +62,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	$order_review_heading = apply_filters( 'woocommerce_checkout_order_review_heading', __( 'Your order', 'woocommerce' ) );
 	if ( $order_review_heading ) :
 		?>
-		<h3 id="order_review_heading"><?php esc_html( $order_review_heading ); ?></h3>
+		<h3 id="order_review_heading"><?php esc_html_e( $order_review_heading ); ?></h3>
 	<?php endif; ?>
 
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -55,7 +55,6 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	/**
 	 * Filter to modify the output of the order review heading.
 	 *
-	 *
 	 * @param string $output The heading text.
 	 */
 	$order_review_heading = apply_filters( 'woocommerce_checkout_order_review_heading', __( 'Your order', 'woocommerce' ) );

--- a/plugins/woocommerce/templates/checkout/form-checkout.php
+++ b/plugins/woocommerce/templates/checkout/form-checkout.php
@@ -52,11 +52,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 
 	<?php
-	/**
-	 * Filter to modify the output of the order review heading.
-	 *
-	 * @param string $output The heading text.
-	 */
+	// Filter to modify the output of the order review heading.
 	$order_review_heading = apply_filters( 'woocommerce_checkout_order_review_heading', __( 'Your order', 'woocommerce' ) );
 	if ( $order_review_heading ) :
 		?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added new filter `woocommerce_checkout_order_review_heading` to allow customizing the 'Your Order' text on the checkout form.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use add_filter() to override the text like this: ```add_filter('woocommerce_checkout_order_review_heading', function ($text) {
    return 'Order Summary';
});```


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
