### PR TITLE
Blueprint - Add a warning when an invalid step is given.

### DIFF
--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -81,7 +81,7 @@ class ImportStep {
 		$result = StepProcessorResult::success( 'ImportStep' );
 
 		if ( ! isset( $this->indexed_importers[ $this->step_definition->step ] ) ) {
-			$result->add_error( "Unable to find an importer for {$this->step_definition->step}" );
+			$result->add_warn( "Unable to find an importer for {$this->step_definition->step}" );
 			return $result;
 		}
 

--- a/packages/php/blueprint/src/StepProcessorResult.php
+++ b/packages/php/blueprint/src/StepProcessorResult.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
  * A class returned by StepProcessor classes containing result of the process and messages.
  */
 class StepProcessorResult {
-	const MESSAGE_TYPES = array( 'error', 'info', 'debug' );
+	const MESSAGE_TYPES = array( 'error', 'info', 'debug', 'warn' );
 
 	/**
 	 * Messages
@@ -126,6 +126,17 @@ class StepProcessorResult {
 	 */
 	public function add_info( string $message ) {
 		$this->add_message( $message, 'info' );
+	}
+
+	/**
+	 * Add a new warn message.
+	 *
+	 * @param string $message message.
+	 *
+	 * @return void
+	 */
+	public function add_warn( string $message ) {
+		$this->add_message( $message, 'warn' );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -49,7 +49,7 @@ class ExportSchemaTest extends TestCase {
 		$result = $mock->export();
 		$this->assertCount( 1, $result['steps'] );
 		$this->assertEquals( 'setSiteOptions', $result['steps'][0]['step'] );
-		$this->assertEquals( array(), $result['steps'][0]['options'] );
+		$this->assertEquals( (object) array(), $result['steps'][0]['options'] );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/ImportStepTest.php
+++ b/packages/php/blueprint/tests/Unit/ImportStepTest.php
@@ -46,13 +46,13 @@ class ImportStepTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function test_it_returns_error_when_it_cannot_find_valid_importer() {
+	public function test_it_returns_warn_when_it_cannot_find_valid_importer() {
 		$rand     = wp_rand( 1, 99999999 );
 		$importer = new ImportStep( (object) array( 'step' => 'dummy' . $rand ) );
 		$result   = $importer->import();
 
-		$this->assertCount( 1, $result->get_messages( 'error' ) );
-		$this->assertEquals( 'Unable to find an importer for dummy' . $rand, $result->get_messages( 'error' )[0]['message'] );
+		$this->assertCount( 1, $result->get_messages( 'warn' ) );
+		$this->assertEquals( 'Unable to find an importer for dummy' . $rand, $result->get_messages( 'warn' )[0]['message'] );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/SetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/SetSiteOptionsTest.php
@@ -20,7 +20,7 @@ class SetSiteOptionsTest extends TestCase {
 
 		$expected_array = array(
 			'step'    => 'setSiteOptions',
-			'options' => $options,
+			'options' => (object) $options,
 		);
 
 		$this->assertEquals( $expected_array, $setSiteOptions->prepare_json_array() );
@@ -44,12 +44,8 @@ class SetSiteOptionsTest extends TestCase {
 					'type' => 'string',
 					'enum' => array( 'setSiteOptions' ),
 				),
-				'options' => array(
-					'type'                 => 'object',
-					'additionalProperties' => new \stdClass(),
-				),
 			),
-			'required'   => array( 'step', 'options' ),
+			'required'   => array( 'step'  ),
 		);
 
 		$this->assertEquals( $expected_schema, SetSiteOptions::get_schema() );


### PR DESCRIPTION
* When an invalid step is given, add a warning instead of returning an error

* Fixed broken tests

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55846 

This PR adds a warning instead of return an error when an unsupported step is provided.

It also fixes broken tests due to the changes in the previous PRs. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checking the code and running the tests should be sufficient. Test for this change is https://github.com/woocommerce/woocommerce/pull/55847/files#diff-024d9cea1f81907bfbb3dfd8b3242cbc323680a41480c8f95d669f53b9788923R49
2. Checkout the branch locally and cd into `packages/php/blueprint`
3. Make sure your Docker is running.
4. Run `composer test:setup`.
5. Run `composer test:unit`.
6. Make sure all tests pass.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Blueprint - add a warning instead of return an error when an unsupported step is provided
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
