### PR TITLE
Fix email rendering issues found in Litmus

### DIFF
--- a/plugins/woocommerce/changelog/54572-email-litmus-fixes
+++ b/plugins/woocommerce/changelog/54572-email-litmus-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve new email rendering in older Outlooks

--- a/plugins/woocommerce/templates/emails/admin-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/admin-cancelled-order.php
@@ -64,9 +64,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/admin-failed-order.php
@@ -65,9 +65,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/admin-new-order.php
@@ -63,9 +63,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-completed-order.php
@@ -64,9 +64,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-failed-order.php
@@ -72,9 +72,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /**

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.7.0
+ * @version 9.8.0
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -113,9 +113,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /**

--- a/plugins/woocommerce/templates/emails/customer-new-account-blocks.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account-blocks.php
@@ -54,9 +54,9 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content email-additional-content-aligned">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 /**
  * Fires to output the email footer.

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -54,9 +54,9 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content email-additional-content-aligned">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -63,9 +63,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.7.0
+ * @version 9.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/customer-on-hold-order.php
@@ -62,9 +62,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/customer-processing-order.php
@@ -65,9 +65,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-refunded-order.php
@@ -79,9 +79,9 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -61,9 +61,9 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<div class="email-additional-content email-additional-content-aligned">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-	echo $email_improvements_enabled ? '</div>' : '';
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
 do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.7.0
+ * @version 9.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -26,7 +26,7 @@ $shipping = $order->get_formatted_shipping_address();
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: 40px; padding:0;" border="0">
+?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '16px' : '40px'; ?>; padding:0;" border="0">
 	<tr>
 		<td class="font-family text-align-left" style="border:0; padding:0;" valign="top" width="50%">
 			<?php if ( $email_improvements_enabled ) { ?>

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -26,7 +26,7 @@ $shipping = $order->get_formatted_shipping_address();
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '16px' : '40px'; ?>; padding:0;" border="0">
+?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '0' : '40px'; ?>; padding:0;" border="0">
 	<tr>
 		<td class="font-family text-align-left" style="border:0; padding:0;" valign="top" width="50%">
 			<?php if ( $email_improvements_enabled ) { ?>
@@ -89,3 +89,4 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 		<?php endif; ?>
 	</tr>
 </table>
+<?php echo $email_improvements_enabled ? '<br>' : ''; ?>

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -30,7 +30,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 	<tr>
 		<td class="font-family text-align-left" style="border:0; padding:0;" valign="top" width="50%">
 			<?php if ( $email_improvements_enabled ) { ?>
-				<b><?php esc_html_e( 'Billing address', 'woocommerce' ); ?></b>
+				<b class="address-title"><?php esc_html_e( 'Billing address', 'woocommerce' ); ?></b>
 			<?php } else { ?>
 				<h2><?php esc_html_e( 'Billing address', 'woocommerce' ); ?></h2>
 			<?php } ?>
@@ -61,7 +61,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && $shipping ) : ?>
 			<td class="font-family text-align-left" style="padding:0;" valign="top" width="50%">
 				<?php if ( $email_improvements_enabled ) { ?>
-					<b><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></b>
+					<b class="address-title"><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></b>
 				<?php } else { ?>
 					<h2><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></h2>
 				<?php } ?>

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -40,26 +40,42 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 						<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="inner_wrapper">
 							<tr>
 								<td align="center" valign="top">
-									<div id="template_header_image">
-										<?php
-										$img = get_option( 'woocommerce_email_header_image' );
-										/**
-										 * This filter is documented in templates/emails/email-styles.php
-										 *
-										 * @since 9.6.0
-										 */
-										if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
-											$img_transient = get_transient( 'woocommerce_email_header_image' );
-											$img           = false !== $img_transient ? $img_transient : $img;
-										}
+									<?php
+									$img = get_option( 'woocommerce_email_header_image' );
+									/**
+									 * This filter is documented in templates/emails/email-styles.php
+									 *
+									 * @since 9.6.0
+									 */
+									if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
+										$img_transient = get_transient( 'woocommerce_email_header_image' );
+										$img           = false !== $img_transient ? $img_transient : $img;
+									}
 
-										if ( $img ) {
-											echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( get_bloginfo( 'name', 'display' ) ) . '" /></p>';
-										} elseif ( $email_improvements_enabled ) {
-											echo '<p class="email-logo-text">' . esc_html( get_bloginfo( 'name', 'display' ) ) . '</p>';
-										}
+									if ( $email_improvements_enabled ) :
 										?>
-									</div>
+										<table border="0" cellpadding="0" cellspacing="0" width="100%">
+											<tr>
+												<td id="template_header_image">
+													<?php
+													if ( $img ) {
+														echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( get_bloginfo( 'name', 'display' ) ) . '" /></p>';
+													} else {
+														echo '<p class="email-logo-text">' . esc_html( get_bloginfo( 'name', 'display' ) ) . '</p>';
+													}
+													?>
+												</td>
+											</tr>
+										</table>
+									<?php else : ?>
+										<div id="template_header_image">
+											<?php
+											if ( $img ) {
+												echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( get_bloginfo( 'name', 'display' ) ) . '" /></p>';
+											}
+											?>
+										</div>
+									<?php endif; ?>
 									<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_container">
 										<tr>
 											<td align="center" valign="top">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -54,7 +54,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		$after  = '';
 	}
 	if ( $email_improvements_enabled ) {
-		echo '<span>';
+		echo '<br><span>';
 	}
 	/* translators: %s: Order ID. */
 	$order_number_string = __( '[Order #%s]', 'woocommerce' );

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.7.0
+ * @version 9.8.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -86,7 +86,26 @@ foreach ( $items as $item_id => $item ) :
 							 */
 							do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
 
-							wc_display_item_meta( $item );
+							$item_meta = wc_display_item_meta(
+								$item,
+								array(
+									'before'       => '',
+									'after'        => '',
+									'separator'    => '<br>',
+									'echo'         => false,
+									'label_before' => '<span>',
+									'label_after'  => ':</span> ',
+								)
+							);
+							echo '<div class="email-order-item-meta">';
+							echo wp_kses(
+								$item_meta,
+								array(
+									'br'   => array(),
+									'span' => array(),
+								)
+							);
+							echo '</div>';
 
 							/**
 							 * Allow other plugins to add additional product information.

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -177,8 +177,8 @@ body {
 	padding-bottom: 24px;
 }
 
-.email-additional-content {
-	padding-top: 32px;
+#body_content table td td.email-additional-content {
+	padding: 32px 0 0;
 }
 
 .email-additional-content p {
@@ -507,7 +507,7 @@ h2.email-order-detail-heading span {
 		}
 
 		.email-additional-content {
-			padding-top: 0 !important;
+			padding-top: 16px !important;
 		}
 	<?php else : ?>
 		#header_wrapper {

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -77,7 +77,7 @@ if ( wc_hex_is_light( $body ) ) {
 
 // If email improvements are enabled, always use the base color for links.
 if ( $email_improvements_enabled ) {
-	$link_color   = $base;
+	$link_color = $base;
 }
 
 $border_color    = wc_light_or_dark( $body, 'rgba(0, 0, 0, .2)', 'rgba(255, 255, 255, .2)' );

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -185,6 +185,8 @@ body {
 }
 
 #body_content table td td.email-additional-content {
+	color: <?php echo esc_attr( $text ); ?>;
+	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 	padding: 32px 0 0;
 }
 
@@ -344,6 +346,7 @@ body {
 
 .address {
 	<?php if ( $email_improvements_enabled ) { ?>
+		color: <?php echo esc_attr( $text ); ?>;
 		font-style: normal;
 		padding: 8px 0;
 	<?php } else { ?>
@@ -364,7 +367,9 @@ body {
 	margin: 0 0 12px 0;
 }
 
-.text {
+.text,
+.address-title,
+.order-item-data {
 	color: <?php echo esc_attr( $text ); ?>;
 	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 }

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -177,6 +177,12 @@ body {
 	padding-bottom: 24px;
 }
 
+.email-order-item-meta {
+	color: <?php echo esc_attr( $footer_text ); ?>;
+	font-size: 14px;
+	line-height: 140%;
+}
+
 #body_content table td td.email-additional-content {
 	padding: 32px 0 0;
 }
@@ -299,18 +305,14 @@ body {
 }
 
 #body_content td ul.wc-item-meta {
-	font-size: <?php echo $email_improvements_enabled ? '14px' : 'small'; ?>;
-	margin: <?php echo $email_improvements_enabled ? '0' : '1em 0 0'; ?>;
+	font-size: small;
+	margin: 1em 0 0>;
 	padding: 0;
-	<?php if ( $email_improvements_enabled ) { ?>
-	color: <?php echo esc_attr( $footer_text ); ?>;
-	line-height: 140%;
-	<?php } ?>;
 	list-style: none;
 }
 
 #body_content td ul.wc-item-meta li {
-	margin: <?php echo $email_improvements_enabled ? '0' : '0.5em 0 0'; ?>;
+	margin: 0.5em 0 0;
 	padding: 0;
 }
 
@@ -493,7 +495,7 @@ h2.email-order-detail-heading span {
 			font-size: 12px !important;
 		}
 
-		#body_content td ul.wc-item-meta {
+		.email-order-item-meta {
 			font-size: 12px !important;
 		}
 

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -78,9 +78,9 @@ if ( wc_hex_is_light( $body ) ) {
 // If email improvements are enabled, always use the base color for links.
 if ( $email_improvements_enabled ) {
 	$link_color   = $base;
-	$border_color = wc_light_or_dark( $body, 'rgba(0, 0, 0, .2)', 'rgba(255, 255, 255, .2)' );
 }
 
+$border_color    = wc_light_or_dark( $body, 'rgba(0, 0, 0, .2)', 'rgba(255, 255, 255, .2)' );
 $bg_darker_10    = wc_hex_darker( $bg, 10 );
 $body_darker_10  = wc_hex_darker( $body, 10 );
 $base_lighter_20 = wc_hex_lighter( $base, 20 );

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -77,7 +77,8 @@ if ( wc_hex_is_light( $body ) ) {
 
 // If email improvements are enabled, always use the base color for links.
 if ( $email_improvements_enabled ) {
-	$link_color = $base;
+	$link_color   = $base;
+	$border_color = wc_light_or_dark( $body, 'rgba(0, 0, 0, .2)', 'rgba(255, 255, 255, .2)' );
 }
 
 $bg_darker_10    = wc_hex_darker( $bg, 10 );
@@ -211,8 +212,7 @@ body {
 #template_footer #credit {
 	border: 0;
 	<?php if ( $email_improvements_enabled ) : ?>
-		border-top: 1px solid #ccc;
-		border-top: 1px solid rgba(0, 0, 0, .2);
+		border-top: 1px solid <?php echo esc_attr( $border_color ); ?>;
 	<?php endif; ?>
 	color: <?php echo esc_attr( $footer_text ); ?>;
 	font-family: <?php echo $safe_font_family; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
@@ -258,8 +258,7 @@ body {
 }
 
 #body_content .email-order-details tbody tr:last-child td {
-	border-bottom: 1px solid #ccc;
-	border-bottom: 1px solid rgba(0, 0, 0, .2);
+	border-bottom: 1px solid <?php echo esc_attr( $border_color ); ?>;
 	padding-bottom: 24px;
 }
 
@@ -292,14 +291,12 @@ body {
 
 #body_content .email-order-details .order-totals-last td,
 #body_content .email-order-details .order-totals-last th {
-	border-bottom: 1px solid #ccc;
-	border-bottom: 1px solid rgba(0, 0, 0, .2);
+	border-bottom: 1px solid <?php echo esc_attr( $border_color ); ?>;
 	padding-bottom: 24px;
 }
 
 #body_content .email-order-details .order-customer-note td {
-	border-bottom: 1px solid #ccc;
-	border-bottom: 1px solid rgba(0, 0, 0, .2);
+	border-bottom: 1px solid <?php echo esc_attr( $border_color ); ?>;
 	padding-bottom: 24px;
 	padding-top: 24px;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There should be no visible changes for modern email clients. These fixes only affect older Outlook versions with an old rendering engine. The goal is not to be pixel-perfect with modern clients but to not look broken. There are still some visual issues in old email clients, but the result should be good enough. 

|  Before  |  After |
| --------|------|
|  <img width="629" alt="Screenshot 2025-02-18 at 16 13 05" src="https://github.com/user-attachments/assets/6c097efa-175d-4811-a815-8f273d4623f1" />  |  <img width="631" alt="Screenshot 2025-02-18 at 16 13 47" src="https://github.com/user-attachments/assets/77109f30-6f7b-4208-9b6c-0e9caa1b456c" /> |

Fixed issues:
1. Spacing around logo/title
2. Order number and date on new line
3. Product meta info line breaks
4. Font family and color in product names and addresses
5. Different spacing in addresses
6. Additional content spacing 

Known, not fixed issues:
1. Missing borders
2. Line height in some elements

Closes #54572. Depends on #55562.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Email improvements` feature in **WooCommerce > Settings > Advanced > Features**. 
2. Go to **WooCommerce > Settings > Emails**.
3. Copy the HTML of the email preview.
4. Paste the HTML in [Litmus](https://www.litmus.com/) to compare different email clients.

<!-- End testing instructions -->
