### PR TITLE
[dev] CI: more cases to skip CI-workflow on git push.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,10 @@ on:
       - '**/changelog/**'
       - '.cursor/**'
       - '**/*.md'
-      - 'changelog.txt'
+      - '**/changelog.txt'
       - '.gitignore'
+      - '.github/**'
+      - '!.github/workflows/ci.yml'
     branches:
       - 'trunk'
       - 'release/*'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update the workflow ignore-config with more cases where it shouldn't run.

### How to test the changes in this Pull Request:

- CI-checks shall pass
- This PR and it's merge will trigger the workflow as we are changing it