### PR TITLE
Add Cost of Goods Sold information in the order editor in admin

### DIFF
--- a/plugins/woocommerce/changelog/pr-55840
+++ b/plugins/woocommerce/changelog/pr-55840
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Cost of Goods Sold information in the order editor in admin

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2188,6 +2188,10 @@ ul.wc_coupon_list_block {
 			}
 		}
 
+		.cost-total {
+			opacity: 50%;
+		}
+
 		.refunded-total {
 			color: $red;
 		}
@@ -2389,12 +2393,19 @@ ul.wc_coupon_list_block {
 				text-align: center;
 			}
 
+			.item_cost {
+				.view {
+					opacity: 50%;
+				}
+			}
+
 			.cost,
 			.tax,
 			.quantity,
 			.line_cost,
 			.line_tax,
 			.tax_class,
+			.item_price,
 			.item_cost {
 				text-align: right;
 
@@ -3910,6 +3921,7 @@ table.wc_input_table {
 		background-color: #fefbcc;
 	}
 
+	.item_price,
 	.item_cost,
 	.cost {
 		text-align: right;
@@ -4572,7 +4584,7 @@ table {
 }
 
 #wc-shipping-zone-region-picker-root .woocommerce-tree-select-control {
-	
+
 	.components-base-control {
 		padding: 2px 8px;
 		border-radius: 4px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2393,7 +2393,7 @@ ul.wc_coupon_list_block {
 				text-align: center;
 			}
 
-			.item_cost {
+			.item_cost_of_goods {
 				.view {
 					opacity: 50%;
 				}
@@ -2405,7 +2405,7 @@ ul.wc_coupon_list_block {
 			.line_cost,
 			.line_tax,
 			.tax_class,
-			.item_price,
+			.item_cost_of_goods,
 			.item_cost {
 				text-align: right;
 
@@ -3921,7 +3921,7 @@ table.wc_input_table {
 		background-color: #fefbcc;
 	}
 
-	.item_price,
+	.item_cost_of_goods,
 	.item_cost,
 	.cost {
 		text-align: right;

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1964,7 +1964,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			 *
 			 * @since 9.8.0
 			 */
-			$html = apply_filters( 'woocommerce_empty_cogs_html', '', $this );
+			$html = apply_filters( 'woocommerce_product_empty_cogs_html', '', $this );
 		} else {
 			$html = wc_price( $value ) . $this->get_price_suffix();
 		}
@@ -1978,7 +1978,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		 *
 		 * @since 9.8.0
 		 */
-		return apply_filters( 'woocommerce_get_cogs_html', $html, $value, $this );
+		return apply_filters( 'woocommerce_product_get_cogs_html', $html, $value, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -50,7 +50,7 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 	<?php do_action( 'woocommerce_admin_order_item_values', $product, $item, absint( $item_id ) ); ?>
 
 	<?php if ( wc_get_container()->get( CostOfGoodsSoldController::class )->feature_is_enabled() ) : ?>
-		<td class="item_cost" width="1%" data-sort-value="<?php echo esc_attr( $item->get_cogs_value() ); ?>">
+		<td class="item_cost_of_goods" width="1%" data-sort-value="<?php echo esc_attr( $item->get_cogs_value() ); ?>">
 			<div class="view">
 				<?php
 				echo $item->get_cogs_value_html();
@@ -58,7 +58,7 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 			</div>
 		</td>
 	<?php endif; ?>
-	<td class="item_price" width="1%" data-sort-value="<?php echo esc_attr( $order->get_item_subtotal( $item, false, true ) ); ?>">
+	<td class="item_cost" width="1%" data-sort-value="<?php echo esc_attr( $order->get_item_subtotal( $item, false, true ) ); ?>">
 		<div class="view">
 			<?php
 			echo wc_price( $order->get_item_subtotal( $item, false, true ), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -53,7 +53,7 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 		<td class="item_cost_of_goods" width="1%" data-sort-value="<?php echo esc_attr( $item->get_cogs_value() ); ?>">
 			<div class="view">
 				<?php
-				echo $item->get_cogs_value_html();
+				echo wp_kses_post( $item->get_cogs_value_html() );
 				?>
 			</div>
 		</td>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -9,6 +9,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
+
 $product      = $item->get_product();
 $product_link = $product ? admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ) : '';
 $thumbnail    = $product ? apply_filters( 'woocommerce_admin_order_item_thumbnail', $product->get_image( 'thumbnail', array( 'title' => '' ), false ), $item_id, $item ) : '';
@@ -47,7 +49,16 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 
 	<?php do_action( 'woocommerce_admin_order_item_values', $product, $item, absint( $item_id ) ); ?>
 
-	<td class="item_cost" width="1%" data-sort-value="<?php echo esc_attr( $order->get_item_subtotal( $item, false, true ) ); ?>">
+	<?php if ( wc_get_container()->get( CostOfGoodsSoldController::class )->feature_is_enabled() ) : ?>
+		<td class="item_cost" width="1%" data-sort-value="<?php echo esc_attr( $item->get_cogs_value() ); ?>">
+			<div class="view">
+				<?php
+				echo $item->get_cogs_value_html();
+				?>
+			</div>
+		</td>
+	<?php endif; ?>
+	<td class="item_price" width="1%" data-sort-value="<?php echo esc_attr( $order->get_item_subtotal( $item, false, true ) ); ?>">
 		<div class="view">
 			<?php
 			echo wc_price( $order->get_item_subtotal( $item, false, true ), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -44,9 +44,9 @@ if ( wc_tax_enabled() ) {
 				<th class="item sortable" colspan="2" data-sort="string-ins"><?php esc_html_e( 'Item', 'woocommerce' ); ?></th>
 				<?php do_action( 'woocommerce_admin_order_item_headers', $order ); ?>
 				<?php if ( $cogs_is_enabled ) : ?>
-					<th class="item_cost sortable" data-sort="float"><?php esc_html_e( 'Cost', 'woocommerce' ); ?></th>
+					<th class="item_cost_of_goods sortable" data-sort="float"><?php esc_html_e( 'Cost', 'woocommerce' ); ?></th>
 				<?php endif; ?>
-				<th class="item_price sortable" data-sort="float"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
+				<th class="item_cost sortable" data-sort="float"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 				<th class="quantity sortable" data-sort="int"><?php esc_html_e( 'Qty', 'woocommerce' ); ?></th>
 				<th class="line_cost sortable" data-sort="float"><?php esc_html_e( 'Total', 'woocommerce' ); ?></th>
 				<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\WooCommerce\Internal\CostOfGoodsSold\CostOfGoodsSoldController;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -27,6 +28,7 @@ $line_items          = $order->get_items( apply_filters( 'woocommerce_admin_orde
 $discounts           = $order->get_items( 'discount' );
 $line_items_fee      = $order->get_items( 'fee' );
 $line_items_shipping = $order->get_items( 'shipping' );
+$cogs_is_enabled     = wc_get_container()->get( CostOfGoodsSoldController::class )->feature_is_enabled();
 
 if ( wc_tax_enabled() ) {
 	$order_taxes      = $order->get_taxes();
@@ -41,7 +43,10 @@ if ( wc_tax_enabled() ) {
 			<tr>
 				<th class="item sortable" colspan="2" data-sort="string-ins"><?php esc_html_e( 'Item', 'woocommerce' ); ?></th>
 				<?php do_action( 'woocommerce_admin_order_item_headers', $order ); ?>
-				<th class="item_cost sortable" data-sort="float"><?php esc_html_e( 'Cost', 'woocommerce' ); ?></th>
+				<?php if ( $cogs_is_enabled ) : ?>
+					<th class="item_cost sortable" data-sort="float"><?php esc_html_e( 'Cost', 'woocommerce' ); ?></th>
+				<?php endif; ?>
+				<th class="item_price sortable" data-sort="float"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 				<th class="quantity sortable" data-sort="int"><?php esc_html_e( 'Qty', 'woocommerce' ); ?></th>
 				<th class="line_cost sortable" data-sort="float"><?php esc_html_e( 'Total', 'woocommerce' ); ?></th>
 				<?php
@@ -280,6 +285,20 @@ if ( wc_tax_enabled() ) {
 				</td>
 			</tr>
 
+		</table>
+	<?php endif; ?>
+
+	<?php if ( $cogs_is_enabled ) : ?>
+		<div class="clear"></div>
+
+		<table class="wc-order-totals">
+			<tr>
+				<td class="label cost-total"><?php esc_html_e( 'Cost Total', 'woocommerce' ); ?>:</td>
+				<td width="1%"></td>
+				<td class="total cost-total">
+					<?php echo wc_price( $order->get_cogs_total_value(), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</td>
+			</tr>
 		</table>
 	<?php endif; ?>
 

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -576,11 +576,11 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		 * Filter to customize how the Cost of Goods Sold value for an order item gets rendered to HTML.
 		 *
 		 * @param string $html The rendered HTML.
-		 * @param WC_Order_Item $product The order item.
 		 * @param float $value The cost value that is being rendered.
+		 * @param WC_Order_Item $product The order item.
 		 *
 		 * @since 9.9.0
 		 */
-		return apply_filters( 'woocommerce_order_item_cogs_html', $cogs_value_html, $this, $cogs_value );
+		return apply_filters( 'woocommerce_order_item_cogs_html', $cogs_value_html, $cogs_value, $this );
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -546,4 +546,41 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			$this->set_prop( 'cogs_value', $value );
 		}
 	}
+
+	/**
+	 * Returns the Cost of Goods Sold value in html format.
+	 *
+	 * @return string
+	 */
+	public function get_cogs_value_html(): string {
+		if ( ! $this->cogs_is_enabled( __METHOD__ ) ) {
+			return '';
+		}
+
+		if ( ! $this->has_cogs() ) {
+			/**
+			 * Filter to customize how a non-existing Cost of Goods Sold value for an order item (whose has_cogs method returns false) gets rendered to HTML.
+			 *
+			 * @param string $html The rendered HTML.
+			 * @param WC_Order_Item $product The order item for which the "there's no cost" indication is rendered.
+			 *
+			 * @since 9.9.0
+			 */
+			return apply_filters( 'woocommerce_order_item_no_cogs_html', "<span class='na'>&ndash;</span>", $this );
+		}
+
+		$cogs_value      = $this->get_cogs_value();
+		$cogs_value_html = wc_price( $cogs_value, array( 'currency' => $this->get_order()->get_currency() ) );
+
+		/**
+		 * Filter to customize how the Cost of Goods Sold value for an order item gets rendered to HTML.
+		 *
+		 * @param string $html The rendered HTML.
+		 * @param WC_Order_Item $product The order item.
+		 * @param float $value The cost value that is being rendered.
+		 *
+		 * @since 9.9.0
+		 */
+		return apply_filters( 'woocommerce_order_item_cogs_html', $cogs_value_html, $this, $cogs_value );
+	}
 }

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -240,7 +240,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 
 		$cogs_value = (float) $cogs_value;
 		if ( 0.0 === $cogs_value ) {
-			$this->order_item_data_store->delete_metadata( $item->get_id(), '_cogs_value', '', true );
+			$this->order_item_data_store->delete_metadata( $item->get_id(), '_cogs_value', '' );
 		} else {
 			$this->order_item_data_store->update_metadata( $item->get_id(), '_cogs_value', $cogs_value );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request adds Cost of Goods Sold information in the order details page in admin:

![image](https://github.com/user-attachments/assets/bf2b8fb9-e02a-4791-818d-2296ead520b6)

The backend changes here are minimal since all the code API to deal with cost values in orders was already introduced in https://github.com/woocommerce/woocommerce/pull/52067.

Note that the existing "Cost" column is renamed to "Price" to avoid confussion. This change is permanent, it applies even when the Cost of Goods Sold feature is disabled.

Additional changes:

* Two new hooks are introduced: `woocommerce_order_item_no_cogs_html` and `woocommerce_order_item_cogs_html`.
* Given the above, to reduce confussion and ambiguity the existing `woocommerce_empty_cogs_html` and `woocommerce_get_cogs_html` hooks are renamed to `woocommerce_product_empty_cogs_html` and `woocommerce_product_get_cogs_html` respectively.
* A bug in the order items data store (introduced in https://github.com/woocommerce/woocommerce/pull/52067) is fixed: when the cost metadata for a line item had to be deleted, all the existing metadata entries for all the existing order items were actually deleted.

### How to test the changes in this Pull Request:

1. Enable the Cost of Goods Sold feature if you haven't done that yet (WooCommerce - Settings - Advanced - Features, check the box for "Cost of Goods Sold" and save).
2. Create a few products and assign costs to them (you can use the testing instructions of https://github.com/woocommerce/woocommerce/pull/54399). Include simple and variable products, and variations with and without an explicit cost set.
3. Create an order using the shop frontend, include the products you created or modified above. Add more than one unit of at least one of the products with cost.
4. Open the order details in admin and verify that the values displayed in the "Cost" column are correct for each order item. In particular, items corresponding to products with no cost should display zero; for variations with no explicit cost set, the default cost as set in the parent product should display; and for items with more than one unit of the product, the cost should be the unit cost times the quantity.
5. Verify that the "Cost Total" amount in the order summary is indeed the sum of all the item costs.
6. Edit the order by adding new items, deleting items, and modifying quantities. Verify that all costs are updated accordignly. (The exception is the case of adding new items: in this case you need to hit "Recalculate" for the cost of the new lines to show, but you need to do that anyway in order to update the order totals).
7. Verify that hitting "Recalculate" correctly updates the costs, even if you haven't changed anything in the order.
8. Disable the Cost of Goods Sold feature, reload the order page and verify that no cost information is shown whatsoever (but the column previously titled "Cost" still displays "Price" instead).
9. Repeat all with an order created directly from the admin backend.

There's an additional feature that needs a small code change to be tested. The `get_cogs_value_html` method of the `WC_Order_Item` class (and derived classes) will return a dash if the `has_cogs` method of the class returns false (as opposed to rendering a zero if `has_cogs` returns true but a particular instance has no cost defined), but we are using this method only for product items, for which `has_cogs` always returns true. So to test this behavior you can do the following temporary change to the `WC_Order_Item_Product` class: redefine the `has_cogs` method as follows:

```php
public function has_cogs(): bool {
	return $this->get_prop( 'cogs_value' ) !== 0.0;
}
```

Then reload the order details page and verify that the lines corresponding to products with a cost of zero display a dash, instead of zero, in the cost column.

With the previous code modification still in place, you can add the following snippet to test the new hooks:

```php
add_filter('woocommerce_order_item_no_cogs_html', fn($html, $item) => '<p>No cost for ' . $item->get_id() . '</p>', 2, 10);
add_filter('woocommerce_order_item_cogs_html', fn($html, $value, $item) => '<p>Cost for ' . $item->get_id() . ': ' . $value . '</p>', 3, 10);
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
