### PR TITLE
Marketplace: update notices and bubbles

### DIFF
--- a/plugins/woocommerce/changelog/55657-update-23241-marketplace-notices
+++ b/plugins/woocommerce/changelog/55657-update-23241-marketplace-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update notices and badges for WooCommerce.com Update Manager

--- a/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
@@ -441,7 +441,9 @@ export default function Content(): JSX.Element {
 			<InstallNewProductModal products={ filteredProducts } />
 			{ selectedTab !== 'business-services' &&
 				selectedTab !== 'my-subscriptions' && <ConnectNotice /> }
-			{ selectedTab === 'my-subscriptions' && <PluginInstallNotice /> }
+			{ selectedTab !== 'business-services' && (
+				<PluginInstallNotice selectedTab={ selectedTab } />
+			) }
 			{ selectedTab !== 'business-services' && (
 				<SubscriptionsExpiredExpiringNotice type="expired" />
 			) }

--- a/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/content/content.tsx
@@ -441,7 +441,7 @@ export default function Content(): JSX.Element {
 			<InstallNewProductModal products={ filteredProducts } />
 			{ selectedTab !== 'business-services' &&
 				selectedTab !== 'my-subscriptions' && <ConnectNotice /> }
-			{ selectedTab !== 'business-services' && <PluginInstallNotice /> }
+			{ selectedTab === 'my-subscriptions' && <PluginInstallNotice /> }
 			{ selectedTab !== 'business-services' && (
 				<SubscriptionsExpiredExpiringNotice type="expired" />
 			) }

--- a/plugins/woocommerce/client/admin/client/marketplace/components/woo-update-manager-plugin/plugin-install-notice.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/woo-update-manager-plugin/plugin-install-notice.tsx
@@ -14,10 +14,21 @@ import {
 } from '../constants';
 import './woo-update-manager-plugin.scss';
 
-export default function PluginInstallNotice() {
+export default function PluginInstallNotice( props: { selectedTab: string } ) {
 	const wccomSettings = getAdminSetting( 'wccomHelper', {} );
+
 	if ( ! wccomSettings?.isConnected ) {
 		return null;
+	}
+
+	const { selectedTab } = props;
+
+	// If we're not on the my subscriptions tab...
+	if ( selectedTab !== 'my-subscriptions' ) {
+		// And the my subscriptions tab has been visited in the past, don't show the notice.
+		if ( wccomSettings?.mySubscriptionsTabLoaded ) {
+			return null;
+		}
 	}
 
 	if (

--- a/plugins/woocommerce/client/admin/client/marketplace/components/woo-update-manager-plugin/woo-update-manager-plugin.scss
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/woo-update-manager-plugin/woo-update-manager-plugin.scss
@@ -35,6 +35,8 @@
 		}
 
 		.components-notice__buttons {
+			display: flex;
+			gap: 8px;
 			margin-top: 12px;
 		}
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -75,6 +75,7 @@ class WC_Helper_Admin {
 			'storeCountry'               => wc_get_base_location()['country'],
 			'inAppPurchaseURLParams'     => WC_Admin_Addons::get_in_app_purchase_url_params(),
 			'installedProducts'          => $installed_products,
+			'mySubscriptionsTabLoaded'   => WC_Helper_Options::get( 'my_subscriptions_tab_loaded' ),
 			'wooUpdateManagerInstalled'  => WC_Woo_Update_Manager_Plugin::is_plugin_installed(),
 			'wooUpdateManagerActive'     => WC_Woo_Update_Manager_Plugin::is_plugin_active(),
 			'wooUpdateManagerInstallUrl' => WC_Woo_Update_Manager_Plugin::generate_install_url(),

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
@@ -125,8 +125,9 @@ class WC_Helper_Subscriptions_API {
 	 * as JSON.
 	 */
 	public static function get_subscriptions() {
-		if ( ! WC_Helper_Options::get( 'my_subscriptions_tab_loaded' ) ) {
-			WC_Helper_Options::update( 'my_subscriptions_tab_loaded', date('Y-m-d H:i:s') );
+		// If the site is connected, mark the time when the my subscriptions tab is first loaded.
+		if ( WC_Helper::is_site_connected() === true && empty( WC_Helper_Options::get( 'my_subscriptions_tab_loaded' ) ) ) {
+			WC_Helper_Options::update( 'my_subscriptions_tab_loaded', date( 'Y-m-d H:i:s' ) );
 		}
 
 		$subscriptions = WC_Helper::get_subscription_list_data();

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
@@ -125,6 +125,10 @@ class WC_Helper_Subscriptions_API {
 	 * as JSON.
 	 */
 	public static function get_subscriptions() {
+		if ( ! WC_Helper_Options::get( 'my_subscriptions_tab_loaded' ) ) {
+			WC_Helper_Options::update( 'my_subscriptions_tab_loaded', date('Y-m-d H:i:s') );
+		}
+
 		$subscriptions = WC_Helper::get_subscription_list_data();
 		wp_send_json(
 			array_values(

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -775,7 +775,7 @@ class WC_Helper_Updater {
 	 */
 	public static function get_updates_count_html() {
 		$count      = self::get_updates_count_based_on_site_status();
-		$count_html = sprintf( '<span class="update-plugins count-%d"><span class="update-count">%d</span></span>', $count, number_format_i18n( $count ) );
+		$count_html = sprintf( ' <span class="update-plugins count-%d"><span class="update-count">%d</span></span>', $count, number_format_i18n( $count ) );
 
 		return $count_html;
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1808,10 +1808,6 @@ class WC_Helper {
 		// Break the by-ref.
 		unset( $subscription );
 
-		if ( ! WC_Helper_Options::get( 'my_subscriptions_tab_loaded' ) ) {
-			WC_Helper_Options::update( 'my_subscriptions_tab_loaded', date('Y-m-d H:i:s') );
-		}
-
 		return $subscriptions;
 	}
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1808,6 +1808,10 @@ class WC_Helper {
 		// Break the by-ref.
 		unset( $subscription );
 
+		if ( ! WC_Helper_Options::get( 'my_subscriptions_tab_loaded' ) ) {
+			WC_Helper_Options::update( 'my_subscriptions_tab_loaded', date('Y-m-d H:i:s') );
+		}
+
 		return $subscriptions;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Marketplace.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketplace.php
@@ -7,14 +7,13 @@ namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use WC_Helper_Options;
 use WC_Helper_Updater;
-use WC_Woo_Update_Manager_Plugin;
 
 /**
  * Contains backend logic for the Marketplace feature.
  */
 class Marketplace {
-
 	const MARKETPLACE_TAB_SLUG = 'woo';
 
 	/**
@@ -52,7 +51,8 @@ class Marketplace {
 			return;
 		}
 
-		$marketplace_pages = self::get_marketplace_pages();
+		$marketplace_pages = $this->get_marketplace_pages();
+
 		foreach ( $marketplace_pages as $marketplace_page ) {
 			if ( ! is_null( $marketplace_page ) ) {
 				wc_admin_register_page( $marketplace_page );
@@ -63,12 +63,12 @@ class Marketplace {
 	/**
 	 * Get report pages.
 	 */
-	public static function get_marketplace_pages() {
+	public function get_marketplace_pages() {
 		$marketplace_pages = array(
 			array(
 				'id'         => 'woocommerce-marketplace',
 				'parent'     => 'woocommerce',
-				'title'      => __( 'Extensions', 'woocommerce' ) . WC_Helper_Updater::get_updates_count_html(),
+				'title'      => __( 'Extensions', 'woocommerce' ) . $this->badge(),
 				'page_title' => __( 'Extensions', 'woocommerce' ),
 				'path'       => '/extensions',
 			),
@@ -80,6 +80,16 @@ class Marketplace {
 		 * @since 8.0
 		 */
 		return apply_filters( 'woocommerce_marketplace_menu_items', $marketplace_pages );
+	}
+
+	private function badge(): string {
+		$option = WC_Helper_Options::get( 'my_subscriptions_tab_loaded' );
+
+		if ( ! $option ) {
+			return WC_Helper_Updater::get_updates_count_html();
+		}
+
+		return '';
 	}
 
 	/**
@@ -160,4 +170,5 @@ class Marketplace {
 		</style>
 		<?php
 	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/23241.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout **trunk** and get a new build
2. Connect your store to WooCommerce.com but please uninstall WooCommerce.com Update Manager.
3. Checkout this branch and get a new build
4. First, visit the WooCommerce homepage: http://localhost:8888/wp-admin/admin.php?page=wc-admin
5. Confirm you see the **1** badge next to the **Extensions** submenu
6. Visit Discover, Extensions and Themes tabs. Confirm all have the WUM notice.
    - Visit Business services tab too to confirm it's **not** appearing there. 
8. Visit [My Subscriptions tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions) and then refresh the page
    - At this point we set  `my_subscriptions_tab_loaded` using `WC_Helper_Options::update`
    - To see the data structure, please do `cd plugins/woocommerce && nvm use && pnpm -- wp-env run cli wp option get woocommerce_helper_data`
    - If you'd like to set it to null, `cd plugins/woocommerce && nvm use && pnpm -- wp-env run cli wp shell` and then `WC_Helper_Options::update('my_subscriptions_tab_loaded', null);`. 
    - If you'd like to delete the key fully, again in `wp shell` run:
    ```
    $data = get_option( 'woocommerce_helper_data', array() );
    unset( $data['my_subscriptions_tab_loaded'] );
    update_option( 'woocommerce_helper_data', $data );
    ```
9. Confirm you no longer see the badge next to the **Extensions** submenu
10. Confirm you see a notice starting with "Please install the WooCommerce.com Update Manager" in the My Subscriptions tab.
11. Visit Discover, Extensions, Themes and Business Services tab and confirm you don't see the WooCommerce.com Update Manager notice.  
12. Delete the `my_subscriptions_tab_loaded` Helper option (following the command snippets in step 6). 
13. Load the Extensions page and confirm you see the notice again. On the notice, click the **download** button to download the ZIP. Manually update the plugin file but please don't activate it. 
14. Visit the Extensions tab again and confirm the notice is still up but with a different message, urging to activate it. 
15. Activate WUM and visit the Extensions tab again. Confirm you don't get a notice on the page and there is no bubble next to the Extensions sub menu item.
17. Please test around this issue

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Update notices and badges for WooCommerce.com Update Manager
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
