### PR TITLE
Add WC_VERSION input to the on-demand job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
         default: 'default'
         type: string
       wc-version:
-        description: 'Specific WooCommerce version to test against.'
+        description: 'Specific WooCommerce version to install by the test jobs supporting it'
         required: false
         type: string
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ on:
         required: true
         default: 'default'
         type: string
+      wc-version:
+        description: 'Specific WooCommerce version to test against.'
+        required: false
+        type: string
 
 concurrency:
   # Cancel concurrent jobs but not for push event. For push use the run_id to have a unique group.
@@ -228,6 +232,7 @@ jobs:
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }} # required by Metrics tests
           LAST_FAILED_RUN: ${{ vars.LAST_FAILED_RUN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          WC_VERSION: ${{ inputs.wc-version }}
         run: |
           lastRunFile="${{ steps.download-last-run-info.outputs.download-path }}/last-run__${{ strategy.job-index }}/.last-run.json"
           lastRunFileDest="$ARTIFACTS_PATH/.last-run.json"

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -21,7 +21,7 @@ on:
         required: false
       wc-version:
         type: string
-        description: 'If you want to test against a specific WC version, provide it here. Available versions: https://github.com/woocommerce/woocommerce/releases'
+        description: 'Optional. Only for `on-demand` or `custom` triggers. Most jobs (wp-env) ignore this. Available WC versions: https://github.com/woocommerce/woocommerce/releases'
         required: false
 
 jobs:

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -19,6 +19,10 @@ on:
         type: string
         description: 'Custom event name: In case the `Event name` choice is `custom`, this field is required.'
         required: false
+      wc-version:
+        type: string
+        description: 'If you want to test against a specific WC version, provide it here. Available versions: https://github.com/woocommerce/woocommerce/releases'
+        required: false
 
 jobs:
   validate-input:
@@ -36,4 +40,5 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       trigger: ${{ inputs.trigger == 'custom' && inputs.custom-trigger || inputs.trigger }}
+      wc-version: ${{ inputs.wc-version }}
     secrets: inherit

--- a/plugins/woocommerce/changelog/55675-e2e-on-demand-add-wc-version
+++ b/plugins/woocommerce/changelog/55675-e2e-on-demand-add-wc-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add an option to `on-demand` job to accept WC_VERSION

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-pressable/playwright.config.js
@@ -19,17 +19,7 @@ config = {
 		},
 		{
 			name: 'e2e-pressable',
-			testIgnore: [
-				'**/api-tests/**',
-				'**/customize-store/**',
-				'**/js-file-monitor/**',
-			],
-			grepInvert,
-			dependencies: [ 'reset', 'site setup' ],
-		},
-		{
-			name: 'api-pressable',
-			testMatch: [ '**/api-tests/**' ],
+			testMatch: [ '**/basic/basic.spec.js' ],
 			grepInvert,
 			dependencies: [ 'reset', 'site setup' ],
 		},

--- a/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/envs/default-wpcom/playwright.config.js
@@ -18,17 +18,7 @@ config = {
 		},
 		{
 			name: 'e2e-wpcom',
-			testIgnore: [
-				'**/api-tests/**',
-				'**/customize-store/**',
-				'**/js-file-monitor/**',
-			],
-			grepInvert,
-			dependencies: [ 'reset', 'site setup' ],
-		},
-		{
-			name: 'api-wpcom',
-			testMatch: [ '**/api-tests/**' ],
+			testMatch: [ '**/basic/basic.spec.js' ],
 			grepInvert,
 			dependencies: [ 'reset', 'site setup' ],
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add an option to [`on-demand` job](https://github.com/woocommerce/woocommerce/actions/workflows/tests-on-demand.yml) to accept `WC_VERSION` as a parameter. With this change, we can specify which WC version will be installed on the external environments while running tests. 

Closes #55694 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

ℹ️ **NOTE:** I'll revert this commit [7aaa20f](https://github.com/woocommerce/woocommerce/pull/55675/commits/7aaa20fc8334b1e3cc11ea718c73bdabd3489a87) as soon as we finish testing. I left it for testing, so that we can run only `basic.spec.js` and not taking too much of CI time.  

1. Go to https://github.com/woocommerce/woocommerce/actions/workflows/tests-on-demand.yml
2. Click on Run workflow button
3. Choose this PR's branch - `e2e/on-demand-add-wc-version`
4. One new input field should show in the dropdown -> "If you want to test against a specific WC version, provide it here. Available versions: https://github.com/woocommerce/woocommerce/releases"
5. In the input field enter one of the [previous releases](https://github.com/woocommerce/woocommerce/releases), eg. `9.7.0-rc.1`
6. Run the workflow

Expected results:
- Check the job for Pressable website. Specified WC version should be installed ([example](https://github.com/woocommerce/woocommerce/actions/runs/13437369015/job/37543034864#step:9:136));
- Go to Pressable website, verify that the specified WC version is installed and activated.

Additional case - passing WC version that doesn't exist, eg. `9.9.x.y.z`:
- The job should fail ([example](https://github.com/woocommerce/woocommerce/actions/runs/13437705199/job/37544017536#step:9:128))
- Does this failure make sense? Should we handle error in a different way? 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add an option to `on-demand` job to accept WC_VERSION

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
