### PR TITLE
POC: Open Min Cart drawer based on session

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/frontend.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/mini-cart/frontend.ts
@@ -165,6 +165,13 @@ window.addEventListener( 'load', () => {
 			loadContents();
 		};
 
+		// Auto-open the drawer if the session storage is set from the single product page.
+		// Remove the session storage before opening the drawer to prevent reopening on page refresh.
+		if ( sessionStorage.getItem( 'open_mini_cart_drawer' ) ) {
+			sessionStorage.removeItem( 'open_mini_cart_drawer' );
+			openDrawer();
+		}
+
 		// Load the scripts if a device is touch-enabled. We don't get the mouseover or focus events on touch devices,
 		// so the event listeners below won't work.
 		if (

--- a/plugins/woocommerce/client/legacy/js/frontend/mini-cart-drawer.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/mini-cart-drawer.js
@@ -1,0 +1,5 @@
+document.addEventListener( 'click', function ( event ) {
+	if ( event.target.classList.contains( 'single_add_to_cart_button' ) ) {
+		sessionStorage.setItem( 'open_mini_cart_drawer', 'true' );
+	}
+} );

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -189,6 +189,11 @@ class WC_Frontend_Scripts {
 		$version = Constants::get_constant( 'WC_VERSION' );
 
 		$register_scripts = array(
+			'mini-cart-drawer'           => array(
+				'src'     => self::get_asset_url( 'assets/js/frontend/mini-cart-drawer' . $suffix . '.js' ),
+				'deps'    => array( 'jquery' ),
+				'version' => $version,
+			),
 			'flexslider'                 => array(
 				'src'     => self::get_asset_url( 'assets/js/flexslider/jquery.flexslider' . $suffix . '.js' ),
 				'deps'    => array( 'jquery' ),
@@ -422,6 +427,11 @@ class WC_Frontend_Scripts {
 				add_action( 'wp_footer', 'woocommerce_photoswipe' );
 			}
 			self::enqueue_script( 'wc-single-product' );
+		}
+
+		// Load Mini Cart drawer script on single product pages only.
+		if ( is_product() && 'yes' === get_option( 'woocommerce_enable_ajax_add_to_cart' ) ) {
+			self::enqueue_script( 'mini-cart-drawer' );
 		}
 
 		// Only enqueue the geolocation script if the Default Current Address is set to "Geolocate


### PR DESCRIPTION
> [!CAUTION]  
> **DO NOT MERGE THIS PR**, as it's a POC!  

### Changes proposed in this Pull Request:  

This PR is a POC for using session storage as a trigger to open the Mini Cart drawer. When a shopper clicks the add to cart button on the single product page, the session storage entry `open_mini_cart_drawer` will be created:  

<img width="560" alt="Screenshot 2025-02-23 at 17 02 55" src="https://github.com/user-attachments/assets/e1f3ec3f-03e8-4078-9c2b-08a64a470f50" />


If the Mini Cart component detects that the session storage entry `open_mini_cart_drawer` exists, it deletes that entry and opens the Mini Cart drawer.  

Related: #55587  

<!-- Begin testing instructions -->  

### How to test the changes in this Pull Request:  

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->  

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:  

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=products`.  
2. Verify the option `Enable AJAX add to cart buttons on archives` is enabled.  
3. Go to the frontend.  
4. Open a single product page.  
5. Add the product to the cart.  
6. Verify that the Mini Cart drawer slides out.  
7. Test the previous steps against different products, e.g. simple, virtual, bookable, etc.  

### Screenshot  

https://github.com/user-attachments/assets/fe13e2b4-627c-4605-a1f0-34ac477e5633

<!-- End testing instructions -->  

### Changelog entry  

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->  
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->  

<!-- Due to org permissions, the job might fail for PRs created from a fork under GitHub organizations. Possible solutions: -->  
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->  
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->  

-   [x] Automatically create a changelog entry from the details below.  

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->  

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)  

<details>  

<summary>Changelog Entry Details</summary>  

#### Significance  

<!-- Choose only one -->  

-   [ ] Patch  
-   [x] Minor  
-   [ ] Major  

#### Type  

<!-- Choose only one -->  

-   [ ] Fix - Fixes an existing bug  
-   [ ] Add - Adds functionality  
-   [x] Update - Update existing functionality  
-   [ ] Dev - Development related task  
-   [ ] Tweak - A minor adjustment to the codebase  
-   [ ] Performance - Address performance issues  
-   [ ] Enhancement - Improvement to existing functionality  

#### Message <!-- Add a changelog message here -->  

This PR is a POC for using session storage as a trigger to open the Mini Cart drawer. 

</details>  

<details>  

<summary>Changelog Entry Comment</summary>  

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->  

</details>