### PR TITLE
[Performance] Optimize the beta tester enqueeing logic

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-enqueeing-logic
+++ b/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-enqueeing-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Split JS into multiple chunks to avoid loading on every admin page.

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-product-editor-devtools.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-product-editor-devtools.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Beta Tester Plugin Live Branches feature class.
+ * Beta Tester Plugin Product Editor Devtools feature class.
  *
  * @package WC_Beta_Tester
  */
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Beta_Tester Live Branches Feature Class.
+ * WC_Beta_Tester Product Editor Devtools Feature Class.
  */
 class WC_Beta_Tester_Product_Editor_Devtools {
 	/**
@@ -60,7 +60,7 @@ class WC_Beta_Tester_Product_Editor_Devtools {
 			array(),
 			$css_file_version
 		);
-	
+
 		wp_enqueue_style( 'woocommerce-beta-tester-product-editor-devtools' );
 	}
 }

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-product-editor-devtools.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-product-editor-devtools.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Beta Tester Plugin Live Branches feature class.
+ *
+ * @package WC_Beta_Tester
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Beta_Tester Live Branches Feature Class.
+ */
+class WC_Beta_Tester_Product_Editor_Devtools {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ) );
+	}
+
+	/**
+	 * Register product editor devtools scripts.
+	 */
+	public function register_scripts() {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
+		if ( ! class_exists( 'Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			return;
+		}
+		if ( ! Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) || ! \Automattic\WooCommerce\Admin\PageController::is_admin_page() ) {
+			return;
+		}
+
+		$script_path       = '/build/product-editor-devtools.js';
+		$script_asset_path = dirname( __FILE__ ) . '/../build/product-editor-devtools.asset.php';
+		$script_asset      = file_exists( $script_asset_path )
+			? require $script_asset_path
+			: array(
+				'dependencies' => array(),
+				'version'      => filemtime( $script_path ),
+			);
+		$script_url        = WC_Beta_Tester::instance()->plugin_url() . $script_path;
+
+		wp_register_script(
+			'woocommerce-beta-tester-product-editor-devtools',
+			$script_url,
+			$script_asset['dependencies'],
+			$script_asset['version'],
+			true
+		);
+
+		wp_enqueue_script( 'woocommerce-beta-tester-product-editor-devtools' );
+
+		$css_file_version = filemtime( dirname( __FILE__ ) . '/../build/product-editor-devtools.css' );
+		wp_register_style(
+			'woocommerce-beta-tester-product-editor-devtools',
+			plugins_url( '/../build/product-editor-devtools.css', __FILE__ ),
+			array(),
+			$css_file_version
+		);
+	
+		wp_enqueue_style( 'woocommerce-beta-tester-product-editor-devtools' );
+	}
+}
+
+return new WC_Beta_Tester_Product_Editor_Devtools();

--- a/plugins/woocommerce-beta-tester/plugin.php
+++ b/plugins/woocommerce-beta-tester/plugin.php
@@ -27,3 +27,55 @@ add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) 
 	return $feature_config;
 } );
 
+/**
+ * Register the JS.
+ */
+function enqueue_beta_tester_app_script() {
+	if ( ! defined( 'WC_ADMIN_APP' ) ) {
+		return;
+	}
+	$screen = get_current_screen();
+	if ( ! $screen || 'tools_page_woocommerce-admin-test-helper' !== $screen->id ) {
+		return;
+	}
+	$script_path       = '/build/app.js';
+	$script_asset_path = dirname( __FILE__ ) . '/build/app.asset.php';
+	$script_asset      = file_exists( $script_asset_path )
+		? require $script_asset_path
+		: array(
+			'dependencies' => array(),
+			'version'      => filemtime( $script_path ),
+		);
+	$script_url        = plugins_url( $script_path, __FILE__ );
+
+	$script_asset['dependencies'][] = WC_ADMIN_APP; // Add WCA as a dependency to ensure it loads first.
+
+	wp_register_script(
+		'woocommerce-admin-test-helper-app',
+		$script_url,
+		$script_asset['dependencies'],
+		$script_asset['version'],
+		true
+	);
+	wp_enqueue_script( 'woocommerce-admin-test-helper-app' );
+
+	$css_file_version = filemtime( dirname( __FILE__ ) . '/build/app.css' );
+
+	wp_register_style(
+		'wp-components',
+		plugins_url( 'dist/components/style.css', __FILE__ ),
+		array(),
+		$css_file_version
+	);
+
+	wp_register_style(
+		'woocommerce-admin-test-helper-app',
+		plugins_url( '/build/app.css', __FILE__ ),
+		array( 'wp-components' ),
+		$css_file_version
+	);
+
+	wp_enqueue_style( 'woocommerce-admin-test-helper-app' );
+}
+
+add_action( 'admin_enqueue_scripts', 'enqueue_beta_tester_app_script' );

--- a/plugins/woocommerce-beta-tester/plugin.php
+++ b/plugins/woocommerce-beta-tester/plugin.php
@@ -1,31 +1,47 @@
 <?php
-add_action( 'admin_menu', function() {
-	add_management_page(
-		'WooCommerce Admin Test Helper',
-		'WCA Test Helper',
-		'install_plugins',
-		'woocommerce-admin-test-helper',
-		function() {
-			?><div id="woocommerce-admin-test-helper-app-root"></div><?php
+/**
+ * Beta Tester Plugin filters and actions.
+ *
+ * @package WC_Beta_Tester
+ */
+
+add_action(
+	'admin_menu',
+	function() {
+		add_management_page(
+			'WooCommerce Admin Test Helper',
+			'WCA Test Helper',
+			'install_plugins',
+			'woocommerce-admin-test-helper',
+			function() {
+				?><div id="woocommerce-admin-test-helper-app-root"></div>
+				<?php
+			}
+		);
+	}
+);
+
+add_action(
+	'wp_loaded',
+	function() {
+		require_once __DIR__ . '/vendor/autoload.php';
+		require 'api/api.php';
+	}
+);
+
+add_filter(
+	'woocommerce_admin_get_feature_config',
+	function( $feature_config ) {
+		$feature_config['beta-tester-slotfill-examples'] = false;
+		$custom_feature_values                           = get_option( 'wc_admin_helper_feature_values', array() );
+		foreach ( $custom_feature_values as $feature => $value ) {
+			if ( isset( $feature_config[ $feature ] ) ) {
+				$feature_config[ $feature ] = $value;
+			}
 		}
-	);
-} );
-
-add_action( 'wp_loaded', function() {
-	require_once __DIR__ . '/vendor/autoload.php';
-	require( 'api/api.php' );
-} );
-
-add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) {
-	$feature_config['beta-tester-slotfill-examples'] = false;
-    $custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
-    foreach ( $custom_feature_values as $feature => $value ) {
-        if ( isset(  $feature_config[$feature] ) ) {
-            $feature_config[$feature] = $value;
-        }
-    }
-	return $feature_config;
-} );
+		return $feature_config;
+	}
+);
 
 /**
  * Register the JS.

--- a/plugins/woocommerce-beta-tester/src/app/index.js
+++ b/plugins/woocommerce-beta-tester/src/app/index.js
@@ -1,1 +1,18 @@
-export { App } from './app';
+/**
+ * External dependencies
+ */
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { App } from './app';
+import '../index.scss';
+
+const appRoot = document.getElementById(
+	'woocommerce-admin-test-helper-app-root'
+);
+
+if ( appRoot ) {
+	createRoot( appRoot ).render( <App /> );
+}

--- a/plugins/woocommerce-beta-tester/src/index.js
+++ b/plugins/woocommerce-beta-tester/src/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { createRoot } from '@wordpress/element';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -10,7 +9,6 @@ import { addFilter } from '@wordpress/hooks';
 import { App } from './app';
 import './index.scss';
 import './example-fills/experimental-woocommerce-wcpay-feature';
-import { registerProductEditorDevTools } from './product-editor-dev-tools';
 import { registerExceptionFilter } from './remote-logging/register-exception-filter';
 
 const appRoot = document.getElementById(
@@ -21,5 +19,4 @@ if ( appRoot ) {
 	createRoot( appRoot ).render( <App /> );
 }
 
-registerProductEditorDevTools();
 registerExceptionFilter();

--- a/plugins/woocommerce-beta-tester/src/index.js
+++ b/plugins/woocommerce-beta-tester/src/index.js
@@ -1,22 +1,7 @@
 /**
- * External dependencies
- */
-import { createRoot } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
-import { App } from './app';
-import './index.scss';
 import './example-fills/experimental-woocommerce-wcpay-feature';
 import { registerExceptionFilter } from './remote-logging/register-exception-filter';
-
-const appRoot = document.getElementById(
-	'woocommerce-admin-test-helper-app-root'
-);
-
-if ( appRoot ) {
-	createRoot( appRoot ).render( <App /> );
-}
 
 registerExceptionFilter();

--- a/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/index.ts
+++ b/plugins/woocommerce-beta-tester/src/product-editor-dev-tools/index.ts
@@ -9,10 +9,10 @@ import { registerPlugin } from '@wordpress/plugins';
 import { ProductEditorDevTools } from './product-editor-dev-tools';
 import './index.scss';
 
-export function registerProductEditorDevTools() {
+function registerProductEditorDevTools() {
 	registerPlugin( 'woocommerce-product-editor-dev-tools', {
-		// @ts-expect-error: 'scope' does exist
 		scope: 'woocommerce-product-block-editor',
 		render: ProductEditorDevTools,
 	} );
 }
+registerProductEditorDevTools();

--- a/plugins/woocommerce-beta-tester/src/remote-logging/constants.ts
+++ b/plugins/woocommerce-beta-tester/src/remote-logging/constants.ts
@@ -1,0 +1,1 @@
+export const API_NAMESPACE = '/wc-admin-test-helper';

--- a/plugins/woocommerce-beta-tester/src/remote-logging/index.tsx
+++ b/plugins/woocommerce-beta-tester/src/remote-logging/index.tsx
@@ -10,12 +10,15 @@ import { log, init as initRemoteLogging } from '@woocommerce/remote-logging';
 // @ts-ignore no types
 // eslint-disable-next-line @woocommerce/dependency-group
 import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { API_NAMESPACE } from './constants';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore no types
 // eslint-disable-next-line @woocommerce/dependency-group
 import { STORE_KEY as optionsStore } from '../options/data/constants';
-
-export const API_NAMESPACE = '/wc-admin-test-helper';
 
 interface RemoteLoggingStatus {
 	isEnabled: boolean;

--- a/plugins/woocommerce-beta-tester/src/remote-logging/register-exception-filter.tsx
+++ b/plugins/woocommerce-beta-tester/src/remote-logging/register-exception-filter.tsx
@@ -12,7 +12,7 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE } from './';
+import { API_NAMESPACE } from './constants';
 // @ts-ignore no types
 import { STORE_KEY as optionsStore } from '../options/data/constants';
 

--- a/plugins/woocommerce-beta-tester/webpack.config.js
+++ b/plugins/woocommerce-beta-tester/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
 	entry: {
 		...defaultConfig.entry,
 		// Separate entry point for the live-branches page.
+		app: './src/app/index.js',
 		'live-branches': './src/live-branches/index.tsx',
 		'product-editor-devtools': './src/product-editor-dev-tools/index.ts',
 	},

--- a/plugins/woocommerce-beta-tester/webpack.config.js
+++ b/plugins/woocommerce-beta-tester/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
 		...defaultConfig.entry,
 		// Separate entry point for the live-branches page.
 		'live-branches': './src/live-branches/index.tsx',
+		'product-editor-devtools': './src/product-editor-dev-tools/index.ts',
 	},
 	module: {
 		...defaultConfig.module,

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -105,26 +105,22 @@ function add_extension_register_script() {
 	);
 	wp_enqueue_script( 'woocommerce-admin-test-helper' );
 
-	$css_file_version = filemtime( dirname( __FILE__ ) . '/build/index.css' );
+	$css_file = dirname( __FILE__ ) . '/build/index.css';
+	if ( file_exists( $css_file ) ) {
+		$css_file_version = filemtime( $css_file );
 
-	wp_register_style(
-		'wp-components',
-		plugins_url( 'dist/components/style.css', __FILE__ ),
-		array(),
-		$css_file_version
-	);
+		wp_register_style(
+			'woocommerce-admin-test-helper',
+			plugins_url( '/build/index.css', __FILE__ ),
+			// Add any dependencies styles may have, such as wp-components.
+			array(
+				'wp-components',
+			),
+			$css_file_version
+		);
 
-	wp_register_style(
-		'woocommerce-admin-test-helper',
-		plugins_url( '/build/index.css', __FILE__ ),
-		// Add any dependencies styles may have, such as wp-components.
-		array(
-			'wp-components',
-		),
-		$css_file_version
-	);
-
-	wp_enqueue_style( 'woocommerce-admin-test-helper' );
+		wp_enqueue_style( 'woocommerce-admin-test-helper' );
+	}
 }
 
 add_action( 'admin_enqueue_scripts', 'add_extension_register_script' );

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -185,3 +185,4 @@ if ( $simulate_error ) {
 
 // Initialize the live branches feature.
 require_once dirname( __FILE__ ) . '/includes/class-wc-beta-tester-live-branches.php';
+require_once dirname( __FILE__ ) . '/includes/class-wc-beta-tester-product-editor-devtools.php';

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -94,7 +94,9 @@ function add_extension_register_script() {
 		);
 	$script_url        = plugins_url( $script_path, __FILE__ );
 
-	$script_asset['dependencies'][] = WC_ADMIN_APP; // Add WCA as a dependency to ensure it loads first.
+	if ( class_exists( '\Automattic\WooCommerce\Admin\PageController' ) && \Automattic\WooCommerce\Admin\PageController::is_admin_page() ) {
+		$script_asset['dependencies'][] = WC_ADMIN_APP; // Add WCA as a dependency to ensure it loads first.
+	}
 
 	wp_register_script(
 		'woocommerce-admin-test-helper',
@@ -113,9 +115,7 @@ function add_extension_register_script() {
 			'woocommerce-admin-test-helper',
 			plugins_url( '/build/index.css', __FILE__ ),
 			// Add any dependencies styles may have, such as wp-components.
-			array(
-				'wp-components',
-			),
+			array(),
 			$css_file_version
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When working on https://github.com/woocommerce/woocommerce/issues/46771 I noticed that the beta tester JS gets enqueued on every admin page, although a lot of the JS is only needed on the beta tester settings page.
We also have some logic for adding an inspector in the new product editor which was also being enqueued everywhere.

This PR updates the build to include an `app.js` and a `product-editor-devtools.js` bundle.
- `app.js` and `app.css` only get enqueued when the beta tester settings page is loaded ( **Tools > WCA Test Helper** )
- `product-editor-devtools.js` only gets enqueued when the product editor is enabled and a WooCommerce Admin page is loaded.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce build` and `pnpm --filter=@woocommerce/plugin-woocommerce-beta-tester build`
2. Enable the build WooCommerce and the Beta Tester plugin on a new WooCommerce site and finish the onboarding.
3. Go to **Tools > WCA Test Helper** and click on each tab, they should still render correctly
4. Enable the new product editor under **WooCommerce > Settings > Advanced > Features** and go to **Products > Add new product**
5. Click the 3-dot menu in the top right and click **Show developer tools**
6. This should correctly render a footer with several tabs ( tabs don't need testing, but for example the **product** tab should show the JSON of the product, or **Block inspector** should show the block json of the block you focused on. You can see it change if you click on different fields or section headers ).
7. Open your console and go to the **Network** tab and filter by `beta-tester`
8. Refresh the product editor page and notice how it loads 4 files ( two are the product editor devtools JS and CSS )
9. Disable the product editor in **WooCommerce > Settings > Advanced > Features** and go to **WooCommerce > Home**
10. It should load only two files now ( `index.js` and the `live-branches.js` file ).
11. Go to **Tools > WCA Test Helper**, it should load 4 files again, the same two as above and `app.js` & `app.css`
12. Go to **WooCommerce > Live Branches**, this page should load correctly ( I didn't change anything here ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
