### PR TITLE
Enable stalebot for community PRs

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -17,11 +17,11 @@ jobs:
             pull-requests: write
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         steps:
-            - name: Process stale issues
+            - name: Process stale issues and PRs
               uses: actions/stale@v9.0.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
+                  stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically closed."
                   close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
                   operations-per-run: 140
                   days-before-stale: -1
@@ -29,10 +29,15 @@ jobs:
                   days-before-issue-stale: 7
                   days-before-issue-close: 7
                   stale-issue-label: 'status: stale'
-                  stale-pr-label: 'status: stale'
                   exempt-issue-labels: 'type: enhancement'
                   only-issue-labels: 'needs: author feedback'
                   close-issue-label: "status: can't reproduce"
+                  days-before-pr-stale: 7
+                  days-before-pr-close: 7
+                  stale-pr-label: 'status: stale'
+                  only-pr-labels: 'needs: author feedback,type: community contribution'
+                  stale-pr-message: "As a part of this repository's maintenance, this PR is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this PR will be automatically closed."
+                  close-pr-message: 'This PR was closed because it has been 14 days with no activity.'
                   ascending: true
             - name: Process stale flaky tests issues
               uses: actions/stale@v9.0.0
@@ -74,11 +79,11 @@ jobs:
                           repo: context.repo.repo,
                           pull_number: pr.number
                         });
-                        
+
                         // Find the latest approval date for this PR
                         let latestApproval = null;
                         const approvalReviews = [];
-                        
+
                         for (const review of reviews) {
                           if (review.state === 'APPROVED') {
                             const reviewDate = new Date(review.submitted_at);
@@ -88,14 +93,14 @@ jobs:
                             }
                           }
                         }
-                        
+
                         // Process only if we found any approvals
                         if (latestApproval) {
                           console.log(`PR #${pr.number} latest approval on ${latestApproval.toISOString()}`);
-                          
+
                           if (latestApproval < thirtyDaysAgo) {
                             console.log(`Found ${approvalReviews.length} approvals to dismiss on PR #${pr.number} (latest approval was on ${latestApproval.toISOString()})`);
-                            
+
                             // Dismiss all approvals
                             for (const review of approvalReviews) {
                               console.log(`Dismissing approval from ${review.user.login}`);

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -12,7 +12,7 @@ jobs:
     stale:
         runs-on: ubuntu-latest
         permissions:
-            contents: read
+            contents: write
             issues: write
             pull-requests: write
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -38,6 +38,7 @@ jobs:
                   only-pr-labels: 'needs: author feedback,type: community contribution'
                   stale-pr-message: "As a part of this repository's maintenance, this PR is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this PR will be automatically closed."
                   close-pr-message: 'This PR was closed because it has been 14 days with no activity.'
+                  delete-branch: true
                   ascending: true
             - name: Process stale flaky tests issues
               uses: actions/stale@v9.0.0

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -32,12 +32,12 @@ jobs:
                   exempt-issue-labels: 'type: enhancement'
                   only-issue-labels: 'needs: author feedback'
                   close-issue-label: "status: can't reproduce"
-                  days-before-pr-stale: 7
-                  days-before-pr-close: 7
+                  days-before-pr-stale: 30
+                  days-before-pr-close: 14
                   stale-pr-label: 'status: stale'
                   only-pr-labels: 'needs: author feedback,type: community contribution'
-                  stale-pr-message: "As a part of this repository's maintenance, this PR is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this PR will be automatically closed."
-                  close-pr-message: 'This PR was closed because it has been 14 days with no activity.'
+                  stale-pr-message: "As a part of this repository's maintenance, this PR is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 30 days with no activity this PR will be automatically closed."
+                  close-pr-message: 'This PR was closed because it has been 1.5 months with no activity.'
                   delete-branch: true
                   ascending: true
             - name: Process stale flaky tests issues

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -35,8 +35,8 @@ jobs:
                   days-before-pr-stale: 30
                   days-before-pr-close: 14
                   stale-pr-label: 'status: stale'
-                  only-pr-labels: 'needs: author feedback,type: community contribution'
-                  stale-pr-message: "As a part of this repository's maintenance, this PR is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 30 days with no activity this PR will be automatically closed."
+                  only-pr-labels: 'needs: author feedback'
+                  stale-pr-message: "As a part of this repository's maintenance, this PR is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 14 days with no activity this PR will be automatically closed."
                   close-pr-message: 'This PR was closed because it has been 1.5 months with no activity.'
                   delete-branch: true
                   ascending: true


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR enables stalebot for community PRs (those with label `type: community contribution`) that are marked as `needs: author feedback`.

Same as with issues, they will be marked as stale after 7 days of inactivity and then closed after another 7 days have passed.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Testing in real life might be difficult because of the times involved, though the code added to stalebot for PRs is pretty much the same we have for issues, which has been working fine. In any case, I'm providing some (convoluted) instructions to test in a repo clone if necessary.

1. Create a fork of the WooCommerce repo.
1. Make sure the following issue labels exist in this fork:
    - `needs: author feedback`
    - `status: stale`
    - `type: community contribution`
1. Add your fork as a remote in your local clone of the WC repo:
   ```
   git remote add woo_fork YOUR_FORK_REMOTE_URL
   ```
1. Push this branch as your fork's `trunk`:
   ```
   git push woo_fork repo/enable-stalebot-for-prs:trunk --force
   ```

   ⚠️ Make sure to run the commands as indicated (changing only `woo_fork` and `YOUR_FORK_REMOTE_URL` as necessary), so that you don't affect the main repo (don't use `origin`!).
1. Use the GH UI to create 2 PRs in your fork with any changes you like.
1. Label one of the PRs as `type: community contribution` and leave the other alone.
1. Edit file `stalebot.yml` using the GH UI in your fork. Temporarily change `days-before-pr-stale: 7` to `days-before-pr-stale: 0`. Commit directly to `trunk`.
1. Go to **Actions > Process stale issues and PRs** in your fork. Click **Run workflow > Run workflow** and wait for the workflow to finish running.
1. Go to **Pull requests** in your fork. Nothing should've happened to your 2 PRs.
1. Label both PRs as `needs: author feedback`.
1. Repeat step 8.
1. Go to **Pull requests** again and confirm that the PR with label `type: community contribution` now has label `status: stale` too and a comment about inactivity has been added. The other PR must be exactly as before.
1. Edit file `stalebot.yml` using the GH UI in your fork. Temporarily change `days-before-pr-stale: 1` back to `days-before-pr-stale: 7`. Also change `days-before-pr-close: 7` to `days-before-pr-close: 0`. Commit directly to `trunk`.
1. Repeat step 8.
1. Go to **Pull requests** again. The PR that had the `status: stale` label must have been closed (with a comment), while the other PR remains intact.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
