### PR TITLE
[Experimental] Moves schema based `rules` for additional fields to the top level

### DIFF
--- a/plugins/woocommerce/changelog/update-top-level-validation-rules-54875
+++ b/plugins/woocommerce/changelog/update-top-level-validation-rules-54875
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Behind feature flag.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-import {
-	Field,
-	FormFields,
-	CountryAddressFields,
-	KeyedFormFields,
-	FieldLocaleOverrides,
-} from '@woocommerce/settings';
-import { __, sprintf } from '@wordpress/i18n';
-import { isNumber, isString } from '@woocommerce/types';
 import { COUNTRY_LOCALE } from '@woocommerce/block-settings';
+import {
+	CountryAddressFields,
+	Field,
+	FieldLocaleOverrides,
+	FormFields,
+	KeyedFormFields,
+} from '@woocommerce/settings';
+import { isNumber, isString } from '@woocommerce/types';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Gets props from the core locale, then maps them to the shape we require in the client.
@@ -99,8 +99,10 @@ const prepareFormFields = (
 
 	return fieldKeys
 		.map( ( field ) => {
-			const defaultConfig = defaultFields[ field ] || {};
-			const localeConfig = localeConfigs[ field ] || {};
+			const defaultConfig =
+				field in defaultFields ? defaultFields[ field ] : {};
+			const localeConfig =
+				field in localeConfigs ? localeConfigs[ field ] : {};
 
 			return {
 				key: field,

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-fields.ts
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
+import { useSchemaParser } from '@woocommerce/base-hooks';
 import {
 	CURRENT_USER_IS_ADMIN,
 	FormFields,
-	KeyedFormField,
 	FormType,
+	KeyedFormField,
 } from '@woocommerce/settings';
-import { useSchemaParser } from '@woocommerce/base-hooks';
 import { useRef } from '@wordpress/element';
 import fastDeepEqual from 'fast-deep-equal/es6';
 
@@ -41,11 +41,11 @@ export const useFormFields = < T extends keyof FormFields >(
 
 	const updatedFields = formFields.map( ( field ) => {
 		const defaultConfig = defaultFields[ field.key ] || {};
-		if ( defaultConfig.rules && parser ) {
+		if ( parser ) {
 			if ( hasSchemaRules( defaultConfig, 'required' ) ) {
 				let schema = {};
 				if (
-					Object.keys( defaultConfig.rules.required ).some(
+					Object.keys( defaultConfig.required ).some(
 						( key ) =>
 							key === 'cart' ||
 							key === 'checkout' ||
@@ -54,10 +54,10 @@ export const useFormFields = < T extends keyof FormFields >(
 				) {
 					schema = {
 						type: 'object',
-						properties: defaultConfig.rules.required,
+						properties: defaultConfig.required,
 					};
 				} else {
-					schema = defaultConfig.rules.required;
+					schema = defaultConfig.required;
 				}
 
 				try {
@@ -73,7 +73,7 @@ export const useFormFields = < T extends keyof FormFields >(
 			if ( hasSchemaRules( defaultConfig, 'hidden' ) ) {
 				const schema = {
 					type: 'object',
-					properties: defaultConfig.rules.hidden,
+					properties: defaultConfig.hidden,
 				};
 				try {
 					const result = parser.validate( schema, data );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -2,25 +2,25 @@
  * External dependencies
  */
 import {
-	KeyedFormFields,
-	FormFields,
-	AddressFormValues,
-	ContactFormValues,
-	OrderFormValues,
-	FormType,
-} from '@woocommerce/settings';
-import {
-	useSchemaParser,
 	DocumentObject,
 	usePrevious,
+	useSchemaParser,
 } from '@woocommerce/base-hooks';
-import type { JSONSchemaType, ErrorObject } from 'ajv';
-import { __, sprintf } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
-import fastDeepEqual from 'fast-deep-equal/es6';
-import { isPostcode, getFieldLabel } from '@woocommerce/blocks-checkout';
-import { isEmail } from '@wordpress/url';
+import { getFieldLabel, isPostcode } from '@woocommerce/blocks-checkout';
+import {
+	AddressFormValues,
+	ContactFormValues,
+	FormFields,
+	FormType,
+	KeyedFormFields,
+	OrderFormValues,
+} from '@woocommerce/settings';
 import { nonNullable } from '@woocommerce/types';
+import { useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { isEmail } from '@wordpress/url';
+import type { ErrorObject, JSONSchemaType } from 'ajv';
+import fastDeepEqual from 'fast-deep-equal/es6';
 
 /**
  * Internal dependencies
@@ -144,7 +144,7 @@ export const useFormValidation = (
 			! field.hidden && // And visible
 			( field.required || field.key in values ) // And is required or has a optional with a value (or both).
 		) {
-			acc[ field.key ] = field.rules.validation;
+			acc[ field.key ] = field.validation;
 		}
 		return acc;
 	}, {} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/utils.ts
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
+import { DocumentObject } from '@woocommerce/base-hooks';
 import {
 	AddressForm,
 	AddressFormValues,
 	Field,
-	KeyedFormFields,
+	KeyedParsedFormFields,
 } from '@woocommerce/settings';
 import { isObject, objectHasProp } from '@woocommerce/types';
+import type { JSONSchemaType } from 'ajv';
 
 export interface FieldProps {
 	id: string;
@@ -16,13 +18,13 @@ export interface FieldProps {
 	autoCapitalize: string | undefined;
 	autoComplete: string | undefined;
 	errorMessage: string | undefined;
-	required: boolean | undefined;
+	required: boolean;
 	placeholder: string | undefined;
 	className: string;
 }
 
 export const createFieldProps = (
-	field: KeyedFormFields[ number ],
+	field: KeyedParsedFormFields[ number ],
 	formId: string,
 	fieldAddressType: string
 ): FieldProps => ( {
@@ -54,7 +56,7 @@ export const createCheckboxFieldProps = ( fieldProps: FieldProps ) => {
 };
 export const getFieldData = < T extends keyof AddressForm >(
 	key: T,
-	fields: KeyedFormFields,
+	fields: KeyedParsedFormFields,
 	values: AddressFormValues
 ): {
 	field: AddressForm[ typeof key ] & {
@@ -78,6 +80,8 @@ export const getFieldData = < T extends keyof AddressForm >(
 export const hasSchemaRules = (
 	field: Field,
 	key: 'required' | 'hidden' | 'validation'
-): field is Field => {
+): field is Field & {
+	[ K in typeof key ]: JSONSchemaType< DocumentObject< 'global' > >;
+} => {
 	return isObject( field[ key ] ) && Object.keys( field[ key ] ).length > 0;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/utils.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { DocumentObject } from '@woocommerce/base-hooks';
 import {
 	AddressForm,
 	AddressFormValues,
@@ -9,7 +8,6 @@ import {
 	KeyedFormFields,
 } from '@woocommerce/settings';
 import { isObject, objectHasProp } from '@woocommerce/types';
-import { JSONSchemaType } from 'ajv';
 
 export interface FieldProps {
 	id: string;
@@ -79,15 +77,7 @@ export const getFieldData = < T extends keyof AddressForm >(
 
 export const hasSchemaRules = (
 	field: Field,
-	key: keyof Field[ 'rules' ]
-): field is Field & {
-	rules: {
-		[ k in typeof key ]: JSONSchemaType< DocumentObject< 'global' > >;
-	};
-} => {
-	return (
-		isObject( field.rules ) &&
-		isObject( field.rules[ key ] ) &&
-		Object.keys( field.rules[ key ] ).length > 0
-	);
+	key: 'required' | 'hidden' | 'validation'
+): field is Field => {
+	return isObject( field[ key ] ) && Object.keys( field[ key ] ).length > 0;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/address.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/address.ts
@@ -2,25 +2,25 @@
  * External dependencies
  */
 import prepareFormFields from '@woocommerce/base-components/cart-checkout/form/prepare-form-fields';
-import { isEmail } from '@wordpress/url';
 import {
+	ADDRESS_FORM_KEYS,
+	SHIPPING_COUNTRIES,
+	SHIPPING_STATES,
+} from '@woocommerce/block-settings';
+import {
+	AddressForm,
+	BillingAddress,
+	defaultFields,
+	ShippingAddress,
+} from '@woocommerce/settings';
+import {
+	isObject,
 	isString,
 	type CartResponseBillingAddress,
 	type CartResponseShippingAddress,
-	isObject,
 } from '@woocommerce/types';
-import {
-	ShippingAddress,
-	BillingAddress,
-	defaultFields,
-	AddressForm,
-} from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	SHIPPING_COUNTRIES,
-	SHIPPING_STATES,
-	ADDRESS_FORM_KEYS,
-} from '@woocommerce/block-settings';
+import { isEmail } from '@wordpress/url';
 
 /**
  * Compare two addresses and see if they are the same.
@@ -101,10 +101,11 @@ export const emptyHiddenAddressFields = <
 		defaultFields,
 		address.country
 	);
+
 	const newAddress = Object.assign( {}, address );
 
 	addressForm.forEach( ( { key, hidden } ) => {
-		if ( hidden && isValidAddressKey( key, address ) ) {
+		if ( hidden === true && isValidAddressKey( key, address ) ) {
 			newAddress[ key ] = '';
 		}
 	} );
@@ -213,7 +214,7 @@ export const isAddressComplete = (
 			: addressForm;
 
 	return filteredAddressForm.every( ( { key, hidden, required } ) => {
-		if ( hidden || ! required ) {
+		if ( hidden === true || required === false ) {
 			return true;
 		}
 		return isValidAddressKey( key, address ) && address[ key ] !== '';

--- a/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import type { AllHTMLAttributes, AriaAttributes } from 'react';
-import type { JSONSchemaType } from 'ajv';
 import type { DocumentObject } from '@woocommerce/base-hooks';
+import type { JSONSchemaType } from 'ajv';
+import type { AllHTMLAttributes, AriaAttributes } from 'react';
 
 /**
  * Internal dependencies
  */
-import { getSetting } from './utils';
 import { SelectOption } from '../../base/components';
+import { getSetting } from './utils';
 
 // A list of attributes that can be added to a custom field when registering it.
 type CustomFieldAttributes = Pick<
@@ -35,10 +35,12 @@ export interface Field {
 	autocomplete: string;
 	// How this field value is capitalized.
 	autocapitalize?: string;
-	// Set to true if the field is required.
-	required: boolean;
-	// Set to true if the field should not be rendered.
-	hidden: boolean;
+	// Set to true if the field is required or a JSON schema object.
+	required: boolean | JSONSchemaType< DocumentObject< 'global' > > | [];
+	// Set to true if the field should not be rendered or a JSON schema object.
+	hidden: boolean | JSONSchemaType< DocumentObject< 'global' > > | [];
+	// A JSON schema object for validation.
+	validation?: JSONSchemaType< DocumentObject< 'global' > > | [];
 	// Fields will be sorted and render in this order, lowest to highest.
 	index: number;
 	// The type of input to render. Defaults to text.
@@ -49,12 +51,6 @@ export interface Field {
 	placeholder?: string;
 	// Additional attributes added when registering a field. String in key is required for data attributes.
 	attributes?: Record< keyof CustomFieldAttributes, string >;
-	// The rules for the field.
-	rules: {
-		required?: JSONSchemaType< DocumentObject< 'global' > > | []; // Empty array because server returns an empty array when no rules are set.
-		validation?: JSONSchemaType< DocumentObject< 'global' > > | [];
-		hidden?: JSONSchemaType< DocumentObject< 'global' > > | [];
-	};
 }
 
 /**
@@ -106,6 +102,8 @@ export type KeyedFormFields = Array<
 	{
 		key: keyof FormFields;
 		errorMessage?: string;
+		required: boolean;
+		hidden: boolean;
 	} & FormFields[ keyof FormFields ]
 >;
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
@@ -40,7 +40,7 @@ export interface Field {
 	// Set to true if the field should not be rendered or a JSON schema object.
 	hidden: boolean | JSONSchemaType< DocumentObject< 'global' > > | [];
 	// A JSON schema object for validation.
-	validation?: JSONSchemaType< DocumentObject< 'global' > > | [];
+	validation: JSONSchemaType< DocumentObject< 'global' > > | [];
 	// Fields will be sorted and render in this order, lowest to highest.
 	index: number;
 	// The type of input to render. Defaults to text.
@@ -99,12 +99,22 @@ export type FormFields = AddressForm & ContactForm & OrderForm;
  * KeyedFormFields is the array shape of FormFields object with the key added to each field.
  */
 export type KeyedFormFields = Array<
-	{
+	FormFields[ keyof FormFields ] & {
 		key: keyof FormFields;
 		errorMessage?: string;
-		required: boolean;
+	}
+>;
+
+/**
+ * KeyedParsedFormFields is the array shape of FormFields object with the key added to each field.
+ */
+export type KeyedParsedFormFields = Array<
+	FormFields[ keyof FormFields ] & {
+		key: keyof FormFields;
+		errorMessage?: string;
 		hidden: boolean;
-	} & FormFields[ keyof FormFields ]
+		required: boolean;
+	}
 >;
 /**
  * All possible values for a form.
@@ -123,11 +133,6 @@ export type ShippingAddress = AddressFormValues;
 export interface BillingAddress extends AddressFormValues {
 	email: string;
 }
-
-export type KeyedFormField< T extends keyof FormFields > = FormField & {
-	key: T;
-	errorMessage?: string;
-};
 
 export type CountryAddressFields = Record< string, FormFields >;
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -553,17 +553,10 @@ class CheckoutFields {
 	 * @return array|false The updated $field_data array or false if an error was encountered.
 	 */
 	private function process_checkbox_field( $field_data, $options ) {
-		$id = $options['id'];
-
-		if ( isset( $options['required'] ) && ! is_bool( $options['required'] ) ) {
-			$message = sprintf( 'The required property for field with id: "%s" must be a boolean, you passed %s. The field will not be registered.', $id, gettype( $options['required'] ) );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
-			return false;
-		}
-
+		$id                     = $options['id'];
 		$field_data['required'] = $options['required'] ?? false;
 
-		if ( ( ! isset( $field_data['required'] ) || false === $field_data['required'] ) && ! empty( $options['error_message'] ) ) {
+		if ( false === $field_data['required'] && ! empty( $options['error_message'] ) ) {
 			$message = sprintf( 'Passing an error message to a non-required checkbox "%s" will have no effect. The error message has been removed from the field.', $id );
 			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '9.8.0' );
 			unset( $field_data['error_message'] );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -170,7 +170,7 @@ class CheckoutFields {
 	 * @return WP_Error|void If there is a validation error, return an WP_Error object.
 	 */
 	public function default_validate_callback( $value, $field ) {
-		if ( ! empty( $field['required'] ) && empty( $value ) ) {
+		if ( true === $field['required'] && empty( $value ) ) {
 			return new WP_Error(
 				'woocommerce_required_checkout_field',
 				sprintf(
@@ -211,7 +211,7 @@ class CheckoutFields {
 				'show_in_order_confirmation' => true,
 				'sanitize_callback'          => array( $this, 'default_sanitize_callback' ),
 				'validate_callback'          => array( $this, 'default_validate_callback' ),
-				'rules'                      => [],
+				'validation'                 => [],
 			],
 		);
 
@@ -249,8 +249,8 @@ class CheckoutFields {
 			if ( $this->is_hidden_field( $field, $document_object ) ) {
 				return false;
 			}
-			if ( ! empty( $field['rules']['required'] ) ) {
-				return true === Validation::validate_document_object( $document_object, $field['rules']['required'] );
+			if ( $this->contains_valid_rules( $field['required'] ) ) {
+				return true === Validation::validate_document_object( $document_object, $field['required'] );
 			}
 		}
 		return true === $field['required'];
@@ -267,10 +267,10 @@ class CheckoutFields {
 		if ( is_string( $field ) ) {
 			$field = $this->additional_fields[ $field ] ?? [];
 		}
-		if ( $document_object && ! empty( $field['rules']['hidden'] ) ) {
-			return true === Validation::validate_document_object( $document_object, $field['rules']['hidden'] );
+		if ( $document_object && $this->contains_valid_rules( $field['hidden'] ) ) {
+			return true === Validation::validate_document_object( $document_object, $field['hidden'] );
 		}
-		return false; // `hidden` prop is not supported yet.
+		return true === $field['hidden'];
 	}
 
 	/**
@@ -283,7 +283,7 @@ class CheckoutFields {
 		if ( is_string( $field ) ) {
 			$field = $this->additional_fields[ $field ] ?? [];
 		}
-		return ! empty( $field['rules']['required'] ) || ! empty( $field['rules']['hidden'] );
+		return $this->contains_valid_rules( $field['required'] ) || $this->contains_valid_rules( $field['hidden'] );
 	}
 
 	/**
@@ -294,11 +294,21 @@ class CheckoutFields {
 	 * @return bool|\WP_Error True if the field is valid, a WP_Error otherwise.
 	 */
 	public function is_valid_field( $field, $document_object = null ) {
-		if ( $document_object && ! empty( $field['rules']['validation'] ) ) {
-			$field_schema = Validation::get_field_schema_with_context( $field['id'], $field['rules']['validation'], $document_object->get_context() );
+		if ( $document_object && $this->contains_valid_rules( $field['validation'] ) ) {
+			$field_schema = Validation::get_field_schema_with_context( $field['id'], $field['validation'], $document_object->get_context() );
 			return Validation::validate_document_object( $document_object, $field_schema );
 		}
 		return true;
+	}
+
+	/**
+	 * Returns true if the property is an array and not empty.
+	 *
+	 * @param mixed $property The property to check.
+	 * @return bool
+	 */
+	protected function contains_valid_rules( $property ) {
+		return is_array( $property ) && ! empty( $property );
 	}
 
 	/**
@@ -312,7 +322,7 @@ class CheckoutFields {
 		if ( is_string( $field ) ) {
 			$field = $this->additional_fields[ $field ] ?? [];
 		}
-		if ( $document_object && ! empty( $field['rules']['validation'] ) ) {
+		if ( $document_object && $this->contains_valid_rules( $field['validation'] ) ) {
 			return function ( $field_value, $field ) use ( $document_object ) {
 				$errors = new WP_Error();
 
@@ -440,26 +450,19 @@ class CheckoutFields {
 			return false;
 		}
 
-		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
-			// Hidden fields are not supported right now. They will be registered with hidden => false.
-			$message = sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id );
-			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
-			// Don't return here unlike the other fields because this is not an issue that will prevent registration.
-		}
+		// If experimental blocks are enabled, we need to validate schema based rules.
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$rule_fields = [ 'required', 'hidden', 'validation' ];
+			$allow_bool  = [ 'required', 'hidden' ];
 
-		if ( Features::is_enabled( 'experimental-blocks' ) && ! empty( $options['rules'] ) ) {
-			if ( ! is_array( $options['rules'] ) ) {
-				$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], 'The rules must be an array.' );
-				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
-				return false;
-			}
+			foreach ( $rule_fields as $rule_field ) {
+				if ( ! empty( $options[ $rule_field ] ) ) {
+					if ( in_array( $rule_field, $allow_bool, true ) && is_bool( $options[ $rule_field ] ) ) {
+						continue;
+					}
 
-			$valid = Validation::is_valid_schema( $options['rules'] );
+					$valid = Validation::is_valid_schema( $options[ $rule_field ] );
 
-			if ( is_wp_error( $valid ) ) {
-				$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], $valid->get_error_message() );
-				_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
-				return false;
 			}
 		}
 
@@ -478,10 +481,6 @@ class CheckoutFields {
 			$field_data = $this->process_checkbox_field( $field_data, $options );
 		} elseif ( 'select' === $field_data['type'] ) {
 			$field_data = $this->process_select_field( $field_data, $options );
-		}
-		// If the field has conditional rules, we need to set the required property to false so it can be evaluated.
-		if ( Features::is_enabled( 'experimental-blocks' ) && ! empty( $field_data['rules']['required'] ) ) {
-			$field_data['required'] = false;
 		}
 		return $field_data;
 	}
@@ -902,6 +901,10 @@ class CheckoutFields {
 
 				if ( is_wp_error( $validate_callback_result ) ) {
 					$errors->merge_from( $validate_callback_result );
+				} elseif ( false === $validate_callback_result ) {
+					/* translators: %s: is the field label */
+					$error_message = sprintf( __( 'Please provide a valid %s', 'woocommerce' ), $field['label'] );
+					$errors->add( 'woocommerce_invalid_checkout_field', $error_message );
 				}
 			}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -463,6 +463,12 @@ class CheckoutFields {
 
 					$valid = Validation::is_valid_schema( $options[ $rule_field ] );
 
+					if ( is_wp_error( $valid ) ) {
+						$message = sprintf( 'Unable to register field with id: "%s". %s', $options['id'], $rule_field . ': ' . $valid->get_error_message() );
+						_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+						return false;
+					}
+				}
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php
@@ -270,7 +270,7 @@ class CheckoutFields {
 		if ( $document_object && $this->contains_valid_rules( $field['hidden'] ) ) {
 			return true === Validation::validate_document_object( $document_object, $field['hidden'] );
 		}
-		return true === $field['hidden'];
+		return false; // Fields cannot be registered as hidden.
 	}
 
 	/**
@@ -448,6 +448,13 @@ class CheckoutFields {
 			$message = sprintf( 'Unable to register field with id: "%s". %s', $id, 'The validate_callback must be a valid callback.' );
 			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
 			return false;
+		}
+
+		if ( ! empty( $options['hidden'] ) && true === $options['hidden'] ) {
+			// Hidden fields are not supported right now. They will be registered with hidden => false.
+			$message = sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id );
+			_doing_it_wrong( 'woocommerce_register_additional_checkout_field', esc_html( $message ), '8.6.0' );
+			// Don't return here unlike the other fields because this is not an issue that will prevent registration.
 		}
 
 		// If experimental blocks are enabled, we need to validate schema based rules.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsFrontend.php
@@ -349,7 +349,7 @@ class CheckoutFieldsFrontend {
 			$field_value = $field_values[ $field_key ];
 
 			if ( empty( $field_value ) ) {
-				if ( ! empty( $field['required'] ) ) {
+				if ( true === $field['required'] ) {
 					$errors->add(
 						'required_field',
 						/* translators: %s: is the field label */

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -264,7 +264,7 @@ class Checkout extends AbstractCartRoute {
 
 			foreach ( $additional_fields as $field_key => $field ) {
 				// Skip values that were not posted if the request is partial or the field is not required.
-				if ( ! isset( $field_values[ $field_key ] ) && ( $is_partial || empty( $field['required'] ) ) ) {
+				if ( ! isset( $field_values[ $field_key ] ) && ( $is_partial || true !== $field['required'] ) ) {
 					continue;
 				}
 
@@ -273,7 +273,7 @@ class Checkout extends AbstractCartRoute {
 				$sanitized_field_value = $sanitized_field_values[ $field_key ] ?? '';
 
 				if ( empty( $field_value ) ) {
-					if ( ! empty( $field['required'] ) ) {
+					if ( true === $field['required'] ) {
 						/* translators: %s: is the field label */
 						$error_message = sprintf( __( '%s is required', 'woocommerce' ), $field['label'] );
 						if ( 'shipping_address' === $context ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -294,7 +294,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'required'    => $this->additional_fields_controller->is_conditional_field( $field ) ? false : $field['required'],
+				'required'    => $this->additional_fields_controller->is_conditional_field( $field ) ? false : true === $field['required'],
 			];
 
 			if ( 'select' === $field['type'] ) {

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -326,7 +326,7 @@ class CheckoutSchema extends AbstractSchema {
 				'description' => $field['label'],
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'required'    => $this->additional_fields_controller->is_conditional_field( $field ) ? false : $field['required'],
+				'required'    => $this->additional_fields_controller->is_conditional_field( $field ) ? false : true === $field['required'],
 			];
 
 			if ( 'select' === $field['type'] ) {
@@ -364,7 +364,7 @@ class CheckoutSchema extends AbstractSchema {
 		return array_reduce(
 			array_keys( $additional_fields_schema ),
 			function ( $carry, $key ) use ( $additional_fields_schema ) {
-				return $carry || $additional_fields_schema[ $key ]['required'];
+				return $carry || true === $additional_fields_schema[ $key ]['required'];
 			},
 			false
 		);
@@ -422,7 +422,7 @@ class CheckoutSchema extends AbstractSchema {
 
 		// on POST, loop over the schema instead of the fields. This is to ensure missing fields are validated.
 		foreach ( $additional_field_schema as $key => $schema ) {
-			if ( ! isset( $fields[ $key ] ) && ! $schema['required'] ) {
+			if ( ! isset( $fields[ $key ] ) && true !== $schema['required'] ) {
 				// Optional fields can go missing.
 				continue;
 			}

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -395,7 +395,7 @@ class OrderController {
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
 			// Skip validation if field is not required.
-			if ( ! $address_field['required'] ) {
+			if ( true !== $address_field['required'] ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutFieldsTest.php
@@ -92,31 +92,29 @@ class CheckoutFieldsTest extends WP_UnitTestCase {
 				'type'     => 'checkbox',
 			),
 			array(
-				'id'       => 'namespace/vat-number',
-				'label'    => 'VAT Number',
-				'location' => 'address',
-				'required' => true,
-				'rules'    => array(
-					'hidden'     => array(
-						'customer' => array(
-							'properties' => array(
-								'address' => array(
-									'properties' => array(
-										'country' => array(
-											'type' => 'string',
-											'not'  => array(
-												'enum' => array_merge( WC()->countries->get_european_union_countries( 'eu_vat' ), array( 'GB' ) ),
-											),
+				'id'         => 'namespace/vat-number',
+				'label'      => 'VAT Number',
+				'location'   => 'address',
+				'required'   => true,
+				'hidden'     => array(
+					'customer' => array(
+						'properties' => array(
+							'address' => array(
+								'properties' => array(
+									'country' => array(
+										'type' => 'string',
+										'not'  => array(
+											'enum' => array_merge( WC()->countries->get_european_union_countries( 'eu_vat' ), array( 'GB' ) ),
 										),
 									),
 								),
 							),
 						),
 					),
-					'validation' => array(
-						'type'    => 'string',
-						'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
-					),
+				),
+				'validation' => array(
+					'type'    => 'string',
+					'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
 				),
 			),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -2482,11 +2482,11 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The rules must be an array.' );
 		\woocommerce_register_additional_checkout_field(
 			array(
-				'id'       => 'namespace/test-id',
-				'label'    => 'Test Field',
-				'location' => 'address',
-				'required' => true,
-				'rules'    => 'invalid-rules',
+				'id'         => 'namespace/test-id',
+				'label'      => 'Test Field',
+				'location'   => 'address',
+				'required'   => true,
+				'validation' => 'invalid-rules',
 			)
 		);
 		remove_action( 'doing_it_wrong_run', array( $doing_it_wrong_mocker, 'doing_it_wrong_run' ), 10, 2 );
@@ -2502,15 +2502,13 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The properties must match schema: {properties}' );
 		\woocommerce_register_additional_checkout_field(
 			array(
-				'id'       => 'namespace/test-id',
-				'label'    => 'Test Field',
-				'location' => 'address',
-				'required' => true,
-				'rules'    => array(
-					'validation' => array(
-						'type'    => 'invalid-type',
-						'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
-					),
+				'id'         => 'namespace/test-id',
+				'label'      => 'Test Field',
+				'location'   => 'address',
+				'required'   => true,
+				'validation' => array(
+					'type'    => 'invalid-type',
+					'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
 				),
 			)
 		);
@@ -2519,13 +2517,11 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The validation rules must be an array.' );
 		\woocommerce_register_additional_checkout_field(
 			array(
-				'id'       => 'namespace/test-id',
-				'label'    => 'Test Field',
-				'location' => 'address',
-				'required' => true,
-				'rules'    => array(
-					'validation' => 'invalid-value',
-				),
+				'id'         => 'namespace/test-id',
+				'label'      => 'Test Field',
+				'location'   => 'address',
+				'required'   => true,
+				'validation' => 'invalid-value',
 			)
 		);
 		remove_action( 'doing_it_wrong_run', array( $doing_it_wrong_mocker, 'doing_it_wrong_run' ), 10, 2 );
@@ -2543,15 +2539,13 @@ class AdditionalFields extends MockeryTestCase {
 		add_action( 'doing_it_wrong_run', array( $doing_it_wrong_mocker, 'doing_it_wrong_run' ), 10, 2 );
 		\woocommerce_register_additional_checkout_field(
 			array(
-				'id'       => 'namespace/test-id',
-				'label'    => 'Test Field',
-				'location' => 'address',
-				'required' => true,
-				'rules'    => array(
-					'validation' => array(
-						'type'    => 'string',
-						'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
-					),
+				'id'         => 'namespace/test-id',
+				'label'      => 'Test Field',
+				'location'   => 'address',
+				'required'   => true,
+				'validation' => array(
+					'type'    => 'string',
+					'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
 				),
 			)
 		);
@@ -2569,10 +2563,7 @@ class AdditionalFields extends MockeryTestCase {
 				'id'       => 'namespace/test-id',
 				'label'    => 'Test Field',
 				'location' => 'address',
-				'required' => true,
-				'rules'    => array(
-					'required' => 'invalid-value',
-				),
+				'required' => 'invalid-value',
 			)
 		);
 		remove_action( 'doing_it_wrong_run', array( $doing_it_wrong_mocker, 'doing_it_wrong_run' ), 10, 2 );
@@ -2594,16 +2585,14 @@ class AdditionalFields extends MockeryTestCase {
 				'label'    => 'Test Field',
 				'location' => 'address',
 				'required' => true,
-				'rules'    => array(
-					'required' => array(
-						'customer' => array(
-							'properties' => array(
-								'billing_address' => array(
-									'properties' => array(
-										'country' => array(
-											'type' => 'string',
-											'enum' => 'GB',
-										),
+				'required' => array(
+					'customer' => array(
+						'properties' => array(
+							'billing_address' => array(
+								'properties' => array(
+									'country' => array(
+										'type' => 'string',
+										'enum' => 'GB',
 									),
 								),
 							),
@@ -2633,16 +2622,14 @@ class AdditionalFields extends MockeryTestCase {
 				'location' => 'address',
 				'type'     => 'text',
 				'required' => true,
-				'rules'    => array(
-					'hidden' => array(
-						'customer' => array(
-							'properties' => array(
-								'address' => array(
-									'properties' => array(
-										'country' => array(
-											'type' => 'string',
-											'enum' => array( 'US' ), // Hidden for US.
-										),
+				'hidden'   => array(
+					'customer' => array(
+						'properties' => array(
+							'billing_address' => array(
+								'properties' => array(
+									'country' => array(
+										'type' => 'string',
+										'enum' => array( 'US' ), // Hidden for US.
 									),
 								),
 							),

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -2499,7 +2499,7 @@ class AdditionalFields extends MockeryTestCase {
 	 * Test for errors when providing the wrong validation rules schema.
 	 */
 	public function test_invalid_validation_rules_schema() {
-		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The properties must match schema: {properties}' );
+		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". validation: The properties must match schema: {properties}' );
 		\woocommerce_register_additional_checkout_field(
 			array(
 				'id'         => 'namespace/test-id',

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1056,7 +1056,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
 				'woocommerce_register_additional_checkout_field',
-				\esc_html( sprintf( 'The required property for field with id: "%s" must be a boolean, you passed string. The field will not be registered.', $id ) ),
+				\esc_html( sprintf( 'Unable to register field with id: "%s". required: Rules must be defined as an array.', $id ) ),
 			)
 		)->once();
 
@@ -1335,61 +1335,6 @@ class AdditionalFields extends MockeryTestCase {
 		$this->assertEquals(
 			true,
 			$data['schema']['properties']['additional_fields']['properties'][ $id ]['required']
-		);
-
-		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
-
-		// Ensures the field isn't registered.
-		$this->assertFalse( $this->controller->is_field( $id ), \sprintf( '%s is still registered', $id ) );
-	}
-
-	/**
-	 * Ensure an error is triggered when a field is registered with hidden set to true.
-	 */
-	public function test_register_hidden_field_error() {
-		$id                    = 'plugin-namespace/hidden-field';
-		$doing_it_wrong_mocker = \Mockery::mock( 'ActionCallback' );
-		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
-			array(
-				'woocommerce_register_additional_checkout_field',
-				\esc_html( sprintf( 'Registering a field with hidden set to true is not supported. The field "%s" will be registered as visible.', $id ) ),
-			)
-		)->once();
-
-		add_action(
-			'doing_it_wrong_run',
-			array(
-				$doing_it_wrong_mocker,
-				'doing_it_wrong_run',
-			),
-			10,
-			2
-		);
-
-		\woocommerce_register_additional_checkout_field(
-			array(
-				'id'       => $id,
-				'label'    => 'Hidden Field',
-				'location' => 'address',
-				'type'     => 'text',
-				'hidden'   => true,
-			)
-		);
-
-		// Fields should still be registered regardless of the error, but not hidden.
-		$request  = new \WP_REST_Request( 'OPTIONS', '/wc/store/v1/checkout' );
-		$response = rest_get_server()->dispatch( $request );
-
-		$data = $response->get_data();
-
-		$this->assertArrayHasKey( $id, $data['schema']['properties']['billing_address']['properties'] );
-
-		\remove_action(
-			'doing_it_wrong_run',
-			array(
-				$doing_it_wrong_mocker,
-				'doing_it_wrong_run',
-			)
 		);
 
 		\__internal_woocommerce_blocks_deregister_checkout_field( $id );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1230,7 +1230,7 @@ class AdditionalFields extends MockeryTestCase {
 		$doing_it_wrong_mocker->shouldReceive( 'doing_it_wrong_run' )->withArgs(
 			array(
 				'woocommerce_register_additional_checkout_field',
-				\esc_html( sprintf( 'The required property for field with id: "%s" must be a boolean, you passed string. The field will not be registered.', $id ) ),
+				\esc_html( sprintf( 'Unable to register field with id: "%s". required: Rules must be defined as an array.', $id ) ),
 			)
 		)->once();
 
@@ -2479,7 +2479,7 @@ class AdditionalFields extends MockeryTestCase {
 	 * Test for errors when providing the wrong rules schema.
 	 */
 	public function test_invalid_rules_schema() {
-		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The rules must be an array.' );
+		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". validation: Rules must be defined as an array.' );
 		\woocommerce_register_additional_checkout_field(
 			array(
 				'id'         => 'namespace/test-id',
@@ -2514,7 +2514,7 @@ class AdditionalFields extends MockeryTestCase {
 		);
 		remove_action( 'doing_it_wrong_run', array( $doing_it_wrong_mocker, 'doing_it_wrong_run' ), 10, 2 );
 
-		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The validation rules must be an array.' );
+		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". validation: Rules must be defined as an array.' );
 		\woocommerce_register_additional_checkout_field(
 			array(
 				'id'         => 'namespace/test-id',
@@ -2557,7 +2557,7 @@ class AdditionalFields extends MockeryTestCase {
 	 * Test for errors when providing the wrong required rules schema.
 	 */
 	public function test_invalid_required_rules_schema() {
-		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". The required rules must be an array.' );
+		$doing_it_wrong_mocker = $this->add_doing_it_wrong_error_mocker( 'woocommerce_register_additional_checkout_field', 'Unable to register field with id: "namespace/test-id". required: Rules must be defined as an array.' );
 		\woocommerce_register_additional_checkout_field(
 			array(
 				'id'       => 'namespace/test-id',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves schema based `rules` for additional fields to the top level (required, hidden, validation). Updates client, server, and tests.

Closes #54875

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Covered by unit tests and behind a feature flag.

Developers can test with an experimental build and a field snippet:

```php
add_action(
	'woocommerce_init',
	function () {
		$fields = array(
			array(
				'id'                => 'plugin-namespace/gov-id',
				'label'             => 'Government ID',
				'location'          => 'address',
				'type'              => 'text',
				'required'          => true,
				'attributes'        => array(
					'title'          => 'This is a gov id',
					'autocomplete'   => 'gov-id',
					'autocapitalize' => 'none',
					'maxLength'      => '30',
				),
				'sanitize_callback' => function ( $value ) {
					return trim( $value );
				},
				'validate_callback' => function ( $value ) {
					return strlen( $value ) > 3;
				},
			),
			array(
				'id'       => 'plugin-namespace/job-function',
				'label'    => 'What is your main role at your company?',
				'location' => 'contact',
				'required' => true,
				'type'     => 'select',
				'options'  => array(
					array(
						'label' => 'Director',
						'value' => 'director',
					),
					array(
						'label' => 'Engineering',
						'value' => 'engineering',
					),
					array(
						'label' => 'Customer Support',
						'value' => 'customer-support',
					),
					array(
						'label' => 'Other',
						'value' => 'other',
					),
				),
			),
			array(
				'id'       => 'plugin-namespace/leave-on-porch',
				'label'    => __( 'Please leave my package on the porch if I\'m not home', 'woocommerce' ),
				'location' => 'order',
				'type'     => 'checkbox',
			),
			array(
				'id'         => 'namespace/vat-number',
				'label'      => 'VAT Number',
				'location'   => 'address',
				'required'   => true,
				'hidden'     => array(
					'customer' => array(
						'properties' => array(
							'address' => array(
								'properties' => array(
									'country' => array(
										'type' => 'string',
										'not'  => array(
											'enum' => array_merge( WC()->countries->get_european_union_countries( 'eu_vat' ), array( 'GB' ) ),
										),
									),
								),
							),
						),
					),
				),
				'validation' => array(
					'type'    => 'string',
					'pattern' => '^[A-Z]{2}[0-9A-Z]{2,12}$',
				),
			),
		);
		array_map( 'woocommerce_register_additional_checkout_field', $fields );
	}
);
```

Confirm the VAT field shows conditionally, and validation runs for the Gov-ID field.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
