### PR TITLE
Optimize product query for product creation task on page load

### DIFF
--- a/plugins/woocommerce/changelog/update-54443
+++ b/plugins/woocommerce/changelog/update-54443
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Optimize product query for product creation task on page load

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -82,6 +82,10 @@ class Products extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
+		if ( $this->has_previously_completed() ) {
+			return true;
+		}
+
 		return self::has_products();
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -24,10 +24,9 @@ class Products extends Task {
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_import_return_notice_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_load_sample_return_notice_script' ) );
 
-		add_action( 'woocommerce_update_product', array( $this, 'delete_product_count_cache' ) );
-		add_action( 'woocommerce_new_product', array( $this, 'delete_product_count_cache' ) );
-		add_action( 'wp_trash_post', array( $this, 'delete_product_count_cache' ) );
-		add_action( 'untrashed_post', array( $this, 'delete_product_count_cache' ) );
+		add_action( 'woocommerce_update_product', array( $this, 'maybe_set_has_product_transient' ), 10, 2 );
+		add_action( 'woocommerce_new_product', array( $this, 'maybe_set_has_product_transient' ), 10, 2 );
+		add_action( 'untrashed_post', array( $this, 'maybe_set_has_product_transient_on_untrashed_post' ) );
 		add_action( 'current_screen', array( $this, 'maybe_redirect_to_add_product_tasklist' ), 30, 0 );
 	}
 
@@ -177,12 +176,40 @@ class Products extends Task {
 	}
 
 	/**
-	 * Delete the product count transient used in has_products() method to refresh the cache.
+	 * Set the has products transient if the post qualifies as a user created product.
 	 *
-	 * @return void
+	 * @param int $post_id Post ID.
 	 */
-	public static function delete_product_count_cache() {
-		delete_transient( self::HAS_PRODUCT_TRANSIENT );
+	public function maybe_set_has_product_transient_on_untrashed_post( $post_id ) {
+		if ( get_post_type( $post_id ) !== 'product' ) {
+			return;
+		}
+
+		$this->maybe_set_has_product_transient( $post_id, wc_get_product( $post_id ) );
+	}
+
+	/**
+	 * Set the has products transient if the product qualifies as a user created product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @param WC_Product $product Product object.
+	 */
+	public function maybe_set_has_product_transient( $product_id, $product ) {
+		if ( ! $this->has_previously_completed() && $this->is_valid_product( $product ) ) {
+			set_transient( self::HAS_PRODUCT_TRANSIENT, 'yes' );
+		}
+	}
+
+	/**
+	 * Check if the product qualifies as a user created product.
+	 *
+	 * @param WC_Product $product Product object.
+	 * @return bool
+	 */
+	private function is_valid_product( $product ) {
+		return ProductStatus::PUBLISH === $product->get_status() &&
+			! $product->get_meta( '_headstart_post' ) &&
+			get_post_meta( $product->get_id(), '_edit_last', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -197,6 +197,7 @@ class Products extends Task {
 	public function maybe_set_has_product_transient( $product_id, $product ) {
 		if ( ! $this->has_previously_completed() && $this->is_valid_product( $product ) ) {
 			set_transient( self::HAS_PRODUCT_TRANSIENT, 'yes' );
+			$this->possibly_track_completion();
 		}
 	}
 
@@ -246,7 +247,7 @@ class Products extends Task {
 
 		$value = $products_query->post_count > 0 ? 'yes' : 'no';
 		set_transient( self::HAS_PRODUCT_TRANSIENT, $value );
-		return $value;
+		return 'yes' === $value;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The product creation task was making calls on each page load to check if a published, edited product exists.  This PR improves performance by doing a few things:

* Limits the need to re-query products once the task has initially been completed.  We use the existing option which tracks task completion.
* Optimizes the SQL by removing the use of `SQL_CALC_FOUND_ROWS` and adding `LIMIT 0,1` since we only need to know if a single record exists.
* Updates the transient on product update, creation, and untrash so we don't need to re-query products on the next page load.

Closes #54443 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

For the following tests, it can be helpful to download a transient manager such as [this](https://wordpress.org/plugins/transients-manager/) to help manage transients.

#### Test Query


For all tests, enable `WP_DEBUG` and `WP_DEBUG_LOG` in your wp-config.php file and add the below PHP snippet.
```PHP
add_filter( 'posts_request', function( $sql ) {
	error_log( $sql );
	return $sql;
}, 10, 1 );
```

1. Start with a fresh site with no products (you may need to delete the `woocommerce_product_task_has_product_transient` transient if you've previously visited a page)
4. Navigate to any WooCommerce page
5. In your debug log, find the query that includes `_headstart_post`.  It should look like this:
```SQL
SELECT   wp_posts.ID
FROM wp_posts
LEFT JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id AND wp_postmeta.meta_key = '_headstart_post' )  LEFT JOIN wp_postmeta AS mt1 ON ( wp_posts.ID = mt1.post_id )
WHERE 1=1  AND ( 
  wp_postmeta.post_id IS NULL 
  OR 
  mt1.meta_key = '_edit_last'
) AND wp_posts.post_type = 'product'
AND ((wp_posts.post_status = 'publish'))
GROUP BY wp_posts.ID
ORDER BY wp_posts.post_date DESC
LIMIT 0, 1
```
4. Note that `SQL_CALC_FOUND_ROWS` is not used in the query and the result is limited to 1.

#### Testing product updates cache

1. After visting any WooCommerce page, confirm that `woocommerce_product_task_has_product_transient` is set with a value of `no`.
2. Add a product
3. Check that the value of the transient has changed to `yes`
4. Update the transient value back to `no` and delete the `woocommerce_task_list_tracked_completed_tasks` option.
6. Update the existing product with any changes
7. Check that the value of the transient has changed back to `yes`
8. Trash the product
9. Update the transient value back to `no` and delete the `woocommerce_task_list_tracked_completed_tasks` option.
10. Untrash the product
11. Check that the value of the transient has changed back to `yes`
12. Check that the above query with `_headstart_post` has not been run again since the initial time.


#### Testing task completion 
1. Make sure at least one published product is added to your site.
7. Delete the transient `woocommerce_product_task_has_product_transient`
8. Make sure the above query with `_headstart_post` is not run again.
9. Optionally, delete all published products and check that the task is still complete

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
