### PR TITLE
Product Collection: Move FilterableControl on top of order by controls

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/index.tsx
@@ -164,6 +164,9 @@ const ProductCollectionInspectorControls = (
 				{ showInheritQueryControl && (
 					<InheritQueryControl { ...queryControlProps } />
 				) }
+				{ showFilterableControl && (
+					<FilterableControl { ...queryControlProps } />
+				) }
 				{ showCustomOrderControl && (
 					<CustomQueryOrderByControl { ...queryControlProps } />
 				) }
@@ -171,9 +174,6 @@ const ProductCollectionInspectorControls = (
 					<DefaultQueryOrderByControl
 						trackInteraction={ trackInteraction }
 					/>
-				) }
-				{ showFilterableControl && (
-					<FilterableControl { ...queryControlProps } />
 				) }
 				<LayoutOptionsControl { ...displayControlProps } />
 				<WidthOptionsControl { ...dimensionsControlProps } />

--- a/plugins/woocommerce/changelog/fix-filterable-control-order
+++ b/plugins/woocommerce/changelog/fix-filterable-control-order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Move FilterableControl on top of order by controls in the Product Collection block
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/54166.

In #54166 we moved the _Order by_ controls of the Product Collection block up, but they were put before the `<FilterableControl />`, that made it so the order of the controls was inconsistent between when editing a post/page and when editing the template.

### How to test the changes in this Pull Request:

1. Create a post or page and add the Product Collection block. Select the _Create your own_ option.
2. Verify the _Query type_ appears before the _Order by_ control.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/6ae1c43a-0302-41c6-82d4-101e58e8478a) | ![imatge](https://github.com/user-attachments/assets/9b341eab-e8de-43d2-9aeb-3f68ff94d226)