### PR TITLE
Deprecate the obsolete WC_Log_Handler_File class and related functionality

### DIFF
--- a/plugins/woocommerce/changelog/fix-44736-logger-deprecations
+++ b/plugins/woocommerce/changelog/fix-44736-logger-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Deprecate the obsolete file logging class WC_Log_Handler_File in favor of the newer LogHandlerFileV2

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -116,8 +116,15 @@ class WC_Admin_Status {
 
 	/**
 	 * Show the log page contents for file log handler.
+	 *
+	 * @deprecated 9.8.0
 	 */
 	public static function status_logs_file() {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0'
+		);
+
 		$logs = self::scan_log_files();
 
 		if ( ! empty( $_REQUEST['log_file'] ) && isset( $logs[ sanitize_title( wp_unslash( $_REQUEST['log_file'] ) ) ] ) ) { // WPCS: input var ok, CSRF ok.
@@ -192,10 +199,17 @@ class WC_Admin_Status {
 	/**
 	 * Return the log file handle.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @param string $filename Filename to get the handle for.
 	 * @return string
 	 */
 	public static function get_log_file_handle( $filename ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0'
+		);
+
 		return substr( $filename, 0, strlen( $filename ) > 48 ? strlen( $filename ) - 48 : strlen( $filename ) - 4 );
 	}
 
@@ -232,9 +246,16 @@ class WC_Admin_Status {
 	/**
 	 * Scan the log files.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @return array
 	 */
 	public static function scan_log_files() {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0'
+		);
+
 		return WC_Log_Handler_File::get_log_files();
 	}
 
@@ -299,8 +320,15 @@ class WC_Admin_Status {
 
 	/**
 	 * Remove/delete the chosen file.
+	 *
+	 * @deprecated 9.8.0
 	 */
 	public static function remove_log() {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0'
+		);
+
 		if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'remove_log' ) ) { // WPCS: input var ok, sanitization ok.
 			wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 		}

--- a/plugins/woocommerce/includes/class-wc-logger.php
+++ b/plugins/woocommerce/includes/class-wc-logger.php
@@ -126,14 +126,23 @@ class WC_Logger implements WC_Logger_Interface {
 	 * Add a log entry.
 	 *
 	 * This is not the preferred method for adding log messages. Please use log() or any one of
-	 * the level methods (debug(), info(), etc.). This method may be deprecated in the future.
+	 * the level methods (debug(), info(), etc.).
+	 *
+	 * @deprecated 9.8.0
 	 *
 	 * @param string $handle File handle.
 	 * @param string $message Message to log.
 	 * @param string $level Logging level.
+	 *
 	 * @return bool
 	 */
 	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			self::class . '::log'
+		);
+
 		$message = apply_filters( 'woocommerce_logger_add_message', $message, $handle );
 		$this->log(
 			$level,
@@ -144,6 +153,7 @@ class WC_Logger implements WC_Logger_Interface {
 			)
 		);
 		wc_do_deprecated_action( 'woocommerce_log_add', array( $handle, $message ), '3.0', 'This action has been deprecated with no alternative.' );
+
 		return true;
 	}
 

--- a/plugins/woocommerce/includes/log-handlers/class-wc-log-handler-file.php
+++ b/plugins/woocommerce/includes/log-handlers/class-wc-log-handler-file.php
@@ -6,6 +6,8 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
 use Automattic\WooCommerce\Utilities\LoggingUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -14,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Handles log entries by writing to a file.
+ *
+ * @deprecated 9.8.0 Use LogHandlerFileV2 instead.
  *
  * @class          WC_Log_Handler_File
  * @version        1.0.0
@@ -76,6 +80,8 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Handle a log entry.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @param int    $timestamp Log timestamp.
 	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
 	 * @param string $message Log message.
@@ -90,6 +96,11 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	 * @return bool False if value was not handled and true if value was handled.
 	 */
 	public function handle( $timestamp, $level, $message, $context ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			LogHandlerFileV2::class . '::handle',
+		);
 
 		if ( isset( $context['source'] ) && $context['source'] ) {
 			$handle = $context['source'];
@@ -221,11 +232,19 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Clear entries from chosen file.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @param string $handle Log handle.
 	 *
 	 * @return bool
 	 */
 	public function clear( $handle ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			LogHandlerFileV2::class . '::clear',
+		);
+
 		$result = false;
 
 		// Close the file if it's already open.
@@ -247,11 +266,19 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Remove/delete the chosen file.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @param string $handle Log handle.
 	 *
 	 * @return bool
 	 */
 	public function remove( $handle ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			FileController::class . '::delete_files'
+		);
+
 		$removed       = false;
 		$logs          = $this->get_log_files();
 		$log_directory = LoggingUtil::get_log_directory();
@@ -347,10 +374,17 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Get a log file path.
 	 *
+	 * @deprecated 9.8.0 Download files via the Logs screen in WP Admin instead.
+	 *
 	 * @param string $handle Log name.
 	 * @return bool|string The log file path or false if path cannot be determined.
 	 */
 	public static function get_log_file_path( $handle ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0'
+		);
+
 		$log_directory = LoggingUtil::get_log_directory();
 
 		if ( function_exists( 'wp_hash' ) ) {
@@ -366,11 +400,19 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	 *
 	 * File names consist of the handle, followed by the date, followed by a hash, .log.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @since 3.3
 	 * @param string $handle Log name.
 	 * @return bool|string The log file name or false if cannot be determined.
 	 */
 	public static function get_log_file_name( $handle ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			LoggingUtil::class . '::generate_log_file_id',
+		);
+
 		if ( function_exists( 'wp_hash' ) ) {
 			$date_suffix = date( 'Y-m-d', time() );
 			$hash_suffix = wp_hash( $handle );
@@ -406,10 +448,18 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Delete all logs older than a defined timestamp.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @since 3.4.0
 	 * @param integer $timestamp Timestamp to delete logs before.
 	 */
 	public static function delete_logs_before_timestamp( $timestamp = 0 ) {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			LogHandlerFileV2::class . '::delete_logs_before_timestamp',
+		);
+
 		if ( ! $timestamp ) {
 			return;
 		}
@@ -429,10 +479,18 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Get all log files in the log directory.
 	 *
+	 * @deprecated 9.8.0
+	 *
 	 * @since 3.4.0
 	 * @return array
 	 */
 	public static function get_log_files() {
+		wc_deprecated_function(
+			__METHOD__,
+			'9.8.0',
+			FileController::class . '::get_files'
+		);
+
 		$log_directory = LoggingUtil::get_log_directory();
 
 		$files  = @scandir( $log_directory ); // @codingStandardsIgnoreLine.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This officially deprecates the old log file handler that was made obsolete last year with the introduction of the `LogHandlerFileV2` class. It also deprecates the `add` method in `WC_Logger`, which has had a note in its doc block for several years saying "This method may be deprecated in the future". We're finally doing it.

Fixes #44736

### How to test the changes in this Pull Request:

TBD