### PR TITLE
Fix Storybook build

### DIFF
--- a/plugins/woocommerce-blocks/storybook/webpack.config.js
+++ b/plugins/woocommerce-blocks/storybook/webpack.config.js
@@ -16,6 +16,7 @@ const tsConfig = require( '../tsconfig.base.json' );
 
 const aliases = Object.keys( tsConfig.compilerOptions.paths ).reduce(
 	( acc, key ) => {
+		// Filter out @wordpress/* paths to allow resolution from node_modules instead of build-types directory specified in tsconfig.
 		if ( ! key.startsWith( '@wordpress' ) ) {
 			const currentPath = tsConfig.compilerOptions.paths[ key ][ 0 ];
 			acc[ key.replace( '/*', '' ) ] = path.resolve(

--- a/plugins/woocommerce-blocks/storybook/webpack.config.js
+++ b/plugins/woocommerce-blocks/storybook/webpack.config.js
@@ -16,11 +16,13 @@ const tsConfig = require( '../tsconfig.base.json' );
 
 const aliases = Object.keys( tsConfig.compilerOptions.paths ).reduce(
 	( acc, key ) => {
-		const currentPath = tsConfig.compilerOptions.paths[ key ][ 0 ];
-		acc[ key.replace( '/*', '' ) ] = path.resolve(
-			__dirname,
-			'../' + currentPath.replace( '/*', '/' )
-		);
+		if ( ! key.startsWith( '@wordpress' ) ) {
+			const currentPath = tsConfig.compilerOptions.paths[ key ][ 0 ];
+			acc[ key.replace( '/*', '' ) ] = path.resolve(
+				__dirname,
+				'../' + currentPath.replace( '/*', '/' )
+			);
+		}
 		return acc;
 	},
 	{}

--- a/plugins/woocommerce/changelog/fix-storybook_build
+++ b/plugins/woocommerce/changelog/fix-storybook_build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the WooCommerce Blocks storybook build by updating the build aliases.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The storybook build was failing: example: https://github.com/woocommerce/woocommerce/actions/runs/13535454812/job/37826191054
This started with the addition of `@wordpress/*/build-types` configs to the tsconfig paths file.
I filtered these out for the storybook specifically to fix this.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter='@woocommerce/storybook' build` ( should build correctly )
2. Run `npx http-server tools/storybook/storybook-static`
3. Go to the url the http-server provided, it should load the storybook correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
