### PR TITLE
Add filters for email preview settings ids

### DIFF
--- a/plugins/woocommerce/changelog/55475-email-preview-settings-ids-filters
+++ b/plugins/woocommerce/changelog/55475-email-preview-settings-ids-filters
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Add filters for email preview settings ids
+Add filters for email preview setting ids

--- a/plugins/woocommerce/changelog/55475-email-preview-settings-ids-filters
+++ b/plugins/woocommerce/changelog/55475-email-preview-settings-ids-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add filters for email preview settings ids

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -129,7 +129,7 @@ export const registerSettingsEmailPreviewFill = () => {
 		emailTypes = JSON.parse( emailTypesData || '' );
 	} catch ( e ) {}
 	const settingsIdsData = slotElement.getAttribute(
-		'data-email-settings-ids'
+		'data-email-setting-ids'
 	);
 	let settingsIds: string[] = [];
 	try {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -671,7 +671,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			id="wc_settings_email_preview_slotfill"
 			data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
 			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
-			data-email-settings-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::get_email_style_settings_ids() ) ); ?>"
+			data-email-setting-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::get_email_style_setting_ids() ) ); ?>"
 		></div>
 		<?php
 	}
@@ -699,7 +699,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				id="wc_settings_email_preview_slotfill"
 				data-preview-url="<?php echo esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ); ?>"
 				data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
-				data-email-settings-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::get_email_content_settings_ids( $email->id ) ) ); ?>"
+				data-email-setting-ids="<?php echo esc_attr( wp_json_encode( EmailPreview::get_email_content_setting_ids( $email->id ) ) ); ?>"
 			></div>
 			<input type="hidden" id="woocommerce_email_from_name" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_name' ) ); ?>" />
 			<input type="hidden" id="woocommerce_email_from_address" value="<?php echo esc_attr( get_option( 'woocommerce_email_from_address' ) ); ?>" />
@@ -712,7 +712,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * prevent conflicts where the preview would show values from previous session.
 	 */
 	private function delete_transient_email_settings() {
-		$setting_ids = EmailPreview::get_all_email_settings_ids();
+		$setting_ids = EmailPreview::get_all_email_setting_ids();
 		foreach ( $setting_ids as $id ) {
 			delete_transient( $id );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -33,7 +33,7 @@ class EmailPreview {
 	 *
 	 * @var array
 	 */
-	private static array $email_style_settings_ids = array(
+	private static array $email_style_setting_ids = array(
 		'woocommerce_email_background_color',
 		'woocommerce_email_base_color',
 		'woocommerce_email_body_background_color',
@@ -51,14 +51,14 @@ class EmailPreview {
 	 *
 	 * @var array
 	 */
-	private static array $email_content_settings_ids = array();
+	private static array $email_content_setting_ids = array();
 
 	/**
-	 * Whether the email settings IDs are initialized.
+	 * Whether the email setting IDs are initialized.
 	 *
 	 * @var bool
 	 */
-	private static bool $email_settings_ids_initialized = false;
+	private static bool $email_setting_ids_initialized = false;
 
 	/**
 	 * The email type to preview.
@@ -94,51 +94,51 @@ class EmailPreview {
 	}
 
 	/**
-	 * Get all email settings IDs.
+	 * Get all email setting IDs.
 	 */
-	public static function get_all_email_settings_ids() {
-		if ( ! self::$email_settings_ids_initialized ) {
-			self::$email_settings_ids_initialized = true;
+	public static function get_all_email_setting_ids() {
+		if ( ! self::$email_setting_ids_initialized ) {
+			self::$email_setting_ids_initialized = true;
 
 			$emails = WC()->mailer()->get_emails();
 			foreach ( $emails as $email ) {
-				self::$email_content_settings_ids = array_merge(
-					self::$email_content_settings_ids,
-					self::get_email_content_settings_ids( $email->id )
+				self::$email_content_setting_ids = array_merge(
+					self::$email_content_setting_ids,
+					self::get_email_content_setting_ids( $email->id )
 				);
 			}
-			self::$email_content_settings_ids = array_unique( self::$email_content_settings_ids );
+			self::$email_content_setting_ids = array_unique( self::$email_content_setting_ids );
 		}
 		return array_merge(
-			self::$email_style_settings_ids,
-			self::$email_content_settings_ids,
+			self::$email_style_setting_ids,
+			self::$email_content_setting_ids,
 		);
 	}
 
 	/**
-	 * Get email style settings IDs.
+	 * Get email style setting IDs.
 	 */
-	public static function get_email_style_settings_ids() {
+	public static function get_email_style_setting_ids() {
 		/**
-		 * Filter the email style settings IDs. Email preview automatically refreshes when these settings are changed.
+		 * Filter the email style setting IDs. Email preview automatically refreshes when these settings are changed.
 		 *
-		 * @param array $settings_ids The email style settings IDs.
+		 * @param array $setting_ids The email style setting IDs.
 		 *
 		 * @since 9.8.0
 		 */
-		return apply_filters( 'woocommerce_email_preview_email_style_settings_ids', self::$email_style_settings_ids );
+		return apply_filters( 'woocommerce_email_preview_email_style_setting_ids', self::$email_style_setting_ids );
 	}
 
 	/**
-	 * Get email content settings IDs for specific email.
+	 * Get email content setting IDs for specific email.
 	 *
 	 * @param string|null $email_id Email ID.
 	 */
-	public static function get_email_content_settings_ids( ?string $email_id ) {
+	public static function get_email_content_setting_ids( ?string $email_id ) {
 		if ( ! $email_id ) {
 			return array();
 		}
-		$settings_ids = array(
+		$setting_ids = array(
 			"woocommerce_{$email_id}_subject",
 			"woocommerce_{$email_id}_heading",
 			"woocommerce_{$email_id}_additional_content",
@@ -146,14 +146,14 @@ class EmailPreview {
 		);
 
 		/**
-		 * Filter the email content settings IDs for specific email. Email preview automatically refreshes when these settings are changed.
+		 * Filter the email content setting IDs for specific email. Email preview automatically refreshes when these settings are changed.
 		 *
-		 * @param array  $settings_ids The email content settings IDs.
+		 * @param array  $setting_ids The email content setting IDs.
 		 * @param string $email_id The email ID.
 		 *
 		 * @since 9.8.0
 		 */
-		return apply_filters( 'woocommerce_email_preview_email_content_settings_ids', $settings_ids, $email_id );
+		return apply_filters( 'woocommerce_email_preview_email_content_setting_ids', $setting_ids, $email_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -119,7 +119,14 @@ class EmailPreview {
 	 * Get email style settings IDs.
 	 */
 	public static function get_email_style_settings_ids() {
-		return self::$email_style_settings_ids;
+		/**
+		 * Filter the email style settings IDs. Email preview automatically refreshes when these settings are changed.
+		 *
+		 * @param array $settings_ids The email style settings IDs.
+		 *
+		 * @since 9.8.0
+		 */
+		return apply_filters( 'woocommerce_email_preview_email_style_settings_ids', self::$email_style_settings_ids );
 	}
 
 	/**
@@ -131,12 +138,22 @@ class EmailPreview {
 		if ( ! $email_id ) {
 			return array();
 		}
-		return array(
+		$settings_ids = array(
 			"woocommerce_{$email_id}_subject",
 			"woocommerce_{$email_id}_heading",
 			"woocommerce_{$email_id}_additional_content",
 			"woocommerce_{$email_id}_email_type",
 		);
+
+		/**
+		 * Filter the email content settings IDs for specific email. Email preview automatically refreshes when these settings are changed.
+		 *
+		 * @param array  $settings_ids The email content settings IDs.
+		 * @param string $email_id The email ID.
+		 *
+		 * @since 9.8.0
+		 */
+		return apply_filters( 'woocommerce_email_preview_email_content_settings_ids', $settings_ids, $email_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreviewRestController.php
@@ -159,7 +159,7 @@ class EmailPreviewRestController extends RestApiControllerBase {
 				'type'              => 'string',
 				'description'       => 'The key for the transient. Must be one of the allowed options.',
 				'validate_callback' => function ( $key ) {
-					if ( ! in_array( $key, EmailPreview::get_all_email_settings_ids(), true ) ) {
+					if ( ! in_array( $key, EmailPreview::get_all_email_setting_ids(), true ) ) {
 						return new \WP_Error(
 							'woocommerce_rest_not_allowed_key',
 							sprintf( 'The provided key "%s" is not allowed.', $key ),

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
@@ -44,8 +44,8 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_settings__all_settings_are_present() {
 		$sut = new WC_Settings_Accounts();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'account_registration_options'                 => array( 'title', 'sectionend' ),
@@ -69,7 +69,7 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_anonymize_completed_orders'       => 'relative_date_selector',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-advanced-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-advanced-test.php
@@ -85,8 +85,8 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_default_settings_returns_all_settings( $site_is_https ) {
 		$sut = new WC_Settings_Advanced();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		update_option( 'home', $site_is_https ? 'https://foo.bar' : 'http://foo.bar' );
 
@@ -120,7 +120,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 			unset( $expected['unforce_ssl_checkout'], $expected['force_ssl_checkout'] );
 		}
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**
@@ -136,10 +136,10 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_show_marketplace_suggestions' => 'checkbox',
 		);
 
-		$settings               = $sut->get_settings_for_section( 'woocommerce_com' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( 'woocommerce_com' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**
@@ -153,10 +153,10 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_api_enabled' => 'checkbox',
 		);
 
-		$settings               = $sut->get_settings_for_section( 'legacy_api' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( 'legacy_api' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
@@ -66,8 +66,8 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_default_settings_returns_all_settings() {
 		$sut = new WC_Settings_Emails();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'email_notification_settings'              => array( 'title', 'sectionend' ),
@@ -88,7 +88,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_merchant_email_notifications' => 'checkbox',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**
@@ -102,8 +102,8 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 
 		$sut = new WC_Settings_Emails();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'email_notification_settings'              => array( 'title', 'sectionend' ),
@@ -128,7 +128,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_merchant_email_notifications' => 'checkbox',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 
 		$features_controller->change_feature_enable( 'email_improvements', $original_value );
 	}

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-general-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-general-test.php
@@ -44,8 +44,8 @@ class WC_Settings_General_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_settings__all_settings_are_present() {
 		$sut = new WC_Settings_General();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'woocommerce_store_address'               => 'text',
@@ -72,7 +72,7 @@ class WC_Settings_General_Test extends WC_Settings_Unit_Test_Case {
 			'pricing_options'                         => array( 'title', 'sectionend' ),
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-payment-gateways-test.php
@@ -67,15 +67,15 @@ class WC_Settings_Payment_Gateways_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_default_settings_returns_all_settings() {
 		$sut = new WC_Settings_Payment_Gateways();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'payment_gateways_options' => 'sectionend',
 			''                         => array( 'title', 'payment_gateways_banner', 'payment_gateways' ),
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -83,8 +83,8 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_default_settings_returns_all_settings() {
 		$sut = new WC_Settings_Products();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'catalog_options'                              => array( 'title', 'sectionend' ),
@@ -103,7 +103,7 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_review_rating_required'           => 'checkbox',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**
@@ -112,8 +112,8 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_inventory_settings_returns_all_settings() {
 		$sut = new WC_Settings_Products();
 
-		$settings               = $sut->get_settings_for_section( 'inventory' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( 'inventory' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'product_inventory_options'           => array( 'title', 'sectionend' ),
@@ -128,7 +128,7 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_stock_format'            => 'select',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**
@@ -137,8 +137,8 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_downloadable_settings_returns_all_settings() {
 		$sut = new WC_Settings_Products();
 
-		$settings               = $sut->get_settings_for_section( 'downloadable' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( 'downloadable' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'digital_download_options'                         => array( 'title', 'sectionend' ),
@@ -151,7 +151,7 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_downloads_count_partial'        => 'checkbox',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-shipping-test.php
@@ -87,8 +87,8 @@ class WC_Settings_Shipping_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_options_settings_returns_all_settings() {
 		$sut = new WC_Settings_Shipping();
 
-		$settings               = $sut->get_settings_for_section( 'options' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( 'options' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'shipping_options'                           => array( 'title', 'sectionend' ),
@@ -98,7 +98,7 @@ class WC_Settings_Shipping_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_shipping_debug_mode'            => 'checkbox',
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
@@ -50,8 +50,8 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_settings_for_default_section() {
 		$sut = new WC_Settings_Tax();
 
-		$settings               = $sut->get_settings_for_section( '' );
-		$settings_ids_and_types = $this->get_ids_and_types( $settings );
+		$settings              = $sut->get_settings_for_section( '' );
+		$setting_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
 			'tax_options'                       => array( 'title', 'sectionend' ),
@@ -67,7 +67,7 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 			''                                  => array( 'conflict_error', 'add_settings_slot' ),
 		);
 
-		$this->assertEquals( $expected, $settings_ids_and_types );
+		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-unit-test-case.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-unit-test-case.php
@@ -37,19 +37,19 @@ abstract class WC_Settings_Unit_Test_Case extends WC_Unit_Test_Case {
 	 * @return array The transformed settings.
 	 */
 	public function get_ids_and_types( $settings ) {
-		$settings_ids_and_types = array();
+		$setting_ids_and_types = array();
 		foreach ( $settings as $setting ) {
 			$id   = array_key_exists( 'id', $setting ) ? $setting['id'] : null;
 			$type = $setting['type'];
-			if ( ! array_key_exists( $id, $settings_ids_and_types ) ) {
-				$settings_ids_and_types[ $id ] = $type;
-			} elseif ( is_array( $settings_ids_and_types[ $id ] ) ) {
-				$settings_ids_and_types[ $id ][] = $type;
+			if ( ! array_key_exists( $id, $setting_ids_and_types ) ) {
+				$setting_ids_and_types[ $id ] = $type;
+			} elseif ( is_array( $setting_ids_and_types[ $id ] ) ) {
+				$setting_ids_and_types[ $id ][] = $type;
 			} else {
-				$settings_ids_and_types[ $id ] = array( $settings_ids_and_types[ $id ], $type );
+				$setting_ids_and_types[ $id ] = array( $setting_ids_and_types[ $id ], $type );
 			}
 		}
 
-		return $settings_ids_and_types;
+		return $setting_ids_and_types;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewRestControllerTest.php
@@ -255,7 +255,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'Missing parameter(s): key, value', $response->get_data()['message'] );
 
-		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0] );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_setting_ids()[0] );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'Missing parameter(s): value', $response->get_data()['message'] );
@@ -280,7 +280,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test saving transient for an unregistered email fails
 	 */
 	public function test_save_transient_with_unregistered_email() {
-		$keys = EmailPreview::get_email_content_settings_ids( 'unregistered_email_id' );
+		$keys = EmailPreview::get_email_content_setting_ids( 'unregistered_email_id' );
 		foreach ( $keys as $key ) {
 			$request  = $this->get_save_transient_request( $key, 'value' );
 			$response = $this->server->dispatch( $request );
@@ -293,7 +293,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test saving transient for registered email
 	 */
 	public function test_save_transient_with_registered_email() {
-		$keys = EmailPreview::get_email_content_settings_ids( EmailPreview::DEFAULT_EMAIL_ID );
+		$keys = EmailPreview::get_email_content_setting_ids( EmailPreview::DEFAULT_EMAIL_ID );
 		foreach ( $keys as $key ) {
 			$request  = $this->get_save_transient_request( $key, 'value' );
 			$response = $this->server->dispatch( $request );
@@ -312,7 +312,7 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		add_filter( 'user_has_cap', $filter_callback );
 
-		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0], 'value' );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_setting_ids()[0], 'value' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
@@ -324,11 +324,11 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test saving transient with a successful saving.
 	 */
 	public function test_save_transient_success_response() {
-		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0], 'value' );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_setting_ids()[0], 'value' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'Transient saved for key ' . EmailPreview::get_email_style_settings_ids()[0] . '.', $response->get_data()['message'] );
+		$this->assertEquals( 'Transient saved for key ' . EmailPreview::get_email_style_setting_ids()[0] . '.', $response->get_data()['message'] );
 	}
 
 	/**
@@ -362,10 +362,10 @@ class EmailPreviewRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test saving transient with a failed saving.
 	 */
 	public function test_save_transient_error_response() {
-		set_transient( EmailPreview::get_email_style_settings_ids()[0], 'value', HOUR_IN_SECONDS );
+		set_transient( EmailPreview::get_email_style_setting_ids()[0], 'value', HOUR_IN_SECONDS );
 
 		// Saving the transient will fail because the transient key is already set to the same value.
-		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_settings_ids()[0], 'value' );
+		$request  = $this->get_save_transient_request( EmailPreview::get_email_style_setting_ids()[0], 'value' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 500, $response->get_status() );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -252,9 +252,9 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	 * Test that transient values are applied in email preview
 	 */
 	public function test_transient_values_in_preview() {
-		$original_value = get_option( EmailPreview::get_email_style_settings_ids()[0] );
-		update_option( EmailPreview::get_email_style_settings_ids()[0], 'option_value' );
-		set_transient( EmailPreview::get_email_style_settings_ids()[0], 'transient_value', HOUR_IN_SECONDS );
+		$original_value = get_option( EmailPreview::get_email_style_setting_ids()[0] );
+		update_option( EmailPreview::get_email_style_setting_ids()[0], 'option_value' );
+		set_transient( EmailPreview::get_email_style_setting_ids()[0], 'transient_value', HOUR_IN_SECONDS );
 
 		$this->sut->set_email_type( EmailPreview::DEFAULT_EMAIL_TYPE );
 		$content = $this->sut->render();
@@ -262,8 +262,8 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 		$this->assertStringNotContainsString( 'option_value', $content );
 		$this->assertStringContainsString( 'transient_value', $content );
 
-		update_option( EmailPreview::get_email_style_settings_ids()[0], $original_value );
-		delete_transient( EmailPreview::get_email_style_settings_ids()[0] );
+		update_option( EmailPreview::get_email_style_setting_ids()[0], $original_value );
+		delete_transient( EmailPreview::get_email_style_setting_ids()[0] );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds two new filters (`woocommerce_email_preview_email_style_setting_ids` and `woocommerce_email_preview_email_content_setting_ids`) to allow extensions that enhance WooCommerce emails to add their new email settings to be watched by email preview and when changed, email previews refreshes. 

Closes #55475.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. https://github.com/woocommerce/woocommerce-back-in-stock-notifications/issues/366

<!-- End testing instructions -->
