### PR TITLE
fix: Handle numeric product slugs in category-based permalinks

### DIFF
--- a/plugins/woocommerce/changelog/55741-fix-46670-rewrite-rules-numeric-product-names
+++ b/plugins/woocommerce/changelog/55741-fix-46670-rewrite-rules-numeric-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 404 errors for products with numeric slugs in sub-categories when using category-based permalinks.


### PR DESCRIPTION
When using category-based permalinks (%product_cat%) in WooCommerce, products with purely numeric slugs (e.g., "123") in sub-categories were incorrectly returning 404 errors. This occurred because the rewrite rules were interpreting the numeric slug as a pagination parameter instead of a product identifier.

This fix was suggested using Cursor AI, but implemented and manually tested (following the testing instructions) by me. Please do thoroughly review the PR and suggest any improvements to the code. 

This fix:
- Adds a specific rewrite rule to handle numeric-only product slugs
- Maintains existing pagination functionality for non-numeric slugs
- Only applies when using category-based permalinks
- Preserves backward compatibility with existing URLs
- Follows WordPress and WooCommerce coding standards

Technical details:
- Modifies wc_fix_rewrite_rules() to add specific handling for numeric slugs
- Adds the rule before the general product rule to ensure proper precedence
- Removes pagination parameter matching for numeric-only slugs
- Maintains all other existing rewrite rule functionality

Fixes #46670

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where WooCommerce products with numeric-only slugs (e.g., "123") in sub-categories return 404 errors when using category-based permalinks. The problem occurs because WooCommerce's rewrite rules incorrectly interpret the numeric slug as a pagination parameter instead of a product identifier.

The fix modifies the `wc_fix_rewrite_rules()` function to:
- Add specific handling for numeric-only product slugs
- Maintain existing pagination functionality for non-numeric slugs
- Only apply changes when using category-based permalinks
- Preserve backward compatibility with existing URLs

Closes #46670.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Setup:
   - Ensure WooCommerce is installed and activated
   - Set permalinks to use category base (WooCommerce > Settings > Permalinks > Product permalinks: `/shop/%product_cat%/`)
   - Create a parent category (e.g., "Electronics")
   - Create a sub-category (e.g., "Phones")

2. Test numeric slug in sub-category:
   - Create a new product
   - Set its slug to a numeric value (e.g., "123")
   - Assign it to the sub-category (Phones)
   - Publish the product
   - Visit the product URL (should be something like `/shop/electronics/phones/123/`)
   - Verify the product page loads correctly instead of showing a 404 error

3. Test pagination still works:
   - Create multiple products in a category
   - Visit the category page
   - Click on the pagination link to test pagination
   - Verify pagination works as expected

4. Test non-numeric slugs:
   - Create a product with a regular text slug (e.g., "test-product")
   - Verify the product page loads correctly

<!-- End testing instructions -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch

#### Type
- [x] Fix - Fixes an existing bug

#### Message
Fix 404 errors for products with numeric slugs in sub-categories when using category-based permalinks.
</details>
