### PR TITLE
Blockified Add to Cart with Options block: block icon and border should be purple

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.scss
@@ -17,4 +17,8 @@
 			}
 		}
 	}
+
+	&__block-icon {
+		color: $studio-woocommerce-purple-50;
+	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.scss
@@ -1,9 +1,4 @@
 .wp-block-woocommerce-add-to-cart-with-options {
-	&__skeleton-wrapper {
-		max-width: 300px;
-		margin-bottom: $gap;
-	}
-
 	&.block-editor-block-list__block:not(.remove-outline) {
 		&.is-highlighted::after,
 		&.is-hovered:not(.is-selected)::after,
@@ -17,8 +12,19 @@
 			}
 		}
 	}
+}
 
-	&__block-icon {
-		color: $studio-woocommerce-purple-50;
+.wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper {
+	max-width: 300px;
+	margin-bottom: $gap;
+}
+
+.wp-block-woocommerce-add-to-cart-with-options__block-icon {
+	color: $studio-woocommerce-purple-50;
+}
+
+.block-editor-list-view-leaf.is-selected .block-editor-list-view-block-contents {
+	.wp-block-woocommerce-add-to-cart-with-options__block-icon {
+		color: inherit;
 	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.scss
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit.scss
@@ -1,4 +1,20 @@
-.wc-block-editor-add-to-cart-with-options__skeleton-wrapper {
-	max-width: 300px;
-	margin-bottom: $gap;
+.wp-block-woocommerce-add-to-cart-with-options {
+	&__skeleton-wrapper {
+		max-width: 300px;
+		margin-bottom: $gap;
+	}
+
+	&.block-editor-block-list__block:not(.remove-outline) {
+		&.is-highlighted::after,
+		&.is-hovered:not(.is-selected)::after,
+		&.is-selected::after {
+			outline-color: var(--wp-block-synced-color);
+		}
+
+		&.block-editor-block-list__block:not([contenteditable]):focus {
+			&::after {
+				outline-color: var(--wp-block-synced-color);
+			}
+		}
+	}
 }

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -70,7 +70,7 @@ const AddToCartOptionsEdit = ( props: BlockEditProps< Attributes > ) => {
 				/>
 			) : (
 				<div { ...blockProps }>
-					<div className="wc-block-editor-add-to-cart-with-options__skeleton-wrapper">
+					<div className="wp-block-woocommerce-add-to-cart-with-options__skeleton-wrapper">
 						<Skeleton numberOfLines={ 3 } />
 					</div>
 					<Disabled>

--- a/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/add-to-cart-with-options/index.tsx
@@ -30,7 +30,14 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 		{
 			...( metadata as BlockConfiguration< Attributes > ),
 			icon: {
-				src: button,
+				src: ( { size }: { size?: number } ) => (
+					<span
+						className="wp-block-woocommerce-add-to-cart-with-options__block-icon"
+						style={ { height: size, width: size } }
+					>
+						{ button }
+					</span>
+				),
 			},
 			edit: AddToCartOptionsEdit,
 			save: () => null,

--- a/plugins/woocommerce/changelog/add-55014
+++ b/plugins/woocommerce/changelog/add-55014
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Change the Add to Cart with Options block icon and border to purple


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55014

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin
2. Go to WooCommerce Admin Test Helper > Features and enable experimental-blocks and blockified-add-to-cart.
3. Go to Appearance > Editor > Templates > Single Product, select the Add to Cart with Options block and update it to the blockified one.
4. When mouse hover the block, its borders should be shown on purple like a template part.
5. When selecting the block, its borders and icon should be shown on purple like a template part.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
