### PR TITLE
Improve slow queries for the log list table when using the database logger

### DIFF
--- a/plugins/woocommerce/changelog/fix-54538-slow-log-queries
+++ b/plugins/woocommerce/changelog/fix-54538-slow-log-queries
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve the performance of the log viewer when using the database storage option and a high number of log entries are present

--- a/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
@@ -25,6 +25,13 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	public const PER_PAGE_USER_OPTION_KEY = 'woocommerce_status_log_items_per_page';
 
 	/**
+	 * The key for the option that stores the list of unique sources that exist in the log table.
+	 *
+	 * @const string
+	 */
+	public const SOURCE_CACHE_OPTION_KEY = 'woocommerce_status_log_db_sources';
+
+	/**
 	 * Initialize the log table list.
 	 */
 	public function __construct() {
@@ -269,14 +276,7 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	 * @global wpdb $wpdb
 	 */
 	protected function source_dropdown() {
-		global $wpdb;
-
-		$sources = $wpdb->get_col(
-			"SELECT DISTINCT source
-			FROM {$wpdb->prefix}woocommerce_log
-			WHERE source != ''
-			ORDER BY source ASC"
-		);
+		$sources = $this->get_sources();
 
 		if ( ! empty( $sources ) ) {
 			$selected_source = isset( $_REQUEST['source'] ) ? $_REQUEST['source'] : '';
@@ -297,6 +297,37 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 				</select>
 			<?php
 		}
+	}
+
+	/**
+	 * Get the list of unique sources in the log table.
+	 *
+	 * The query in this method can be slow when there are a high number of log entries. The list of sources also
+	 * most likely doesn't change that often. So this indefinitely caches the list into the WP options table. The
+	 * cache will get cleared by the log handler if a new source is being added. See WC_Log_Handler_DB::handle().
+	 *
+	 * @return array
+	 */
+	protected function get_sources() {
+		global $wpdb;
+
+		$sources = get_option( self::SOURCE_CACHE_OPTION_KEY, null );
+		if ( is_array( $sources ) ) {
+			return $sources;
+		}
+
+		$sql     = "
+			SELECT DISTINCT source
+			FROM {$wpdb->prefix}woocommerce_log
+			WHERE source != ''
+			ORDER BY source ASC
+		";
+		$sources = $wpdb->get_col( $sql );
+
+		// Autoload this option so that the log handler doesn't have to run another query when checking the source list.
+		update_option( self::SOURCE_CACHE_OPTION_KEY, $sources, true );
+
+		return $sources;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
@@ -316,12 +316,14 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 			return $sources;
 		}
 
-		$sql     = "
+		$sql = "
 			SELECT DISTINCT source
 			FROM {$wpdb->prefix}woocommerce_log
 			WHERE source != ''
 			ORDER BY source ASC
 		";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Not necessary.
 		$sources = $wpdb->get_col( $sql );
 
 		// Autoload this option so that the log handler doesn't have to run another query when checking the source list.
@@ -356,6 +358,7 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 			{$where} {$order} {$limit} {$offset}
 		";
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The query parts are prepared in their respective methods.
 		$this->items = $wpdb->get_results( $query_items, ARRAY_A );
 		$total_items = $this->get_total_items_count();
 
@@ -392,7 +395,9 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 			{$where}
 		";
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The where clause is prepared in a separate method.
 		$count = intval( $wpdb->get_var( $count_query ) );
+
 		if ( $count > 100000 ) {
 			set_transient( $transient_key, $count, 10 * MINUTE_IN_SECONDS );
 		} else {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
@@ -391,7 +391,7 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 		if ( ! empty( $_REQUEST['orderby'] ) && in_array( $_REQUEST['orderby'], $valid_orders ) ) {
 			$by = wc_clean( $_REQUEST['orderby'] );
 		} else {
-			$by = 'timestamp';
+			$by = 'log_id';
 		}
 		$by = esc_sql( $by );
 
@@ -401,7 +401,12 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 			$order = 'DESC';
 		}
 
-		return "ORDER BY {$by} {$order}, log_id {$order}";
+		$orderby = "ORDER BY {$by} {$order}";
+		if ( 'log_id' !== $by ) {
+			$orderby .= ", log_id {$order}";
+		}
+
+		return $orderby;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/log-handlers/class-wc-log-handler-db.php
+++ b/plugins/woocommerce/includes/log-handlers/class-wc-log-handler-db.php
@@ -138,7 +138,24 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 
 		$format   = array_fill( 0, count( $log_ids ), '%d' );
 		$query_in = '(' . implode( ',', $format ) . ')';
-		return $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_log WHERE log_id IN {$query_in}", $log_ids ) ); // @codingStandardsIgnoreLine.
+
+		$result = $wpdb->query(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->prepare(
+				"
+					DELETE FROM {$wpdb->prefix}woocommerce_log
+					WHERE log_id IN {$query_in}
+				",
+				$log_ids
+			)
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		if ( false !== $result ) {
+			\WC_Cache_Helper::get_transient_version( 'logs-db', true );
+		}
+
+		return $result;
 	}
 
 	/**
@@ -160,6 +177,8 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 				date( 'Y-m-d H:i:s', $timestamp )
 			)
 		);
+
+		\WC_Cache_Helper::get_transient_version( 'logs-db', true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/log-handlers/class-wc-log-handler-db.php
+++ b/plugins/woocommerce/includes/log-handlers/class-wc-log-handler-db.php
@@ -38,11 +38,16 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 	 * @return bool False if value was not handled and true if value was handled.
 	 */
 	public function handle( $timestamp, $level, $message, $context ) {
-
 		if ( isset( $context['source'] ) && $context['source'] ) {
 			$source = $context['source'];
 		} else {
 			$source = $this->get_log_source();
+		}
+
+		// Clear the source cache if this is a new source.
+		$cached_sources = get_option( WC_Admin_Log_Table_List::SOURCE_CACHE_OPTION_KEY, array() );
+		if ( ! in_array( $source, $cached_sources, true ) ) {
+			delete_option( WC_Admin_Log_Table_List::SOURCE_CACHE_OPTION_KEY );
 		}
 
 		return $this->add( $timestamp, $level, $message, $source, $context );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds various query optimizations and caching interventions to mitigate performance issues reported on the database log viewer screen. Using a log table with ~1M test log entries, these changes reduced the total page generation time (as measured by the Query Monitor plugin) from 0.55s to 0.14s on my local environment. That's a ~75% reduction!

Fixes #54538
Fixes #54540
Fixes #54541

### How to test the changes in this Pull Request:

1. Install and activate the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin so you can observe queries and performance on WP Admin screens.
1. Configure WC to use database logging instead of the default filesystem logging:
    * Go to WooCommerce > Status > Logs > Settings.
    * Under Log Storage choose Database and Save changes.
2. Download and unzip [this database dump file](https://github.com/user-attachments/files/18875272/wordpress_2025-02-19.sql.zip), and then import it into your database. I use [Sequel Ace](https://sequel-ace.com/) for things like this, but you could also do it with the [wp-cli command](https://developer.wordpress.org/cli/commands/db/import/). This should add ~1M test log entries to the `wp_woocommerce_log` table.
3. Go to WooCommerce > Status > Logs. You should see a list table of log entries, and it should tell you how many total entries there are. Look at the Query Monitor output in the admin bar at the top of the screen and note the first number, which is the total page generation time.
4. One of the changes in this PR is to the `ORDER BY` clause of the query that gets the log entries for the list table. It should now default to ordering by the `log_id`, which is the primary key for the log table. Click on the "Timestamp" column header of the log table so that the logs are ordered by timestamp instead. Query Monitor should show that this is significantly slower. Click the "Logs" tab link to return the list table to the default sorting state.
5. Add this snippet to your test site. It will add a new log entry every time you refresh the screen while looking at the site. (Don't forget to remove this snippet when you're done testing!)
    ```php
	add_action(
		'init',
		function () {
			wc_get_logger()->debug( 'test', array( 'source' => 'asdf1' ) );
		}
	);
    ```
6. While on the log viewer screen, refresh a couple of times. Note that the total number of log entries _doesn't_ change because that value gets cached for 10 minutes.
7. Rather than waiting 10 minutes for the cache to expire, you can run `wp transient delete --all`. Then refresh the screen. The total number should now update, and Query Monitor may tell you that the page generation time is a bit slower, because it had to run the extra query to refresh the total count number.
8. Update the snippet added earlier so that it has a different, unique `source` value, then refresh the log viewer screen again. Query Monitor should show a slower time again because the sources query had to run to refresh the cached value.
9. Check out the trunk branch and compare the numbers from Query Monitor to those that you saw with this PR branch.