### PR TITLE
Marketplace: update connection notice rule

### DIFF
--- a/plugins/woocommerce/changelog/55711-update-22709-show-connect-notice-to-new-stores
+++ b/plugins/woocommerce/changelog/55711-update-22709-show-connect-notice-to-new-stores
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update connection notice display rules in the Marketplace

--- a/plugins/woocommerce/client/admin/client/marketplace/components/connect-notice/connect-notice.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/connect-notice/connect-notice.tsx
@@ -65,6 +65,14 @@ export default function ConnectNotice(): JSX.Element | null {
 			),
 			formattedStoreName
 		),
+		new: sprintf(
+			/* translators: %s: store name set from the store settings, if not set, it will be "Your store" */
+			__(
+				'%s is not yet connected to a WooCommerce.com account. Please complete the connection to manage your subscriptions, install extensions, and get streamlined support.',
+				'woocommerce'
+			),
+			formattedStoreName
+		),
 	};
 
 	const description = noticeText[ noticeType ];

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -731,7 +731,8 @@ class WC_Helper_Updater {
 
 	/**
 	 * Get the type of woo connect notice to be shown in the WC Settings and Marketplace pages.
-	 * - If a store is connected to woocommerce.com or has no installed woo plugins, return 'none'.
+	 * - If a store is connected to woocommerce.com return 'none'.
+	 * - If a store has no installed woo plugins, return 'new'.
 	 * - If a store has installed woo plugins but no updates, return 'short'.
 	 * - If a store has an installed woo plugin with update, return 'long'.
 	 *
@@ -745,7 +746,7 @@ class WC_Helper_Updater {
 		$woo_plugins = WC_Helper::get_local_woo_plugins();
 
 		if ( empty( $woo_plugins ) ) {
-			return 'none';
+			return 'new';
 		}
 
 		$update_data = self::get_update_data();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Stores with no WooCommerce.com extensions don't see the connection notice. This PR changes that rule to display the notice with the new value proposition. 

Closes https://github.com/Automattic/woocommerce.com/issues/22709.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and rebuild assets
2. Uninstall all extensions that are distributed from WooCommerce.com 
3. Make sure you are not connected to WooCommerce.com
4. Visit **WooCommerce > Extensions** and confirm you see the new notice (screenshots below)
5. Connect your store to WooCommerce.com and confirm the notice disappears
6. Disconnect again and confirm the notice comes back
7. Install a WooCommerce.com extension and confirm now notice changes to end with "to get updates and streamlined support."
8. Dismiss the notice and reload the page. Confirm the notice is not visible
9. Please test around this issue

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Update connection notice display rules in the Marketplace
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

### Screenshots
![Image](https://github.com/user-attachments/assets/4aeb1bf8-6e84-4195-8dfc-b418234724c6)
