### PR TITLE
Use placeholder image included in WooCommerce files in email preview

### DIFF
--- a/plugins/woocommerce/changelog/55671-email-preview-placeholder
+++ b/plugins/woocommerce/changelog/55671-email-preview-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing placeholder image in email preview when file is deleted

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -475,6 +475,8 @@ class EmailPreview {
 		add_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
 		// Get shipping method without needing to save it in the order.
 		add_filter( 'woocommerce_order_shipping_method', array( $this, 'get_shipping_method' ) );
+		// Use placeholder image included in WooCommerce files.
+		add_filter( 'woocommerce_order_item_thumbnail', array( $this, 'get_placeholder_image' ) );
 	}
 
 	/**
@@ -485,6 +487,7 @@ class EmailPreview {
 		remove_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10 );
 		remove_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
 		remove_filter( 'woocommerce_order_shipping_method', array( $this, 'get_shipping_method' ) );
+		remove_filter( 'woocommerce_order_item_thumbnail', array( $this, 'get_placeholder_image' ) );
 	}
 
 	/**
@@ -514,5 +517,14 @@ class EmailPreview {
 	 */
 	public function enable_preview_mode() {
 		return true;
+	}
+
+	/**
+	 * Get the placeholder image for the preview email.
+	 *
+	 * @return string
+	 */
+	public function get_placeholder_image() {
+		return '<img src="' . WC()->plugin_url() . '/assets/images/placeholder.png" width="48" height="48" alt="" />';
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55671.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `Email improvements` in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. Check that email preview products have a placeholder image.
4. Go to **WooCommerce > Settings > Products**.
5. Note the placeholder image ID.
6. Go to `/wp-admin/upload.php?item=ID` (replace `ID` with actual number).
7. Remove the file from the`/wp-content/uploads/` that this attachment refers to, but **don't remove the attachment itself**.
8. Go to **WooCommerce > Settings > Emails** and observe that the email preview products still show placeholder images.

<!-- End testing instructions -->
