### PR TITLE
[Experimental] Hidden visibility parsing for Store API and additional fields

### DIFF
--- a/plugins/woocommerce/changelog/add-visibility-rule-parsing-additional-fields
+++ b/plugins/woocommerce/changelog/add-visibility-rule-parsing-additional-fields
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Conditional additional checkout fields behind feature flag.
+
+

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -485,11 +485,11 @@ abstract class WC_Data {
 			}
 
 			if ( ! empty( $matches ) ) {
-				// Set matches to null so only one key gets the new value.
+				// Update first match and delete the rest.
+				$array_key = array_shift( $matches );
 				foreach ( $matches as $meta_data_array_key ) {
 					$this->meta_data[ $meta_data_array_key ]->value = null;
 				}
-				$array_key = current( $matches );
 			}
 		}
 
@@ -709,8 +709,7 @@ abstract class WC_Data {
 				do_action( "added_{$this->object_type}_meta", $meta->id, $this->get_id(), $meta->key, $meta->value );
 
 				$meta->apply_changes();
-			} else {
-				if ( $meta->get_changes() ) {
+			} elseif ( $meta->get_changes() ) {
 					$this->data_store->update_meta( $this, $meta );
 					/**
 					 * Fires immediately after updating metadata.
@@ -723,7 +722,6 @@ abstract class WC_Data {
 					do_action( "updated_{$this->object_type}_meta", $meta->id, $this->get_id(), $meta->key, $meta->value );
 
 					$meta->apply_changes();
-				}
 			}
 		}
 		if ( ! empty( $this->cache_group ) ) {

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -208,8 +208,6 @@ class WC_Form_Handler {
 
 		$customer->save();
 
-		wc_add_notice( __( 'Address changed successfully.', 'woocommerce' ) );
-
 		/**
 		 * Hook: woocommerce_customer_save_address.
 		 *
@@ -218,9 +216,16 @@ class WC_Form_Handler {
 		 * @since 3.6.0
 		 * @param int    $user_id User ID being saved.
 		 * @param string $address_type Type of address; 'billing' or 'shipping'.
+		 * @param array  $address The address fields. Since 9.8.0.
+		 * @param WC_Customer $customer The customer object being saved. Since 9.8.0.
 		 */
-		do_action( 'woocommerce_customer_save_address', $user_id, $address_type );
+		do_action( 'woocommerce_customer_save_address', $user_id, $address_type, $address, $customer );
 
+		if ( 0 < wc_notice_count( 'error' ) ) {
+			return;
+		}
+
+		wc_add_notice( __( 'Address changed successfully.', 'woocommerce' ) );
 		wp_safe_redirect( wc_get_endpoint_url( 'edit-address', '', wc_get_page_permalink( 'myaccount' ) ) );
 		exit;
 	}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -115,7 +115,15 @@ class CheckoutFieldsFrontend {
 		}
 
 		$customer = new WC_Customer( get_current_user_id() );
-		$fields   = $this->checkout_fields_controller->get_fields_for_location( 'address' );
+
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$document_object = new DocumentObject();
+			$document_object->set_customer( $customer );
+			$document_object->set_context( $address_type . '_address' );
+			$fields = $this->checkout_fields_controller->get_contextual_fields_for_location( 'address', $document_object );
+		} else {
+			$fields = $this->checkout_fields_controller->get_fields_for_location( 'address' );
+		}
 
 		if ( ! $fields || ! $customer ) {
 			return;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -264,9 +264,10 @@ class CheckoutFieldsFrontend {
 	 * @param array       $address Address fields.
 	 * @param WC_Customer $customer Customer object.
 	 */
-	public function save_address_fields( $user_id, $address_type, $address, $customer ) {
+	public function save_address_fields( $user_id, $address_type, $address = [], $customer = null ) {
 		try {
-			$result = $this->update_additional_fields_for_customer( $customer, 'address', $address_type );
+			$customer = $customer ?? new WC_Customer( $user_id );
+			$result   = $this->update_additional_fields_for_customer( $customer, 'address', $address_type );
 
 			if ( is_wp_error( $result ) ) {
 				foreach ( $result->get_error_messages() as $error_message ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/DocumentObject.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/DocumentObject.php
@@ -222,4 +222,13 @@ class DocumentObject {
 			'checkout' => $this->get_checkout_data(),
 		];
 	}
+
+	/**
+	 * Get the current context.
+	 *
+	 * @return null|string The context.
+	 */
+	public function get_context() {
+		return $this->context;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
@@ -91,19 +91,23 @@ class Validation {
 	 * @return bool
 	 */
 	public static function has_field_schema( $fields ) {
+		$return = false;
+
 		foreach ( $fields as $field ) {
-			if ( ! empty( $field['rules'] ) && is_array( $field['rules'] ) &&
+			if (
+				! empty( $field['rules'] ) && is_array( $field['rules'] ) &&
 				(
 					! empty( $field['rules']['required'] ) ||
 					! empty( $field['rules']['hidden'] ) ||
 					! empty( $field['rules']['validation'] )
 				)
 			) {
-				return true;
+				$return = true;
+				break;
 			}
 		}
 
-		return false;
+		return $return;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
@@ -91,23 +91,19 @@ class Validation {
 	 * @return bool
 	 */
 	public static function has_field_schema( $fields ) {
-		$return = false;
-
 		foreach ( $fields as $field ) {
-			if (
-				! empty( $field['rules'] ) && is_array( $field['rules'] ) &&
+			if ( ! empty( $field['rules'] ) && is_array( $field['rules'] ) &&
 				(
 					! empty( $field['rules']['required'] ) ||
 					! empty( $field['rules']['hidden'] ) ||
 					! empty( $field['rules']['validation'] )
 				)
 			) {
-				$return = true;
-				break;
+				return true;
 			}
 		}
 
-		return $return;
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -277,6 +277,15 @@ class Checkout extends AbstractCartRoute {
 			$sanitized_field_values = (array) $sanitized_request->get_param( $context_data['param'] ) ?? [];
 
 			foreach ( $additional_fields as $field_key => $field ) {
+				$is_hidden = $this->additional_fields_controller->is_hidden_field( $field, $document_object, $context );
+
+				// Skip hidden fields from validation logic and ensure they are unset from the main request.
+				if ( $is_hidden ) {
+					$field_values[ $field_key ] = null;
+					$request->set_param( $context_data['param'], $field_values );
+					continue;
+				}
+
 				$is_required = $this->additional_fields_controller->is_required_field( $field, $document_object, $context );
 
 				// Skip optional fields that are not set when the request is partial.

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -278,8 +278,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 	 */
 	protected function get_additional_address_fields_schema() {
 		$additional_fields_keys = $this->additional_fields_controller->get_address_fields_keys();
-
-		$fields = $this->additional_fields_controller->get_additional_fields();
+		$fields                 = $this->additional_fields_controller->get_additional_fields();
 
 		$address_fields = array_filter(
 			$fields,
@@ -291,13 +290,11 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 
 		$schema = [];
 		foreach ( $address_fields as $key => $field ) {
-			$is_conditionally_required = ! empty( $field['rules']['required'] ) || ! empty( $field['rules']['hidden'] );
-
 			$field_schema = [
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'required'    => $is_conditionally_required ? false : $field['required'],
+				'required'    => $this->additional_fields_controller->is_conditional_field( $field ) ? false : $field['required'],
 			];
 
 			if ( 'select' === $field['type'] ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -291,11 +291,13 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 
 		$schema = [];
 		foreach ( $address_fields as $key => $field ) {
+			$is_conditionally_required = ! empty( $field['rules']['required'] ) || ! empty( $field['rules']['hidden'] );
+
 			$field_schema = [
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'required'    => $field['required'],
+				'required'    => $is_conditionally_required ? false : $field['required'],
 			];
 
 			if ( 'select' === $field['type'] ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -322,13 +322,11 @@ class CheckoutSchema extends AbstractSchema {
 		$additional_fields = array_merge( ...$args );
 		$schema            = [];
 		foreach ( $additional_fields as $key => $field ) {
-			$is_conditionally_required = ! empty( $field['rules']['required'] ) || ! empty( $field['rules']['hidden'] );
-
 			$field_schema = [
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'required'    => $is_conditionally_required ? false : $field['required'],
+				'required'    => $this->additional_fields_controller->is_conditional_field( $field ) ? false : $field['required'],
 			];
 
 			if ( 'select' === $field['type'] ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -322,11 +322,13 @@ class CheckoutSchema extends AbstractSchema {
 		$additional_fields = array_merge( ...$args );
 		$schema            = [];
 		foreach ( $additional_fields as $key => $field ) {
+			$is_conditionally_required = ! empty( $field['rules']['required'] ) || ! empty( $field['rules']['hidden'] );
+
 			$field_schema = [
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'required'    => $field['required'],
+				'required'    => $is_conditionally_required ? false : $field['required'],
 			];
 
 			if ( 'select' === $field['type'] ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -1,11 +1,15 @@
 <?php
+declare( strict_types = 1);
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFieldsSchema\DocumentObject;
+use Automattic\WooCommerce\Admin\Features\Features;
 use WC_Customer;
+
 /**
  * CheckoutTrait
  *
@@ -201,29 +205,22 @@ trait CheckoutTrait {
 	 * Persist additional fields for the order after validating them.
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
-	 *
-	 * @throws RouteException On error.
 	 */
 	private function persist_additional_fields_for_order( \WP_REST_Request $request ) {
-		$errors         = new \WP_Error();
-		$request_fields = $request['additional_fields'] ?? [];
-
-		if ( empty( $request_fields ) ) {
-			return;
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$document_object = $this->get_document_object_from_rest_request( $request );
+			$document_object->set_context( $context );
+			$additional_fields = $this->additional_fields_controller->get_contextual_fields_for_location( 'order', $document_object );
+		} else {
+			$additional_fields = $this->additional_fields_controller->get_fields_for_location( 'order' );
 		}
 
-		foreach ( $request_fields as $key => $value ) {
-			try {
-				$this->additional_fields_controller->validate_field_for_location( $key, $value, 'order' );
-			} catch ( \Exception $e ) {
-				$errors[] = $e->getMessage();
-				continue;
+		$field_values = (array) $request['additional_fields'] ?? [];
+
+		foreach ( $additional_fields as $key => $field ) {
+			if ( isset( $field_values[ $key ] ) ) {
+				$this->additional_fields_controller->persist_field_for_order( $key, $field_values[ $key ], $this->order, 'other', false );
 			}
-			$this->additional_fields_controller->persist_field_for_order( $key, $value, $this->order, 'other', false );
-		}
-
-		if ( $errors->has_errors() ) {
-			throw new RouteException( 'woocommerce_rest_checkout_invalid_additional_fields', $errors->get_error_messages(), 400 );
 		}
 
 		// We need to sync the customer additional fields with the order otherwise they will be overwritten on next page load.
@@ -235,5 +232,35 @@ trait CheckoutTrait {
 			);
 			$customer->save();
 		}
+	}
+
+	/**
+	 * Returns a document object from a REST request.
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return DocumentObject The document object or null if experimental blocks are not enabled.
+	 */
+	public function get_document_object_from_rest_request( \WP_REST_Request $request ) {
+		return new DocumentObject(
+			[
+				'customer' => [
+					'billing_address'   => $request['billing_address'],
+					'shipping_address'  => $request['shipping_address'],
+					'additional_fields' => array_intersect_key(
+						$request['additional_fields'] ?? [],
+						array_flip( $this->additional_fields_controller->get_contact_fields_keys() )
+					),
+				],
+				'checkout' => [
+					'payment_method'    => $request['payment_method'],
+					'create_account'    => $request['create_account'],
+					'customer_note'     => $request['customer_note'],
+					'additional_fields' => array_intersect_key(
+						$request['additional_fields'] ?? [],
+						array_flip( $this->additional_fields_controller->get_order_fields_keys() )
+					),
+				],
+			]
+		);
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -209,7 +209,7 @@ trait CheckoutTrait {
 	private function persist_additional_fields_for_order( \WP_REST_Request $request ) {
 		if ( Features::is_enabled( 'experimental-blocks' ) ) {
 			$document_object = $this->get_document_object_from_rest_request( $request );
-			$document_object->set_context( $context );
+			$document_object->set_context( 'order' );
 			$additional_fields = $this->additional_fields_controller->get_contextual_fields_for_location( 'order', $document_object );
 		} else {
 			$additional_fields = $this->additional_fields_controller->get_fields_for_location( 'order' );

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -137,9 +137,9 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	public function test_get_contextual_fields_for_location_address() {
 		$fields = $this->controller->get_contextual_fields_for_location( 'address' );
 
-		$this->assertIsArray( $fields, 'Fields should be an array. Got: ' . print_r( $fields, true ) );
-		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields, print_r( array_keys( $fields ), true ) );
-		$this->assertArrayHasKey( 'namespace/vat-number', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
+		$this->assertArrayHasKey( 'namespace/vat-number', $fields );
 	}
 
 	/**
@@ -148,8 +148,8 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	public function test_get_contextual_fields_for_location_contact() {
 		$fields = $this->controller->get_contextual_fields_for_location( 'contact' );
 
-		$this->assertIsArray( $fields, 'Fields should be an array. Got: ' . print_r( $fields, true ) );
-		$this->assertArrayHasKey( 'plugin-namespace/job-function', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'plugin-namespace/job-function', $fields );
 	}
 
 	/**
@@ -158,8 +158,8 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 	public function test_get_contextual_fields_for_location_order() {
 		$fields = $this->controller->get_contextual_fields_for_location( 'order' );
 
-		$this->assertIsArray( $fields, 'Fields should be an array. Got: ' . print_r( $fields, true ) );
-		$this->assertArrayHasKey( 'plugin-namespace/leave-on-porch', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertIsArray( $fields );
+		$this->assertArrayHasKey( 'plugin-namespace/leave-on-porch', $fields );
 	}
 
 	/**
@@ -177,8 +177,8 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$document_object->set_customer( $customer );
 
 		$fields = $this->controller->get_contextual_fields_for_location( 'address', $document_object );
-		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields, print_r( array_keys( $fields ), true ) );
-		$this->assertArrayHasKey( 'namespace/vat-number', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
+		$this->assertArrayHasKey( 'namespace/vat-number', $fields );
 
 		// Test VAT field is hidden with US address.
 		$customer->set_shipping_country( 'US' );
@@ -187,7 +187,7 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 		$document_object->set_customer( $customer );
 
 		$fields = $this->controller->get_contextual_fields_for_location( 'address', $document_object );
-		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields, print_r( array_keys( $fields ), true ) );
-		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields );
+		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -1,0 +1,193 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Domain\Services;
+
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFieldsSchema\DocumentObject;
+use WP_UnitTestCase;
+
+/**
+ * Tests for CheckoutFields class.
+ */
+class CheckoutFieldsTest extends WP_UnitTestCase {
+	/**
+	 * The system under test.
+	 *
+	 * @var CheckoutFields
+	 */
+	private $controller;
+
+	/**
+	 * Setup test case.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->register_fields();
+		$this->controller = Package::container()->get( CheckoutFields::class );
+	}
+
+	/**
+	 * Tear down Rest API server and remove fields.
+	 */
+	public function tearDown(): void {
+		$this->unregister_fields();
+		parent::tearDown();
+	}
+
+	/**
+	 * Register fields for testing.
+	 */
+	private function register_fields() {
+		$this->fields = array(
+			array(
+				'id'                => 'plugin-namespace/gov-id',
+				'label'             => 'Government ID',
+				'location'          => 'address',
+				'type'              => 'text',
+				'required'          => true,
+				'attributes'        => array(
+					'title'          => 'This is a gov id',
+					'autocomplete'   => 'gov-id',
+					'autocapitalize' => 'none',
+					'maxLength'      => '30',
+				),
+				'sanitize_callback' => function ( $value ) {
+					return trim( $value );
+				},
+				'validate_callback' => function ( $value ) {
+					return strlen( $value ) > 3;
+				},
+			),
+			array(
+				'id'       => 'plugin-namespace/job-function',
+				'label'    => 'What is your main role at your company?',
+				'location' => 'contact',
+				'required' => true,
+				'type'     => 'select',
+				'options'  => array(
+					array(
+						'label' => 'Director',
+						'value' => 'director',
+					),
+					array(
+						'label' => 'Engineering',
+						'value' => 'engineering',
+					),
+					array(
+						'label' => 'Customer Support',
+						'value' => 'customer-support',
+					),
+					array(
+						'label' => 'Other',
+						'value' => 'other',
+					),
+				),
+			),
+			array(
+				'id'       => 'plugin-namespace/leave-on-porch',
+				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
+				'location' => 'order',
+				'type'     => 'checkbox',
+			),
+			array(
+				'id'       => 'namespace/vat-number',
+				'label'    => 'VAT Number',
+				'location' => 'address',
+				'required' => true,
+				'rules'    => array(
+					'hidden'     => array(
+						'customer' => array(
+							'properties' => array(
+								'address' => array(
+									'properties' => array(
+										'country' => array(
+											'type' => 'string',
+											'not'  => array(
+												'enum' => array_merge( WC()->countries->get_european_union_countries( 'eu_vat' ), array( 'GB' ) ),
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+					'validation' => array(
+						'type'    => 'string',
+						'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
+					),
+				),
+			),
+		);
+		array_map( 'woocommerce_register_additional_checkout_field', $this->fields );
+	}
+
+	/**
+	 * Unregister fields after testing.
+	 */
+	private function unregister_fields() {
+		$fields = $this->controller->get_additional_fields();
+		array_map( '__internal_woocommerce_blocks_deregister_checkout_field', array_keys( $fields ) );
+	}
+
+	/**
+	 * Test get_contextual_fields_for_location returns correct fields for billing location.
+	 */
+	public function test_get_contextual_fields_for_location_address() {
+		$fields = $this->controller->get_contextual_fields_for_location( 'address' );
+
+		$this->assertIsArray( $fields, 'Fields should be an array. Got: ' . print_r( $fields, true ) );
+		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertArrayHasKey( 'namespace/vat-number', $fields, print_r( array_keys( $fields ), true ) );
+	}
+
+	/**
+	 * Test get_contextual_fields_for_location returns correct fields for billing location.
+	 */
+	public function test_get_contextual_fields_for_location_contact() {
+		$fields = $this->controller->get_contextual_fields_for_location( 'contact' );
+
+		$this->assertIsArray( $fields, 'Fields should be an array. Got: ' . print_r( $fields, true ) );
+		$this->assertArrayHasKey( 'plugin-namespace/job-function', $fields, print_r( array_keys( $fields ), true ) );
+	}
+
+	/**
+	 * Test get_contextual_fields_for_location returns correct fields for billing location.
+	 */
+	public function test_get_contextual_fields_for_location_order() {
+		$fields = $this->controller->get_contextual_fields_for_location( 'order' );
+
+		$this->assertIsArray( $fields, 'Fields should be an array. Got: ' . print_r( $fields, true ) );
+		$this->assertArrayHasKey( 'plugin-namespace/leave-on-porch', $fields, print_r( array_keys( $fields ), true ) );
+	}
+
+	/**
+	 * Test get_contextual_fields_for_location returns correct fields for billing location.
+	 */
+	public function test_get_contextual_fields_for_location_address_with_context() {
+		$customer        = \WC_Helper_Customer::create_mock_customer();
+		$document_object = new DocumentObject();
+		$document_object->set_context( 'shipping_address' );
+
+		// Test VAT field is shown with UK address.
+		$customer->set_shipping_country( 'GB' );
+		$customer->set_shipping_state( '' );
+		$customer->set_shipping_postcode( 'PP121PP' );
+		$document_object->set_customer( $customer );
+
+		$fields = $this->controller->get_contextual_fields_for_location( 'address', $document_object );
+		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertArrayHasKey( 'namespace/vat-number', $fields, print_r( array_keys( $fields ), true ) );
+
+		// Test VAT field is hidden with US address.
+		$customer->set_shipping_country( 'US' );
+		$customer->set_shipping_state( 'CA' );
+		$customer->set_shipping_postcode( '90210' );
+		$document_object->set_customer( $customer );
+
+		$fields = $this->controller->get_contextual_fields_for_location( 'address', $document_object );
+		$this->assertArrayHasKey( 'plugin-namespace/gov-id', $fields, print_r( array_keys( $fields ), true ) );
+		$this->assertArrayNotHasKey( 'namespace/vat-number', $fields, print_r( array_keys( $fields ), true ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support on the PHP side for `hidden` field rules for checkout fields. Updates and refactors how schema is evaluated for fields.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

_This work is behind a feature flag._ Testers should do a full build to check there are no regressions.

```
pnpm --filter=@woocommerce/plugin-woocommerce build
```

Test with some additional fields with various rules. Example:

<details>

```php
add_action(
	'woocommerce_init',
	function () {
		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'namespace/vat-number',
				'label'    => 'VAT Number',
				'location' => 'address',
				'required' => true,
				'rules'    => array(
					'hidden'     => array(
						'customer' => array(
							'properties' => array(
								'address' => array(
									'properties' => array(
										'country' => array(
											'type' => 'string',
											'not'  => array(
												'enum' => array_merge( WC()->countries->get_european_union_countries( 'eu_vat' ), array( 'GB' ) ),
											),
										),
									),
								),
							),
						),
					),
					'validation' => array(
						'type'    => 'string',
						'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
					),
				),
			)
		);
		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'namespace/reason-for-purchase',
				'label'    => 'Reason for Purchase',
				'location' => 'contact',
				'required' => true,
			)
		);
	}
);
```

</details>

Testing checkout both fields will be required. Order should place and fields should appear under My Account.

For development builds, the feature flag is enabled:

```
pnpm --filter=@woocommerce/plugin-woocommerce watch:build
```

1. With the code snippet above, go to the my account page. Edit an address. If its not already a GB address, add one and save.
2. Confirm the VAT number is required and visible. Confirm you can edit it and validation works if you enter invalid number.
3. Edit the address to a US address. Confirm after saving, the VAT field is no longer visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
