### PR TITLE
Fix white screen flash during Customize Your Store loading transition

### DIFF
--- a/plugins/woocommerce/changelog/55528-fix-cys-loader-white-screen
+++ b/plugins/woocommerce/changelog/55528-fix-cys-loader-white-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix white screen flash during Customize Your Store task loading transition.

--- a/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/state-machine.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/design-without-ai/state-machine.tsx
@@ -303,6 +303,9 @@ export const designWithNoAiStateMachineDefinition = createMachine(
 						},
 					},
 					assembleSite: {
+						meta: {
+							component: ApiCallLoader,
+						},
 						initial: 'pending',
 						states: {
 							pending: {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR addresses the issue where a white screen briefly appears during the loading sequence when transitioning from the "Start Designing" button click to the Assembler page in the Customize Your Store (CYS) task. The change ensures a smoother transition between states in the Assembler loading sequence.


Closes #53743.

### How to test the changes in this Pull Request:

1. Go to `WooCommerce > Home`
2. Click on the Customize Your Store (CYS) task
3. Click on the `Start Designing` button
4. Verify that no white screen appears during the transition

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix white screen flash during Customize Your Store task loading transition.
</details>