### PR TITLE
Fix loading email preview when email is registered with different key than the class name

### DIFF
--- a/plugins/woocommerce/changelog/55869-email-preview-key-class
+++ b/plugins/woocommerce/changelog/55869-email-preview-key-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix loading email preview when email is registered with different key than the class name

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -164,7 +164,11 @@ class EmailPreview {
 	 * @throws \InvalidArgumentException When the email type is invalid.
 	 */
 	public function set_email_type( string $email_type ) {
-		$emails = WC()->mailer()->get_emails();
+		$wc_emails = WC()->mailer()->get_emails();
+		$emails    = array_combine(
+			array_map( 'get_class', $wc_emails ),
+			$wc_emails
+		);
 		if ( ! in_array( $email_type, array_keys( $emails ), true ) ) {
 			throw new \InvalidArgumentException( 'Invalid email type' );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55869.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Described in https://github.com/woocommerce/woocommerce/discussions/54779#discussioncomment-12312799

<!-- End testing instructions -->