### PR TITLE
Refactor `show_shipping` usage by merging blocks and legacy cart functionality

### DIFF
--- a/plugins/woocommerce/changelog/refactor-show-shipping-usage-54894
+++ b/plugins/woocommerce/changelog/refactor-show-shipping-usage-54894
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Merge legacy cart and block based cart shipping calculation methods to ensure shipping calculations happen only when a full address has been provided.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1407,7 +1407,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * Get cart's owner.
 	 *
 	 * @since  3.2.0
-	 * @return WC_Customer
+	 * @return \WC_Customer
 	 */
 	public function get_customer() {
 		return WC()->customer;
@@ -1479,22 +1479,20 @@ class WC_Cart extends WC_Legacy_Cart {
 			return $this->shipping_methods;
 		}
 
-		$this->shipping_methods        = $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) );
 		$this->has_calculated_shipping = true;
+		$this->shipping_methods        = $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) );
 
 		$shipping_costs = wp_list_pluck( $this->shipping_methods, 'cost' );
 		$shipping_taxes = wp_list_pluck( $this->shipping_methods, 'taxes' );
-
-		$this->set_shipping_total( array_sum( $shipping_costs ) );
-		$this->set_shipping_tax( array_sum( $shipping_taxes ) );
-
-		$merged_taxes = array();
+		$merged_taxes   = array();
 		foreach ( $shipping_taxes as $taxes ) {
 			foreach ( $taxes as $tax_id => $tax_amount ) {
 				$merged_taxes[ $tax_id ] = ( $merged_taxes[ $tax_id ] ?? 0 ) + $tax_amount;
 			}
 		}
 
+		$this->set_shipping_total( array_sum( $shipping_costs ) );
+		$this->set_shipping_tax( array_sum( $merged_taxes ) );
 		$this->set_shipping_taxes( $merged_taxes );
 
 		return $this->shipping_methods;
@@ -1625,7 +1623,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
 			$customer = $this->get_customer();
 
-			if ( ! $customer instanceof WC_Customer || ! $customer->has_full_shipping_address() ) {
+			if ( ! $customer instanceof \WC_Customer || ! $customer->has_full_shipping_address() ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1586,8 +1586,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool whether or not the cart needs shipping
 	 */
 	public function needs_shipping() {
-		// If there are no shipping methods or no cart contents, no need to calculate shipping.
-		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) || ! $this->get_cart_contents() ) {
+		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -54,6 +54,14 @@ class WC_Cart extends WC_Legacy_Cart {
 	protected $shipping_methods;
 
 	/**
+	 * Whether the shipping totals have been calculated. This will only return true if shipping was calculated, not if
+	 * shipping is disabled or if there are no cart contents.
+	 *
+	 * @var bool
+	 */
+	protected $has_calculated_shipping = false;
+
+	/**
 	 * Total defaults used to reset.
 	 *
 	 * @var array
@@ -1448,24 +1456,45 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
+	 * Whether the shipping totals have been calculated.
+	 *
+	 * @return bool
+	 */
+	public function has_calculated_shipping() {
+		return $this->has_calculated_shipping;
+	}
+
+	/**
 	 * Uses the shipping class to calculate shipping then gets the totals when its finished.
 	 */
 	public function calculate_shipping() {
-		$this->shipping_methods = $this->needs_shipping() ? $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) ) : array();
+		// Reset totals.
+		$this->set_shipping_total( 0 );
+		$this->set_shipping_tax( 0 );
+		$this->set_shipping_taxes( array() );
+		$this->shipping_methods        = array();
+		$this->has_calculated_shipping = false;
 
+		if ( ! $this->needs_shipping() || ! $this->show_shipping() ) {
+			return $this->shipping_methods;
+		}
+
+		$this->shipping_methods        = $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) );
+		$this->has_calculated_shipping = true;
+
+		$shipping_costs = wp_list_pluck( $this->shipping_methods, 'cost' );
 		$shipping_taxes = wp_list_pluck( $this->shipping_methods, 'taxes' );
-		$merged_taxes   = array();
+
+		$this->set_shipping_total( array_sum( $shipping_costs ) );
+		$this->set_shipping_tax( array_sum( $shipping_taxes ) );
+
+		$merged_taxes = array();
 		foreach ( $shipping_taxes as $taxes ) {
 			foreach ( $taxes as $tax_id => $tax_amount ) {
-				if ( ! isset( $merged_taxes[ $tax_id ] ) ) {
-					$merged_taxes[ $tax_id ] = 0;
-				}
-				$merged_taxes[ $tax_id ] += $tax_amount;
+				$merged_taxes[ $tax_id ] = ( $merged_taxes[ $tax_id ] ?? 0 ) + $tax_amount;
 			}
 		}
 
-		$this->set_shipping_total( array_sum( wp_list_pluck( $this->shipping_methods, 'cost' ) ) );
-		$this->set_shipping_tax( array_sum( $merged_taxes ) );
 		$this->set_shipping_taxes( $merged_taxes );
 
 		return $this->shipping_methods;
@@ -1557,7 +1586,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool whether or not the cart needs shipping
 	 */
 	public function needs_shipping() {
-		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) ) {
+		// If there are no shipping methods or no cart contents, no need to calculate shipping.
+		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) || ! $this->get_cart_contents() ) {
 			return false;
 		}
 		$needs_shipping = false;
@@ -1582,49 +1612,30 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Sees if the customer has entered enough data to calc the shipping yet.
+	 * Sees if the customer has entered enough data to calculate shipping.
 	 *
 	 * @return bool
 	 */
 	public function show_shipping() {
-		if ( ! wc_shipping_enabled() || ! $this->get_cart_contents() ) {
+		if ( ! wc_shipping_enabled() ) {
 			return false;
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
-			$country = $this->get_customer()->get_shipping_country();
-			if ( ! $country ) {
-				return false;
-			}
-			$country_fields = WC()->countries->get_address_fields( $country, 'shipping_' );
-			/**
-			 * Filter to not require shipping state for shipping calculation, even if it is required at checkout.
-			 * This can be used to allow shipping calculations to be done without a state.
-			 *
-			 * @since 8.4.0
-			 *
-			 * @param bool $show_state Whether to use the state field. Default true.
-			 */
-			$state_enabled  = apply_filters( 'woocommerce_shipping_calculator_enable_state', true );
-			$state_required = isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'];
-			if ( $state_enabled && $state_required && ! $this->get_customer()->get_shipping_state() ) {
-				return false;
-			}
-			/**
-			 * Filter to not require shipping postcode for shipping calculation, even if it is required at checkout.
-			 * This can be used to allow shipping calculations to be done without a postcode.
-			 *
-			 * @since 8.4.0
-			 *
-			 * @param bool $show_postcode Whether to use the postcode field. Default true.
-			 */
-			$postcode_enabled  = apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true );
-			$postcode_required = isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'];
-			if ( $postcode_enabled && $postcode_required && '' === $this->get_customer()->get_shipping_postcode() ) {
+			$customer = $this->get_customer();
+
+			if ( ! $customer instanceof WC_Customer || ! $customer->has_full_shipping_address() ) {
 				return false;
 			}
 		}
 
+		/**
+		 * Filter to allow plugins to prevent shipping calculations.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param bool $ready Whether the cart is ready to calculate shipping.
+		 */
 		return apply_filters( 'woocommerce_cart_ready_to_calc_shipping', true );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1590,6 +1590,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) || ! $this->get_cart_contents() ) {
 			return false;
 		}
+
 		$needs_shipping = false;
 
 		foreach ( $this->get_cart_contents() as $values ) {
@@ -1617,7 +1618,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function show_shipping() {
-		if ( ! wc_shipping_enabled() ) {
+		// If there are no shipping methods or no cart contents, no need to calculate shipping.
+		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) || ! $this->get_cart_contents() ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -957,7 +957,7 @@ class WC_Checkout {
 			} elseif ( ! in_array( $shipping_country, array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				if ( WC()->countries->country_exists( $shipping_country ) ) {
 					/* translators: %s: shipping location (prefix e.g. 'to' + ISO 3166-1 alpha-2 country code) */
-					$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . $shipping_country ) );
+					$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix( $shipping_country ) . ' ' . $shipping_country ) );
 				}
 			} else {
 				$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -432,7 +432,7 @@ class ShippingController {
 
 		$customer = WC()->customer;
 
-		if ( ! $customer instanceof WC_Customer || ! $customer->has_full_shipping_address() ) {
+		if ( $customer instanceof WC_Customer && $customer->has_full_shipping_address() ) {
 			return $packages;
 		}
 

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -415,54 +415,6 @@ class ShippingController {
 	}
 
 	/**
-	 * Checks whether the address is "full" in the sense that it contains all required fields to calculate shipping rates.
-	 *
-	 * @return bool Whether the customer has a full shipping address (address_1, city, state, postcode, country).
-	 * Only required fields are checked.
-	 */
-	public function has_full_shipping_address() {
-		$customer = WC()->customer;
-
-		if ( ! $customer instanceof WC_Customer ) {
-			return false;
-		}
-
-		// These are the important fields required to get the shipping rates.
-		$shipping_address = array(
-			'city'     => $customer->get_shipping_city(),
-			'state'    => $customer->get_shipping_state(),
-			'postcode' => $customer->get_shipping_postcode(),
-			'country'  => $customer->get_shipping_country(),
-		);
-		$address_fields   = WC()->countries->get_country_locale();
-		$locale_key       = ! empty( $shipping_address['country'] ) && array_key_exists( $shipping_address['country'], $address_fields ) ? $shipping_address['country'] : 'default';
-		$default_locale   = $address_fields['default'];
-		$country_locale   = $address_fields[ $locale_key ] ?? array();
-
-		/**
-		 * Checks all shipping address fields against the country's locale settings.
-		 *
-		 * If there's a `required` setting for the field in the country-specific locale, that setting is used, otherwise
-		 * the default locale's setting is used. If the default locale doesn't have a setting either, the field is
-		 * considered optional and therefore valid, even if empty.
-		 */
-		foreach ( $shipping_address as $key => $value ) {
-			// Skip further checks if the field has a value. From this point on $value is empty.
-			if ( ! empty( $value ) ) {
-				continue;
-			}
-
-			$locale_to_check = isset( $country_locale[ $key ]['required'] ) ? $country_locale : $default_locale;
-
-			// If the locale requires the field return false.
-			if ( isset( $locale_to_check[ $key ]['required'] ) && true === wc_string_to_bool( $locale_to_check[ $key ]['required'] ) ) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Remove shipping (i.e. delivery, not local pickup) if
 	 * "Hide shipping costs until an address is entered" is enabled,
 	 * and no address has been entered yet.
@@ -478,9 +430,9 @@ class ShippingController {
 			return $packages;
 		}
 
-		$has_full_address = $this->has_full_shipping_address();
+		$customer = WC()->customer;
 
-		if ( $has_full_address ) {
+		if ( ! $customer instanceof WC_Customer || ! $customer->has_full_shipping_address() ) {
 			return $packages;
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
@@ -338,17 +338,11 @@ class CartSchema extends AbstractSchema {
 		// Get cart errors first so if recalculations are performed, it's reflected in the response.
 		$cart_errors = $this->get_cart_errors( $cart );
 
-		// The core cart class will not include shipping in the cart totals if `show_shipping()` returns false. This can
-		// happen if an address is required, or through the use of hooks. This tracks if shipping has actually been
-		// calculated so we can avoid returning costs and rates prematurely.
-		$has_calculated_shipping = $cart->show_shipping();
-
-		$has_local_pickup_methods = LocalPickupUtils::is_local_pickup_enabled() && count( LocalPickupUtils::get_local_pickup_method_ids() ) > 0;
-
 		// Get shipping packages to return in the response from the cart. Always get the shipping packages if local
 		// pickup is enabled and has methods. If the address is required then regular shipping rates will be filtered
 		// out later.
-		$shipping_packages = $has_calculated_shipping || $has_local_pickup_methods ? $controller->get_shipping_packages() : [];
+		$has_local_pickup_methods = LocalPickupUtils::is_local_pickup_enabled() && count( LocalPickupUtils::get_local_pickup_method_ids() ) > 0;
+		$shipping_packages        = $cart->has_calculated_shipping() || $has_local_pickup_methods ? $controller->get_shipping_packages() : [];
 
 		// Get visible cross sells products.
 		$cross_sells = array_filter( array_map( 'wc_get_product', $cart->get_cross_sells() ), 'wc_products_array_filter_visible' );
@@ -363,7 +357,7 @@ class CartSchema extends AbstractSchema {
 			'needs_payment'           => $cart->needs_payment(),
 			'needs_shipping'          => $cart->needs_shipping(),
 			'payment_requirements'    => $this->extend->get_payment_requirements(),
-			'has_calculated_shipping' => $has_calculated_shipping,
+			'has_calculated_shipping' => $cart->has_calculated_shipping(),
 			'shipping_rates'          => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
 			'items_count'             => $cart->get_cart_contents_count(),
 			'items_weight'            => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
@@ -381,8 +375,7 @@ class CartSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_totals( $cart ) {
-		$has_calculated_shipping = $cart->show_shipping();
-		$decimals                = wc_get_price_decimals();
+		$decimals = wc_get_price_decimals();
 
 		return [
 			'total_items'        => $this->prepare_money_response( $cart->get_subtotal(), $decimals ),
@@ -391,8 +384,8 @@ class CartSchema extends AbstractSchema {
 			'total_fees_tax'     => $this->prepare_money_response( $cart->get_fee_tax(), $decimals ),
 			'total_discount'     => $this->prepare_money_response( $cart->get_discount_total(), $decimals ),
 			'total_discount_tax' => $this->prepare_money_response( $cart->get_discount_tax(), $decimals ),
-			'total_shipping'     => $has_calculated_shipping ? $this->prepare_money_response( $cart->get_shipping_total(), $decimals ) : null,
-			'total_shipping_tax' => $has_calculated_shipping ? $this->prepare_money_response( $cart->get_shipping_tax(), $decimals ) : null,
+			'total_shipping'     => $cart->has_calculated_shipping() ? $this->prepare_money_response( $cart->get_shipping_total(), $decimals ) : null,
+			'total_shipping_tax' => $cart->has_calculated_shipping() ? $this->prepare_money_response( $cart->get_shipping_tax(), $decimals ) : null,
 			// Explicitly request context='edit'; default ('view') will render total as markup.
 			'total_price'        => $this->prepare_money_response( $cart->get_total( 'edit' ), $decimals ),
 			'total_tax'          => $this->prepare_money_response( $cart->get_total_tax(), $decimals ),

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -4,6 +4,7 @@
  *
  * @package WooCommerce\Tests\Cart.
  */
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 
 /**
  * Class WC_Cart_Test

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -9,6 +9,14 @@
  * Class WC_Cart_Test
  */
 class WC_Cart_Test extends \WC_Unit_Test_Case {
+	/**
+	 * Called before every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$fixtures = new FixtureData();
+		$fixtures->shipping_add_flat_rate();
+	}
 
 	/**
 	 * tearDown.

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -228,6 +228,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		// Set address for shipping calculation required for "woocommerce_shipping_cost_requires_address".
 		WC()->cart->get_customer()->set_shipping_country( 'US' );
 		WC()->cart->get_customer()->set_shipping_state( 'NY' );
+		WC()->cart->get_customer()->set_shipping_city( 'New York' );
 		WC()->cart->get_customer()->set_shipping_postcode( '12345' );
 		$this->assertTrue( WC()->cart->show_shipping() );
 
@@ -236,6 +237,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$product->delete( true );
 		WC()->cart->get_customer()->set_shipping_country( 'GB' );
 		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_city( '' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -246,12 +246,14 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		// Country that does not require state.
 		WC()->cart->get_customer()->set_shipping_country( 'LB' );
 		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_city( 'Test' );
 		WC()->cart->get_customer()->set_shipping_postcode( '12345' );
 		$this->assertTrue( WC()->cart->show_shipping() );
 
 		// Country that does not require postcode.
 		WC()->cart->get_customer()->set_shipping_country( 'NG' );
 		WC()->cart->get_customer()->set_shipping_state( 'AB' );
+		WC()->cart->get_customer()->set_shipping_city( 'Test' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 		$this->assertTrue( WC()->cart->show_shipping() );
 
@@ -260,6 +262,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$product->delete( true );
 		WC()->cart->get_customer()->set_shipping_country( 'GB' );
 		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_city( 'Test' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -12,7 +12,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Called before every test.
 	 */
-	protected function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
 		$fixtures = new FixtureData();
 		$fixtures->shipping_add_flat_rate();

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -54,7 +54,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_cart_needs_shipping_address',
-			function() {
+			function () {
 				return true;
 			}
 		);
@@ -76,7 +76,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function test_order_notes() {
 		$data = array(
 			'ship_to_different_address' => false,
-			'order_comments'             => '<a href="http://attackerpage.com/csrf.html">This text should not save inside an anchor.</a><script>alert("alert")</script>',
+			'order_comments'            => '<a href="http://attackerpage.com/csrf.html">This text should not save inside an anchor.</a><script>alert("alert")</script>',
 			'payment_method'            => WC_Gateway_BACS::ID,
 		);
 
@@ -181,28 +181,28 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function test_validate_checkout_adds_we_dont_ship_error_only_if_country_exists( $country, $expect_we_dont_ship_error ) {
 		add_filter(
 			'woocommerce_countries_allowed_countries',
-			function() {
+			function () {
 				return array( 'ES' );
 			}
 		);
 
 		add_filter(
 			'woocommerce_cart_needs_shipping',
-			function() {
+			function () {
 				return true;
 			}
 		);
 
 		add_filter(
 			'wc_shipping_enabled',
-			function() {
+			function () {
 				return true;
 			}
 		);
 
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'wc_get_shipping_method_count' => function( $include_legacy = false, $enabled_only = false ) {
+				'wc_get_shipping_method_count' => function ( $include_legacy = false, $enabled_only = false ) {
 					return 1;
 				},
 			)
@@ -219,7 +219,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->sut->validate_checkout( $data, $errors );
 
 		$this->assertEquals(
-			$expect_we_dont_ship_error ? 'Unfortunately <strong>we do not ship to the JP</strong>. Please enter an alternative shipping address.' : '',
+			$expect_we_dont_ship_error ? 'Unfortunately <strong>we do not ship to JP</strong>. Please enter an alternative shipping address.' : '',
 			$errors->get_error_message( 'shipping' )
 		);
 	}
@@ -239,4 +239,3 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		WC()->customer = $orig_customer;
 	}
 }
-

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -41,23 +41,23 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 	public function test_has_full_shipping_address_returns_correctly() {
 		// With GB, state is not required. Test it returns false with only a country, nothing else.
 		WC()->customer->set_shipping_country( 'GB' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		WC()->customer->set_shipping_city( 'Preston' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 
 		// Now switch to US, ensure that it returns false because state is not input.
 		WC()->customer->set_shipping_country( 'US' );
 		WC()->customer->set_shipping_postcode( '90210' );
 		WC()->customer->set_shipping_city( 'Beverly Hills' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		// Now add state, ensure that it returns true.
 		WC()->customer->set_shipping_state( 'CA' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 
 		// Now add a filter to set US state to optional, and UK state to required.
 		add_filter(
@@ -76,15 +76,15 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 
 		// Test that US state is now optional.
 		WC()->customer->set_shipping_state( '' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 
 		// Test that UK state is now required.
 		WC()->customer->set_shipping_country( 'GB' );
 		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		// Finally test that it passes when an ordinarily optional prop filtered to be required is provided.
 		WC()->customer->set_shipping_state( 'Lancashire' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -86,5 +86,8 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 		// Finally test that it passes when an ordinarily optional prop filtered to be required is provided.
 		WC()->customer->set_shipping_state( 'Lancashire' );
 		$this->assertTrue( WC()->customer->has_full_shipping_address() );
+
+		// Remove filter.
+		remove_all_filters( 'woocommerce_get_country_locale' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR consolidates shipping address handling between blocks and the legacy cart shortcode. `needs_shipping()` and `show_shipping()` are refactored to use the `WC_Customer->has_full_shipping_address()` class method to see if a full shipping address has been provided.

`WC_Cart_Totals` no longer checks `show_shipping`, instead opting to just grab whatever has been calculated in the cart.

Finally, the `WC_Cart` class tracks if calculations have ran or not, so we no longer need to derive this from the Store API.

Closes #54894

Existing tests were updated to match new logic e.g. to ensure shipping methods exist before tests run. The ShippingController tests were updated to use the method in `WC_Customer` (which was moved and updated).

One thing that might be an issue, tests previously passed without a defined `city` because the `show_shipping` method only checked for country, state, postcode. This was however inconsistent with the shipping form which also requested `city`. With the changes, `city` is now required too. Do you see an issue with this @opr? We could make city optional in the `has_full_shipping_address` method if so. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Setup shipping and shipping zones, and enable "Hide shipping costs until an address is entered"
2. In an incognito session go through the full flow, testing shipping calculator and rate selection. 
3. Note that shipping methods and totals are hidden until the calculator is used. 
4. Test this on both legacy shortcode cart and block based cart.
5. Turn off "Hide shipping costs until an address is entered". Repeat the above tests, but notice shipping is shown without a full address. You can check this again with incognito session, and a "Default customer location" under general settings set to store address.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
