### PR TITLE
Fix several deprecation warnings within the product editor

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -63,6 +63,7 @@
 				"@wordpress/postcss-themes",
 				"@wordpress/prettier-config",
 				"@wordpress/primitives",
+				"@wordpress/private-apis",
 				"@wordpress/scripts",
 				"@wordpress/server-side-render",
 				"@wordpress/style-engine",

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -153,10 +153,11 @@
           "menu_title": "Frequently Asked Questions",
           "tags": "reference",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/cart-and-checkout-blocks/faq.md",
-          "hash": "3289920c5224a5c392617620b839df1454431257abf2162744b1fa9040314378",
+          "hash": "31bfbf216252c709466e293c6b2159858db994e9cdb530d8f13ffc327ab07ea7",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/cart-and-checkout-blocks/faq.md",
           "id": "041787aca25af363a5eff3e710bd669cc8aebc4b",
           "links": {
+            "./slot-fills.md": "e388101586765dd9aca752d66d667d74951a1504",
             "./removing-checkout-fields.md": "030247059754260bce6285cfb352a4a733f1f677"
           }
         },
@@ -1249,7 +1250,7 @@
             {
               "post_title": "Extending the product form with custom fields",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/docs/product-editor-development/how-to-guides/custom-field-tutorial.md",
-              "hash": "dfa00ed71af6eda1f539684657d5c880850ececea4c07bd11e89a605fab77ec7",
+              "hash": "75a6f3c40384262c44c3c4ae71fdf7f26e6c7c5561c5b0f88661e1f6d63fc2a2",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/docs/product-editor-development/how-to-guides/custom-field-tutorial.md",
               "id": "fed80efbb225df9054fadd6e1fc45c2cd03e7f99"
             }
@@ -1953,5 +1954,5 @@
       "categories": []
     }
   ],
-  "hash": "c65911eef0536e1d618ee58176ebfa0074433a61f7b8b7c8b043b639610f263b"
+  "hash": "7a688f3ce563ed941994959844bdc4f90e8e7efb2ecefd4d121f264d947fcab0"
 }

--- a/docs/product-editor-development/how-to-guides/custom-field-tutorial.md
+++ b/docs/product-editor-development/how-to-guides/custom-field-tutorial.md
@@ -139,14 +139,14 @@ add_action(
 We recommend using components from `@wordpress/components` as this will also keep the styling consistent. We will use the [ComboboxControl](https://wordpress.github.io/gutenberg/?path=/docs/components-comboboxcontrol--docs) core component in this field.
 
 We can add it to our `edit` function pretty easily by making use of `wp.components`. We will also add a constant for the filter options.
-**Note:** I also added the `blockProps` to the top element, we still recommend using this as some of these props are being used in the product form. When we add the block props we need to also let the form know it is an interactive element. We do this by adding at-least one attribute with the `__experimentalRole` set to `content`.
+**Note:** I also added the `blockProps` to the top element, we still recommend using this as some of these props are being used in the product form. When we add the block props we need to also let the form know it is an interactive element. We do this by adding at-least one attribute with the `role` set to `content`.
 So lets add this to our `index.js` attributes:
 
 ```javascript
  attributes: {
     "message": {
         "type": "string",
-        "__experimentalRole": "content",
+        "role": "content",
         "source": "text",
         "selector": "div"
     }

--- a/packages/js/block-templates/changelog/fix-experimental_role_warning
+++ b/packages/js/block-templates/changelog/fix-experimental_role_warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removing the use of __experimentalRole and using role instead.

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -51,6 +51,7 @@
 	},
 	"dependencies": {
 		"@woocommerce/expression-evaluation": "workspace:*",
+		"@woocommerce/settings": "^1.0.0",
 		"@wordpress/block-editor": "wp-6.6",
 		"@wordpress/blocks": "wp-6.6",
 		"@wordpress/core-data": "wp-6.6",
@@ -88,8 +89,8 @@
 		"wireit": "0.14.10"
 	},
 	"peerDependencies": {
-		"@wordpress/data": "wp-6.6",
 		"@types/react": "18.3.x",
+		"@wordpress/data": "wp-6.6",
 		"react": "18.3.x",
 		"react-dom": "18.3.x"
 	},

--- a/packages/js/block-templates/src/typings/index.d.ts
+++ b/packages/js/block-templates/src/typings/index.d.ts
@@ -1,0 +1,13 @@
+declare module '@woocommerce/settings' {
+	export declare function getAdminLink( path: string ): string;
+	export declare function getSetting< T >(
+		name: string,
+		fallback?: unknown,
+		filter = ( val: unknown, fb: unknown ) =>
+			typeof val !== 'undefined' ? val : fb
+	): T;
+	export declare function isWpVersion(
+		version: string,
+		operator: '>' | '>=' | '=' | '<' | '<='
+	): boolean;
+}

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';
 import { evaluate } from '@woocommerce/expression-evaluation';
+import { isWpVersion, getSetting } from '@woocommerce/settings';
 import { ComponentType } from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet, natively (not until 7.0.0).
@@ -90,37 +91,61 @@ function getEdit<
 	};
 }
 
+let requiresExperimentalRole = isWpVersion( '6.5', '<=' );
+const adminSettings: { gutenberg_version?: string } = getSetting( 'admin' );
+if ( requiresExperimentalRole && adminSettings.gutenberg_version ) {
+	requiresExperimentalRole =
+		parseFloat( adminSettings?.gutenberg_version ) >= 19.5;
+}
+
 function augmentAttributes<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	T extends Record< string, any > = Record< string, any >
 >( attributes: T ) {
 	// Note: If you modify this function, also update the server-side
 	// Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry::augment_attributes() function.
-	return {
+	const augmentedAttributes = {
 		...attributes,
 		...{
 			_templateBlockId: {
 				type: 'string',
-				__experimentalRole: 'content',
+				role: 'content',
 			},
 			_templateBlockOrder: {
 				type: 'integer',
-				__experimentalRole: 'content',
+				role: 'content',
 			},
 			_templateBlockHideConditions: {
 				type: 'array',
-				__experimentalRole: 'content',
+				role: 'content',
 			},
 			_templateBlockDisableConditions: {
 				type: 'array',
-				__experimentalRole: 'content',
+				role: 'content',
 			},
 			disabled: attributes.disabled || {
 				type: 'boolean',
-				__experimentalRole: 'content',
+				role: 'content',
 			},
 		},
 	};
+	if ( requiresExperimentalRole ) {
+		return Object.keys( augmentedAttributes ).reduce(
+			( acc, key: keyof T ) => {
+				if ( augmentedAttributes[ key ].role ) {
+					acc[ key ] = {
+						...augmentedAttributes[ key ],
+						__experimentalRole: augmentedAttributes[ key ].role,
+					};
+				} else {
+					acc[ key ] = augmentedAttributes[ key ];
+				}
+				return acc;
+			},
+			{} as T
+		);
+	}
+	return augmentedAttributes;
 }
 
 /**
@@ -146,6 +171,7 @@ export function registerWooBlockType<
 		return;
 	}
 
+	console.log( 'metadata.name', metadata.name );
 	const augmentedMetadata = {
 		...metadata,
 		attributes: augmentAttributes( metadata.attributes ),

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -171,7 +171,6 @@ export function registerWooBlockType<
 		return;
 	}
 
-	console.log( 'metadata.name', metadata.name );
 	const augmentedMetadata = {
 		...metadata,
 		attributes: augmentAttributes( metadata.attributes ),

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -91,11 +91,11 @@ function getEdit<
 	};
 }
 
-let requiresExperimentalRole = isWpVersion( '6.5', '<=' );
+let requiresExperimentalRole = isWpVersion( '6.7', '<' );
 const adminSettings: { gutenberg_version?: string } = getSetting( 'admin' );
 if ( requiresExperimentalRole && adminSettings.gutenberg_version ) {
 	requiresExperimentalRole =
-		parseFloat( adminSettings?.gutenberg_version ) >= 19.5;
+		parseFloat( adminSettings?.gutenberg_version ) < 19.4;
 }
 
 function augmentAttributes<

--- a/packages/js/block-templates/src/utils/test/register-woo-block-type-older-wp-version.test.ts
+++ b/packages/js/block-templates/src/utils/test/register-woo-block-type-older-wp-version.test.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import { registerWooBlockType } from '../register-woo-block-type';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	isWpVersion: jest.fn().mockReturnValue( true ),
+	getSetting: jest.fn().mockReturnValue( {} ),
+} ) );
+
+describe( 'registerWooBlockType with older wp version', () => {
+	it( 'should add __experimentalRole to attributes when wp version is less than 6.7', () => {
+		const block = {
+			name: 'test/block',
+			metadata: {
+				attributes: {
+					foo: {
+						type: 'boolean',
+						default: false,
+						role: 'content',
+					},
+				},
+			},
+			settings: {
+				foo: 'bar',
+				edit: jest.fn(),
+			},
+		};
+
+		( registerBlockType as jest.Mock ).mockClear();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore ts2345 Complaining about the type of the foo attribute; it's fine.
+		registerWooBlockType( block );
+
+		const args = ( registerBlockType as jest.Mock ).mock.calls[ 0 ][ 0 ];
+		const attributes = args.attributes;
+		for ( const attribute of Object.values( attributes ) ) {
+			expect( attribute ).toHaveProperty( '__experimentalRole' );
+		}
+	} );
+} );

--- a/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
+++ b/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
@@ -44,22 +44,22 @@ describe( 'registerWooBlockType', () => {
 					},
 					_templateBlockId: {
 						type: 'string',
-						__experimentalRole: 'content',
+						role: 'content',
 					},
 					_templateBlockOrder: {
 						type: 'integer',
-						__experimentalRole: 'content',
+						role: 'content',
 					},
 					_templateBlockHideConditions: {
 						type: 'array',
-						__experimentalRole: 'content',
+						role: 'content',
 					},
 					_templateBlockDisableConditions: {
-						__experimentalRole: 'content',
+						role: 'content',
 						type: 'array',
 					},
 					disabled: {
-						__experimentalRole: 'content',
+						role: 'content',
 						type: 'boolean',
 					},
 				},

--- a/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
+++ b/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-
 /**
  * Internal dependencies
  */
@@ -10,6 +9,11 @@ import { registerWooBlockType } from '../register-woo-block-type';
 
 jest.mock( '@wordpress/blocks', () => ( {
 	registerBlockType: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	isWpVersion: jest.fn().mockReturnValue( false ),
+	getSetting: jest.fn().mockReturnValue( {} ),
 } ) );
 
 describe( 'registerWooBlockType', () => {
@@ -21,6 +25,7 @@ describe( 'registerWooBlockType', () => {
 					foo: {
 						type: 'boolean',
 						default: false,
+						role: 'content',
 					},
 				},
 			},
@@ -41,6 +46,7 @@ describe( 'registerWooBlockType', () => {
 					foo: {
 						type: 'boolean',
 						default: false,
+						role: 'content',
 					},
 					_templateBlockId: {
 						type: 'string',

--- a/packages/js/create-product-editor-block/changelog/fix-experimental_role_warning
+++ b/packages/js/create-product-editor-block/changelog/fix-experimental_role_warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update sample block __experimentalRole to use role instead.

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -16,7 +16,7 @@ module.exports = {
 		attributes: {
 			message: {
 				type: 'string',
-				__experimentalRole: 'content',
+				role: 'content',
 				source: 'text',
 				selector: 'div',
 			},

--- a/packages/js/data/changelog/fix-experimental_role_warning
+++ b/packages/js/data/changelog/fix-experimental_role_warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove deprecated use of select from @wordpress/data-controls, using controls.resolveSelect instead.

--- a/packages/js/data/src/utils.ts
+++ b/packages/js/data/src/utils.ts
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { apiFetch, select } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
+import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -110,7 +111,10 @@ export function* request< Query extends BaseQueryParams, DataType >(
  * @throws {Error} If the user does not have the required capability.
  */
 export function* checkUserCapability( capability: string ) {
-	const currentUser: WCUser = yield select( userStore, 'getCurrentUser' );
+	const currentUser: WCUser = yield controls.resolveSelect(
+		userStore,
+		'getCurrentUser'
+	);
 
 	if ( ! currentUser.capabilities[ capability ] ) {
 		throw new Error( `User does not have ${ capability } capability.` );

--- a/packages/js/internal-js-tests/changelog/fix-experimental_role_warning
+++ b/packages/js/internal-js-tests/changelog/fix-experimental_role_warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add isWpVersion mock function to the @woocommerce/settings mock.

--- a/packages/js/internal-js-tests/src/mocks/woocommerce-settings.js
+++ b/packages/js/internal-js-tests/src/mocks/woocommerce-settings.js
@@ -8,4 +8,25 @@ module.exports = {
 		}
 		return path;
 	},
+	isWpVersion: ( version, operator ) => {
+		if ( global.wcSettings.wpVersion ) {
+			const wpVersion = parseFloat( global.wcSettings.wpVersion );
+			version = parseFloat( version );
+			switch ( operator ) {
+				case '<':
+					return wpVersion < version;
+				case '<=':
+					return wpVersion <= version;
+				case '>':
+					return wpVersion > version;
+				case '>=':
+					return wpVersion >= version;
+				case '==':
+					return wpVersion === version;
+				case '!=':
+					return wpVersion !== version;
+			}
+		}
+		return false;
+	},
 };

--- a/packages/js/product-editor/changelog/fix-experimental_role_warning
+++ b/packages/js/product-editor/changelog/fix-experimental_role_warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removing the use of __experimentalRole and using role instead.

--- a/packages/js/product-editor/src/blocks/generic/checkbox/block.json
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"title": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"label": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/generic/collapsible/block.json
+++ b/packages/js/product-editor/src/blocks/generic/collapsible/block.json
@@ -9,7 +9,7 @@
 	"attributes": {
 		"toggleText": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"initialCollapsed": {
 			"type": "boolean"

--- a/packages/js/product-editor/src/blocks/generic/conditional/block.json
+++ b/packages/js/product-editor/src/blocks/generic/conditional/block.json
@@ -8,7 +8,7 @@
 	"textdomain": "default",
 	"attributes": {
 		"mustMatch": {
-			"__experimentalRole": "content",
+			"role": "content",
 			"type": "array",
 			"items": {
 				"type": "object"

--- a/packages/js/product-editor/src/blocks/generic/linked-product-list/block.json
+++ b/packages/js/product-editor/src/blocks/generic/linked-product-list/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"property": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"emptyState": {
 			"type": "object",

--- a/packages/js/product-editor/src/blocks/generic/notice/block.json
+++ b/packages/js/product-editor/src/blocks/generic/notice/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"message": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/number/block.json
+++ b/packages/js/product-editor/src/blocks/generic/number/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"property": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/generic/pricing/block.json
+++ b/packages/js/product-editor/src/blocks/generic/pricing/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"property": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"label": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/generic/radio/block.json
+++ b/packages/js/product-editor/src/blocks/generic/radio/block.json
@@ -27,7 +27,7 @@
 				"type": "object"
 			},
 			"default": [],
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"disabled": {
 			"type": "boolean",

--- a/packages/js/product-editor/src/blocks/generic/section-description/block.json
+++ b/packages/js/product-editor/src/blocks/generic/section-description/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/section/block.json
+++ b/packages/js/product-editor/src/blocks/generic/section/block.json
@@ -17,7 +17,7 @@
 		},
 		"description": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"blockGap": {
 			"type": "string",

--- a/packages/js/product-editor/src/blocks/generic/select/block.json
+++ b/packages/js/product-editor/src/blocks/generic/select/block.json
@@ -10,7 +10,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"property": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/generic/subsection-description/block.json
+++ b/packages/js/product-editor/src/blocks/generic/subsection-description/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/subsection/block.json
+++ b/packages/js/product-editor/src/blocks/generic/subsection/block.json
@@ -17,7 +17,7 @@
 		},
 		"description": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"blockGap": {
 			"type": "string",

--- a/packages/js/product-editor/src/blocks/generic/taxonomy/block.json
+++ b/packages/js/product-editor/src/blocks/generic/taxonomy/block.json
@@ -10,31 +10,31 @@
 	"attributes": {
 		"slug": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"property": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"createTitle": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"dialogNameHelpText": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"parentTaxonomyText": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"help": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/text-area/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text-area/block.json
@@ -16,7 +16,7 @@
 		},
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"placeholder": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/generic/text/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"property": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/generic/toggle/block.json
+++ b/packages/js/product-editor/src/blocks/generic/toggle/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"help": {
 			"type": "string"
@@ -34,7 +34,7 @@
 		},
 		"disabledCopy": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"checkedValue": {
 			"type": "object"

--- a/packages/js/product-editor/src/blocks/product-fields/attributes/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/attributes/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"visibility": {
 			"type": "string",

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields-toggle/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/custom-fields/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/custom-fields/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/description/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/description/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"__contentEditable": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/images/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/images/block.json
@@ -15,7 +15,7 @@
 	"attributes": {
 		"mediaId": {
 			"type": "number",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"property": {
 			"type": "string"
@@ -25,7 +25,7 @@
 			"default": true
 		},
 		"images": {
-			"__experimentalRole": "content",
+			"role": "content",
 			"type": "array",
 			"items": {
 				"type": "number"

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-email/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-email/block.json
@@ -15,7 +15,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-sku/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-sku/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"disabled": {
 			"type": "boolean",

--- a/packages/js/product-editor/src/blocks/product-fields/name/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/name/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"autoFocus": {
 			"type": "boolean",

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -164,7 +164,7 @@ export function NameBlockEdit( {
 		const tooltipText = featured ? unmarkedText : markedText;
 
 		return (
-			<Tooltip text={ tooltipText } position="top center">
+			<Tooltip text={ tooltipText } placement="top">
 				{ featured ? (
 					<Button
 						icon={ starFilled }

--- a/packages/js/product-editor/src/blocks/product-fields/password/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/password/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/product-details-section-description/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/product-list/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/product-list/block.json
@@ -12,7 +12,7 @@
 	"attributes": {
 		"property": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"help": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"label": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"help": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"title": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"disabled": {
 			"type": "boolean",

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/block.json
@@ -14,7 +14,7 @@
 	"attributes": {
 		"__contentEditable": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"disabled": {
 			"type": "boolean",

--- a/packages/js/product-editor/src/blocks/product-fields/summary/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/block.json
@@ -48,7 +48,7 @@
 		},
 		"content": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/tag/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/tag/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"name": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"label": {
 			"type": "string"

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"description": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/block.json
@@ -13,7 +13,7 @@
 	"attributes": {
 		"description": {
 			"type": "string",
-			"__experimentalRole": "content"
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
@@ -80,7 +80,7 @@ export const AttributeListItem: React.FC< AttributeListItemProps > = ( {
 					<Tooltip
 						// @ts-expect-error className is missing in TS, should remove this when it is included.
 						className="woocommerce-attribute-list-item__actions-tooltip"
-						position="top center"
+						placement="top"
 						text={ VISIBLE_TEXT }
 					>
 						<div className="woocommerce-attribute-list-item__actions-icon-wrapper">

--- a/packages/js/product-editor/src/utils/date/format-schedule-datetime.ts
+++ b/packages/js/product-editor/src/utils/date/format-schedule-datetime.ts
@@ -5,7 +5,7 @@ import {
 	DateSettings,
 	dateI18n,
 	getDate,
-	__experimentalGetSettings as getSettings,
+	getSettings,
 	isInTheFuture,
 } from '@wordpress/date';
 import { __, _x, isRTL, sprintf } from '@wordpress/i18n';

--- a/packages/js/product-editor/src/utils/date/get-site-settings-timezone-abbreviation.ts
+++ b/packages/js/product-editor/src/utils/date/get-site-settings-timezone-abbreviation.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	TimezoneConfig,
-	__experimentalGetSettings as getSettings,
-} from '@wordpress/date';
+import { TimezoneConfig, getSettings } from '@wordpress/date';
 
 export function getSiteSettingsTimezoneAbbreviation() {
 	const { timezone } = getSettings() as {

--- a/packages/js/product-editor/src/utils/date/is-site-settings-time-12-hour-formatted.ts
+++ b/packages/js/product-editor/src/utils/date/is-site-settings-time-12-hour-formatted.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	DateSettings,
-	__experimentalGetSettings as getSettings,
-} from '@wordpress/date';
+import { DateSettings, getSettings } from '@wordpress/date';
 
 export function isSiteSettingsTime12HourFormatted() {
 	const settings = getSettings() as DateSettings;

--- a/packages/js/product-editor/src/utils/date/is-site-settings-timezone-same-as-date-timezone.ts
+++ b/packages/js/product-editor/src/utils/date/is-site-settings-timezone-same-as-date-timezone.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	DateSettings,
-	__experimentalGetSettings as getSettings,
-} from '@wordpress/date';
+import { DateSettings, getSettings } from '@wordpress/date';
 
 export function isSiteSettingsTimezoneSameAsDateTimezone( date: Date ) {
 	const { timezone } = getSettings() as DateSettings;

--- a/plugins/woocommerce-blocks/package.json
+++ b/plugins/woocommerce-blocks/package.json
@@ -185,6 +185,7 @@
 		"@wordpress/postcss-plugins-preset": "1.6.0",
 		"@wordpress/postcss-themes": "1.0.5",
 		"@wordpress/prettier-config": "1.4.0",
+		"@wordpress/private-apis": "1.16.0",
 		"@wordpress/scripts": "30.6.0",
 		"@wordpress/stylelint-config": "^21.36.0",
 		"ajv-cli": "3.3.x",

--- a/plugins/woocommerce/changelog/fix-experimental_role_warning
+++ b/plugins/woocommerce/changelog/fix-experimental_role_warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update product editor blocks to use __experimentalRole if using WP 6.6 or lower. Also prevent summary and descriptions blocks from moving.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -221,7 +221,7 @@ class BlockRegistry {
 				);
 				$gutenberg_version = $gutenberg_data['Version'];
 			}
-			return version_compare( $gutenberg_version, '19.5', '>=' );
+			return version_compare( $gutenberg_version, '19.4', '>=' );
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+use Automattic\WooCommerce\Blocks\Utils\Utils;
 
 /**
  * Product block registration and style registration functionality.
@@ -160,33 +161,70 @@ class BlockRegistry {
 	 * @param array $attributes Block attributes.
 	 */
 	private function augment_attributes( $attributes ) {
+		global $wp_version;
 		// Note: If you modify this function, also update the client-side
 		// registerWooBlockType function in @woocommerce/block-templates.
-		return array_merge(
+		$augmented_attributes = array_merge(
 			$attributes,
 			array(
 				'_templateBlockId'                => array(
 					'type'               => 'string',
-					'__experimentalRole' => 'content',
+					'role' => 'content',
 				),
 				'_templateBlockOrder'             => array(
 					'type'               => 'integer',
-					'__experimentalRole' => 'content',
+					'role' => 'content',
 				),
 				'_templateBlockHideConditions'    => array(
 					'type'               => 'array',
-					'__experimentalRole' => 'content',
+					'role' => 'content',
 				),
 				'_templateBlockDisableConditions' => array(
 					'type'               => 'array',
-					'__experimentalRole' => 'content',
+					'role' => 'content',
 				),
 				'disabled'                        => isset( $attributes['disabled'] ) ? $attributes['disabled'] : array(
 					'type'               => 'boolean',
-					'__experimentalRole' => 'content',
+					'role' => 'content',
 				),
 			)
 		);
+		if ( ! $this->has_role_support() ) {
+			foreach ( $augmented_attributes as $key => $attribute ) {
+				if ( isset( $attribute['role'] ) ) {
+					$augmented_attributes[ $key ]['__experimentalRole'] = $attribute['role'];
+				}
+			}
+		}
+		return $augmented_attributes;
+	}
+
+	/**
+	 * Checks for block attribute role support.
+	 */
+	private function has_role_support() {
+		if ( Utils::wp_version_compare( '6.7', '>=' ) ) {
+			return true;
+		}
+
+		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+			$gutenberg_version = '';
+
+			if ( defined( 'GUTENBERG_VERSION' ) ) {
+				$gutenberg_version = GUTENBERG_VERSION;
+			}
+
+			if ( ! $gutenberg_version ) {
+				$gutenberg_data    = get_file_data(
+					WP_PLUGIN_DIR . '/gutenberg/gutenberg.php',
+					array( 'Version' => 'Version' )
+				);
+				$gutenberg_version = $gutenberg_data['Version'];
+			}
+			return version_compare( $gutenberg_version, '19.5', '>=' );
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -168,23 +168,23 @@ class BlockRegistry {
 			$attributes,
 			array(
 				'_templateBlockId'                => array(
-					'type'               => 'string',
+					'type' => 'string',
 					'role' => 'content',
 				),
 				'_templateBlockOrder'             => array(
-					'type'               => 'integer',
+					'type' => 'integer',
 					'role' => 'content',
 				),
 				'_templateBlockHideConditions'    => array(
-					'type'               => 'array',
+					'type' => 'array',
 					'role' => 'content',
 				),
 				'_templateBlockDisableConditions' => array(
-					'type'               => 'array',
+					'type' => 'array',
 					'role' => 'content',
 				),
 				'disabled'                        => isset( $attributes['disabled'] ) ? $attributes['disabled'] : array(
-					'type'               => 'boolean',
+					'type' => 'boolean',
 					'role' => 'content',
 				),
 			)

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -220,6 +220,9 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 					'property' => 'description',
 					'label'    => __( 'Note', 'woocommerce' ),
 					'help'     => 'Enter an optional note displayed on the product page when customers select this variation.',
+					'lock'     => array(
+						'move' => true,
+					),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -354,6 +354,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'woocommerce'
 					),
 					'property' => 'short_description',
+					'lock'     => array(
+						'move' => true,
+					),
 				),
 			)
 		);
@@ -387,6 +390,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'helpText' => null,
 					'label'    => null,
 					'property' => 'description',
+					'lock'     => array(
+						'move' => true,
+					),
 				),
 			)
 		);
@@ -884,6 +890,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'property'    => 'purchase_note',
 					'label'       => __( 'Post-purchase note', 'woocommerce' ),
 					'placeholder' => __( 'Enter an optional note attached to the order confirmation message sent to the shopper.', 'woocommerce' ),
+					'lock'        => array(
+						'move' => true,
+					),
 				),
 			)
 		);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
         version: 2.3.2
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@9.4.0)
+        version: 4.3.4(supports-color@5.5.0)
       dompurify:
         specifier: ^2.5.7
         version: 2.5.7
@@ -1601,7 +1601,7 @@ importers:
         version: 4.0.1
       '@wordpress/e2e-test-utils':
         specifier: wp-6.6
-        version: 11.0.1(encoding@0.1.13)(jest@24.9.0)(puppeteer-core@23.11.1)
+        version: 11.0.1(encoding@0.1.13)(jest@29.7.0(@types/node@22.9.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)))(puppeteer-core@23.11.1)
       config:
         specifier: 3.3.7
         version: 3.3.7
@@ -3128,7 +3128,7 @@ importers:
     dependencies:
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@9.4.0)
+        version: 4.3.4(supports-color@5.5.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.23.5
@@ -3237,7 +3237,7 @@ importers:
         version: 4.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@9.4.0)
+        version: 4.3.4(supports-color@5.5.0)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -3401,7 +3401,7 @@ importers:
         version: 30.6.0(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/node@22.9.1)(@types/webpack@4.41.38)(file-loader@6.2.0(webpack@5.70.0))(node-notifier@8.0.2)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
       '@wordpress/stylelint-config':
         specifier: ^21.36.0
-        version: 21.36.0(postcss@8.4.32)(stylelint@14.16.1)
+        version: 21.36.0(postcss@8.4.49)(stylelint@14.16.1)
       allure-commandline:
         specifier: ^2.32.2
         version: 2.32.2
@@ -4002,6 +4002,9 @@ importers:
       '@wordpress/prettier-config':
         specifier: 1.4.0
         version: 1.4.0(wp-prettier@2.8.5)
+      '@wordpress/private-apis':
+        specifier: 1.16.0
+        version: 1.16.0
       '@wordpress/scripts':
         specifier: 30.6.0
         version: 30.6.0(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/node@20.17.8)(@types/webpack@4.41.38)(babel-plugin-macros@3.1.0)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
@@ -4355,7 +4358,7 @@ importers:
         version: 3.34.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@9.4.0)
+        version: 4.3.4(supports-color@5.5.0)
       dompurify:
         specifier: ^2.5.7
         version: 2.5.7
@@ -27287,7 +27290,7 @@ snapshots:
       '@wordpress/primitives': 3.55.0
       '@wordpress/react-i18n': 3.55.0
       classnames: 2.3.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -27412,7 +27415,7 @@ snapshots:
       '@babel/traverse': 7.23.5
       '@babel/types': 7.23.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -27435,7 +27438,7 @@ snapshots:
       '@babel/traverse': 7.23.5
       '@babel/types': 7.23.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -27455,7 +27458,7 @@ snapshots:
       '@babel/traverse': 7.23.5
       '@babel/types': 7.23.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -34384,9 +34387,7 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@jest/reporters@25.5.1':
     dependencies:
@@ -34588,9 +34589,7 @@ snapshots:
       jest-runner: 24.9.0
       jest-runtime: 24.9.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@jest/test-sequencer@25.5.4':
     dependencies:
@@ -34600,9 +34599,12 @@ snapshots:
       jest-runner: 25.5.4
       jest-runtime: 25.5.4
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
 
-  '@jest/test-sequencer@26.6.3':
+  '@jest/test-sequencer@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))':
     dependencies:
       '@jest/test-result': 26.6.2
       graceful-fs: 4.2.11
@@ -34610,7 +34612,11 @@ snapshots:
       jest-runner: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   '@jest/test-sequencer@27.5.1':
     dependencies:
@@ -35192,7 +35198,7 @@ snapshots:
       '@oclif/color': 1.0.13
       '@oclif/core': 2.15.0(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       fs-extra: 9.1.0
       http-call: 5.3.0
       load-json-file: 5.3.0
@@ -35636,25 +35642,6 @@ snapshots:
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack-hot-middleware@2.25.4)(webpack@5.97.1)':
-    dependencies:
-      ansi-html-community: 0.0.8
-      common-path-prefix: 3.0.0
-      core-js-pure: 3.34.0
-      error-stack-parser: 2.1.4
-      find-up: 5.0.0
-      html-entities: 2.4.0
-      loader-utils: 2.0.4
-      react-refresh: 0.14.2
-      schema-utils: 3.3.0
-      source-map: 0.7.4
-      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@types/webpack': 4.41.38
-      type-fest: 3.13.1
-      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
-      webpack-hot-middleware: 2.25.4
-
   '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1(webpack@5.89.0(@swc/core@1.3.100)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20))':
     dependencies:
       ansi-html-community: 0.0.8
@@ -35686,11 +35673,11 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.38
       type-fest: 3.13.1
-      webpack-dev-server: 4.15.1(webpack-cli@3.3.12)(webpack@5.70.0)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
       webpack-hot-middleware: 2.25.4
 
   '@polka/url@1.0.0-next.24': {}
@@ -37741,7 +37728,7 @@ snapshots:
       style-loader: 1.3.0(webpack@4.47.0(webpack-cli@3.3.12))
       terser-webpack-plugin: 4.2.3(webpack@4.47.0(webpack-cli@3.3.12))
       ts-dedent: 2.2.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@4.47.0(webpack-cli@3.3.12)))(webpack@4.47.0(webpack-cli@3.3.12))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@4.47.0(webpack-cli@3.3.12))
       util-deprecate: 1.0.2
       webpack: 4.47.0(webpack-cli@3.3.12)
       webpack-dev-middleware: 3.7.3(webpack@4.47.0(webpack-cli@3.3.12))
@@ -38861,7 +38848,7 @@ snapshots:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3(webpack@4.47.0(webpack-cli@3.3.12))
       ts-dedent: 2.2.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@4.47.0(webpack-cli@3.3.12)))(webpack@4.47.0(webpack-cli@3.3.12))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@4.47.0(webpack-cli@3.3.12))
       util-deprecate: 1.0.2
       webpack: 4.47.0(webpack-cli@3.3.12)
       webpack-dev-middleware: 3.7.3(webpack@4.47.0(webpack-cli@3.3.12))
@@ -39540,18 +39527,18 @@ snapshots:
       regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
 
-  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)':
+  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39))(postcss@7.0.39)':
     dependencies:
       '@babel/core': 7.26.0
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.32)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
     transitivePeerDependencies:
       - supports-color
 
-  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)':
+  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39))(postcss@7.0.39)':
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.32)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -40867,7 +40854,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/type-utils': 5.56.0(eslint@8.55.0)(typescript@5.7.2)
       '@typescript-eslint/utils': 5.56.0(eslint@8.55.0)(typescript@5.7.2)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.55.0
       grapheme-splitter: 1.0.4
       ignore: 5.3.0
@@ -40886,7 +40873,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.55.0)(typescript@5.7.2)
       '@typescript-eslint/utils': 5.62.0(eslint@8.55.0)(typescript@5.7.2)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.55.0
       graphemer: 1.4.0
       ignore: 5.3.0
@@ -40947,7 +40934,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.7.2)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.55.0
     optionalDependencies:
       typescript: 5.7.2
@@ -41518,8 +41505,8 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
 
   '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
     dependencies:
@@ -41533,8 +41520,8 @@ snapshots:
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
 
   '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)':
     dependencies:
@@ -41546,13 +41533,6 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 4.15.1(debug@4.3.4)(webpack-cli@4.10.0)(webpack@5.89.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack@5.97.1)':
-    dependencies:
-      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
-    optionalDependencies:
-      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
-
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.91.0)':
     dependencies:
       webpack: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
@@ -41562,10 +41542,10 @@ snapshots:
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.97.1)':
     dependencies:
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
     optionalDependencies:
-      webpack-dev-server: 4.15.1(webpack-cli@3.3.12)(webpack@5.70.0)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
 
   '@wojtekmaj/enzyme-adapter-react-17@0.6.7(enzyme@3.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -41956,7 +41936,7 @@ snapshots:
       '@wordpress/keycodes': 4.0.1
       '@wordpress/notices': 5.0.2(react@18.3.1)
       '@wordpress/preferences': 4.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/style-engine': 2.10.0
       '@wordpress/token-list': 3.10.0
@@ -42013,7 +41993,7 @@ snapshots:
       '@wordpress/keycodes': 4.10.0
       '@wordpress/notices': 5.15.1(react@18.3.1)
       '@wordpress/preferences': 4.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/style-engine': 2.10.0
       '@wordpress/token-list': 3.10.0
@@ -42071,7 +42051,7 @@ snapshots:
       '@wordpress/keycodes': 4.10.0
       '@wordpress/notices': 5.15.1(react@18.3.1)
       '@wordpress/preferences': 4.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/style-engine': 2.10.0
       '@wordpress/token-list': 3.10.0
@@ -42233,7 +42213,7 @@ snapshots:
       '@wordpress/notices': 5.0.2(react@18.3.1)
       '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/server-side-render': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -42290,7 +42270,7 @@ snapshots:
       '@wordpress/notices': 5.0.2(react@18.3.1)
       '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/server-side-render': 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -42431,7 +42411,7 @@ snapshots:
       '@wordpress/html-entities': 4.0.1
       '@wordpress/i18n': 5.0.1
       '@wordpress/is-shallow-equal': 5.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/shortcode': 4.10.0
       change-case: 4.1.2
@@ -42461,7 +42441,7 @@ snapshots:
       '@wordpress/html-entities': 4.10.0
       '@wordpress/i18n': 5.10.0
       '@wordpress/is-shallow-equal': 5.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/shortcode': 4.10.0
       '@wordpress/warning': 3.10.0
@@ -42539,7 +42519,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/keyboard-shortcuts': 5.10.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       clsx: 2.1.1
       cmdk: 1.0.0(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -42559,7 +42539,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/keyboard-shortcuts': 5.10.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       clsx: 2.1.1
       cmdk: 1.0.0(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -42875,7 +42855,7 @@ snapshots:
       '@wordpress/is-shallow-equal': 5.10.0
       '@wordpress/keycodes': 4.0.1
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/warning': 3.0.1
       change-case: 4.1.2
@@ -42931,7 +42911,7 @@ snapshots:
       '@wordpress/is-shallow-equal': 5.10.0
       '@wordpress/keycodes': 4.0.1
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/warning': 3.0.1
       change-case: 4.1.2
@@ -42987,7 +42967,7 @@ snapshots:
       '@wordpress/is-shallow-equal': 5.10.0
       '@wordpress/keycodes': 4.10.0
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/warning': 3.10.0
       change-case: 4.1.2
@@ -43245,7 +43225,7 @@ snapshots:
       '@wordpress/i18n': 5.0.1
       '@wordpress/icons': 10.11.0
       '@wordpress/notices': 5.0.2(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/router': 1.11.0(react@18.3.1)
       '@wordpress/url': 4.0.1
       react: 18.3.1
@@ -43324,7 +43304,7 @@ snapshots:
       '@wordpress/html-entities': 4.0.1
       '@wordpress/i18n': 5.0.1
       '@wordpress/is-shallow-equal': 5.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/sync': 1.10.0
       '@wordpress/undo-manager': 1.10.0
@@ -43357,7 +43337,7 @@ snapshots:
       '@wordpress/html-entities': 4.10.0
       '@wordpress/i18n': 5.10.0
       '@wordpress/is-shallow-equal': 5.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/sync': 1.10.0
       '@wordpress/undo-manager': 1.10.0
@@ -43391,7 +43371,7 @@ snapshots:
       '@wordpress/html-entities': 4.10.0
       '@wordpress/i18n': 5.10.0
       '@wordpress/is-shallow-equal': 5.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/sync': 1.10.0
       '@wordpress/undo-manager': 1.10.0
@@ -43468,7 +43448,7 @@ snapshots:
       '@wordpress/element': 6.0.1
       '@wordpress/is-shallow-equal': 5.10.0
       '@wordpress/priority-queue': 3.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/redux-routine': 5.12.0(redux@4.2.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
@@ -43487,7 +43467,7 @@ snapshots:
       '@wordpress/element': 6.10.0
       '@wordpress/is-shallow-equal': 5.10.0
       '@wordpress/priority-queue': 3.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/redux-routine': 5.12.0(redux@4.2.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
@@ -43531,7 +43511,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/warning': 3.8.1
       clsx: 2.1.1
       react: 18.3.1
@@ -43553,7 +43533,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/warning': 3.10.0
       clsx: 2.1.1
       react: 18.3.1
@@ -43621,7 +43601,7 @@ snapshots:
   '@wordpress/dependency-extraction-webpack-plugin@3.7.0(webpack@5.97.1)':
     dependencies:
       json2php: 0.0.4
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-sources: 3.2.3
 
   '@wordpress/dependency-extraction-webpack-plugin@6.16.0(webpack@5.91.0)':
@@ -43747,7 +43727,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@wordpress/e2e-test-utils@11.0.1(encoding@0.1.13)(jest@24.9.0)(puppeteer-core@23.11.1)':
+  '@wordpress/e2e-test-utils@11.0.1(encoding@0.1.13)(jest@29.7.0(@types/node@22.9.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)))(puppeteer-core@23.11.1)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@wordpress/api-fetch': 7.0.1
@@ -43755,7 +43735,7 @@ snapshots:
       '@wordpress/url': 4.0.1
       change-case: 4.1.2
       form-data: 4.0.0
-      jest: 24.9.0
+      jest: 29.7.0(@types/node@22.9.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       node-fetch: 2.7.0(encoding@0.1.13)
       puppeteer-core: 23.11.1
     transitivePeerDependencies:
@@ -43901,7 +43881,7 @@ snapshots:
       '@wordpress/notices': 5.0.2(react@18.3.1)
       '@wordpress/plugins': 7.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.0.1
       '@wordpress/viewport': 6.0.2(react@18.3.1)
       '@wordpress/warning': 3.0.1
@@ -44022,7 +44002,7 @@ snapshots:
       '@wordpress/preferences': 4.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.11.0(react@18.3.1)
       '@wordpress/priority-queue': 3.10.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/router': 1.11.0(react@18.3.1)
       '@wordpress/style-engine': 2.10.0
@@ -44130,7 +44110,7 @@ snapshots:
       '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/server-side-render': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -44188,7 +44168,7 @@ snapshots:
       '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/server-side-render': 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -44248,7 +44228,7 @@ snapshots:
       '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.14.0(react@18.3.1)
       '@wordpress/server-side-render': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -44612,7 +44592,7 @@ snapshots:
       '@wordpress/notices': 5.15.1(react@18.3.1)
       '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.10.0
       '@wordpress/warning': 3.10.0
       change-case: 4.1.2
@@ -44881,7 +44861,7 @@ snapshots:
       '@wordpress/icons': 10.11.0
       '@wordpress/plugins': 7.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/viewport': 6.0.2(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
@@ -44904,7 +44884,7 @@ snapshots:
       '@wordpress/icons': 10.11.0
       '@wordpress/plugins': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/viewport': 6.10.0(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
@@ -45266,7 +45246,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/notices': 5.15.1(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.10.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -45293,7 +45273,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/notices': 5.15.1(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.10.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -45439,7 +45419,7 @@ snapshots:
       '@wordpress/element': 6.0.1
       '@wordpress/i18n': 5.0.1
       '@wordpress/icons': 10.11.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -45459,7 +45439,7 @@ snapshots:
       '@wordpress/element': 6.10.0
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -45670,7 +45650,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/notices': 5.15.1(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.10.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -45694,7 +45674,7 @@ snapshots:
       '@wordpress/i18n': 5.10.0
       '@wordpress/icons': 10.11.0
       '@wordpress/notices': 5.15.1(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.10.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -45807,7 +45787,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/element': 6.0.1
-      '@wordpress/private-apis': 1.10.0
+      '@wordpress/private-apis': 1.16.0
       '@wordpress/url': 4.0.1
       history: 5.3.0
       react: 18.3.1
@@ -45840,7 +45820,7 @@ snapshots:
       expect-puppeteer: 4.4.0
       filenamify: 4.3.0
       jest: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
-      jest-circus: 26.6.3
+      jest-circus: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       jest-dev-server: 5.0.3(debug@4.3.4)
       jest-environment-node: 26.6.2
       markdownlint: 0.23.1
@@ -45919,7 +45899,7 @@ snapshots:
       expect-puppeteer: 4.4.0
       filenamify: 4.3.0
       jest: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
-      jest-circus: 26.6.3
+      jest-circus: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       jest-dev-server: 5.0.3(debug@4.3.4)
       jest-environment-node: 26.6.2
       markdownlint: 0.23.1
@@ -46028,7 +46008,7 @@ snapshots:
       webpack: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@4.10.0)
       webpack-bundle-analyzer: 4.7.0
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
-      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.91.0)
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -46060,7 +46040,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.7
       '@playwright/test': 1.50.1
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack-hot-middleware@2.25.4)(webpack@5.97.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.25.4)(webpack@5.97.1)
       '@svgr/webpack': 8.1.0(typescript@5.7.2)
       '@wordpress/babel-preset-default': 8.13.0
       '@wordpress/browserslist-config': 6.0.1
@@ -46119,8 +46099,8 @@ snapshots:
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.91.0))(webpack@5.97.1)
       webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack@5.97.1)
-      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/node'
@@ -46211,7 +46191,7 @@ snapshots:
       webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1)
-      webpack-dev-server: 4.15.1(webpack-cli@3.3.12)(webpack@5.70.0)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.97.1)
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/node'
@@ -47647,7 +47627,7 @@ snapshots:
       '@babel/core': 7.25.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   babel-messages@6.23.0:
     dependencies:
@@ -49140,7 +49120,7 @@ snapshots:
     dependencies:
       '@types/webpack': 4.41.38
       del: 4.1.1
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   cli-boxes@1.0.0: {}
 
@@ -49614,7 +49594,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   copy-webpack-plugin@11.0.0(webpack@5.91.0):
     dependencies:
@@ -50022,7 +50002,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.32)
       postcss-value-parser: 4.2.0
       semver: 7.6.3
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   css-select-base-adapter@0.1.1: {}
 
@@ -51238,7 +51218,7 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-webpack@0.13.2)(eslint-plugin-import@2.28.1)(eslint@8.55.0):
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.15.0
       eslint: 8.55.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.55.0)
@@ -51255,7 +51235,7 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-webpack@0.13.8)(eslint-plugin-import@2.29.0)(eslint@8.55.0):
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.15.0
       eslint: 8.55.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.8)(eslint@8.55.0)
@@ -52686,7 +52666,7 @@ snapshots:
 
   follow-redirects@1.15.6(debug@4.3.4):
     optionalDependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
 
   follow-redirects@1.5.10:
     dependencies:
@@ -54961,7 +54941,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-circus@26.6.3:
+  jest-circus@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)):
     dependencies:
       '@babel/traverse': 7.25.3
       '@jest/environment': 26.6.2
@@ -54985,7 +54965,11 @@ snapshots:
       stack-utils: 2.0.6
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   jest-circus@27.5.1:
     dependencies:
@@ -55243,7 +55227,7 @@ snapshots:
   jest-config@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.26.0
-      '@jest/test-sequencer': 26.6.3
+      '@jest/test-sequencer': 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       '@jest/types': 26.6.2
       babel-jest: 26.6.3(@babel/core@7.26.0)
       chalk: 4.1.2
@@ -55253,7 +55237,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3
+      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -55880,9 +55864,12 @@ snapshots:
       pretty-format: 25.5.0
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
 
-  jest-jasmine2@26.6.3:
+  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)):
     dependencies:
       '@babel/traverse': 7.25.9
       '@jest/environment': 26.6.2
@@ -55903,7 +55890,11 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   jest-jasmine2@27.5.1:
     dependencies:
@@ -57565,7 +57556,7 @@ snapshots:
       chalk: 5.2.0
       cli-truncate: 3.1.0
       commander: 10.0.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 7.2.0
       lilconfig: 2.1.0
       listr2: 5.0.8(enquirer@2.4.1)
@@ -58549,7 +58540,7 @@ snapshots:
   mini-css-extract-plugin@2.7.6(webpack@5.97.1):
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   minimalistic-assert@1.0.1: {}
 
@@ -58823,7 +58814,7 @@ snapshots:
     dependencies:
       carlo: 0.9.46
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       isbinaryfile: 3.0.3
       mime: 2.6.0
       opn: 5.5.0
@@ -59373,7 +59364,7 @@ snapshots:
       '@oclif/plugin-warn-if-update-available': 2.1.1(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)
       aws-sdk: 2.1515.0
       concurrently: 7.6.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
       github-slugger: 1.5.0
@@ -60119,11 +60110,11 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
+  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39):
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.32)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
 
   postcss-less@3.1.4:
     dependencies:
@@ -60201,7 +60192,7 @@ snapshots:
       klona: 2.0.6
       postcss: 8.4.32
       semver: 7.6.3
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -60652,9 +60643,13 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
-  postcss-syntax@0.36.2(postcss@8.4.32):
+  postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39):
     dependencies:
-      postcss: 8.4.32
+      postcss: 7.0.39
+    optionalDependencies:
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39)
+      postcss-less: 3.1.4
+      postcss-scss: 2.1.1
 
   postcss-unique-selectors@4.0.1:
     dependencies:
@@ -61019,7 +61014,7 @@ snapshots:
   puppeteer-core@13.7.0(encoding@0.1.13):
     dependencies:
       cross-fetch: 3.1.5(encoding@0.1.13)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       devtools-protocol: 0.0.981744
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -61087,7 +61082,7 @@ snapshots:
   puppeteer@17.1.3(encoding@0.1.13):
     dependencies:
       cross-fetch: 3.1.5(encoding@0.1.13)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       devtools-protocol: 0.0.1036444
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -61340,7 +61335,7 @@ snapshots:
 
   react-docgen-typescript-plugin@1.0.5(typescript@5.7.2)(webpack@5.91.0):
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -61447,7 +61442,7 @@ snapshots:
 
   react-error-boundary@3.1.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.23.5
+      '@babel/runtime': 7.26.0
       react: 18.3.1
 
   react-fast-compare@3.2.2: {}
@@ -62616,7 +62611,7 @@ snapshots:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.69.5
 
@@ -62942,7 +62937,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -63120,7 +63115,7 @@ snapshots:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.0.2
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   source-map-resolve@0.5.3:
     dependencies:
@@ -63665,8 +63660,8 @@ snapshots:
 
   stylelint@13.13.1:
     dependencies:
-      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)
-      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)
+      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39))(postcss@7.0.39)
+      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39))(postcss@7.0.39)
       autoprefixer: 9.8.6
       balanced-match: 2.0.0
       chalk: 4.1.2
@@ -63692,7 +63687,7 @@ snapshots:
       micromatch: 4.0.7
       normalize-selector: 0.2.0
       postcss: 7.0.39
-      postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39)
       postcss-less: 3.1.4
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.1
@@ -63700,7 +63695,7 @@ snapshots:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.0.13
-      postcss-syntax: 0.36.2(postcss@8.4.32)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.32))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -63725,7 +63720,7 @@ snapshots:
       colord: 2.9.3
       cosmiconfig: 7.1.0
       css-functions-list: 3.2.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@5.5.0)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -65084,15 +65079,6 @@ snapshots:
       schema-utils: 1.0.0
       webpack: 5.89.0(@swc/core@1.3.100)(webpack-cli@4.10.0)
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@4.47.0(webpack-cli@3.3.12)))(webpack@4.47.0(webpack-cli@3.3.12)):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 4.47.0(webpack-cli@3.3.12)
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@4.47.0(webpack-cli@3.3.12))
-
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.70.0))(webpack@5.97.1):
     dependencies:
       loader-utils: 2.0.4
@@ -65101,6 +65087,15 @@ snapshots:
       webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.70.0)
+
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@4.47.0(webpack-cli@3.3.12)):
+    dependencies:
+      loader-utils: 2.0.4
+      mime-types: 2.1.35
+      schema-utils: 3.3.0
+      webpack: 4.47.0(webpack-cli@3.3.12)
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@4.47.0(webpack-cli@3.3.12))
 
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@5.89.0):
     dependencies:
@@ -65655,26 +65650,6 @@ snapshots:
     optionalDependencies:
       webpack-bundle-analyzer: 4.7.0
 
-  webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack@5.97.1):
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack@5.97.1)
-      colorette: 2.0.20
-      commander: 10.0.1
-      cross-spawn: 7.0.3
-      envinfo: 7.11.0
-      fastest-levenshtein: 1.0.16
-      import-local: 3.1.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-merge: 5.10.0
-    optionalDependencies:
-      webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
-
   webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -65689,11 +65664,11 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.1(webpack-cli@3.3.12)(webpack@5.70.0)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.91.0)
 
   webpack-cli@5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0):
     dependencies:
@@ -65724,15 +65699,6 @@ snapshots:
       webpack: 4.47.0(webpack-cli@3.3.12)
       webpack-log: 2.0.0
 
-  webpack-dev-middleware@5.3.3(webpack@5.70.0):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-      webpack: 5.70.0(@swc/core@1.3.100)(webpack-cli@3.3.12)
-
   webpack-dev-middleware@5.3.3(webpack@5.89.0(@swc/core@1.3.100)(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
@@ -65760,6 +65726,15 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
       webpack: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+
+  webpack-dev-middleware@5.3.3(webpack@5.97.1):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.3
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@6.1.1(webpack@5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)):
     dependencies:
@@ -65822,47 +65797,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.15.1(webpack-cli@3.3.12)(webpack@5.70.0):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.5
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.10
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.1.1
-      chokidar: 3.5.3
-      colorette: 2.0.20
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.2
-      graceful-fs: 4.2.11
-      html-entities: 2.4.0
-      http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.4)
-      ipaddr.js: 2.1.0
-      launch-editor: 2.6.1
-      open: 8.4.2
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.2.0
-      selfsigned: 2.4.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.70.0)
-      ws: 8.15.0
-    optionalDependencies:
-      webpack: 5.70.0(@swc/core@1.3.100)(webpack-cli@3.3.12)
-      webpack-cli: 3.3.12(webpack@5.70.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
   webpack-dev-server@4.15.1(webpack-cli@3.3.12)(webpack@5.89.0):
     dependencies:
       '@types/bonjour': 3.5.13
@@ -65905,7 +65839,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.91.0):
+  webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -65936,6 +65870,47 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 5.3.3(webpack@5.91.0)
+      ws: 8.15.0
+    optionalDependencies:
+      webpack: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.91.0):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.21
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.5
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.5.10
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.1.1
+      chokidar: 3.5.3
+      colorette: 2.0.20
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.18.2
+      graceful-fs: 4.2.11
+      html-entities: 2.4.0
+      http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.4)
+      ipaddr.js: 2.1.0
+      launch-editor: 2.6.1
+      open: 8.4.2
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.2.0
+      selfsigned: 2.4.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 5.3.3(webpack@5.97.1)
       ws: 8.15.0
     optionalDependencies:
       webpack: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
@@ -65976,11 +65951,11 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.70.0)
+      webpack-dev-middleware: 5.3.3(webpack@5.97.1)
       ws: 8.15.0
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.3.100)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.97.1)
+      webpack: 5.97.1(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
     transitivePeerDependencies:
       - bufferutil
       - debug

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
       '@woocommerce/expression-evaluation':
         specifier: workspace:*
         version: link:../expression-evaluation
+      '@woocommerce/settings':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@wordpress/block-editor':
         specifier: wp-6.6
         version: 13.0.7(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1589,7 +1592,7 @@ importers:
     dependencies:
       '@automattic/puppeteer-utils':
         specifier: github:Automattic/puppeteer-utils#0f3ec50
-        version: https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50
+        version: https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))
       '@woocommerce/api':
         specifier: ^0.2.0
         version: 0.2.0
@@ -3971,7 +3974,7 @@ importers:
         version: 4.9.2(@swc/core@1.3.100)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(file-loader@6.2.0(webpack@5.91.0))(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(node-notifier@8.0.2)(puppeteer-core@23.11.1)(puppeteer@17.1.3(encoding@0.1.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
       '@wordpress/editor':
         specifier: wp-6.7
-        version: 14.8.12(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.8.19(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: 5.22.0
         version: 5.22.0
@@ -7846,10 +7849,12 @@ packages:
   '@humanwhocodes/config-array@0.11.13':
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/config-array@0.5.0':
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -7857,9 +7862,11 @@ packages:
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/object-schema@2.0.1':
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@inquirer/checkbox@4.0.7':
     resolution: {integrity: sha512-lyoF4uYdBBTnqeB1gjPdYkiQ++fz/iYKaP9DON1ZGlldkvAEJsjaOBRdbl5UW1pOSslBRd701jxhAG0MlhHd2w==}
@@ -8432,6 +8439,7 @@ packages:
   '@oclif/screen@3.0.8':
     resolution: {integrity: sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==}
     engines: {node: '>=12.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@octokit/app@14.1.0':
     resolution: {integrity: sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==}
@@ -12347,8 +12355,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/editor@14.8.12':
-    resolution: {integrity: sha512-TSdtaGUTXaj57un5ckOeFXRvRXHCfsmesPwhgPevOyoG2zamWfvy8Gl2h0jsyFxX0kM3sCkxcdlI7W/bih/i6g==}
+  '@wordpress/editor@14.8.19':
+    resolution: {integrity: sha512-C70QtoP17Ya5rxPuHdlYlTdotzJA8UpIkKxFIcHCb3r1nK5MLrUZkwr8JBZEfyGSYR3fld64XVuW+OLunmSnRg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -12453,6 +12461,12 @@ packages:
 
   '@wordpress/fields@0.0.11':
     resolution: {integrity: sha512-ayb097rCW3FDINsjlnyynrW+1ieWxUivSjR5eue6nV//wJ2wPE0tZRbAhaviWhdqzeHjI4vok1ha4RHlTfC1cA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/fields@0.0.17':
+    resolution: {integrity: sha512-T029zG8C8gI91ddBdPRy30sTzoor1sMvtxrbYnKrqZy/VPWpeDjmX67KPTSwTEif/TiGHVaIVpmk/xQfAxE3dA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -13342,6 +13356,7 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -13429,6 +13444,7 @@ packages:
 
   airbnb-prop-types@2.16.0:
     resolution: {integrity: sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==}
+    deprecated: This package has been renamed to 'prop-types-tools'
     peerDependencies:
       react: ^0.14 || ^15.0.0 || ^16.0.0-alpha
 
@@ -13640,6 +13656,7 @@ packages:
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
@@ -15241,6 +15258,7 @@ packages:
 
   copy-concurrently@1.0.5:
     resolution: {integrity: sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==}
+    deprecated: This package is no longer supported.
 
   copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
@@ -16796,21 +16814,25 @@ packages:
   eslint@5.16.0:
     resolution: {integrity: sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==}
     engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@6.7.2:
     resolution: {integrity: sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
     engines: {node: ^10.12.0 || >=12.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@8.55.0:
     resolution: {integrity: sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@5.0.1:
@@ -17115,6 +17137,7 @@ packages:
 
   figgy-pudding@3.5.2:
     resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
 
   figlet@1.7.0:
     resolution: {integrity: sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==}
@@ -17559,6 +17582,7 @@ packages:
 
   fs-write-stream-atomic@1.0.10:
     resolution: {integrity: sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==}
+    deprecated: This package is no longer supported.
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -17601,6 +17625,7 @@ packages:
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -17765,12 +17790,15 @@ packages:
 
   glob@7.1.3:
     resolution: {integrity: sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -18576,6 +18604,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -20436,6 +20465,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -20478,6 +20508,7 @@ packages:
 
   lodash.template@4.5.0:
     resolution: {integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==}
+    deprecated: This package is deprecated. Use https://socket.dev/npm/package/eta instead.
 
   lodash.templatesettings@4.2.0:
     resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
@@ -21140,6 +21171,7 @@ packages:
 
   move-concurrently@1.0.1:
     resolution: {integrity: sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==}
+    deprecated: This package is no longer supported.
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -21497,10 +21529,12 @@ packages:
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   nth-check@1.0.2:
     resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
@@ -21709,6 +21743,7 @@ packages:
 
   osenv@0.1.5:
     resolution: {integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==}
+    deprecated: This package is no longer supported.
 
   p-all@2.1.0:
     resolution: {integrity: sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==}
@@ -23045,12 +23080,12 @@ packages:
   puppeteer@17.1.3:
     resolution: {integrity: sha512-tVtvNSOOqlq75rUgwLeDAEQoLIiBqmRg0/zedpI6fuqIocIkuxG23A7FIl1oVSkuSMMLgcOP5kVhNETmsmjvPw==}
     engines: {node: '>=14.1.0'}
-    deprecated: < 21.3.7 is no longer supported
+    deprecated: < 22.8.2 is no longer supported
 
   puppeteer@2.1.1:
     resolution: {integrity: sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==}
     engines: {node: '>=8.16.0'}
-    deprecated: < 21.3.7 is no longer supported
+    deprecated: < 22.8.2 is no longer supported
 
   pure-rand@6.0.4:
     resolution: {integrity: sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==}
@@ -23058,6 +23093,10 @@ packages:
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qqjs@0.3.11:
     resolution: {integrity: sha512-pB2X5AduTl78J+xRSxQiEmga1jQV0j43jOPs/MTgTLApGFEOn6NgdE2dEjp7nvDtjkIOZbvFIojAiYUx6ep3zg==}
@@ -23569,6 +23608,7 @@ packages:
   read-package-json@6.0.4:
     resolution: {integrity: sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    deprecated: This package is no longer supported. Please use @npmcli/package-json instead.
 
   read-pkg-up@1.0.1:
     resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}
@@ -25016,11 +25056,12 @@ packages:
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@8.1.2:
     resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
     engines: {node: '>=6.4.0 <13 || >=14'}
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superjson@1.13.3:
     resolution: {integrity: sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==}
@@ -26838,6 +26879,7 @@ packages:
 
   xterm@3.14.5:
     resolution: {integrity: sha512-DVmQ8jlEtL+WbBKUZuMxHMBgK/yeIZwkXB81bH+MGaKKnJGYwA+770hzhXPfwEIokK9On9YIFPRleVp/5G7z9g==}
+    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
 
   y-indexeddb@9.0.12:
     resolution: {integrity: sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==}
@@ -27209,25 +27251,6 @@ snapshots:
       - supports-color
 
   '@automattic/material-design-icons@1.0.0': {}
-
-  '@automattic/puppeteer-utils@https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50':
-    dependencies:
-      '@babel/cli': 7.23.4(@babel/core@7.23.5)
-      '@babel/core': 7.23.5
-      '@babel/preset-env': 7.23.5(@babel/core@7.23.5)
-      '@slack/web-api': 5.15.0
-      '@wordpress/e2e-test-utils': 3.0.0(jest@24.9.0)(puppeteer@2.1.1)
-      config: 3.3.7
-      eslint: 6.7.2
-      jest: 24.9.0
-      prettier: wp-prettier@1.19.1
-      puppeteer: 2.1.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - react-native
-      - supports-color
-      - utf-8-validate
 
   '@automattic/puppeteer-utils@https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))':
     dependencies:
@@ -34361,7 +34384,9 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@jest/reporters@25.5.1':
     dependencies:
@@ -41572,7 +41597,7 @@ snapshots:
 
   '@woocommerce/e2e-environment@0.3.0(@babel/core@7.23.5)(react@18.3.1)':
     dependencies:
-      '@automattic/puppeteer-utils': https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50
+      '@automattic/puppeteer-utils': https://codeload.github.com/Automattic/puppeteer-utils/tar.gz/0f3ec50(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))
       '@jest/test-sequencer': 25.5.4
       '@slack/web-api': 6.10.0
       '@woocommerce/api': 0.2.0
@@ -43736,18 +43761,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@wordpress/e2e-test-utils@3.0.0(jest@24.9.0)(puppeteer@2.1.1)':
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@wordpress/keycodes': 2.19.3
-      '@wordpress/url': 2.22.2(react-native@0.73.0(@babel/core@7.23.5)(@babel/preset-env@7.25.7(@babel/core@7.23.5))(encoding@0.1.13)(react@18.3.1))
-      jest: 24.9.0
-      lodash: 4.17.21
-      node-fetch: 1.7.3
-      puppeteer: 2.1.1
-    transitivePeerDependencies:
-      - react-native
-
   '@wordpress/e2e-test-utils@3.0.0(jest@24.9.0)(puppeteer@2.1.1)(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -43777,7 +43790,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.5
       '@wordpress/keycodes': 2.19.3
-      '@wordpress/url': 2.22.2(react-native@0.73.0(@babel/core@7.23.5)(@babel/preset-env@7.25.7(@babel/core@7.23.5))(encoding@0.1.13)(react@18.3.1))
+      '@wordpress/url': 2.22.2(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))
       jest: 29.7.0(@types/node@22.9.1)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       lodash: 4.17.21
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -43790,7 +43803,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.5
       '@wordpress/keycodes': 2.19.3
-      '@wordpress/url': 2.22.2(react-native@0.73.0(@babel/core@7.23.5)(@babel/preset-env@7.25.7(@babel/core@7.23.5))(encoding@0.1.13)(react@18.3.1))
+      '@wordpress/url': 2.22.2(react-native@0.73.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7(@babel/core@7.12.9))(encoding@0.1.13)(react@18.3.1))
       jest: 25.5.4
       lodash: 4.17.21
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -44204,7 +44217,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/editor@14.8.12(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/editor@14.8.19(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 4.10.0
@@ -44222,7 +44235,7 @@ snapshots:
       '@wordpress/deprecated': 4.10.0
       '@wordpress/dom': 4.10.0
       '@wordpress/element': 6.10.0
-      '@wordpress/fields': 0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/fields': 0.0.17(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/hooks': 4.10.0
       '@wordpress/html-entities': 4.10.0
       '@wordpress/i18n': 5.10.0
@@ -44581,39 +44594,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@wordpress/fields@0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@wordpress/blob': 4.10.0
-      '@wordpress/blocks': 13.10.0(react@18.3.1)
-      '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.10.0(react@18.3.1)
-      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
-      '@wordpress/dataviews': 4.12.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.10.0
-      '@wordpress/hooks': 4.10.0
-      '@wordpress/html-entities': 4.10.0
-      '@wordpress/i18n': 5.10.0
-      '@wordpress/icons': 10.11.0
-      '@wordpress/notices': 5.15.1(react@18.3.1)
-      '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.11.0(react@18.3.1)
-      '@wordpress/private-apis': 1.10.0
-      '@wordpress/url': 4.10.0
-      '@wordpress/warning': 3.10.0
-      change-case: 4.1.2
-      client-zip: 2.4.5
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - bufferutil
-      - react-dom
-      - supports-color
-      - utf-8-validate
-
   '@wordpress/fields@0.0.11(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -44635,6 +44615,39 @@ snapshots:
       '@wordpress/private-apis': 1.10.0
       '@wordpress/url': 4.10.0
       '@wordpress/warning': 3.10.0
+      change-case: 4.1.2
+      client-zip: 2.4.5
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - bufferutil
+      - react-dom
+      - supports-color
+      - utf-8-validate
+
+  '@wordpress/fields@0.0.17(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@wordpress/blob': 4.10.0
+      '@wordpress/blocks': 13.10.0(react@18.3.1)
+      '@wordpress/components': 28.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.16.0(react@18.3.1)
+      '@wordpress/core-data': 7.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
+      '@wordpress/dataviews': 4.12.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.16.0
+      '@wordpress/hooks': 4.16.0
+      '@wordpress/html-entities': 4.16.0
+      '@wordpress/i18n': 5.16.0
+      '@wordpress/icons': 10.11.0
+      '@wordpress/notices': 5.15.1(react@18.3.1)
+      '@wordpress/patterns': 2.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/primitives': 4.11.0(react@18.3.1)
+      '@wordpress/private-apis': 1.16.0
+      '@wordpress/url': 4.10.0
+      '@wordpress/warning': 3.16.0
       change-case: 4.1.2
       client-zip: 2.4.5
       react: 18.3.1
@@ -55843,7 +55856,9 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   jest-jasmine2@25.5.4:
     dependencies:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes some of the deprecation messages displayed in the product editor.
The biggest one being the use of `__experimentalRole`, which has been stabilized to `role` ( see https://make.wordpress.org/core/2024/10/20/miscellaneous-block-editor-changes-in-wordpress-6-7/#stabilized-role-property-for-block-attributes )

Closes #55630

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and spin up a WordPress site with version 6.6 or below
2. Enable the new product editor under **WooCommerce > Settings > Advanced > Features**
3. Go to **Products > Add New** and open your `console`
4. Run something like `wp.blocks.getBlockType('woocommerce/product-text-area-field');` and expand the `attributes` key.
5. The `woocommerce/product-text-area-field` should have a label attribute with the `__experimentalRole` value set to `content`, same goes for the `_templateBlockId` and related attributes.
6. You can look at a couple of the other block names as well like the `woocommerce/product-name-field` block.
7. There should be no warning in the console around `__experimentalRole` being deprecated.
8. Make some changes in the product editor like adding a name, price and attributes ( this should work correctly, without any visual defects ).
9. Update your WordPress site to 6.7
10. And edit a product or go to **Products > Add New**, loading the block based product editor.
11. There should be no warning in the console around `__experimentalRole` being deprecated.
12. Run something like `wp.blocks.getBlockType('woocommerce/product-text-area-field');` and expand the `attributes` key ( similar as above ).
13. The `woocommerce/product-text-area-field` should have a label attribute with the `role` value set to `content`, same goes for the `_templateBlockId` and related attributes ( **note** the difference, where we use `role` now below WP 6.7 we use `__experimentalRole` )
14. There should also be no warnings around:
     - The deprecated use of `position` within tooltips
     - Importing `select` from the `@wordpress/data-controls` package
     - Importing `__experimentalGetSettings`
15. Focus on the **summary** and **description** fields and make sure the toolbar doesn't allow you to move or drag the blocks.
Before:
<img width="419" alt="Screenshot 2025-02-19 at 3 52 01 PM" src="https://github.com/user-attachments/assets/0729a2f8-0b87-4f1c-8d7f-240a193ed8b0" />
After:
<img width="412" alt="Screenshot 2025-02-19 at 3 51 40 PM" src="https://github.com/user-attachments/assets/8c56836a-cca1-48e2-80c1-1d54e8cef02b" />

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
