### PR TITLE
Enhance WooCommerce Admin Performance: Split Settings Scripts

### DIFF
--- a/plugins/woocommerce/changelog/55823-enhance-split-settings
+++ b/plugins/woocommerce/changelog/55823-enhance-split-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Enhance WooCommerce Admin Performance: Split Settings Scripts

--- a/plugins/woocommerce/client/admin/client/embed.tsx
+++ b/plugins/woocommerce/client/admin/client/embed.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { createRoot } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import { initRemoteLogging } from './lib/init-remote-logging';
@@ -17,11 +12,6 @@ import './stylesheets/_embed.scss';
 import { renderCustomerEffortScoreTracks } from './shared';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { renderEmbeddedLayout } from './embedded-body-layout';
-import {
-	SettingsPaymentsMainWrapper,
-	SettingsPaymentsOfflineWrapper,
-	SettingsPaymentsWooCommercePaymentsWrapper,
-} from './settings-payments';
 
 const embeddedRoot = document.getElementById( 'woocommerce-embedded-root' );
 
@@ -32,52 +22,3 @@ if ( embeddedRoot ) {
 	renderEmbeddedLayout( embeddedRoot, hydrateUser, settingsGroup );
 	renderCustomerEffortScoreTracks( embeddedRoot );
 }
-
-const renderPaymentsSettings = () => {
-	if (
-		! window.wcAdminFeatures ||
-		window.wcAdminFeatures[ 'reactify-classic-payments-settings' ] !== true
-	) {
-		// Render the payment settings components only if the feature flag is enabled.
-		return;
-	}
-
-	const paymentsMainRoot = document.getElementById(
-		'experimental_wc_settings_payments_main'
-	);
-	const paymentsOfflineRoot = document.getElementById(
-		'experimental_wc_settings_payments_offline'
-	);
-	const paymentsWooCommercePaymentsRoot = document.getElementById(
-		'experimental_wc_settings_payments_woocommerce_payments'
-	);
-
-	if ( paymentsMainRoot ) {
-		createRoot(
-			paymentsMainRoot.insertBefore(
-				document.createElement( 'div' ),
-				null
-			)
-		).render( <SettingsPaymentsMainWrapper /> );
-	}
-
-	if ( paymentsOfflineRoot ) {
-		createRoot(
-			paymentsOfflineRoot.insertBefore(
-				document.createElement( 'div' ),
-				null
-			)
-		).render( <SettingsPaymentsOfflineWrapper /> );
-	}
-
-	if ( paymentsWooCommercePaymentsRoot ) {
-		createRoot(
-			paymentsWooCommercePaymentsRoot.insertBefore(
-				document.createElement( 'div' ),
-				null
-			)
-		).render( <SettingsPaymentsWooCommercePaymentsWrapper /> );
-	}
-};
-
-renderPaymentsSettings();

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
@@ -15,21 +15,10 @@ import { createRoot } from '@wordpress/element';
 import { PrimaryLayout as NoticeArea } from '../layout/shared';
 import { EmbedLayout } from '../layout/embed';
 import { EmbeddedBodyLayout } from './embedded-body-layout';
-import { isFeatureEnabled } from '~/utils/features';
-
-import { possiblyRenderSettingsSlots } from '../settings/settings-slots';
-import { registerTaxSettingsConflictErrorFill } from '../settings/conflict-error-slotfill';
-import { registerPaymentsSettingsBannerFill } from '../payments/payments-settings-banner-slotfill';
-import { registerSiteVisibilitySlotFill } from '../launch-your-store';
-import { registerBlueprintSlotfill } from '../blueprint';
 import {
 	possiblyRenderOrderAttributionSlot,
 	registerOrderAttributionSlotFill,
 } from '../order-attribution-install-banner/order-editor/slot';
-import { registerSettingsEmailColorPaletteFill } from '../settings-email/settings-email-color-palette-slotfill';
-import { registerSettingsEmailImageUrlFill } from '../settings-email/settings-email-image-url-slotfill';
-import { registerSettingsEmailPreviewFill } from '../settings-email/settings-email-preview-slotfill';
-import { registerSettingsEmailFeedbackFill } from '../settings-email/settings-email-feedback-slotfill';
 
 const debug = debugFactory( 'wc-admin:client' );
 
@@ -112,31 +101,8 @@ const renderEmbeddedBody = ( wpBody: HTMLElement, wrap: Element ) => {
  * Registers the slot fills.
  */
 const registerSlotFills = () => {
-	possiblyRenderSettingsSlots();
-	registerTaxSettingsConflictErrorFill();
-	registerPaymentsSettingsBannerFill();
-
-	const features = window.wcAdminFeatures;
-	if ( features?.[ 'launch-your-store' ] === true ) {
-		registerSiteVisibilitySlotFill();
-	}
-
-	if ( isFeatureEnabled( 'blueprint' ) ) {
-		registerBlueprintSlotfill();
-	}
-
 	possiblyRenderOrderAttributionSlot();
 	registerOrderAttributionSlotFill();
-
-	if ( isFeatureEnabled( 'email_improvements' ) ) {
-		registerSettingsEmailPreviewFill( true );
-		registerSettingsEmailColorPaletteFill();
-		registerSettingsEmailImageUrlFill();
-	} else {
-		registerSettingsEmailPreviewFill( false );
-	}
-
-	registerSettingsEmailFeedbackFill();
 };
 
 /**

--- a/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
+++ b/plugins/woocommerce/client/admin/client/embedded-body-layout/render-embedded-layout.tsx
@@ -98,7 +98,7 @@ const renderEmbeddedBody = ( wpBody: HTMLElement, wrap: Element ) => {
 };
 
 /**
- * Registers the slot fills.
+ * Registers slot fills for the embedded layout. This should be used only for pages other than the settings page. For settings pages, slot fills are registered in wp-admin-scripts/settings/
  */
 const registerSlotFills = () => {
 	possiblyRenderOrderAttributionSlot();

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -6,7 +6,7 @@ import { Icon, check, warning } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { isValidEmail } from '@woocommerce/product-editor';
+import { isValidEmail } from '@woocommerce/product-editor/build/utils/validate-email'; // Import from the build directory so we don't load the entire product editor since we only need this one function.
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/index.tsx
@@ -1,0 +1,103 @@
+/**
+ * This file is used to enhance the settings page with additional features such as registering slot fills.
+ */
+
+/**
+ * External dependencies
+ */
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { isFeatureEnabled } from '~/utils/features';
+import {
+	SettingsPaymentsMainWrapper,
+	SettingsPaymentsOfflineWrapper,
+	SettingsPaymentsWooCommercePaymentsWrapper,
+} from '../../settings-payments';
+
+import { possiblyRenderSettingsSlots } from '../../settings/settings-slots';
+import { registerTaxSettingsConflictErrorFill } from '../../settings/conflict-error-slotfill';
+import { registerPaymentsSettingsBannerFill } from '../../payments/payments-settings-banner-slotfill';
+import { registerSiteVisibilitySlotFill } from '../../launch-your-store';
+import { registerBlueprintSlotfill } from '../../blueprint';
+import { registerSettingsEmailColorPaletteFill } from '../../settings-email/settings-email-color-palette-slotfill';
+import { registerSettingsEmailImageUrlFill } from '../../settings-email/settings-email-image-url-slotfill';
+import { registerSettingsEmailPreviewFill } from '../../settings-email/settings-email-preview-slotfill';
+import { registerSettingsEmailFeedbackFill } from '~/settings-email/settings-email-feedback-slotfill';
+
+const renderPaymentsSettings = () => {
+	if (
+		! window.wcAdminFeatures ||
+		window.wcAdminFeatures[ 'reactify-classic-payments-settings' ] !== true
+	) {
+		// Render the payment settings components only if the feature flag is enabled.
+		return;
+	}
+
+	const paymentsMainRoot = document.getElementById(
+		'experimental_wc_settings_payments_main'
+	);
+	const paymentsOfflineRoot = document.getElementById(
+		'experimental_wc_settings_payments_offline'
+	);
+	const paymentsWooCommercePaymentsRoot = document.getElementById(
+		'experimental_wc_settings_payments_woocommerce_payments'
+	);
+
+	if ( paymentsMainRoot ) {
+		createRoot(
+			paymentsMainRoot.insertBefore(
+				document.createElement( 'div' ),
+				null
+			)
+		).render( <SettingsPaymentsMainWrapper /> );
+	}
+
+	if ( paymentsOfflineRoot ) {
+		createRoot(
+			paymentsOfflineRoot.insertBefore(
+				document.createElement( 'div' ),
+				null
+			)
+		).render( <SettingsPaymentsOfflineWrapper /> );
+	}
+
+	if ( paymentsWooCommercePaymentsRoot ) {
+		createRoot(
+			paymentsWooCommercePaymentsRoot.insertBefore(
+				document.createElement( 'div' ),
+				null
+			)
+		).render( <SettingsPaymentsWooCommercePaymentsWrapper /> );
+	}
+};
+
+const registerSlotFills = () => {
+	possiblyRenderSettingsSlots();
+	registerTaxSettingsConflictErrorFill();
+	registerPaymentsSettingsBannerFill();
+
+	const features = window.wcAdminFeatures;
+	if ( features?.[ 'launch-your-store' ] === true ) {
+		registerSiteVisibilitySlotFill();
+	}
+
+	if ( isFeatureEnabled( 'blueprint' ) ) {
+		registerBlueprintSlotfill();
+	}
+
+	if ( isFeatureEnabled( 'email_improvements' ) ) {
+		registerSettingsEmailPreviewFill( true );
+		registerSettingsEmailColorPaletteFill();
+		registerSettingsEmailImageUrlFill();
+	} else {
+		registerSettingsEmailPreviewFill( false );
+	}
+
+	registerSettingsEmailFeedbackFill();
+};
+
+renderPaymentsSettings();
+registerSlotFills();

--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -226,26 +226,23 @@ const webpackConfig = {
 		! process.env.STORYBOOK &&
 			new WooCommerceDependencyExtractionWebpackPlugin( {
 				requestToExternal( request ) {
-					if ( request === '@wordpress/components/build/ui' ) {
-						// The external wp.components does not include ui components, so we need to skip requesting to external here.
-						return null;
-					}
-
 					if ( request.startsWith( '@wordpress/dataviews' ) ) {
 						return null;
 					}
 
+					// Skip requesting to external if the import path is from the build or build-module directory for WordPress packages.
+					// This is required for @wordpress/edit-site to work and also can reduce the bundle size when we don't need to load the entire WordPress package.
 					if (
-						request.startsWith(
-							'@wordpress/interface/build-module'
-						)
+						request.match( /^@wordpress\/.*\/build(?:-module)?/ )
 					) {
 						return null;
 					}
 
-					if ( request.startsWith( '@wordpress/edit-site' ) ) {
-						// The external wp.editSite does not include edit-site components, so we need to skip requesting to external here. We can remove this once the edit-site components are exported in the external wp.editSite.
-						// We use the edit-site components in the customize store.
+					// Skip requesting to external if the import path is from the build or build-module directory for WooCommerce packages.
+					// This can reduce the bundle size when we don't need to load the entire WooCommerce package.
+					if (
+						request.match( /^@woocommerce\/.*\/build(?:-module)?/ )
+					) {
 						return null;
 					}
 				},

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -573,7 +573,6 @@ class PageController {
 		// phpcs:enable WordPress.Security.NonceVerification
 	}
 
-
 	/**
 	 * Returns true if we are on a settings page.
 	 */

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -573,6 +573,16 @@ class PageController {
 		// phpcs:enable WordPress.Security.NonceVerification
 	}
 
+
+	/**
+	 * Returns true if we are on a settings page.
+	 */
+	public static function is_settings_page() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		return isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'];
+		// phpcs:enable WordPress.Security.NonceVerification
+	}
+
 	/**
 	 *  Returns true if we are on a "classic" (non JS app) powered admin page.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -248,6 +248,11 @@ class WCAdminAssets {
 		wp_enqueue_style( 'wc-material-icons' );
 		wp_enqueue_style( 'wc-onboarding' );
 
+		if ( PageController::is_settings_page() ) {
+			$this->register_script( 'wp-admin-scripts', 'settings-embed', true );
+			$this->register_style( 'settings-embed', 'style', array( 'wp-components' ) );
+		}
+
 		// Preload our assets.
 		$this->output_header_preload_tags();
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR builds upon the work in #55822 to further enhance WooCommerce Admin performance by splitting the settings functionality into a separate script bundle. While PR #55822 introduced the initial architecture for script splitting between WC Admin pages and embedded components, this PR extends that approach specifically for the settings pages.

1. Settings Script Splitting:

- Create a dedicated settings-embed entry point for the WooCommerce settings page
- Register settings-embed script and style only when on settings pages

2. Webpack Optimization:
- Update webpack config to dynamically skip external requests for WordPress and WooCommerce build directories
- Replace specific package exclusions with a more general pattern matching approach
- Refactor email preview import to use a specific build path for the isValidEmail utility to avoid loading the entire product editor script.


Comparison of Script Sizes and Resources Loaded:

| Page   | Before: Entry Script Size | Before: Resources Loaded | After: Entry Script Size | After: Resources Loaded |
|--------|---------------------------|--------------------------|--------------------------|-------------------------|
| Order    | 135 kB                   | 8.6 MB                  | 60.2 KB | 6.7 MB


<img width="1147" alt="Screenshot 2025-02-25 at 18 01 49" src="https://github.com/user-attachments/assets/aec2fb0a-32f3-4971-ab94-e6d91d70ab64" />

<img width="1147" alt="Screenshot 2025-02-25 at 18 01 57" src="https://github.com/user-attachments/assets/120381a7-98cc-4c5d-93fc-e9254e356863" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to `WooCommerce > Settings`
2. The settings page loads correctly with the header, activity panel, and settings content.
3. Go to Site Visibility settings and check the Site Visibility settings page renders correctly.
4. Enable `reactify-classic-payments-settings` feature flag using WCA tester
5. Go to WooCommerce > Settings > Payments and check the Reactified Payments settings page renders correctly.



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Enhance WooCommerce Admin Performance: Split Settings Scripts

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
