### PR TITLE
Add a COGS value column to the product meta lookup table

### DIFF
--- a/plugins/woocommerce/changelog/pr-55623
+++ b/plugins/woocommerce/changelog/pr-55623
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a COGS value column to the product meta lookup table

--- a/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
+++ b/plugins/woocommerce/src/Internal/CostOfGoodsSold/CostOfGoodsSoldController.php
@@ -23,6 +23,7 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 	 */
 	public function register() {
 		add_action( 'woocommerce_register_feature_definitions', array( $this, 'add_feature_definition' ) );
+		add_filter( 'woocommerce_debug_tools', array( $this, 'add_debug_tools_entry' ), 999, 1 );
 	}
 
 	/**
@@ -62,6 +63,87 @@ class CostOfGoodsSoldController implements RegisterHooksInterface {
 			'cost_of_goods_sold',
 			__( 'Cost of Goods Sold', 'woocommerce' ),
 			$definition
+		);
+	}
+
+	/**
+	 * Add the entry for "add/remove COGS value column to/from the product meta lookup table" to the WooCommerce admin tools.
+	 *
+	 * @internal Hook handler, not to be explicitly used from outside the class.
+	 *
+	 * @param array $tools_array Array to add the tool to.
+	 * @return array Updated tools array.
+	 */
+	public function add_debug_tools_entry( array $tools_array ): array {
+		// If the feature is disabled we show the tool for removing the column, but not for adding it.
+		$column_exists = $this->product_meta_lookup_table_cogs_value_columns_exist();
+		if ( ! $this->feature_is_enabled() && ! $column_exists ) {
+			return $tools_array;
+		}
+
+		$tools_array['generate_cogs_value_meta_column'] = array(
+			'name'     => $column_exists ?
+				__( 'Remove COGS columns from the product meta lookup table', 'woocommerce' ) :
+				__( 'Create COGS columns in the product meta lookup table', 'woocommerce' ),
+			'button'   => $column_exists ?
+				__( 'Remove columns', 'woocommerce' ) :
+				__( 'Create columns', 'woocommerce' ),
+			'desc'     =>
+				$column_exists ?
+				__( 'This tool will remove the Cost of Goods Sold (COGS) related columns from the product meta lookup table. COGS will continue working (if the feature is enabled) but some functionality will not be available.', 'woocommerce' ) :
+				__( 'This tool will generate the necessary Cost of Goods Sold (COGS) related columns in the product meta lookup table, and populate them from existing product data.', 'woocommerce' ),
+			'callback' =>
+				$column_exists ? array( $this, 'remove_lookup_cogs_columns' ) : array( $this, 'generate_lookup_cogs_columns' ),
+		);
+
+		return $tools_array;
+	}
+
+	/**
+	 * Handler for the "add COGS value column to the product meta lookup table" admin tool.
+	 *
+	 * @internal Tool callback, not to be explicitly used from outside the class.
+	 */
+	public function generate_lookup_cogs_columns() {
+		global $wpdb;
+
+		if ( $this->feature_is_enabled() && ! $this->product_meta_lookup_table_cogs_value_columns_exist() ) {
+			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_product_meta_lookup ADD COLUMN cogs_total_value DECIMAL(19,4)" );
+			$wpdb->query(
+				"UPDATE {$wpdb->prefix}wc_product_meta_lookup AS lookup
+    			JOIN {$wpdb->prefix}postmeta AS pm ON lookup.product_id = pm.post_id
+    			SET lookup.cogs_total_value = CAST(pm.meta_value AS DECIMAL(19, 4))
+    			WHERE pm.meta_key = '_cogs_total_value';"
+			);
+		}
+	}
+
+	/**
+	 * Handler for the "remove COGS value column to the product meta lookup table" admin tool.
+	 *
+	 * @internal Tool callback, not to be explicitly used from outside the class.
+	 */
+	public function remove_lookup_cogs_columns() {
+		global $wpdb;
+
+		if ( $this->product_meta_lookup_table_cogs_value_columns_exist() ) {
+			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_product_meta_lookup DROP COLUMN cogs_total_value" );
+		}
+	}
+
+	/**
+	 * Tells if the COGS value column exists in the product meta lookup table.
+	 *
+	 * @return bool True if the column exists, false otherwise.
+	 */
+	public function product_meta_lookup_table_cogs_value_columns_exist(): bool {
+		global $wpdb;
+
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				"SHOW COLUMNS FROM {$wpdb->prefix}wc_product_meta_lookup LIKE %s",
+				'cogs_total_value'
+			)
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a follow-up to https://github.com/woocommerce/woocommerce/pull/54399. It adds a tool to the WooCommerce admin tools page that allows to create a `cogs_total_value` column in the `wp_wc_product_meta_lookup` table. The column is initially populated from existing cost values when it's created, and then it gets updated every time that a product is saved.

![image](https://github.com/user-attachments/assets/517a20fc-d224-4fbd-b982-2ba7ff519ef4)

![image](https://github.com/user-attachments/assets/9abcb8fb-1f2f-4a28-bace-e15c437a98cd)

The column is nullable and it follows the same semantics of the `_cogs_total_value` product meta item. This means that zero cost values will be stored as `null` in the column, except for product variations, where `null` and zero have actually different meanings.

If the column exists then the "Cost" column in the products list in admin will be sortable:

![image](https://github.com/user-attachments/assets/3a46fcfb-2c9d-46a8-b8b2-c6d3fec0b6b7)

When the Cost of Goods Sold feature is disabled the tool to create or remove the database column is "asymmetric": if the column doesn't exist then the tool to create it won't appear in the tools page, but if the column exists then the tool that allows to remove it from the table will appear.

### How to test the changes in this Pull Request:

**Important!** Note that once you run a tool from the WooCommerce tools page the page reloads with `&action=<tool name>` added to the URL. To avoid confussion you should remove that part from the URL before reloading the page.

1. Enable the Cost of Goods Sold feature and add costs for a few products, including variable products and variations; for the later, have variations with an explicit non-zero cost, with an explicit zero cost, and with no cost value. You can use the testing instructions of https://github.com/woocommerce/woocommerce/pull/54399 as guidance.
2. Go to the tools page (WooCommerce - Status - Tools) and run the "Create COGS columns in the product meta lookup table" tool.
3. Verify that the products meta lookup table has the new column and that it has the proper value for regular products (simple or variable) and for variations. For regular products the column should hold `null` when the cost is zero; for variations, an explicit cost of zero should be stored as such, and a not defined cost should be stored as `null`. Here's how you can check these values from the command line:

```
wp db query "select cogs_total_value from wp_wc_product_meta_lookup where product_id=<product or variation id>"
```

4. Modify the cost of a couple of products and verify that the value in the meta table has been updated (using the query from the previous step). Again, try with regular products and variations; and try with undefined, zero and non-zero values.
5. Go to the products list in admin and verify that the "Cost" column is now sortable and it works as expected. Remember that for now, for variable products what this column shows is simply the default cost as defined in the "General" tab.
6. Go back to the tools page and run the "Remove COGS columns from the product meta lookup table" tool. Verify that the `cogs_total_value` column has disappeared, you can do so by running the following and verifying that the column isn't part of the result:

```
wp db query "select * from wp_wc_product_meta_lookup limit 1"
```

6. Verify that the "Cost" column in the products list still shows correct values, but it isn't sortable anymore.
7. Reload the tools page an run the tool to create the column again.
8. Disable the Cost of Goods Sold feature from the WooCommerce - Settings - Advanced - Features page.
9. Reload the tools page, verify that the tool to remove the column is there, and run it.
10. Reload the tools page and verify that no tools related to the Cost of Goods Sold feature are appearing now.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
