### PR TITLE
[Remote Logging] Improve error filtering and enable non-critical log events

### DIFF
--- a/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
+++ b/plugins/woocommerce-beta-tester/api/remote-logging/remote-logging.php
@@ -98,7 +98,7 @@ function log_remote_event() {
 	$remote_logger = wc_get_container()->get( RemoteLogger::class );
 	$result        = $remote_logger->handle(
 		time(),
-		'critical',
+		'info',
 		'Test PHP event from WC Beta Tester',
 		array(
 			'source'         => 'wc-beta-tester',

--- a/plugins/woocommerce-beta-tester/changelog/update-improve-remote-logging-filter
+++ b/plugins/woocommerce-beta-tester/changelog/update-improve-remote-logging-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Change remote logging event level from critical to info

--- a/plugins/woocommerce/changelog/update-improve-remote-logging-filter
+++ b/plugins/woocommerce/changelog/update-improve-remote-logging-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve remote logging error handling and filtering

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -183,7 +183,7 @@ class RemoteLogger extends \WC_Log_Handler {
 		}
 
 		// Record fatal error stats.
-		if ( WC_Log_Levels::get_level_severity( $level ) === WC_Log_Levels::get_level_severity( WC_Log_Levels::CRITICAL ) ) {
+		if ( WC_Log_Levels::get_level_severity( $level ) >= WC_Log_Levels::get_level_severity( WC_Log_Levels::CRITICAL ) ) {
 			try {
 				$mc_stats = wc_get_container()->get( McStats::class );
 				$mc_stats->add( 'error', 'critical-errors' );

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -323,16 +323,17 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 
+		$wc_plugin_dir = StringUtil::normalize_local_path_slashes( WC_ABSPATH );
+
+		// Check if the error message contains the WooCommerce plugin directory.
+		if ( str_contains( $message, $wc_plugin_dir ) ) {
+			return false;
+		}
+
 		// Without a backtrace, it's impossible to ascertain if the error is third-party. To avoid logging numerous irrelevant errors, we'll consider it a third-party error and ignore it.
 		if ( isset( $context['backtrace'] ) && is_array( $context['backtrace'] ) ) {
-			$wc_plugin_dir   = StringUtil::normalize_local_path_slashes( WC_ABSPATH );
 			$wp_includes_dir = StringUtil::normalize_local_path_slashes( ABSPATH . WPINC );
 			$wp_admin_dir    = StringUtil::normalize_local_path_slashes( ABSPATH . 'wp-admin' );
-
-			// Check if the error message contains the WooCommerce plugin directory.
-			if ( str_contains( $message, $wc_plugin_dir ) ) {
-				return false;
-			}
 
 			// Find the first relevant frame that is not from WordPress core and not empty.
 			$relevant_frame = null;

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -178,22 +178,19 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 
-		// Ignore logs that are less severe than critical. This is temporary to prevent sending too many logs to the remote logging service. We can consider remove this if the remote logging service can handle more logs.
-		if ( WC_Log_Levels::get_level_severity( $level ) < WC_Log_Levels::get_level_severity( WC_Log_Levels::CRITICAL ) ) {
-			return false;
-		}
-
 		if ( $this->is_third_party_error( (string) $message, (array) $context ) ) {
 			return false;
 		}
 
-		try {
-			// Record fatal error stats.
-			$mc_stats = wc_get_container()->get( McStats::class );
-			$mc_stats->add( 'error', 'critical-errors' );
-			$mc_stats->do_server_side_stats();
-		} catch ( \Throwable $e ) {
-			error_log( 'Warning: Failed to record fatal error stats: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		// Record fatal error stats.
+		if ( WC_Log_Levels::get_level_severity( $level ) === WC_Log_Levels::get_level_severity( WC_Log_Levels::CRITICAL ) ) {
+			try {
+				$mc_stats = wc_get_container()->get( McStats::class );
+				$mc_stats->add( 'error', 'critical-errors' );
+				$mc_stats->do_server_side_stats();
+			} catch ( \Throwable $e ) {
+				error_log( 'Warning: Failed to record fatal error stats: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
 		}
 
 		if ( WC_Rate_Limiter::retried_too_soon( self::RATE_LIMIT_ID ) ) {
@@ -326,39 +323,37 @@ class RemoteLogger extends \WC_Log_Handler {
 			return false;
 		}
 
-		// If backtrace is not available, we can't determine if the error is third-party. Log it for further investigation.
-		if ( ! isset( $context['backtrace'] ) || ! is_array( $context['backtrace'] ) ) {
-			return false;
-		}
+		// Without a backtrace, it's impossible to ascertain if the error is third-party. To avoid logging numerous irrelevant errors, we'll consider it a third-party error and ignore it.
+		if ( isset( $context['backtrace'] ) && is_array( $context['backtrace'] ) ) {
+			$wc_plugin_dir   = StringUtil::normalize_local_path_slashes( WC_ABSPATH );
+			$wp_includes_dir = StringUtil::normalize_local_path_slashes( ABSPATH . WPINC );
+			$wp_admin_dir    = StringUtil::normalize_local_path_slashes( ABSPATH . 'wp-admin' );
 
-		$wc_plugin_dir   = StringUtil::normalize_local_path_slashes( WC_ABSPATH );
-		$wp_includes_dir = StringUtil::normalize_local_path_slashes( ABSPATH . WPINC );
-		$wp_admin_dir    = StringUtil::normalize_local_path_slashes( ABSPATH . 'wp-admin' );
-
-		// Check if the error message contains the WooCommerce plugin directory.
-		if ( str_contains( $message, $wc_plugin_dir ) ) {
-			return false;
-		}
-
-		// Find the first relevant frame that is not from WordPress core and not empty.
-		$relevant_frame = null;
-		foreach ( $context['backtrace'] as $frame ) {
-			if ( empty( $frame ) || ! is_string( $frame ) ) {
-				continue;
+			// Check if the error message contains the WooCommerce plugin directory.
+			if ( str_contains( $message, $wc_plugin_dir ) ) {
+				return false;
 			}
 
-			// Skip frames from WordPress core.
-			if ( strpos( $frame, $wp_includes_dir ) !== false || strpos( $frame, $wp_admin_dir ) !== false ) {
-				continue;
+			// Find the first relevant frame that is not from WordPress core and not empty.
+			$relevant_frame = null;
+			foreach ( $context['backtrace'] as $frame ) {
+				if ( empty( $frame ) || ! is_string( $frame ) ) {
+					continue;
+				}
+
+				// Skip frames from WordPress core.
+				if ( strpos( $frame, $wp_includes_dir ) !== false || strpos( $frame, $wp_admin_dir ) !== false ) {
+					continue;
+				}
+
+				$relevant_frame = $frame;
+				break;
 			}
 
-			$relevant_frame = $frame;
-			break;
-		}
-
-		// Check if the relevant frame is from WooCommerce.
-		if ( $relevant_frame && strpos( $relevant_frame, $wc_plugin_dir ) !== false ) {
-			return false;
+			// Check if the relevant frame is from WooCommerce.
+			if ( $relevant_frame && strpos( $relevant_frame, $wc_plugin_dir ) !== false ) {
+				return false;
+			}
 		}
 
 		if ( ! function_exists( 'apply_filters' ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -369,7 +369,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 				'less severe than critical' => array(
 					fn() => null,
 					'error',
-					false,
+					true,
 				),
 				'critical level'            => array(
 					fn() => null,
@@ -550,7 +550,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 				'Missing backtrace'         => array(
 					'Some error message',
 					array( 'source' => 'fatal-errors' ),
-					false,
+					true,
 				),
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes several improvements to WooCommerce's remote logging functionality:

1. Removes the restriction that only logs critical events, allowing logs of all severity levels to be sent to the remote logging server. This enables us to log useful info like:

```php
wc_get_logger()->info(
  'Test info log', 
  array( 'remote-logging' => true ) 
);
```

2. Improves third-party error detection logic to reduce the number of irrelevant errors logged. Currently, there are many irrelevant errors logged due to the lack of backtrace, for example: `Allowed memory size of 268435456 bytes exhausted`, which are not useful for debugging WC issues.

3. Updates the beta tester's test event to use 'info' level instead of 'critical' for testing purposes

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Test Log PHP Event**

1. Create a fresh site
2. Install and activate this [woocommerce-beta-tester.zip](https://github.com/user-attachments/files/18861006/woocommerce-beta-tester.zip).
3. Go to `Tools -> WCA Test Helper -> Remote Logging`
4. Enable remote logging if it's not already enabled
5. Click on `Log PHP Event` button
6. See PCYsg-11XN-p2 for instructions on viewing the event logs
7. Confirm that event is logged

**Test Third-Party Error Detection**

1. Go to `Tools -> WCA Test Helper -> Remote Logging`
2. Enable remote logging if it's not already enabled
3. Modify the theme's `functions.php` to add the following code:

TT4: `wp-content/themes/twentytwentyfour/functions.php`


```php
function simulate_memory_exhaustion() {
	$array = array();
	while ( true ) {
		$array[] = str_repeat( 'a', 1000000 );
	}
}
simulate_memory_exhaustion();
```

4. Go to any wc admin page on the site
5. See fatal error occurred
6. Filter logs by host name to confirm that the error is not logged.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>