### PR TITLE
Fix coming soon determined too early in lifecycle

### DIFF
--- a/plugins/woocommerce/changelog/fix-coming-soon-optimization-lifecycle-hook
+++ b/plugins/woocommerce/changelog/fix-coming-soon-optimization-lifecycle-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coming soon hooks to be after plugins_loaded hook

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -37,17 +37,20 @@ class ComingSoonRequestHandler {
 	final public function init( ComingSoonHelper $coming_soon_helper ) {
 		$this->coming_soon_helper = $coming_soon_helper;
 		// Hook into plugins_loaded to ensure features are initialized to determine coming soon status.
-		add_action( 'plugins_loaded', function() {
-			// Skip if the site is live.
-			if ( $this->coming_soon_helper->is_site_live() ) {
-				return;
-			}
+		add_action(
+			'plugins_loaded',
+			function () {
+				// Skip if the site is live.
+				if ( $this->coming_soon_helper->is_site_live() ) {
+					return;
+				}
 
-			add_filter( 'template_include', array( $this, 'handle_template_include' ) );
-			add_filter( 'wp_theme_json_data_theme', array( $this, 'experimental_filter_theme_json_theme' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
-			add_action( 'after_setup_theme', array( $this, 'possibly_init_block_templates' ), 999 );
-		} );
+				add_filter( 'template_include', array( $this, 'handle_template_include' ) );
+				add_filter( 'wp_theme_json_data_theme', array( $this, 'experimental_filter_theme_json_theme' ) );
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+				add_action( 'after_setup_theme', array( $this, 'possibly_init_block_templates' ), 999 );
+			}
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -36,17 +36,19 @@ class ComingSoonRequestHandler {
 	 */
 	final public function init( ComingSoonHelper $coming_soon_helper ) {
 		$this->coming_soon_helper = $coming_soon_helper;
-		// Skip if the site is live.
-		if ( $this->coming_soon_helper->is_site_live() ) {
-			return;
-		}
+		// Hook into plugins_loaded to ensure features are initialized to determine coming soon status.
+		add_action( 'plugins_loaded', function() {
+			// Skip if the site is live.
+			if ( $this->coming_soon_helper->is_site_live() ) {
+				return;
+			}
 
-		add_filter( 'template_include', array( $this, 'handle_template_include' ) );
-		add_filter( 'wp_theme_json_data_theme', array( $this, 'experimental_filter_theme_json_theme' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
-		add_action( 'after_setup_theme', array( $this, 'possibly_init_block_templates' ), 999 );
+			add_filter( 'template_include', array( $this, 'handle_template_include' ) );
+			add_filter( 'wp_theme_json_data_theme', array( $this, 'experimental_filter_theme_json_theme' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+			add_action( 'after_setup_theme', array( $this, 'possibly_init_block_templates' ), 999 );
+		} );
 	}
-
 
 	/**
 	 * Initializes block templates so we can show coming soon page in non-FSE themes.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/team-ghidorah/issues/380

The coming soon optimization in [this PR](https://github.com/woocommerce/woocommerce/pull/54906/files#diff-4036d5a5c66edc139f05d996eec952ce716b944160128e7cfb149b426343c42aR40) was deciding coming soon option too early. Since option calls are cached in memory, this raises the following issues:

1. It impedes the ability for 3pd and hosting providers to override the option value.
1. Feature class is not loaded by this time, making it limiting to build logic around it even if we hook into the option filter earlier.

As an example, the nightly core build fails in WordPress.com sites since the [override hook](https://github.com/Automattic/wc-calypso-bridge/blob/fd00cfcc99b670fe1be53ae530017741c2d2468a/includes/class-wc-calypso-bridge-coming-soon.php#L40) is not set up when `woocommerce_coming_soon` option is queried, which gets cached in memory.

ChatGPT confirmed all hooks newly wrapped into `plugins_loaded` are called after:

<img width="636" alt="image" src="https://github.com/user-attachments/assets/bbfd6fbd-1b92-43ca-bf31-5135f9bcba9a" />
 
### How to test the changes in this Pull Request:

#### Regression test

1. Enable feature flag `coming-soon-newsletter-template`
3. Go to `Appearance > Editor > Templates > Page: Coming soon`
4. Select different templates under `Design` panel
5. Ensure each loaded correct UI, indicating styles and fonts are loaded as expected ([example with TT25 theme](https://github.com/user-attachments/assets/f6374dee-35fc-4444-b100-3aa2b75629f3))
6. Select any design and save
7. In an incognito window, open up the frontend shop page
8. Observe the page looks correct ([example](https://github.com/user-attachments/assets/b85b7730-5d2f-4928-ac06-35f1f77fc1c3))
9. Change to a non-FSE template, such as Storefront
10. Refresh the incognito window and ensure the coming soon page looks correct

#### Optional: Testing in WordPress.com

1. In a WordPress.com business or ecommerce site, install the build from this PR ([woocommerce.zip](https://github.com/user-attachments/files/18841679/woocommerce.zip))
2. Set the site to coming soon
3. Go to `/_cli` and run `option delete woocommerce_coming_soon` to ensure the option is deleted if it exist so that we'll be able to observe the coming soon value coming from the override hook
4. In an incognito window, open the `/shop`
5. Observe it shows coming soon page

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
