### PR TITLE
[WIP] Add priceType in all cases in structured data

### DIFF
--- a/plugins/woocommerce/changelog/fix-55043-list-price-structured-data
+++ b/plugins/woocommerce/changelog/fix-55043-list-price-structured-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add priceType in all cases in structured data

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -243,6 +243,7 @@ class WC_Structured_Data {
 						'priceSpecification' => array(
 							array(
 								'@type'                 => 'UnitPriceSpecification',
+								'priceType'             => 'https://schema.org/ListPrice',
 								'price'                 => wc_format_decimal( $lowest, wc_get_price_decimals() ),
 								'priceCurrency'         => $currency,
 								'valueAddedTaxIncluded' => wc_prices_include_tax(),
@@ -314,17 +315,13 @@ class WC_Structured_Data {
 
 				$unit_price_specification = array(
 					'@type'                 => 'UnitPriceSpecification',
+					'priceType'             => 'https://schema.org/ListPrice',
 					'price'                 => wc_format_decimal( $min_price, wc_get_price_decimals() ),
 					'priceCurrency'         => $currency,
 					'valueAddedTaxIncluded' => wc_prices_include_tax(),
 					'validThrough'          => $price_valid_until,
 				);
-				if ( $product->is_on_sale() && $min_price !== $min_sale_price ) {
-					// `priceType` should only be specified in prices which are not the current offer.
-					// https://developers.google.com/search/docs/appearance/structured-data/merchant-listing#sale-pricing-example
-					$unit_price_specification['priceType'] = 'https://schema.org/ListPrice';
-				}
-				$markup_offer = array(
+				$markup_offer             = array(
 					'@type'              => 'Offer',
 					'priceSpecification' => array(
 						$unit_price_specification,
@@ -342,6 +339,7 @@ class WC_Structured_Data {
 						$markup_offer['priceSpecification'],
 						array(
 							'@type'                 => 'UnitPriceSpecification',
+							'priceType'             => 'https://schema.org/SalePrice',
 							'price'                 => wc_format_decimal( $min_sale_price, wc_get_price_decimals() ),
 							'priceCurrency'         => $currency,
 							'valueAddedTaxIncluded' => wc_prices_include_tax(),
@@ -352,17 +350,13 @@ class WC_Structured_Data {
 			} else {
 				$unit_price_specification = array(
 					'@type'                 => 'UnitPriceSpecification',
+					'priceType'             => 'https://schema.org/ListPrice',
 					'price'                 => wc_format_decimal( $product->get_regular_price(), wc_get_price_decimals() ),
 					'priceCurrency'         => $currency,
 					'valueAddedTaxIncluded' => wc_prices_include_tax(),
 					'validThrough'          => $price_valid_until,
 				);
-				if ( $product->is_on_sale() ) {
-					// `priceType` should only be specified in prices which are not the current offer.
-					// https://developers.google.com/search/docs/appearance/structured-data/merchant-listing#sale-pricing-example
-					$unit_price_specification['priceType'] = 'https://schema.org/ListPrice';
-				}
-				$markup_offer = array(
+				$markup_offer             = array(
 					'@type'              => 'Offer',
 					'priceSpecification' => array(
 						$unit_price_specification,
@@ -380,6 +374,7 @@ class WC_Structured_Data {
 						$markup_offer['priceSpecification'],
 						array(
 							'@type'                 => 'UnitPriceSpecification',
+							'priceType'             => 'https://schema.org/SalePrice',
 							'price'                 => wc_format_decimal( $product->get_sale_price(), wc_get_price_decimals() ),
 							'priceCurrency'         => $currency,
 							'valueAddedTaxIncluded' => wc_prices_include_tax(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/55061.

See also https://github.com/woocommerce/woocommerce/issues/55043.

According to https://github.com/woocommerce/woocommerce/pull/55061#issuecomment-2653627414, after recent changes, the listed price is no longer showing up in Yandex for products on sale (only the sale price appears). While I wasn't able to reproduce, this is a PR that _might_ fix it.

The changes in this PR go against the [Google recommendations](https://developers.google.com/search/docs/appearance/structured-data/merchant-listing#sale-pricing-example), but apparently the [Google Rich Snippets tester tool](https://search.google.com/test/rich-results) doesn't complain about it. So if we find out that this PR indeed fixes the issue in Yandex, I think it would be worth fixing it.

### How to test the changes in this Pull Request:

1. 