### PR TITLE
Fix apostrophes not correctly rendered in Checkout block saved addresses

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -24,6 +24,7 @@ import { AddressFormValues, ContactFormValues } from '@woocommerce/settings';
 import { objectHasProp } from '@woocommerce/types';
 import { useCheckoutAddress } from '@woocommerce/base-context';
 import fastDeepEqual from 'fast-deep-equal/es6';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -356,7 +357,9 @@ const Form = < T extends AddressFormValues | ContactFormValues >( {
 						type={ field.type }
 						ariaDescribedBy={ ariaDescribedBy }
 						value={
-							( values[ field.key as keyof T ] as string ) || ''
+							decodeEntities(
+								values[ field.key as keyof T ] as string
+							) || ''
 						}
 						onChange={ ( newValue: string ) =>
 							onChange( {

--- a/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -12,6 +12,7 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import { formatAddress } from '@woocommerce/blocks/checkout/utils';
 import { Button } from '@ariakit/react';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -60,13 +61,15 @@ const AddressCard = ( {
 		<div className="wc-block-components-address-card">
 			<address>
 				<span className="wc-block-components-address-card__address-section">
-					{ formattedName }
+					{ decodeEntities( formattedName ) }
 				</span>
 				<div className="wc-block-components-address-card__address-section">
 					{ formattedAddress
 						.filter( ( field ) => !! field )
 						.map( ( field, index ) => (
-							<span key={ `address-` + index }>{ field }</span>
+							<span key={ `address-` + index }>
+								{ decodeEntities( field ) }
+							</span>
 						) ) }
 				</div>
 				{ address.phone ? (

--- a/plugins/woocommerce-blocks/assets/js/data/cart/selectors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/selectors.ts
@@ -8,11 +8,8 @@ import type {
 	CartItem,
 	CartShippingRate,
 	ApiErrorResponse,
-	CartShippingAddress,
-	CartBillingAddress,
 } from '@woocommerce/types';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -35,26 +32,9 @@ export const getCustomerData = (
 	shippingAddress: ShippingAddress;
 	billingAddress: BillingAddress;
 } => {
-	const decodedShippingAddress = {} as ShippingAddress;
-	const decodedBillingAddress = {} as BillingAddress;
-	Object.keys( state.cartData.shippingAddress ).forEach( ( key ) => {
-		decodedShippingAddress[ key as keyof CartShippingAddress ] =
-			decodeEntities(
-				state.cartData.shippingAddress[
-					key as keyof CartShippingAddress
-				]
-			);
-	} );
-	Object.keys( state.cartData.billingAddress ).forEach( ( key ) => {
-		decodedBillingAddress[ key as keyof CartBillingAddress ] =
-			decodeEntities(
-				state.cartData.billingAddress[ key as keyof CartBillingAddress ]
-			);
-	} );
-
 	return {
-		shippingAddress: decodedShippingAddress,
-		billingAddress: decodedBillingAddress,
+		shippingAddress: state.cartData.shippingAddress,
+		billingAddress: state.cartData.billingAddress,
 	};
 };
 

--- a/plugins/woocommerce-blocks/assets/js/data/cart/selectors.ts
+++ b/plugins/woocommerce-blocks/assets/js/data/cart/selectors.ts
@@ -8,8 +8,11 @@ import type {
 	CartItem,
 	CartShippingRate,
 	ApiErrorResponse,
+	CartShippingAddress,
+	CartBillingAddress,
 } from '@woocommerce/types';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -32,9 +35,26 @@ export const getCustomerData = (
 	shippingAddress: ShippingAddress;
 	billingAddress: BillingAddress;
 } => {
+	const decodedShippingAddress = {} as ShippingAddress;
+	const decodedBillingAddress = {} as BillingAddress;
+	Object.keys( state.cartData.shippingAddress ).forEach( ( key ) => {
+		decodedShippingAddress[ key as keyof CartShippingAddress ] =
+			decodeEntities(
+				state.cartData.shippingAddress[
+					key as keyof CartShippingAddress
+				]
+			);
+	} );
+	Object.keys( state.cartData.billingAddress ).forEach( ( key ) => {
+		decodedBillingAddress[ key as keyof CartBillingAddress ] =
+			decodeEntities(
+				state.cartData.billingAddress[ key as keyof CartBillingAddress ]
+			);
+	} );
+
 	return {
-		shippingAddress: state.cartData.shippingAddress,
-		billingAddress: state.cartData.billingAddress,
+		shippingAddress: decodedShippingAddress,
+		billingAddress: decodedBillingAddress,
 	};
 };
 

--- a/plugins/woocommerce/changelog/fix-53622-checkout-address-apostrophes
+++ b/plugins/woocommerce/changelog/fix-53622-checkout-address-apostrophes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix apostrophes not correctly rendered in Checkout block saved addresses


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53622.

This PR makes it so we decode the address fields before printing them to the screen.

The contents returned by [`getCustomerData()`](https://github.com/woocommerce/woocommerce/blob/4e425ab9145eb8a01456aea9d401307114d17a45/plugins/woocommerce-blocks/assets/js/data/cart/selectors.ts#L29) might or might not be encoded. Currently, when they are first hydrated from the backend values printed on the markup, they are encoded, but they are decoded once the user interacts with the form. I think in the long term it would be good to unify that and make sure the store always contains data either encoded or decoded. This PR doesn't fix that and simply decodes it just in case.

### How to test the changes in this Pull Request:

1. Make a purchase, adding apostrophes to as many fields as you can. Make sure to use the `'` character, instead of `’`.

<img src="https://github.com/user-attachments/assets/13f00d6b-6e5e-4dad-b2c1-b683be937ab0" alt="" width="462" />

2. Proceed with the checkout and go back to the Shop page, add another product to cart and go to the Checkout page again.
3. Verify the saved address displays the address with `'` instead of `&#8217;`.

Before | After
--- | ---
![Captura de pantalla de 2025-02-20 10-23-57](https://github.com/user-attachments/assets/9f8d499a-0d8d-4e42-a3c2-9d7e3de7740a) | ![Captura de pantalla de 2025-02-20 10-13-42](https://github.com/user-attachments/assets/fea51d19-8f67-451a-9c28-4828744e4572)