### PR TITLE
#52679 Filter review actions before output in Reviews List Table

### DIFF
--- a/plugins/woocommerce/changelog/55632-filter-review-actions
+++ b/plugins/woocommerce/changelog/55632-filter-review-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Dev - add ability to filter the `comment_row_actions` on the Products > Reviews table

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -578,7 +578,6 @@ class ReviewsListTable extends WP_List_Table {
 		 *                            'Delete', and 'Trash'.
 		 * @param WP_Comment $item The comment object.
 	 	*/
-		
 		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -572,6 +572,7 @@ class ReviewsListTable extends WP_List_Table {
 		/**
 		 * Filters the action links displayed for each review in the Reviews list table.
 		 *
+		 * @since 9.8.0
 		 * @param string[]   $actions An array of comment actions. Default actions include:
 		 *                            'Approve', 'Unapprove', 'Edit', 'Reply', 'Spam',
 		 *                            'Delete', and 'Trash'.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -580,7 +580,6 @@ class ReviewsListTable extends WP_List_Table {
 	 	*/
 		
 		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
-
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -579,6 +579,7 @@ class ReviewsListTable extends WP_List_Table {
 		 * @param WP_Comment $item The comment object.
 		 * */
 		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
+
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -577,7 +577,7 @@ class ReviewsListTable extends WP_List_Table {
 		 *                            'Approve', 'Unapprove', 'Edit', 'Reply', 'Spam',
 		 *                            'Delete', and 'Trash'.
 		 * @param WP_Comment $item The comment object.
-	 	*/
+		 * */
 		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -569,6 +569,17 @@ class ReviewsListTable extends WP_List_Table {
 			);
 		}
 
+		/**
+		 * Filters the action links displayed for each review in the Reviews list table.
+		 *
+		 * @param string[]   $actions An array of comment actions. Default actions include:
+		 *                            'Approve', 'Unapprove', 'Edit', 'Reply', 'Spam',
+		 *                            'Delete', and 'Trash'.
+		 * @param WP_Comment $item The comment object.
+	 	*/
+		
+		$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );
+
 		$always_visible = 'excerpt' === get_user_setting( 'posts_list_mode', 'list' );
 
 		$output = '<div class="' . ( $always_visible ? 'row-actions visible' : 'row-actions' ) . '">';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduce the ability to filter the `comment_row_actions`, like "approve", "edit" on the Review List table within WP Admin > Products > Reviews table. This filter allows other plugins and methods to extend these reviews, as they are basically a comment with a review metadata.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #52679.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Add `$actions = apply_filters( 'comment_row_actions', array_filter( $actions ), $item );` to ReviewsListTable.php in handle_row_actions() method on line 581
2. Create test function to filter:
```
add_filter('comment_row_actions', function($actions) {
    $actions[] = "test"; // New action to add to the filtered actions
    return $actions;
});
```
3. Head to WP Admin > Products > Reviews, and hover over a review to see your test output. 

<!-- End testing instructions -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message Dev - add ability to filter the `comment_row_actions` on the Products > Reviews table

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
