### PR TITLE
[e2e tests] Bump no-wait-for-timeout lint rule to error

### DIFF
--- a/plugins/woocommerce/changelog/e2e-bump-no-wait-for-timeout-lint-rule-to-error
+++ b/plugins/woocommerce/changelog/e2e-bump-no-wait-for-timeout-lint-rule-to-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+[dev] E2E tests: bump âˆno-wait-for-timeout lint rule to error

--- a/plugins/woocommerce/tests/e2e-pw/.eslintrc.js
+++ b/plugins/woocommerce/tests/e2e-pw/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
 	extends: [ 'plugin:playwright/recommended' ],
 	rules: {
+		'playwright/no-wait-for-timeout': 'error',
 		'playwright/no-skipped-test': 'off',
 		'no-console': 'off',
 		'jest/no-test-callback': 'off',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to https://github.com/woocommerce/woocommerce/issues/55710

The playwright/no-wait-for-timeout rule has been updated to error.
This change enforces stricter rules to avoid the use of `waitForTimeout` in Playwright tests, promoting better test practices.

### How to test the changes in this Pull Request:

1. Add a `page.waitForTimeout()` in any e2e test file. 
2. Run ```pnpm --filter="@woocommerce/plugin-woocommerce" lint:changes:branch:js```
It should be logged as an error:

```
  204:11  error  Unexpected use of page.waitForTimeout()    playwright/no-wait-for-timeout
```
