### PR TITLE
Allow WC_Email subclasses to access transient values

### DIFF
--- a/plugins/woocommerce/changelog/55665-email-transient-protected
+++ b/plugins/woocommerce/changelog/55665-email-transient-protected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Allow WC_Email subclasses to access transient values

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1369,7 +1369,7 @@ class WC_Email extends WC_Settings_API {
 	 * @param string $key Option key.
 	 * @param mixed  $empty_value Value to use when option is empty.
 	 */
-	private function get_option_or_transient( string $key, $empty_value = null ) {
+	protected function get_option_or_transient( string $key, $empty_value = null ) {
 		$option = $this->get_option( $key, $empty_value );
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55665.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check that subclasses of `WC_Email` can access the `get_option_or_transient` method.

<!-- End testing instructions -->
