### PR TITLE
Prevent possible fatal error in `EditLock` (during heartbeat request)

### DIFF
--- a/plugins/woocommerce/changelog/fix-50263
+++ b/plugins/woocommerce/changelog/fix-50263
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error during heartbeat request.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
@@ -102,7 +102,7 @@ class EditLock {
 		unset( $response['wp-refresh-post-lock'] );
 
 		$order = wc_get_order( $order_id );
-		if ( ! $order || ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) ) {
+		if ( ! $order || ! is_a( $order, \WC_Order::class ) || ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) ) {
 			return $response;
 		}
 
@@ -143,7 +143,7 @@ class EditLock {
 		$order_ids = array_unique( array_map( 'absint', $data['wc-check-locked-orders'] ) );
 		foreach ( $order_ids as $order_id ) {
 			$order = wc_get_order( $order_id );
-			if ( ! $order ) {
+			if ( ! $order || ! is_a( $order, \WC_Order::class ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds some defensive checks to the `EditLock` code that gets invoked every heartbeat while editing an order or browsing the order list, to prevent a possible fatal error due to an order type mismatch.

Closes #50263.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The context in which this error was detected didn't provide much clues, but seems like an order was being edited (thus locked) while either its type in the database or its class as returned by `wc_get_order( $order_id )` was changed to a refund. This is an unlikely scenario but #50263 proves it somehow happened.

Because of the above, the testing instructions are a bit convoluted.

0. Make sure plugins such as Query Monitor are disabled, as it'll capture the logs preventing you from setting them in your own log files.
1. Go to WC > Orders on the admin.
1. Create an order and make sure to add at least one refund.
1. Take note of the refund number.
1. Enable the following snippet on your site either by including it as a .php file inside `wp-content/mu-plugins/` or by using Code Snippets (or a similar tool).
   ```php
   <?php
   add_action(
	   'wp_ajax_heartbeat',
	   function() {
		   if ( empty( $_POST['data']['wc-refresh-order-lock'] ) ) {
			   return;
		   }
   
		   $_POST['data']['wc-refresh-order-lock'] = YOUR_REFUND_ID;
	   },
	   0
   );
   ```

   Make sure to replace `YOUR_REFUND_ID` by the refund number from step 3.
1. Go to WC > Orders and open the order from step 2.
1. Wait patiently while the heartbeat event is triggered. You can monitor for an `admin-ajax.php` request with `action = heartbeat` using your browser's dev tools.
1. Confirm no errors are logged in your log files.
1. (Optionally) Repeat the above on `trunk` and notice a fatal error being logged.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
