### PR TITLE
Show email background color behind the logo in email settings

### DIFF
--- a/plugins/woocommerce/changelog/55282-email-logo-improvements
+++ b/plugins/woocommerce/changelog/55282-email-logo-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Show email background in email logo settings

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-image-url-existing-image.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-image-url-existing-image.tsx
@@ -45,17 +45,17 @@ export const ExistingImage: React.FC< ExistingImageProps > = ( {
 		};
 	}, [] );
 	return (
-		<div className="wc-settings-email-image-url-existing-image">
+		<div>
 			<div>
 				<button
 					style={ { backgroundColor } }
 					onClick={ () => selectImage( inputId, setImageUrl ) }
-					className="wc-settings-email-image-url-select-image"
+					className="wc-settings-email-select-image"
 					type="button"
 				>
 					<img
 						src={ imageUrl }
-						className="wc-settings-email-image-url-image-preview"
+						className="wc-settings-email-logo-image"
 						alt={ __( 'Image preview', 'woocommerce' ) }
 					/>
 				</button>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-image-url-existing-image.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-image-url-existing-image.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,10 +21,34 @@ export const ExistingImage: React.FC< ExistingImageProps > = ( {
 	imageUrl,
 	setImageUrl,
 } ) => {
+	const [ backgroundColor, setBackgroundColor ] = useState( 'transparent' );
+
+	useEffect( () => {
+		const element = jQuery( '#woocommerce_email_body_background_color' );
+		if ( ! element.length ) {
+			return;
+		}
+		setBackgroundColor( element.val() as string );
+
+		const handleChange = ( jqEvent: JQuery.Event ) => {
+			const event = jqEvent as JQuery.Event & {
+				target: HTMLInputElement;
+			};
+			const value = event.target.value;
+			setBackgroundColor( value );
+		};
+
+		element.on( 'change', handleChange );
+
+		return () => {
+			element.off( 'change', handleChange );
+		};
+	}, [] );
 	return (
 		<div className="wc-settings-email-image-url-existing-image">
 			<div>
 				<button
+					style={ { backgroundColor } }
 					onClick={ () => selectImage( inputId, setImageUrl ) }
 					className="wc-settings-email-image-url-select-image"
 					type="button"

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-image-url-new-image.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-image-url-new-image.tsx
@@ -19,10 +19,10 @@ export const NewImage: React.FC< NewImageProps > = ( {
 	setImageUrl,
 } ) => {
 	return (
-		<div className="wc-settings-email-image-url-new-image">
+		<div>
 			<button
 				onClick={ () => selectImage( inputId, setImageUrl ) }
-				className="wc-settings-email-image-url-select-image"
+				className="wc-settings-email-select-image"
 				type="button"
 			>
 				<img
@@ -30,7 +30,7 @@ export const NewImage: React.FC< NewImageProps > = ( {
 					width="24"
 					height="24"
 					alt={ __( 'Image upload icon', 'woocommerce' ) }
-					className="wc-settings-email-image-url-new-image-icon"
+					className="wc-settings-email-select-image-icon"
 				/>
 			</button>
 		</div>

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -277,9 +277,10 @@ $wc-setting-email-width: 634px;
 	}
 
 	.wc-settings-email-image-url-image-preview {
-		max-width: 400px;
 		border: 1px #ccc solid;
 		border-radius: 4px;
+		max-height: 200px;
+		max-width: 400px;
 
 		&:hover {
 			cursor: pointer;

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -241,61 +241,31 @@ $wc-setting-email-width: 634px;
 	}
 }
 
-.wc-settings-email-image-url-new-image {
+.wc-settings-email-select-image {
 	border: 1px #ccc solid;
 	border-radius: 4px;
-	width: 400px;
-	height: 88px;
+	box-sizing: border-box;
+	margin-bottom: 8px;
+	min-height: 88px;
+	padding: 10px;
 	position: relative;
+	width: 400px;
 
 	&:hover {
-		filter: brightness(0.87);
-	}
-
-	button.wc-settings-email-image-url-select-image {
-		background-color: transparent;
-		border: none;
-		display: block;
-		height: 100%;
-		width: 100%;
-
-		&:hover {
-			cursor: pointer;
-		}
-	}
-
-	img.wc-settings-email-image-url-new-image-icon {
-		position: absolute;
-		inset: 0;
-		margin: auto;
+		border-color: #999;
+		cursor: pointer;
 	}
 }
 
-.wc-settings-email-image-url-existing-image {
-	> div {
-		margin-bottom: 8px;
-	}
+.wc-settings-email-select-image-icon {
+	inset: 0;
+	margin: auto;
+	position: absolute;
+}
 
-	.wc-settings-email-image-url-image-preview {
-		border: 1px #ccc solid;
-		border-radius: 4px;
-		max-height: 200px;
-		max-width: 400px;
-
-		&:hover {
-			cursor: pointer;
-		}
-	}
-
-	button.wc-settings-email-image-url-select-image:not(.button) {
-		background-color: transparent;
-		border: none;
-		padding: 0;
-
-		&:focus {
-			box-shadow: none;
-		}
-	}
+.wc-settings-email-logo-image {
+	max-height: 160px;
+	max-width: 100%;
 }
 
 .wc-settings-email-color-palette-separator {

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.js
@@ -314,7 +314,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page, baseURL } ) => {
 			const emailImageUrlElement =
-				'#wc_settings_email_image_url_slotfill .wc-settings-email-image-url-select-image';
+				'#wc_settings_email_image_url_slotfill .wc-settings-email-select-image';
 			const hasImageUrl = async () => {
 				return (
 					( await page.locator( emailImageUrlElement ).count() ) > 0
@@ -346,30 +346,26 @@ test.describe( 'WooCommerce Email Settings', () => {
 		page,
 		baseURL,
 	} ) => {
-		const newImageElement = '.wc-settings-email-image-url-new-image';
-		const existingImageElement =
-			'.wc-settings-email-image-url-existing-image';
-		const selectImageElement = '.wc-settings-email-image-url-select-image';
+		const logoImageElement = '.wc-settings-email-logo-image';
+		const uploadIconElement = '.wc-settings-email-select-image-icon';
 
 		// Enable the email_improvements feature flag
 		await setFeatureFlag( baseURL, 'yes' );
 		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
 
 		// Pick image
-		await page
-			.locator( `${ newImageElement } ${ selectImageElement }` )
-			.click();
+		await page.locator( '.wc-settings-email-select-image' ).click();
 		await pickImageFromLibrary( page, 'image-03' );
-		await expect( page.locator( existingImageElement ) ).toBeVisible();
-		await expect( page.locator( newImageElement ) ).toBeHidden();
+		await expect( page.locator( logoImageElement ) ).toBeVisible();
+		await expect( page.locator( uploadIconElement ) ).toBeHidden();
 
 		// Remove an image
 		await page
-			.locator( existingImageElement )
+			.locator( '#wc_settings_email_image_url_slotfill' )
 			.getByRole( 'button', { name: 'Remove', exact: true } )
 			.click();
-		await expect( page.locator( existingImageElement ) ).toBeHidden();
-		await expect( page.locator( newImageElement ) ).toBeVisible();
+		await expect( page.locator( logoImageElement ) ).toBeHidden();
+		await expect( page.locator( uploadIconElement ) ).toBeVisible();
 	} );
 
 	test(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds background to the email logo component in Email settings and adds max height so square and tall logos doesn't take too much space.

<img width="682" alt="Screenshot 2025-02-17 at 14 13 56" src="https://github.com/user-attachments/assets/c1f711bf-fab5-46b7-b835-f1a0c0265e0e" />

Closes #55282.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Email improvements` feature in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. When the logo is set, notice that it has the same background as `Content background`. 
4. Change the `Content background` color and check that the logo background is also changed.
5. Upload a square or tall logo and check it's constrained to 160px height.

<!-- End testing instructions -->