### PR TITLE
Use correct aria prop name on `CheckboxControl` component

### DIFF
--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/index.tsx
@@ -15,7 +15,6 @@ export type CheckboxControlProps = {
 	className?: string;
 	label?: string | React.ReactNode;
 	id?: string;
-	ariaDescribedBy?: string | undefined;
 	onChange: ( value: boolean ) => void;
 	children?: ReactNode | null | undefined;
 	hasError?: boolean;

--- a/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce-blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -210,7 +210,7 @@ const ValidatedCheckboxControl = forwardRef<
 					},
 					[ onChange, validateInput ]
 				) }
-				ariaDescribedBy={ ariaDescribedBy }
+				aria-describedby={ ariaDescribedBy }
 				checked={ checked }
 				title="" // This prevents the same error being shown on hover.
 				label={ label }

--- a/plugins/woocommerce/changelog/fix-aria-describedby-checkbox
+++ b/plugins/woocommerce/changelog/fix-aria-describedby-checkbox
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a fix for an unreleased feature
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the aria-describedby prop passed to `CheckboxControl`. The current prop causes a warning in the browser, because `ariaDescribedBy` is not valid, but `aria-describedby` is.

Removing the `ariaDescribedBy` type is fine as the `CheckboxControl` extends `HTMLInputElement` which has `aria-describedby`.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet to your site:

```php
woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'first-plugin-namespace/test-required-field',
				'label'    => 'Test required field',
				'location' => 'contact',
				'required' => true,
				'type'     => 'checkbox',
				'error_message' => 'Please check the box or you will be unable to order test test'
			)
		);
```

2. Add an item to your cart, open your JS console and go to the Checkout block.
3. Ensure you don't see any warnings about `ariaDescribedBy`.
4. Check the box and ensure checkout works OK.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
