### PR TITLE
wcSettings deprecation Proxy - fix array properties

### DIFF
--- a/plugins/woocommerce/changelog/fix-createDeprecatedObjectProxy-array-methods
+++ b/plugins/woocommerce/changelog/fix-createDeprecatedObjectProxy-array-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix bug to unreleased createDeprecatedObjectProxy: Ensure array length is accessible on wcSettings arrays.
+
+

--- a/plugins/woocommerce/client/admin/client/utils/index.js
+++ b/plugins/woocommerce/client/admin/client/utils/index.js
@@ -151,6 +151,18 @@ export const useFullScreen = ( classes ) => {
 export function createDeprecatedObjectProxy( obj, messages, basePath = '' ) {
 	return new Proxy( obj, {
 		get( target, prop, receiver ) {
+			// Handle array methods and properties
+			if ( Array.isArray( target ) ) {
+				// Support array length property
+				if ( prop === 'length' ) {
+					return target.length;
+				}
+				// Support array iterator for destructuring
+				if ( prop === Symbol.iterator ) {
+					return target[ Symbol.iterator ].bind( target );
+				}
+			}
+
 			const nextPath = basePath ? `${ basePath }.${ prop }` : prop;
 
 			// Retrieve the deprecation message (if exists)

--- a/plugins/woocommerce/client/admin/client/utils/test/index.js
+++ b/plugins/woocommerce/client/admin/client/utils/test/index.js
@@ -109,19 +109,29 @@ describe( 'createDeprecatedObjectProxy', () => {
 			3
 		);
 
-		// destructuring
+		// Array destructuring.
 		const copiedArray = [ ...proxiedSettings.admin.onboarding.profile.arr ];
 		expect( copiedArray.length ).toEqual( 3 );
 
-		// Array method forEach
+		// Array method forEach.
 		proxiedSettings.admin.onboarding.profile.arr.forEach( ( item ) => {
 			expect( copiedArray.includes( item ) ).toBe( true );
 		} );
 
-		// Array method push
+		// Array method push.
 		proxiedSettings.admin.onboarding.profile.arr.push( 'four' );
 		expect( proxiedSettings.admin.onboarding.profile.arr.length ).toEqual(
 			4
+		);
+	} );
+
+	it( 'should log a warning when accessing a deprecated array', () => {
+		expect( consoleWarnSpy ).not.toHaveBeenCalled();
+		expect( proxiedSettings.admin.onboarding.profile.arr.length ).toEqual(
+			3
+		);
+		expect( consoleWarnSpy ).toHaveBeenCalledWith(
+			'Deprecated: wcSettings.admin.onboarding.profile is deprecated. It is planned to be released in WooCommerce 10.0.0. Please use `getProfileItems` from the onboarding store. See https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/data/src/onboarding for more information.'
 		);
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/utils/test/index.js
+++ b/plugins/woocommerce/client/admin/client/utils/test/index.js
@@ -71,6 +71,7 @@ describe( 'createDeprecatedObjectProxy', () => {
 				onboarding: {
 					profile: {
 						name: 'hello',
+						arr: [ 'one', 'two', 'three' ],
 					},
 				},
 			},
@@ -101,5 +102,26 @@ describe( 'createDeprecatedObjectProxy', () => {
 	it( 'should not log a warning when accessing a non-deprecated property', () => {
 		expect( proxiedSettings.admin ).toBeDefined();
 		expect( consoleWarnSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should retain array prototype methods', () => {
+		expect( proxiedSettings.admin.onboarding.profile.arr.length ).toEqual(
+			3
+		);
+
+		// destructuring
+		const copiedArray = [ ...proxiedSettings.admin.onboarding.profile.arr ];
+		expect( copiedArray.length ).toEqual( 3 );
+
+		// Array method forEach
+		proxiedSettings.admin.onboarding.profile.arr.forEach( ( item ) => {
+			expect( copiedArray.includes( item ) ).toBe( true );
+		} );
+
+		// Array method push
+		proxiedSettings.admin.onboarding.profile.arr.push( 'four' );
+		expect( proxiedSettings.admin.onboarding.profile.arr.length ).toEqual(
+			4
+		);
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

https://github.com/woocommerce/woocommerce/pull/55707 creates a Proxy around `wc.wcSettings` so that notices can be logged about deprecation. This was causing issues with `Settings` project because some of the nested properties found on `wc.wcSettings` were being destructured, causing a fatal error.

According to chatGPT, this has to do with indexing and the `length` property.

>When using a Proxy in JavaScript, destructuring arrays can break because the length property and indexed elements might not behave as expected, depending on how the proxy is set up. However, you can still make destructuring work by ensuring the proxy correctly handles array indexing and the length property.

I've made changes to account for this but there is a caveat. When an array in found, there is now an early exit from the recursive function

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Locally or on JN open the console and make sure arrays in Settings can be desctructured. These should not cause an error:

```js
window.wcSettings?.admin?.settingsScripts._default;
```

```js
[ ...window.wcSettings?.admin?.settingsScripts._default ]
```
2. Try other array prototype methods.
3. Access `window.wcSettings?.admin?.onboarding.profile` and note the warning is still there.
4. Ensure tests pass in CI.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
