### PR TITLE
Feature - Enable the Mini-Cart drawer on the single product page

### DIFF
--- a/plugins/woocommerce/changelog/55714-feature-Enable-the-Mini-Cart-drawer-on-the-single-product-page
+++ b/plugins/woocommerce/changelog/55714-feature-Enable-the-Mini-Cart-drawer-on-the-single-product-page
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Now the Add to cart functionality in single product page will happen through ajax instead of page reload. Also, the mini cart drawer will open after adding to cart.

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -119,6 +119,21 @@
 				margin-top: 0;
 				margin-bottom: 0;
 				vertical-align: middle;
+
+				&.loading {
+					opacity: 0.25;
+				}
+		
+				&.loading::after {
+					font-family: WooCommerce; /* stylelint-disable-line */
+					content: "\e031";
+					animation: spin 2s linear infinite;
+					margin-right: 0;
+					margin-left: 0.5em;
+					display: inline-block;
+					width: auto;
+					height: auto;
+				}
 			}
 		}
 


### PR DESCRIPTION
Now the Add to cart functionality in single product page will happen through ajax instead of page reload. Also, the mini cart drawer will open after adding to cart.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55587 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to single product page
2. Add to cart
3. Product will be added to cart through ajax and the mini cart drawer will open

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [x] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Now the Add to cart functionality in single product page will happen through ajax instead of page reload. Also, the mini cart drawer will open after adding to cart.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
