### PR TITLE
Add some improvements to the Add to Cart Button migration to @wordpress/interactivity

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -121,7 +121,7 @@ const { state } = store< Store >(
 				const { actions } = ( yield import(
 					'../../../../base/stores/cart-items'
 				) ) as WooStore;
-				actions.refreshCartItems();
+				yield actions.refreshCartItems();
 			},
 			handleAnimationEnd( event: AnimationEvent ) {
 				const context = getContext();

--- a/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -121,7 +121,7 @@ const { state } = store< Store >(
 				const { actions } = ( yield import(
 					'../../../../base/stores/cart-items'
 				) ) as WooStore;
-				yield actions.refreshCartItems();
+				actions.refreshCartItems();
 			},
 			handleAnimationEnd( event: AnimationEvent ) {
 				const context = getContext();

--- a/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
@@ -56,8 +56,7 @@ function emitSyncEvent() {
 	++eventId;
 
 	window.dispatchEvent(
-		// Question: What are the usual names for WooCommerce events?
-		new CustomEvent( 'woocommerce-cart-sync-required', {
+		new CustomEvent( 'wc-blocks_cart_sync_required', {
 			detail: { type: 'from_iAPI', id: eventId },
 		} )
 	);
@@ -195,7 +194,7 @@ export const { state, actions } = ( store as typeof StoreType )< Store >(
 );
 
 window.addEventListener(
-	'woocommerce-cart-sync-required',
+	'wc-blocks_cart_sync_required',
 	async ( event: Event ) => {
 		const customEvent = event as CustomEvent< {
 			type: string;

--- a/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
@@ -26,8 +26,7 @@ export type Store = {
 	};
 	actions: {
 		addCartItem: ( args: { id: number; quantity: number } ) => void;
-		// Todo: Check why if I switch to an async function here the types of the store stop working.
-		refreshCartItems: () => void;
+		refreshCartItems: () => Promise< void >;
 	};
 };
 
@@ -148,18 +147,18 @@ export const { state, actions } = store< Store >( 'woocommerce', {
 				state.cart.items[ itemIndex ].quantity = previousQuantity || 0;
 			}
 		},
-		*refreshCartItems() {
+		async refreshCartItems() {
 			// Skips if there's a pending request.
 			if ( pendingRefresh ) return;
 
 			pendingRefresh = true;
 
 			try {
-				const res: Response = yield fetch(
+				const res: Response = await fetch(
 					`${ state.restUrl }wc/store/v1/cart/items`,
 					{ headers: { 'Content-Type': 'application/json' } }
 				);
-				const json: CartItemsResponse = yield res.json();
+				const json: CartItemsResponse = await res.json();
 
 				// Checks if the response contains an error.
 				if ( ! isSuccessfulResponse( res, json ) )

--- a/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
@@ -62,136 +62,126 @@ function emitSyncEvent() {
 	);
 }
 
-// Todo: Remove the type cast once we import from `@wordpress/interactivity`.
 // Question: disable "used before defined" lint rule?
-export const { state, actions } = ( store as typeof StoreType )< Store >(
-	'woocommerce',
-	{
-		actions: {
-			*addCartItem( { id, quantity }: { id: number; quantity: number } ) {
-				let itemIndex = state.cart.items.findIndex(
-					( { id: productId } ) => id === productId
+export const { state, actions } = store< Store >( 'woocommerce', {
+	actions: {
+		*addCartItem( { id, quantity }: { id: number; quantity: number } ) {
+			let itemIndex = state.cart.items.findIndex(
+				( { id: productId } ) => id === productId
+			);
+			const previousQuantity =
+				state.cart.items[ itemIndex ]?.quantity ?? 0;
+			let key: string | null = null;
+
+			// Optimistically updates the number of items in the cart.
+			if ( itemIndex !== -1 ) {
+				state.cart.items[ itemIndex ].quantity = quantity;
+				key = state.cart.items[ itemIndex ].key || null;
+			} else {
+				state.cart.items.push( { id, quantity } );
+				itemIndex = state.cart.items.length - 1;
+			}
+
+			// Updates the database.
+			try {
+				const res: Response = yield fetch(
+					`${ state.restUrl }wc/store/v1/cart/items/${ key || '' }`,
+					{
+						method: key ? 'PUT' : 'POST',
+						headers: {
+							Nonce: state.nonce,
+							'Content-Type': 'application/json',
+						},
+						body: JSON.stringify( state.cart.items[ itemIndex ] ),
+					}
 				);
-				const previousQuantity =
-					state.cart.items[ itemIndex ]?.quantity ?? 0;
-				let key: string | null = null;
+				const json: CartItemResponse = yield res.json();
 
-				// Optimistically updates the number of items in the cart.
-				if ( itemIndex !== -1 ) {
-					state.cart.items[ itemIndex ].quantity = quantity;
-					key = state.cart.items[ itemIndex ].key || null;
-				} else {
-					state.cart.items.push( { id, quantity } );
-					itemIndex = state.cart.items.length - 1;
-				}
+				// Checks if the response contains an error.
+				if ( ! isSuccessfulResponse( res, json ) )
+					throw generateError( json );
 
-				// Updates the database.
-				try {
-					const res: Response = yield fetch(
-						`${ state.restUrl }wc/store/v1/cart/items/${
-							key || ''
-						}`,
-						{
-							method: key ? 'PUT' : 'POST',
-							headers: {
-								Nonce: state.nonce,
-								'Content-Type': 'application/json',
-							},
-							body: JSON.stringify(
-								state.cart.items[ itemIndex ]
-							),
-						}
-					);
-					const json: CartItemResponse = yield res.json();
+				// Updates the local cart.
+				state.cart.items[ itemIndex ] = json;
 
-					// Checks if the response contains an error.
-					if ( ! isSuccessfulResponse( res, json ) )
-						throw generateError( json );
+				// dispatch legacy event
+				triggerAddedToCartEvent( {
+					preserveCartData: true,
+				} );
 
-					// Updates the local cart.
-					state.cart.items[ itemIndex ] = json;
+				// Dispatches the event to sync the @wordpress/data store.
+				emitSyncEvent();
+			} catch ( error ) {
+				const message = ( error as Error ).message;
 
-					// dispatch legacy event
-					triggerAddedToCartEvent( {
-						preserveCartData: true,
-					} );
+				// Question: can we import this dynamically so it's not loaded on page load?
+				const { actions: noticeActions } = store< StoreNoticesStore >(
+					'woocommerce/store-notices'
+				);
 
-					// Dispatches the event to sync the @wordpress/data store.
-					emitSyncEvent();
-				} catch ( error ) {
-					const message = ( error as Error ).message;
-
-					// Question: can we import this dynamically so it's not loaded on page load?
-					const { actions: noticeActions } =
-						store< StoreNoticesStore >(
-							'woocommerce/store-notices'
-						);
-
-					// If the user deleted the hooked store notice block, the
-					// store won't be present and we should not add a notice.
-					if ( 'addNotice' in noticeActions ) {
-						// The old implementation always overwrites the last
-						// notice, so we remove the last notice before adding a
-						// new one.
-						// Todo: Review this implementation.
-						if ( state.noticeId !== '' ) {
-							noticeActions.removeNotice( state.noticeId );
-						}
-
-						const noticeId = noticeActions.addNotice( {
-							notice: message,
-							type: 'error',
-							dismissible: true,
-						} );
-
-						state.noticeId = noticeId;
+				// If the user deleted the hooked store notice block, the
+				// store won't be present and we should not add a notice.
+				if ( 'addNotice' in noticeActions ) {
+					// The old implementation always overwrites the last
+					// notice, so we remove the last notice before adding a
+					// new one.
+					// Todo: Review this implementation.
+					if ( state.noticeId !== '' ) {
+						noticeActions.removeNotice( state.noticeId );
 					}
 
-					// We don't care about errors blocking execution, but will
-					// console.error for troubleshooting.
-					// eslint-disable-next-line no-console
-					console.error( error );
+					const noticeId = noticeActions.addNotice( {
+						notice: message,
+						type: 'error',
+						dismissible: true,
+					} );
 
-					// Reverts the optimistic update.
-					state.cart.items[ itemIndex ].quantity =
-						previousQuantity || 0;
+					state.noticeId = noticeId;
 				}
-			},
-			*refreshCartItems() {
-				// Skips if there's a pending request.
-				if ( pendingRefresh ) return;
 
-				pendingRefresh = true;
+				// We don't care about errors blocking execution, but will
+				// console.error for troubleshooting.
+				// eslint-disable-next-line no-console
+				console.error( error );
 
-				try {
-					const res: Response = yield fetch(
-						`${ state.restUrl }wc/store/v1/cart/items`,
-						{ headers: { 'Content-Type': 'application/json' } }
-					);
-					const json: CartItemsResponse = yield res.json();
-
-					// Checks if the response contains an error.
-					if ( ! isSuccessfulResponse( res, json ) )
-						throw generateError( json );
-
-					// Updates the local cart.
-					state.cart.items = json;
-
-					// Resets the timeout.
-					refreshTimeout = 3000;
-				} catch ( error ) {
-					// Tries again after the timeout.
-					setTimeout( actions.refreshCartItems, refreshTimeout );
-
-					// Increases the timeout exponentially.
-					refreshTimeout *= 2;
-				} finally {
-					pendingRefresh = false;
-				}
-			},
+				// Reverts the optimistic update.
+				state.cart.items[ itemIndex ].quantity = previousQuantity || 0;
+			}
 		},
-	}
-);
+		*refreshCartItems() {
+			// Skips if there's a pending request.
+			if ( pendingRefresh ) return;
+
+			pendingRefresh = true;
+
+			try {
+				const res: Response = yield fetch(
+					`${ state.restUrl }wc/store/v1/cart/items`,
+					{ headers: { 'Content-Type': 'application/json' } }
+				);
+				const json: CartItemsResponse = yield res.json();
+
+				// Checks if the response contains an error.
+				if ( ! isSuccessfulResponse( res, json ) )
+					throw generateError( json );
+
+				// Updates the local cart.
+				state.cart.items = json;
+
+				// Resets the timeout.
+				refreshTimeout = 3000;
+			} catch ( error ) {
+				// Tries again after the timeout.
+				setTimeout( actions.refreshCartItems, refreshTimeout );
+
+				// Increases the timeout exponentially.
+				refreshTimeout *= 2;
+			} finally {
+				pendingRefresh = false;
+			}
+		},
+	},
+} );
 
 window.addEventListener(
 	'wc-blocks_cart_sync_required',

--- a/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/stores/cart-items.ts
@@ -26,7 +26,8 @@ export type Store = {
 	};
 	actions: {
 		addCartItem: ( args: { id: number; quantity: number } ) => void;
-		refreshCartItems: () => Promise< void >;
+		// Todo: Check why if I switch to an async function here the types of the store stop working.
+		refreshCartItems: () => void;
 	};
 };
 
@@ -147,18 +148,18 @@ export const { state, actions } = store< Store >( 'woocommerce', {
 				state.cart.items[ itemIndex ].quantity = previousQuantity || 0;
 			}
 		},
-		async refreshCartItems() {
+		*refreshCartItems() {
 			// Skips if there's a pending request.
 			if ( pendingRefresh ) return;
 
 			pendingRefresh = true;
 
 			try {
-				const res: Response = await fetch(
+				const res: Response = yield fetch(
 					`${ state.restUrl }wc/store/v1/cart/items`,
 					{ headers: { 'Content-Type': 'application/json' } }
 				);
-				const json: CartItemsResponse = await res.json();
+				const json: CartItemsResponse = yield res.json();
 
 				// Checks if the response contains an error.
 				if ( ! isSuccessfulResponse( res, json ) )

--- a/plugins/woocommerce-blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/index.ts
@@ -107,8 +107,7 @@ subscribe( () => {
 		diffObjects( previousCart, cartData );
 
 		window.dispatchEvent(
-			// Question: What are the usual names for WooCommerce events?
-			new CustomEvent( 'woocommerce-cart-sync-required', {
+			new CustomEvent( 'wc-blocks_cart_sync_required', {
 				detail: { type: 'from_@wordpress/data', id },
 			} )
 		);
@@ -117,7 +116,7 @@ subscribe( () => {
 }, store );
 
 // Listens to cart sync events from the iAPI store.
-window.addEventListener( 'woocommerce-cart-sync-required', ( event: Event ) => {
+window.addEventListener( 'wc-blocks_cart_sync_required', ( event: Event ) => {
 	const customEvent = event as CustomEvent< {
 		type: string;
 		id: number;

--- a/plugins/woocommerce/changelog/update-iapi-add-to-cart-button
+++ b/plugins/woocommerce/changelog/update-iapi-add-to-cart-button
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Add some improvements to the Add to Cart Button migration to @wordpress/interactivity
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces the following changes:

* https://github.com/woocommerce/woocommerce/commit/d23783e2cd2dfd3e01bc0243a9af3e68073a9a70 updates the event names to be aligned with other WooCommerce Blocks events like [Product Collection events](https://github.com/woocommerce/woocommerce/blob/b42419209d77a889d1b64f1e47739ced1c8c3f44/docs/product-collection-block/dom-events.md) and [Cart and Checkout events](https://github.com/woocommerce/woocommerce/blob/b42419209d77a889d1b64f1e47739ced1c8c3f44/docs/cart-and-checkout-blocks/dom-events.md).
* https://github.com/woocommerce/woocommerce/commit/d155cf9fdb760ea4b7943925213ed4c25fe0f727 removes an unnecessary type cast (this one is easier to review hiding whitespace changes).

I did some testing and everything seems to be working fine on my end, but I'm not very familiar with the iAPI so I might have missed something. :pray: 

### How to test the changes in this Pull Request:

1. Add a _Product Collection_ block that contains the _Add to Cart Button_ block into a post or page. Add the _Mini-Cart_ block to the header of your site.
2. Go to the frontend and add products to the cart using the _Product Collection_ block.
3. Verify they are added correctly, the count in the _Add to Cart Button_ block updates and persists after a refresh.
4. Using the _Mini-Cart_ block, remove the product you just added. Verify the _Add to Cart Button_ block updates accordingly.
5. Using your browser devtools, emulate being offline and try adding a product to the cart. Verify an error notice is displayed and the count in the _Add to Cart Button_ block didn't add one.