### PR TITLE
Prevent duplication of order attribution data on classic checkout.

### DIFF
--- a/plugins/woocommerce/changelog/55611-fix-duplicate_order_attribution_failed_order_classic_checkout
+++ b/plugins/woocommerce/changelog/55611-fix-duplicate_order_attribution_failed_order_classic_checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent duplication of order attribution data on classic checkout.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -150,6 +150,12 @@ class OrderAttributionController implements RegisterHooksInterface {
 		add_action(
 			'woocommerce_checkout_order_created',
 			function ( $order ) {
+
+				// Check if this order already has any attribution data to prevent duplicates attribution data.
+				if ( $this->has_attribution( $order ) ) {
+					return;
+				}
+
 				// Nonce check is handled by WooCommerce before woocommerce_checkout_order_created hook.
 				// phpcs:ignore WordPress.Security.NonceVerification
 				$params = $this->get_unprefixed_field_values( $_POST );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow up to #55594 

As reported in https://github.com/woocommerce/woocommerce/issues/55460 we duplicate order attribution data every time an order fails. This is also an issue with classic checkout. So I add the same check as in 55594to see if we've already recorded attribution data before running our woocommerce_order_save_attribution_data  action.

### How to test the changes in this Pull Request:

1. Checkout this branch and build the woocommerce plugin
2. Make sure the checkout page uses classic checkout ( shortcode )

3. Install and configure Stripe:
- Install & activate "WooCommerce Stripe Gateway" plugin
- Go to WooCommerce > Settings > Payments
- Enable Stripe and connect a test account

#### Test Scenarios

1. **Failed Payment Test**
- Add a product to cart
- Go to checkout
- Fill in billing/shipping details
- Use test card: `4000000000000002` (Generic decline)
  - Expiry: Any future date
  - CVC: Any 3 digits
- Click "Place Order" multiple times
- Verify attribution data is only saved once

2. **Insufficient Funds Test**
- Same steps as above but use: `4000000000009995`
- Verify attribution data remains unique

4. **Successful Payment After Failure**
- After failed attempts, use successful test card: `4242424242424242`
- Complete order
- Verify attribution data wasn't duplicated

#### Verification
Check database for attribution meta entries:
```sql
SELECT meta_key, meta_value 
FROM wp_postmeta 
WHERE post_id = [order_id] 
AND meta_key LIKE '_wc_order_attribution_%';
```

- Verify only one set of attribution data exists
- Check order meta in admin

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Prevent duplication of order attribution data on classic checkout.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
