### PR TITLE
[dev] CI: drop GitHub caches for both closed and merged PRs.

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -67,7 +67,7 @@ jobs:
                 WOO_PR_TESTING_ANALYSIS_TEAM_ID: ${{ secrets.WOO_PR_TESTING_ANALYSIS_TEAM_ID }}
 
     process-pull-request-after-close:
-        name: "Process a pull request after it's closed or merged"
+        name: "Process a pull request after it's been closed or merged"
         runs-on: ubuntu-latest
         steps:
             - name: 'Cleanup: GitHub caches associated with the merged branch'

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -68,7 +68,7 @@ jobs:
                 WOO_PR_TESTING_ANALYSIS_TEAM_ID: ${{ secrets.WOO_PR_TESTING_ANALYSIS_TEAM_ID }}
 
     process-pull-request-after-close:
-        name: "Process a pull request after it's been closed or merged"
+        name: "Process a pull request after it's been closed"
         runs-on: ubuntu-latest
         steps:
             - name: 'Cleanup: GitHub caches associated with the merged branch'

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -5,6 +5,7 @@ on:
         paths:
             - 'packages/**'
             - 'plugins/woocommerce/**'
+            - '.github/workflows/pull-request-post-merge-processing.yml'
 
 permissions: {}
 

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -12,7 +12,7 @@ jobs:
     process-pull-request-after-merge:
         name: "Process a pull request after it's merged"
         if: github.event.pull_request.merged == true
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             pull-requests: write
         steps:
@@ -65,6 +65,11 @@ jobs:
                 TEST_ASSISTANCE_BOT_TOKEN: ${{ secrets.TEST_ASSISTANCE_BOT_TOKEN }}
                 WOO_PR_TESTING_ANALYSIS_SLACK_CHANNEL: ${{ secrets.WOO_PR_TESTING_ANALYSIS_SLACK_CHANNEL }}
                 WOO_PR_TESTING_ANALYSIS_TEAM_ID: ${{ secrets.WOO_PR_TESTING_ANALYSIS_TEAM_ID }}
+
+    process-pull-request-after-close:
+        name: "Process a pull request after it's closed or merged"
+        runs-on: ubuntu-latest
+        steps:
             - name: 'Cleanup: GitHub caches associated with the merged branch'
               run: |
                   for cacheKey in $( gh cache list --ref refs/pull/${{ github.event.pull_request.number }}/merge --limit 100 --sort size_in_bytes --json id --jq '.[].id' ); do


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Re-iteration on #55279 and performing the cache cleanup for closed PRs as well.

### How to test the changes in this Pull Request:

- CI-checks shall pass

