### PR TITLE
[e2e tests] Fix strict mode violation in payment task check

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-payment-task-get-paid-strict
+++ b/plugins/woocommerce/changelog/e2e-fix-payment-task-get-paid-strict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix a strict mode violation in setup-checklist spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/onboarding/setup-checklist.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/onboarding/setup-checklist.spec.js
@@ -32,8 +32,6 @@ const test = baseTest.extend( {
 			value: 'AF',
 		} );
 
-		console.log( 'nonSupportedWooPaymentsCountry fixture' );
-
 		await use( page );
 
 		// Reset the default country to its initial state.
@@ -84,7 +82,8 @@ test(
 			'wp-admin/admin.php?page=wc-admin'
 		);
 		await nonSupportedWooPaymentsCountryPage
-			.getByRole( 'button', { name: 'Get paid' } )
+			.locator( '.woocommerce-task-list__item' )
+			.filter( { hasText: 'Get paid' } )
 			.click();
 
 		await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the test 'Can visit the payment setup task from from the task list', which started [failing in daily runs](https://github.com/woocommerce/woocommerce/actions/runs/13513059854/job/37762224268). The cause was a strict mode violation. If the current task is `Get paid` there are two visible buttons with the same text.

This is not failing in trunk, where using 6 shards as opposed to daily runs where there are 5 shards only. The difference in tests order makes for a different environment state a thte time of this test execution.

### How to test the changes in this Pull Request:

Run shard 3/5

```
pnpm test:e2e --shard=3/5
```
Tested in CI here: https://github.com/woocommerce/woocommerce/actions/runs/13518943547/job/37773683956
