### PR TITLE
Fix developer docs for the posts -> categories links

### DIFF
--- a/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md
+++ b/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md
@@ -66,7 +66,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 To call this filter within the editor, wrap the filter registration in a `DOMContentLoaded` event listener and ensure the code runs in the admin panel.
 
-> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md
+++ b/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md
@@ -66,7 +66,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 To call this filter within the editor, wrap the filter registration in a `DOMContentLoaded` event listener and ensure the code runs in the admin panel.
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Test with the path Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -249,7 +249,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Test without the path Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Test with the path Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Test with the path Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -172,7 +172,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -249,7 +249,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Test without the path Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Test without the path Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -335,7 +335,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -413,7 +413,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -503,7 +503,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](./README.md) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Test with the path Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Test with the path Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -172,7 +172,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -249,7 +249,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Test without the path Filters can be also combined. See [Combined filters](README.md) for an example.
+> Test without the path Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -335,7 +335,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -413,7 +413,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -503,7 +503,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Testing Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Test with the path Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -249,7 +249,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Test without the path Filters can be also combined. See [Combined filters](README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -93,7 +93,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
+> Testing Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md
@@ -172,7 +172,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -249,7 +249,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -335,7 +335,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -413,7 +413,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 
@@ -503,7 +503,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md
+++ b/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md
@@ -87,7 +87,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md
+++ b/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md
@@ -87,7 +87,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/coupons.md
+++ b/docs/cart-and-checkout-blocks/available-filters/coupons.md
@@ -64,7 +64,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/coupons.md
+++ b/docs/cart-and-checkout-blocks/available-filters/coupons.md
@@ -64,7 +64,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md
@@ -90,7 +90,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md
+++ b/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md
@@ -90,7 +90,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md
+++ b/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md
@@ -46,7 +46,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md
+++ b/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md
@@ -46,7 +46,7 @@ registerCheckoutFilters( 'example-extension', {
 } );
 ```
 
-> Filters can be also combined. See [Combined filters](./README.md#combined-filters) for an example.
+> Filters can be also combined. See [Combined filters](../available-filters/README.md) for an example.
 
 ### Screenshots <!-- omit in toc -->
 

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -248,7 +248,7 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "13d877d02817506086c7581ccde0861345f661b11234e11a73a363685efcc0a4",
+              "hash": "c03170d19a4eea81fa6fd5d29cc22160e27e24e28edbba67c481fbc23947319e",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
@@ -1939,5 +1939,5 @@
       "categories": []
     }
   ],
-  "hash": "88dea46324c20392ff899f1ed5d30de7c06225c87c97abbc5f5428b566796bdc"
+  "hash": "64555b5aa183e974c1d74b17543596c5b839a4543b2701f8d6a0f75bb41c29a0"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -259,8 +259,8 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "74c23b6f9f3712a6ad6f694737d6f5c11faebc6b69886150f5cdae04d58a7f3d",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/f0b159c78833e6962d5d209e2a027ef93653e883/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
+              "hash": "c03170d19a4eea81fa6fd5d29cc22160e27e24e28edbba67c481fbc23947319e",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
                 "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
@@ -272,7 +272,7 @@
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "hash": "7b04454d705d7ff896df4fa53195b8b6cafdab85eeba667c78d004d26093a289",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/f0b159c78833e6962d5d209e2a027ef93653e883/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "id": "3167c9602b1bd3b206226a0d4415944a5f647495",
               "links": {
                 "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
@@ -1953,5 +1953,5 @@
       "categories": []
     }
   ],
-  "hash": "5410b47c77ef72f41e05330911eefc98be414927ce03414c1b0f896f6a4bec58"
+  "hash": "c65911eef0536e1d618ee58176ebfa0074433a61f7b8b7c8b043b639610f263b"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -212,54 +212,72 @@
               "menu_title": "Totals Footer Item",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
-              "hash": "1ecf815fa1d4d3cdbf6dcd73315fa6900ef7ec587a8c733fcc1ab7a46223e701",
+              "hash": "71c7e2fcfa20530c6c0251912dcd1cbbd87191d795d7b3bdb53420f2caa89ddf",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
-              "id": "90a9b8df374082f1713866a58b810303adb4d3da"
+              "id": "90a9b8df374082f1713866a58b810303adb4d3da",
+              "links": {
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             },
             {
               "post_title": "Cart and Checkout Filters - Order summary items",
               "menu_title": "Order Summary Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
-              "hash": "7bce56ff885db43ed1864e26e9ef2c43367d963acebb3e4e4d3cec6dc9b07d48",
+              "hash": "d736a1951e885445e2d4e1b35dae62071e879c5df3d3eeabe27e2eea04eddfc9",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
-              "id": "78eb3b135f82a3624a49979e3e93334295abd060"
+              "id": "78eb3b135f82a3624a49979e3e93334295abd060",
+              "links": {
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             },
             {
               "post_title": "Cart and Checkout Filters - Coupons",
               "menu_title": "Coupons",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
-              "hash": "85a4ab6e9c7e80112be24ce9532b3a4dcf2771d9284db72946d220580eab5051",
+              "hash": "1dbb6637376fb86a633270edb2aa6665b8216a9f673dd00f79edff5d43c3485f",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
-              "id": "5a022617f3d0267c9b771374f28970e779a6e99d"
+              "id": "5a022617f3d0267c9b771374f28970e779a6e99d",
+              "links": {
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             },
             {
               "post_title": "Cart and Checkout Filters - Checkout and place order button",
               "menu_title": "Checkout and Place Order Button",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
-              "hash": "5cf99bceb7eaf54c0f3c84bd7ded5db38041fac3d20b2a25876c586f20317691",
+              "hash": "a5a8419038d538339422690c5609f13a9f8837f359d5d97af479f4c960b8011d",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
-              "id": "c97ca710c2e8107bf90915e038a34c8a1016c63a"
+              "id": "c97ca710c2e8107bf90915e038a34c8a1016c63a",
+              "links": {
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             },
             {
               "post_title": "Cart and Checkout Filters - Cart line items",
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "fc896ee5fafb919df9c6d855bbdb9e7c2ee3f9f411760b0ad2e61d06b4df374f",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/43566744131bd4d55b2c0fe30dfb700d47bc9f6a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
+              "hash": "74c23b6f9f3712a6ad6f694737d6f5c11faebc6b69886150f5cdae04d58a7f3d",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
+              "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
+              "links": {
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             },
             {
               "post_title": "Cart and Checkout Filters - Inner block types",
               "menu_title": "Inner Block Types",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
-              "hash": "9fb9ace324894ae3042900459feef9447ee2885f598029174b4deb1a2b7ca6e9",
+              "hash": "7b04454d705d7ff896df4fa53195b8b6cafdab85eeba667c78d004d26093a289",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
-              "id": "3167c9602b1bd3b206226a0d4415944a5f647495"
+              "id": "3167c9602b1bd3b206226a0d4415944a5f647495",
+              "links": {
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             }
           ],
           "categories": []
@@ -1936,5 +1954,5 @@
       "categories": []
     }
   ],
-  "hash": "37dbc976a0cf3c170a174b30535f46c1cf76d31188c73012aac436b7d7788846"
+  "hash": "5410b47c77ef72f41e05330911eefc98be414927ce03414c1b0f896f6a4bec58"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -153,11 +153,10 @@
           "menu_title": "Frequently Asked Questions",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/faq.md",
-          "hash": "31bfbf216252c709466e293c6b2159858db994e9cdb530d8f13ffc327ab07ea7",
+          "hash": "3289920c5224a5c392617620b839df1454431257abf2162744b1fa9040314378",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/faq.md",
           "id": "041787aca25af363a5eff3e710bd669cc8aebc4b",
           "links": {
-            "./slot-fills.md": "e388101586765dd9aca752d66d667d74951a1504",
             "./removing-checkout-fields.md": "030247059754260bce6285cfb352a4a733f1f677"
           }
         },

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -261,7 +261,7 @@
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "hash": "74c23b6f9f3712a6ad6f694737d6f5c11faebc6b69886150f5cdae04d58a7f3d",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/f0b159c78833e6962d5d209e2a027ef93653e883/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
                 "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
@@ -273,7 +273,7 @@
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "hash": "7b04454d705d7ff896df4fa53195b8b6cafdab85eeba667c78d004d26093a289",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/f0b159c78833e6962d5d209e2a027ef93653e883/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "id": "3167c9602b1bd3b206226a0d4415944a5f647495",
               "links": {
                 "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -249,7 +249,7 @@
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "hash": "2b41af4a7856278bbd93e7c2318aae1a0763fc973716543b1a5160d5773875f7",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/b4214b92a9e15de24533b9d66165baf7c8ac7356/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
                 "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb",

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -248,7 +248,7 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "c03170d19a4eea81fa6fd5d29cc22160e27e24e28edbba67c481fbc23947319e",
+              "hash": "1931f3e976470539e38a283eb364b710bfc320102288b8342873a03714053f30",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
@@ -1939,5 +1939,5 @@
       "categories": []
     }
   ],
-  "hash": "64555b5aa183e974c1d74b17543596c5b839a4543b2701f8d6a0f75bb41c29a0"
+  "hash": "0e1a4b8b777e7f85b2c9f5abee7466fe4e7cf4719de34165a14385c1009de54c"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -153,10 +153,11 @@
           "menu_title": "Frequently Asked Questions",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/faq.md",
-          "hash": "3289920c5224a5c392617620b839df1454431257abf2162744b1fa9040314378",
+          "hash": "31bfbf216252c709466e293c6b2159858db994e9cdb530d8f13ffc327ab07ea7",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/faq.md",
           "id": "041787aca25af363a5eff3e710bd669cc8aebc4b",
           "links": {
+            "./slot-fills.md": "e388101586765dd9aca752d66d667d74951a1504",
             "./removing-checkout-fields.md": "030247059754260bce6285cfb352a4a733f1f677"
           }
         },
@@ -211,7 +212,7 @@
               "menu_title": "Totals Footer Item",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
-              "hash": "5868d840f3c60a2ca33db3f6f7e1182a50da9be6a93a80469e4f4322c432e295",
+              "hash": "1ecf815fa1d4d3cdbf6dcd73315fa6900ef7ec587a8c733fcc1ab7a46223e701",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/totals-footer-item.md",
               "id": "90a9b8df374082f1713866a58b810303adb4d3da"
             },
@@ -220,7 +221,7 @@
               "menu_title": "Order Summary Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
-              "hash": "3af0250666a92fe13bed7b4867b82954777dec01c28ba7f28f829126ffa3ae86",
+              "hash": "7bce56ff885db43ed1864e26e9ef2c43367d963acebb3e4e4d3cec6dc9b07d48",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/order-summary-items.md",
               "id": "78eb3b135f82a3624a49979e3e93334295abd060"
             },
@@ -229,7 +230,7 @@
               "menu_title": "Coupons",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
-              "hash": "7bf1e0d29203102e9c8c34150a78f8af35dbc47ad2c2ebcc7663354063c0cc98",
+              "hash": "85a4ab6e9c7e80112be24ce9532b3a4dcf2771d9284db72946d220580eab5051",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/coupons.md",
               "id": "5a022617f3d0267c9b771374f28970e779a6e99d"
             },
@@ -238,7 +239,7 @@
               "menu_title": "Checkout and Place Order Button",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
-              "hash": "1b4eab1657ce3a82b492fe418b76078789779061b5ff8ffd9b1af939e49f342a",
+              "hash": "5cf99bceb7eaf54c0f3c84bd7ded5db38041fac3d20b2a25876c586f20317691",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/checkout-and-place-order-button.md",
               "id": "c97ca710c2e8107bf90915e038a34c8a1016c63a"
             },
@@ -247,7 +248,7 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "f88dd38ed6a603704ae57863fac80ff8f10722fad91c2cc6d5bab443dd3293c5",
+              "hash": "593f72b214e9843442f8d064374984d45103fd0495bbb54eef08d6f2751b0f86",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
             },
@@ -256,7 +257,7 @@
               "menu_title": "Inner Block Types",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
-              "hash": "dadef9b92c330c905273831abeee4b02e02741686557e3866f90778e7109311a",
+              "hash": "9fb9ace324894ae3042900459feef9447ee2885f598029174b4deb1a2b7ca6e9",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/additional-cart-checkout-inner-block-types.md",
               "id": "3167c9602b1bd3b206226a0d4415944a5f647495"
             }
@@ -1935,5 +1936,5 @@
       "categories": []
     }
   ],
-  "hash": "54e68eead4fab95dd4bc567b3c258922c5de2e2fc488d18217998bf94c3c4184"
+  "hash": "cd18c5be8f4f5e5e674993e8918f114e72a8a147cdf65a64f9f535f30d1289af"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -249,7 +249,7 @@
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "hash": "fc896ee5fafb919df9c6d855bbdb9e7c2ee3f9f411760b0ad2e61d06b4df374f",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/43566744131bd4d55b2c0fe30dfb700d47bc9f6a/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
             },
             {

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -248,9 +248,12 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "593f72b214e9843442f8d064374984d45103fd0495bbb54eef08d6f2751b0f86",
+              "hash": "51d4c16c5c60f5ad6aad52871d9b82f348b9b075f8437a47ba19eb0d1d86faa3",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
+              "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
+              "links": {
+                "./README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+              }
             },
             {
               "post_title": "Cart and Checkout Filters - Inner block types",
@@ -1936,5 +1939,5 @@
       "categories": []
     }
   ],
-  "hash": "cd18c5be8f4f5e5e674993e8918f114e72a8a147cdf65a64f9f535f30d1289af"
+  "hash": "63ed536238ce6e7c709880b4d8372d5101760f09a3f2cca73d955dab6e7be1a1"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -248,13 +248,9 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "2b41af4a7856278bbd93e7c2318aae1a0763fc973716543b1a5160d5773875f7",
-              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/b4214b92a9e15de24533b9d66165baf7c8ac7356/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
-              "links": {
-                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb",
-                "README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
-              }
+              "hash": "fc896ee5fafb919df9c6d855bbdb9e7c2ee3f9f411760b0ad2e61d06b4df374f",
+              "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
+              "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2"
             },
             {
               "post_title": "Cart and Checkout Filters - Inner block types",
@@ -1940,5 +1936,5 @@
       "categories": []
     }
   ],
-  "hash": "ebb8bd2b81e718276942fc7be28e8efacab33b73e3e70354ab7d020501aa1637"
+  "hash": "37dbc976a0cf3c170a174b30535f46c1cf76d31188c73012aac436b7d7788846"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -248,11 +248,11 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "51d4c16c5c60f5ad6aad52871d9b82f348b9b075f8437a47ba19eb0d1d86faa3",
+              "hash": "13d877d02817506086c7581ccde0861345f661b11234e11a73a363685efcc0a4",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
-                "./README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
               }
             },
             {
@@ -1939,5 +1939,5 @@
       "categories": []
     }
   ],
-  "hash": "63ed536238ce6e7c709880b4d8372d5101760f09a3f2cca73d955dab6e7be1a1"
+  "hash": "88dea46324c20392ff899f1ed5d30de7c06225c87c97abbc5f5428b566796bdc"
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -248,11 +248,12 @@
               "menu_title": "Cart Line Items",
               "tags": "reference",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
-              "hash": "1931f3e976470539e38a283eb364b710bfc320102288b8342873a03714053f30",
+              "hash": "2b41af4a7856278bbd93e7c2318aae1a0763fc973716543b1a5160d5773875f7",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/available-filters/cart-line-items.md",
               "id": "97881b973dc1d08a54c54e0a04ecb75ee48dcee2",
               "links": {
-                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
+                "../available-filters/README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb",
+                "README.md": "4d56fe70f40a64b52b2970d487e5f0527f7234fb"
               }
             },
             {
@@ -1939,5 +1940,5 @@
       "categories": []
     }
   ],
-  "hash": "0e1a4b8b777e7f85b2c9f5abee7466fe4e7cf4719de34165a14385c1009de54c"
+  "hash": "ebb8bd2b81e718276942fc7be28e8efacab33b73e3e70354ab7d020501aa1637"
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR solves 3️⃣ that I described in [this comment](https://github.com/woocommerce/woocommerce/issues/54998#issuecomment-2668460741). In this change, we ensure that links are created using the manifest generation tool. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
Ideally this should be tested locally. For that, we'll need the local VIP environment with the ingestion plugin and:

1. Create a testing version of the manifest which refers to changed documentation files
2. Click "refresh from source" for every post that's part of this PR 
3. After the scheduler runs, confirm that the link behind "Combined filters" in the below pages leads us to the right documentation page

```
https://developer.woocommerce.com/docs/cart-and-checkout-filters-cart-line-items/
https://developer.woocommerce.com/docs/cart-and-checkout-filters-inner-block-types/
https://developer.woocommerce.com/docs/cart-and-checkout-filters-coupons/
https://developer.woocommerce.com/docs/cart-and-checkout-filters-checkout-and-place-order-button/
https://developer.woocommerce.com/docs/cart-and-checkout-filters-totals-footer-item/
https://developer.woocommerce.com/docs/cart-and-checkout-filters-order-summary-items/
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
