### PR TITLE
Prevent fatal error in `wc_no_products_found()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-52342
+++ b/plugins/woocommerce/changelog/fix-52342
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error when calling wc_no_products_found() out of context.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3618,13 +3618,12 @@ if ( ! function_exists( 'wc_no_products_found' ) ) {
 		if ( ! function_exists( 'wc_print_notice' ) ) {
 			// wc_print_notice() is used in our default template, so this likely means this function was called out of
 			// context. We include the notice functions here to avoid a fatal error.
-			include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
-
 			wc_doing_it_wrong(
 				__FUNCTION__,
 				'Function should only be used during frontend requests.',
 				'9.8.0'
 			);
+			return;
 		}
 
 		wc_get_template( 'loop/no-products-found.php' );

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3615,6 +3615,18 @@ if ( ! function_exists( 'wc_no_products_found' ) ) {
 	 * Handles the loop when no products were found/no product exist.
 	 */
 	function wc_no_products_found() {
+		if ( ! function_exists( 'wc_print_notice' ) ) {
+			// wc_print_notice() is used in our default template, so this likely means this function was called out of
+			// context. We include the notice functions here to avoid a fatal error.
+			include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
+
+			wc_doing_it_wrong(
+				__FUNCTION__,
+				'Function should only be used during frontend requests.',
+				'9.8.0'
+			);
+		}
+
 		wc_get_template( 'loop/no-products-found.php' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds some checks for the unlikely case that `wc_no_products_found()` is called from a non-frontend request. This seems to occur particularly when plugins such as Yoast run indexing as part of a cron job.

> [!IMPORTANT]
> #### For discussion
> I'm not very happy with having to include `wc-template-functions.php` file during what's a non-frontend request just to prevent the fatal error, as that might make other code (on a non-frontend request) think certain functionality is available when in reality it is not.
>
> I also considered just returning early when the function didn't exist as it's already an unexpected situation, but given it just loads a template and one that can be overridden in a theme, I wasn't sure whether that was the best solution, though it's definitely the one I'd prefer.
>
> Clearly something to discuss. Happy to adjust the code as needed, of course.

Closes #52342.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the following PHP snippet using Code Snippets or by dropping it inside a .php file in `wp-content/mu-plugins/`:
   ```php
   <?php
   add_action( 'admin_footer', 'wc_no_products_found' );
   ```
1. Visit any admin page on your site.
1. No error should be logged.
1. (Optional) Switch to `trunk` and repeat the above, this time noticing a fatal error in your logs:
   > Uncaught Error: Call to undefined function wc_print_notice() in /.../templates/loop/no-products-found.php:22

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
