### PR TITLE
[API tests] Re-enable previously skipped steps in `products-crud.test.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-tests-api-products-crud-reenable-skipped-steps
+++ b/plugins/woocommerce/changelog/dev-tests-api-products-crud-reenable-skipped-steps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Re-enable previously skipped steps in `products-crud` REST API test.

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/products/products-crud.test.js
@@ -3,9 +3,7 @@ const {
 	expect,
 	tags,
 } = require( '../../../fixtures/api-tests-fixtures' );
-const { BASE_URL } = process.env;
 const { admin } = require( '../../../test-data/data' );
-const shouldSkip = BASE_URL !== undefined;
 
 /**
  * Internal dependencies
@@ -1349,17 +1347,13 @@ test.describe( 'Products API tests: CRUD', () => {
 			);
 			expect( response.status() ).toEqual( 200 );
 
-			// if we're running on CI, then skip -- because objects are cached and they don't disappear instantly.
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				// Verify that the product variation can no longer be retrieved.
-				const getDeletedProductVariationResponse = await request.get(
-					`wp-json/wc/v3/products/${ variableProductId }/variations/${ productVariationId }`
-				);
-				expect( getDeletedProductVariationResponse.status() ).toEqual(
-					404
-				);
-			}
+			// Verify that the product variation can no longer be retrieved.
+			const getDeletedProductVariationResponse = await request.get(
+				`wp-json/wc/v3/products/${ variableProductId }/variations/${ productVariationId }`
+			);
+			expect( getDeletedProductVariationResponse.status() ).toEqual(
+				404
+			);
 		} );
 
 		test( 'can batch update product variations', async ( { request } ) => {
@@ -1439,18 +1433,14 @@ test.describe( 'Products API tests: CRUD', () => {
 				'35.99'
 			);
 
-			// if we're running on CI, then skip -- because objects are cached and they don't disappear instantly.
-			// eslint-disable-next-line playwright/no-conditional-in-test
-			if ( ! shouldSkip ) {
-				// Verify that the deleted product variation can no longer be retrieved.
-				const getDeletedProductVariationResponse = await request.get(
-					`wp-json/wc/v3/products/${ variableProductId }/variations/${ variation1Id }`
-				);
+			// Verify that the deleted product variation can no longer be retrieved.
+			const getDeletedProductVariationResponse = await request.get(
+				`wp-json/wc/v3/products/${ variableProductId }/variations/${ variation1Id }`
+			);
 
-				expect( getDeletedProductVariationResponse.status() ).toEqual(
-					404
-				);
-			}
+			expect( getDeletedProductVariationResponse.status() ).toEqual(
+				404
+			);
 
 			// Batch delete the created product variations
 			await request.post(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up to #55358 where the skipped steps in `products-crud.test.js` are now re-enabled when it's ran against external hosts like Pressable and WPCOM.

It seems that these steps have now been consistently passing in those environments, and could therefore be safe to be unskipped.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the test against Pressable and WPCOM, and make sure it passes on both environments.
```bash
export E2E_ENV_KEY="..."
pnpm test:e2e:wpcom products-crud.test.js
pnpm test:e2e:pressable products-crud.test.js 
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
