### PR TITLE
Fix invalid content in default Refund and Returns Policy page template

### DIFF
--- a/plugins/woocommerce/changelog/55527-fix-refound-and-returns-policy-page-content
+++ b/plugins/woocommerce/changelog/55527-fix-refound-and-returns-policy-page-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix invalid content display in the default Refund and Returns Policy page template when viewed in the site editor.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2589,7 +2589,7 @@ $hpos_table_schema;
 <p>If you are approved, then your refund will be processed, and a credit will automatically be applied to your credit card or original method of payment, within a certain amount of days.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading -->
+<!-- wp:heading {"level":3} -->
 <h3 class="wp-block-heading">Late or missing refunds</h3>
 <!-- /wp:heading -->
 
@@ -2609,7 +2609,7 @@ $hpos_table_schema;
 <p>If you’ve done all of this and you still have not received your refund yet, please contact us at {email address}.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading -->
+<!-- wp:heading {"level":3} -->
 <h3 class="wp-block-heading">Sale items</h3>
 <!-- /wp:heading -->
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Refund and Returns Policy page content showed unexpected or invalid content in the site editor. This PR fixes the issue by adding the required h3 level attribute to H3 headings


<img width="1146" alt="Screenshot 2024-07-08 at 14 53 41" src="https://github.com/woocommerce/woocommerce/assets/4344253/28ebd2d6-27f0-4962-832f-a8fb033b4e02">



This improves the merchant experience when setting up their store's refund policy page.

Closes #49220.

### How to test the changes in this Pull Request:

1. Create a fresh WooCommerce site
2. Go to `WooCommerce > Home`
3. Find the note "Setup a Refund and Returns Policy page to boost your store's credibility" in the Inbox
4. Click on "Edit page"
5. Verify that:
   - The page content loads correctly in the site editor
   - No invalid content or block errors are shown

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix invalid content display in the default Refund and Returns Policy page template when viewed in the site editor.
</details>