### PR TITLE
Fix translated order details showing view action

### DIFF
--- a/plugins/woocommerce/changelog/55571-fix-translated-order-buttons
+++ b/plugins/woocommerce/changelog/55571-fix-translated-order-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where the view action was being displayed on the order details page.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -30,13 +30,8 @@ if ( ! $order ) {
 $order_items        = $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
 $show_purchase_note = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
 $downloads          = $order->get_downloadable_items();
-$actions            = array_filter(
-	wc_get_account_orders_actions( $order ),
-	function ( $key ) {
-		return 'view' !== $key;
-	},
-	ARRAY_FILTER_USE_KEY
-);
+$actions            = wc_get_account_orders_actions( $order );
+unset( $actions['view'] );
 
 // We make sure the order belongs to the user. This will also be true if the user is a guest, and the order belongs to a guest (userID === 0).
 $show_customer_details = $order->get_user_id() === get_current_user_id();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes a bug where the "View" action is displayed on the order details when the page is translated. This is because originally I filtered out the view action by its name, which changes with language. This was introduced in https://github.com/woocommerce/woocommerce/pull/52756

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes [#55491](https://github.com/woocommerce/woocommerce/issues/55491)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

2. Place a test order.
4. Go to My Account → Orders.
5. Click on the order details page.
6. The "view" action should not be there.
7. Set the sit language to anything but English (e.g. Dutch)
8. Check that the "view" action isn't visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a bug where the view action was being displayed on the order details page.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
