### PR TITLE
Add option to send feedback for new email experience

### DIFF
--- a/packages/js/customer-effort-score/changelog/55626-email-improvements-feedback-prompt
+++ b/packages/js/customer-effort-score/changelog/55626-email-improvements-feedback-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "description" prop ignored in CustomerEffortScoreModalContainer

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
@@ -76,6 +76,7 @@ export const CustomerEffortScoreModalContainer: React.FC = () => {
 	return (
 		<CustomerFeedbackModal
 			title={ visibleCESModalData.title }
+			description={ visibleCESModalData.description }
 			showDescription={ visibleCESModalData.showDescription }
 			firstQuestion={ visibleCESModalData.firstQuestion }
 			secondQuestion={ visibleCESModalData.secondQuestion }

--- a/packages/js/customer-effort-score/src/store/reducer.js
+++ b/packages/js/customer-effort-score/src/store/reducer.js
@@ -26,6 +26,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		case TYPES.SHOW_CES_MODAL:
 			const cesModalData = {
 				action: action.surveyProps.action,
+				description: action.surveyProps.description,
 				showDescription: action.surveyProps.showDescription,
 				title: action.surveyProps.title,
 				onSubmitLabel: action.onsubmit_label,

--- a/plugins/woocommerce/changelog/55626-email-improvements-feedback-prompt
+++ b/plugins/woocommerce/changelog/55626-email-improvements-feedback-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add option to send feedback for new email experience

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
@@ -28,6 +28,7 @@ import {
 import { registerSettingsEmailColorPaletteFill } from '../settings-email/settings-email-color-palette-slotfill';
 import { registerSettingsEmailImageUrlFill } from '../settings-email/settings-email-image-url-slotfill';
 import { registerSettingsEmailPreviewFill } from '../settings-email/settings-email-preview-slotfill';
+import { registerSettingsEmailFeedbackFill } from '../settings-email/settings-email-feedback-slotfill';
 
 const debug = debugFactory( 'wc-admin:client' );
 
@@ -131,6 +132,8 @@ const registerSlotFills = () => {
 		registerSettingsEmailImageUrlFill();
 		registerSettingsEmailPreviewFill();
 	}
+
+	registerSettingsEmailFeedbackFill();
 };
 
 /**

--- a/plugins/woocommerce/client/admin/client/settings-email/icon-feedback.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/icon-feedback.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { SVG } from '@wordpress/primitives';
+
+const FeedbackIcon = ( { size = 12 }: { size?: number } ) => (
+	<SVG
+		width={ size }
+		height={ size + 1 }
+		viewBox="0 -1 12 12"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M2.45865 9.08341L1.6665 9.87639L1.6665 1.66675L10.3332 1.66675L10.3332 9.08341L2.45865 9.08341ZM2.87317 10.0834L10.6665 10.0834C11.0347 10.0834 11.3332 9.78494 11.3332 9.41675L11.3332 1.33342C11.3332 0.965226 11.0347 0.666748 10.6665 0.666748H1.33317C0.964982 0.666748 0.666504 0.965225 0.666504 1.33341V11.0166C0.666504 11.2116 0.773993 11.3907 0.946074 11.4825C1.15124 11.5919 1.40385 11.5543 1.56818 11.3898L2.87317 10.0834ZM8.6665 4.66673H3.33317V3.66673H8.6665V4.66673ZM3.33317 7.33339H6.6665V6.33339H3.33317V7.33339Z"
+			fill="currentColor"
+		/>
+	</SVG>
+);
+
+export default FeedbackIcon;

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-ces-feedback.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-ces-feedback.tsx
@@ -5,6 +5,7 @@ import { Button, TextareaControl, TextControl } from '@wordpress/components';
 import { isEmail } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
+import { useCallback, useEffect } from '@wordpress/element';
 import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
 
 /**
@@ -16,20 +17,18 @@ interface EmailCesFeedbackProps {
 	action: string;
 	description?: string;
 	question: string;
+	showOnLoad?: boolean;
 }
 
 export const EmailCesFeedback = ( {
 	action,
 	description,
 	question,
+	showOnLoad = false,
 }: EmailCesFeedbackProps ) => {
 	const { showCesModal } = useDispatch( CES_STORE_KEY );
 
-	if ( ! window.wcTracks?.isEnabled ) {
-		return null;
-	}
-
-	const handleFeedbackClick = () => {
+	const handleFeedbackClick = useCallback( () => {
 		showCesModal( {
 			action,
 			title: __( 'Share your experience', 'woocommerce' ),
@@ -103,16 +102,25 @@ export const EmailCesFeedback = ( {
 				return errors;
 			},
 		} );
-	};
+	}, [ action, question, showCesModal ] );
+
+	useEffect( () => {
+		if ( window.wcTracks?.isEnabled && showOnLoad ) {
+			handleFeedbackClick();
+		}
+	}, [ handleFeedbackClick, showOnLoad ] );
 
 	return (
-		<Button
-			variant="tertiary"
-			icon={ <FeedbackIcon /> }
-			iconSize={ 12 }
-			onClick={ handleFeedbackClick }
-		>
-			{ __( 'Help us improve', 'woocommerce' ) }
-		</Button>
+		window.wcTracks?.isEnabled &&
+		! showOnLoad && (
+			<Button
+				variant="tertiary"
+				icon={ <FeedbackIcon /> }
+				iconSize={ 12 }
+				onClick={ handleFeedbackClick }
+			>
+				{ __( 'Help us improve', 'woocommerce' ) }
+			</Button>
+		)
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-ces-feedback.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-ces-feedback.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { Button, TextareaControl, TextControl } from '@wordpress/components';
+import { isEmail } from '@wordpress/url';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
+
+/**
+ * Internal dependencies
+ */
+import FeedbackIcon from './icon-feedback';
+
+interface EmailCesFeedbackProps {
+	action: string;
+	question: string;
+}
+
+export const EmailCesFeedback = ( {
+	action,
+	question,
+}: EmailCesFeedbackProps ) => {
+	const { showCesModal } = useDispatch( CES_STORE_KEY );
+
+	if ( ! window.wcTracks?.isEnabled ) {
+		return null;
+	}
+
+	const handleFeedbackClick = () => {
+		showCesModal( {
+			action,
+			title: __( 'Share your experience', 'woocommerce' ),
+			showDescription: false,
+			firstQuestion: question,
+			getExtraFieldsToBeShown: (
+				extraFieldsValues: { [ key: string ]: string },
+				setExtraFieldsValues: ( values: {
+					[ key: string ]: string;
+				} ) => void,
+				errors: Record< string, string > | undefined
+			) => {
+				return (
+					<div>
+						<br />
+						<TextareaControl
+							label={ __(
+								'How can we improve the email customizer for you? (Optional)',
+								'woocommerce'
+							) }
+							value={ extraFieldsValues.feedback_comment || '' }
+							onChange={ ( value ) =>
+								setExtraFieldsValues( {
+									...extraFieldsValues,
+									feedback_comment: value,
+								} )
+							}
+							placeholder={ __(
+								'What did you try to achieve with the customizer? What did and didn’t work?',
+								'woocommerce'
+							) }
+						/>
+						<TextControl
+							label={ __(
+								'Email address (Optional)',
+								'woocommerce'
+							) }
+							type="email"
+							value={ extraFieldsValues.email || '' }
+							onChange={ ( value ) =>
+								setExtraFieldsValues( {
+									...extraFieldsValues,
+									email: value,
+								} )
+							}
+							help={
+								errors?.email ? (
+									<span className="woocommerce-customer-effort-score__errors">
+										{ errors.email }
+									</span>
+								) : (
+									__(
+										'Share if you would like to discuss your experience or participate in future research.',
+										'woocommerce'
+									)
+								)
+							}
+						/>
+					</div>
+				);
+			},
+			validateExtraFields: ( { email = '' }: { email?: string } ) => {
+				const errors: Record< string, string > | undefined = {};
+				if ( email.length > 0 && ! isEmail( email ) ) {
+					errors.email = __(
+						'Please enter a valid email address.',
+						'woocommerce'
+					);
+				}
+				return errors;
+			},
+		} );
+	};
+
+	return (
+		<Button
+			variant="tertiary"
+			icon={ <FeedbackIcon /> }
+			iconSize={ 12 }
+			onClick={ handleFeedbackClick }
+		>
+			{ __( 'Help us improve', 'woocommerce' ) }
+		</Button>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-ces-feedback.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-ces-feedback.tsx
@@ -14,11 +14,13 @@ import FeedbackIcon from './icon-feedback';
 
 interface EmailCesFeedbackProps {
 	action: string;
+	description?: string;
 	question: string;
 }
 
 export const EmailCesFeedback = ( {
 	action,
+	description,
 	question,
 }: EmailCesFeedbackProps ) => {
 	const { showCesModal } = useDispatch( CES_STORE_KEY );
@@ -31,7 +33,8 @@ export const EmailCesFeedback = ( {
 		showCesModal( {
 			action,
 			title: __( 'Share your experience', 'woocommerce' ),
-			showDescription: false,
+			showDescription: !! description,
+			description,
 			firstQuestion: question,
 			getExtraFieldsToBeShown: (
 				extraFieldsValues: { [ key: string ]: string },

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-feedback-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-feedback-slotfill.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { SETTINGS_SLOT_FILL_CONSTANT } from '~/settings/settings-slots';
+import { EmailCesFeedback } from './settings-email-ces-feedback';
+
+const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
+
+const EmailFeedbackFill: React.FC = () => {
+	const description = __(
+		'Thank you for trying out our new email customization features. We’d love to hear your feedback on how we could improve the experience.',
+		'woocommerce'
+	);
+	const question = __(
+		'I was able to customize my email designs to match my store’s brand.',
+		'woocommerce'
+	);
+
+	return (
+		<Fill>
+			<EmailCesFeedback
+				action="email_improvements_disabled_feedback"
+				description={ description }
+				question={ question }
+				showOnLoad={ true }
+			/>
+		</Fill>
+	);
+};
+
+export const registerSettingsEmailFeedbackFill = () => {
+	const slotElementId = 'wc_settings_features_email_feedback_slotfill';
+	const slotElement = document.getElementById( slotElementId );
+	if ( ! slotElement ) {
+		return null;
+	}
+	registerPlugin( 'woocommerce-admin-settings-email-feedback', {
+		scope: 'woocommerce-email-feedback-settings',
+		render: () => <EmailFeedbackFill />,
+	} );
+};

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-iframe.tsx
@@ -86,7 +86,7 @@ export const EmailPreviewIframe: React.FC< EmailPreviewIframeProps > = ( {
 				}
 			} );
 		};
-	}, [ nonce, setIsLoading, settingsIds, setCounter ] );
+	}, [ nonce, setIsLoading, settingsIds, setCounter, src, counter ] );
 
 	return (
 		<div>

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -5,6 +5,7 @@ import { createSlotFill, Spinner } from '@wordpress/components';
 import { SelectControlSingleSelectionProps } from '@wordpress/components/build-types/select-control/types';
 import { registerPlugin } from '@wordpress/plugins';
 import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { debounce } from 'lodash';
 
 /**
@@ -20,6 +21,7 @@ import { EmailPreviewHeader } from './settings-email-preview-header';
 import { EmailPreviewIframe } from './settings-email-preview-iframe';
 import { EmailPreviewSend } from './settings-email-preview-send';
 import { EmailPreviewType } from './settings-email-preview-type';
+import { EmailCesFeedback } from './settings-email-ces-feedback';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
@@ -69,6 +71,11 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 		};
 	}, [ isSingleEmail ] );
 
+	const cesQuestion = __(
+		'I am able to customize my email designs to match my store’s brand.',
+		'woocommerce'
+	);
+
 	return (
 		<Fill>
 			<div
@@ -107,6 +114,12 @@ const EmailPreviewFill: React.FC< EmailPreviewFillProps > = ( {
 						setIsLoading={ setIsLoading }
 						settingsIds={ settingsIds }
 					/>
+					<div className="wc-settings-email-preview-ces-feedback">
+						<EmailCesFeedback
+							action="email_improvements_feedback"
+							question={ cesQuestion }
+						/>
+					</div>
 				</div>
 			</div>
 		</Fill>

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -15,6 +15,7 @@ $wc-setting-email-width: 634px;
 	grid-template-rows: 36px 1fr;
 	height: 960px;
 	padding: $wc-setting-email-preview-gap;
+	position: relative;
 	width: 684px;
 
 	@include breakpoint( "<782px" ) {
@@ -239,6 +240,12 @@ $wc-setting-email-width: 634px;
 		font-size: 11px;
 		font-weight: 400;
 	}
+}
+
+.wc-settings-email-preview-ces-feedback {
+	bottom: -40px;
+	position: absolute;
+	right: 0;
 }
 
 .wc-settings-email-select-image {

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -14,6 +14,7 @@ $wc-setting-email-width: 634px;
 	grid-gap: $wc-setting-email-preview-gap;
 	grid-template-rows: 36px 1fr;
 	height: 960px;
+	margin-bottom: 60px;
 	padding: $wc-setting-email-preview-gap;
 	position: relative;
 	width: 684px;
@@ -32,6 +33,7 @@ $wc-setting-email-width: 634px;
 
 .wc-settings-email-preview-container-floating {
 	bottom: 0;
+	margin-bottom: 0;
 	position: absolute;
 	left: $wc-setting-email-width + $wc-setting-email-preview-gap * 2;
 }

--- a/plugins/woocommerce/client/admin/client/settings/settings-slots.js
+++ b/plugins/woocommerce/client/admin/client/settings/settings-slots.js
@@ -31,6 +31,10 @@ export const possiblyRenderSettingsSlots = () => {
 			scope: 'woocommerce-email-preview-settings',
 		},
 		{
+			id: 'wc_settings_features_email_feedback_slotfill',
+			scope: 'woocommerce-email-feedback-settings',
+		},
+		{
 			id: 'wc_settings_email_image_url_slotfill',
 			scope: 'woocommerce-email-image-url-settings',
 		},

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -134,6 +134,7 @@ class FeaturesController {
 		add_filter( 'views_plugins', array( $this, 'handle_plugins_page_views_list' ), 10, 1 );
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'set_change_feature_enable_nonce' ), 20, 1 );
 		add_action( 'admin_init', array( $this, 'change_feature_enable_from_query_params' ), 20, 0 );
+		add_action( self::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'display_email_improvements_feedback_notice' ), 10, 2 );
 	}
 
 	/**
@@ -1580,6 +1581,25 @@ class FeaturesController {
 		if ( count( $query_params_to_remove ) > 1 && isset( $_SERVER['REQUEST_URI'] ) ) {
 			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			wp_safe_redirect( remove_query_arg( $query_params_to_remove, $_SERVER['REQUEST_URI'] ) );
+		}
+	}
+
+	/**
+	 * Display the email improvements feedback notice to render CES modal in.
+	 *
+	 * @param string $feature_id The feature id.
+	 * @param bool   $is_enabled Whether the feature is enabled.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 */
+	public function display_email_improvements_feedback_notice( $feature_id, $is_enabled ): void {
+		if ( 'email_improvements' === $feature_id && ! $is_enabled ) {
+			add_action(
+				'admin_notices',
+				function () {
+					echo '<div id="wc_settings_features_email_feedback_slotfill"></div>';
+				}
+			);
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds option to share feedback on email improvements feature.
1. When enabled, there is now `Help us improve` button below the email preview.
2. When the feature is disabled, a modal will pop up with a feedback form. 

Closes #55626.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Advanced > Features**. 
2. Enable the `Email improvements` feature.
3. Go to **WooCommerce > Settings > Emails**. 
4. Check that there is `Help us improve` button below the email preview.
5. Submit the feedback form and check that the feedback is submitted to Tracks. 
6. Go to **WooCommerce > Settings > Advanced > Features**. 
7. Disable the `Email improvements` feature.
8. Check that a feedback modal is shown after submitting the form. 

<!-- End testing instructions -->
