### PR TITLE
Prevent writing of metadata to the database for orders without ID

### DIFF
--- a/plugins/woocommerce/changelog/fix-55728
+++ b/plugins/woocommerce/changelog/fix-55728
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not write metadata to the db for unsaved HPOS orders.

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -105,6 +105,10 @@ abstract class CustomMetaDataStore {
 		$db_info = $this->get_db_info();
 
 		$object_id  = $object->get_id();
+		if ( ! $object_id ) {
+			return false;
+		}
+
 		$meta_key   = wp_unslash( wp_slash( $meta->key ) );
 		$meta_value = maybe_serialize( is_string( $meta->value ) ? wp_unslash( wp_slash( $meta->value ) ) : $meta->value );
 
@@ -133,7 +137,7 @@ abstract class CustomMetaDataStore {
 	public function update_meta( &$object, $meta ) : bool {
 		global $wpdb;
 
-		if ( ! isset( $meta->id ) || empty( $meta->key ) ) {
+		if ( ! isset( $meta->id ) || empty( $meta->key ) || ! $object->get_id() ) {
 			return false;
 		}
 
@@ -204,6 +208,10 @@ abstract class CustomMetaDataStore {
 	 */
 	public function get_metadata_by_key( &$object, string $meta_key ) {
 		global $wpdb;
+
+		if ( ! $object->get_id() ) {
+			return false;
+		}
 
 		$db_info = $this->get_db_info();
 

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -104,7 +104,7 @@ abstract class CustomMetaDataStore {
 
 		$db_info = $this->get_db_info();
 
-		$object_id  = $object->get_id();
+		$object_id = $object->get_id();
 		if ( ! $object_id ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -3369,7 +3369,8 @@ CREATE TABLE $meta_table (
 		$current_date_time = new \WC_DateTime( $current_time, new \DateTimeZone( 'GMT' ) );
 
 		$should_save =
-			$order->get_date_modified() < $current_date_time && empty( $order->get_changes() )
+			$order->get_id() > 0
+			&& $order->get_date_modified() < $current_date_time && empty( $order->get_changes() )
 			&& ( ! is_object( $meta ) || ! in_array( $meta->key, $this->ephemeral_meta_keys, true ) );
 
 		/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3742,4 +3742,43 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$meta_objects = $meta_store->get_metadata_by_key( $order, '_cogs_total_value' );
 		$this->assertEquals( $expected_saved_value, (float) $meta_objects[0]->meta_value );
 	}
+
+	/**
+	 * @testdox Saving metadata for a non-persisted order doesn't save the order nor the metadata.
+	 */
+	public function test_save_meta_on_non_persisted_order() {
+		global $wpdb;
+
+		$this->toggle_cot_feature_and_usage( true );
+
+		$meta_key   = 'test_meta_key';
+		$meta_value = 'test_meta_value';
+
+		$query = $wpdb->prepare(
+			"SELECT COUNT(*) FROM {$this->sut::get_meta_table_name()} WHERE meta_key = %s AND meta_value = %s",
+			$meta_key,
+			$meta_value
+		);
+
+		// Confirm there's no meta at the start.
+		$this->assertEquals( $wpdb->get_var( $query ), 0 );
+
+		// Confirm there's no meta
+		$order = new \WC_Order();
+		$order->add_meta_data( $meta_key, $meta_value );
+		$order->save_meta_data();
+
+		// Confirm there's still no meta after calling `save_meta_data()` on an unsaved order.
+		$this->assertEquals( $wpdb->get_var( $query ), 0 );
+
+		// Confirm that saving the order persists everything.
+		$order->save();
+		$this->assertEquals( $wpdb->get_var( $query ), 1 );
+
+		// Calling `save_meta_data()` on an already saved order does update metadata.
+		$order->add_meta_data( $meta_key, $meta_value, false );
+		$order->save_meta_data();
+		$this->assertEquals( $wpdb->get_var( $query ), 2 );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3755,30 +3755,29 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$meta_value = 'test_meta_value';
 
 		$query = $wpdb->prepare(
-			"SELECT COUNT(*) FROM {$this->sut::get_meta_table_name()} WHERE meta_key = %s AND meta_value = %s",
+			"SELECT COUNT(*) FROM {$this->sut::get_meta_table_name()} WHERE meta_key = %s AND meta_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- variable is a table name.
 			$meta_key,
 			$meta_value
 		);
 
 		// Confirm there's no meta at the start.
-		$this->assertEquals( $wpdb->get_var( $query ), 0 );
+		$this->assertEquals( $wpdb->get_var( $query ), 0 ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query has already been prepared.
 
-		// Confirm there's no meta
+		// Confirm there's no meta.
 		$order = new \WC_Order();
 		$order->add_meta_data( $meta_key, $meta_value );
 		$order->save_meta_data();
 
 		// Confirm there's still no meta after calling `save_meta_data()` on an unsaved order.
-		$this->assertEquals( $wpdb->get_var( $query ), 0 );
+		$this->assertEquals( $wpdb->get_var( $query ), 0 ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query has already been prepared.
 
 		// Confirm that saving the order persists everything.
 		$order->save();
-		$this->assertEquals( $wpdb->get_var( $query ), 1 );
+		$this->assertEquals( $wpdb->get_var( $query ), 1 ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query has already been prepared.
 
 		// Calling `save_meta_data()` on an already saved order does update metadata.
 		$order->add_meta_data( $meta_key, $meta_value, false );
 		$order->save_meta_data();
-		$this->assertEquals( $wpdb->get_var( $query ), 2 );
+		$this->assertEquals( $wpdb->get_var( $query ), 2 ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query has already been prepared.
 	}
-
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is enabled, adding or updating metadata in an unsaved order _might_ end up creating rows with `order_id = 0` in `wc_orders_meta` and might also result in the order itself being persisted even if it's in an incomplete state.

This PR makes sure no metadata with `order_id = 0` and that the mechanism triggering a full save after a metadata update is only triggered for orders that already have an ID (i.e. were already persisted to the database).

Closes #55728.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. If you're not starting from a "clean" test environment, make sure orders are synced up and that your database doesn't contain any meta rows with `order_id = 0`.
   A way do to achieve this via WP CLI might be:

   ```
   wp db query "DELETE FROM $(wp db prefix)wc_orders_meta WHERE order_id = 0"
   wp wc hpos sync
   ```
1. Go to **WC > Settings > Advanced > Features** and make sure **High-performance order storage** is selected.
   Sync orders if needed (`wp wc hpos sync`) to make sure you can toggle this on.
1. Open a WP-CLI shell (`wp shell`) and run the following commands, while verifying that the output is as indicated.
   ```
   $o = new \WC_Order();
   $o->update_meta_data( 'foo', 'bar' );

   # Should print int(0).
   $o->get_id();
   
   $o->save_meta_data();

   # Should print int(0).
   $o->get_id();

   # Should print a non-zero int.
   $o->save();
   
   # Should print the same non-zero int as above.
   $o->get_id();
   ```
1. Take note of the `int` printed above.
1. Make sure no rows with `order_id = 0` were added to the meta table. The following commands should not return anything:
   ```
   wp db query "SELECT * FROM $(wp db prefix)wc_orders_meta WHERE order_id = 0"
   wp db prefix "SELECT * FROM $(wp db prefix)postmeta WHERE post_id = 0"
   ```
1. Open the order with the ID from step 3-4 in **WC > Orders** and confirm that metadata `foo` with value `bar` is listed inside the **Custom Fields** metabox.
   If the metabox doesn't appear by default, enable it in **Screen Options** at the top.
1. Go to **WC > Settings > Advanced > Features** and choose **WordPress posts storage (legacy)** as order storage. Repeat steps above and confirm that results are identical.
1. (Optional but recommended) Switch to `trunk` and repeat steps 0-5. You should be able to confirm that there are few failures:
   - The order gets saved when `save_meta_data()` is called, and `$o->get_id()` immediately returns an ID even though `$o->save()` hasn't been executed yet.
   - The `foo` metadata is persisted to the database with `order_id = 0`.
   - Despite the strange auto-save, the metadata is actually _missing_ when you go open the order in the backend.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
