### PR TITLE
 Fix duplicate component rendering in WooCommerce admin header

### DIFF
--- a/plugins/woocommerce/client/admin/client/header/index.tsx
+++ b/plugins/woocommerce/client/admin/client/header/index.tsx
@@ -83,19 +83,7 @@ export const Header = ( {
 					bannerType={ ORDER_ATTRIBUTION_INSTALL_BANNER_TYPE_HEADER }
 					eventContext="analytics-overview-header"
 				/>
-			) }{ ' ' }
-			<>
-				{ showLaunchYourStoreStatus && <LaunchYourStoreStatus /> }
-				{ isAnalyticsOverviewScreen && (
-					// @ts-expect-error OrderAttributionInstallBanner is not typed
-					<OrderAttributionInstallBanner
-						bannerType={
-							ORDER_ATTRIBUTION_INSTALL_BANNER_TYPE_HEADER
-						}
-						eventContext="analytics-overview-header"
-					/>
-				) }
-			</>
+			) }
 		</BaseHeader>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/header/test/index.test.js
+++ b/plugins/woocommerce/client/admin/client/header/test/index.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -36,12 +37,14 @@ jest.mock( '~/hooks/use-tasklists-state', () => ( {
 } ) );
 
 jest.mock( '@woocommerce/navigation', () => ( {
+	...jest.requireActual( '@woocommerce/navigation' ),
 	isWCAdmin: () => true,
 	getScreenFromPath: () => 'homescreen',
 	getPath: () => '/analytics/overview',
 } ) );
 
 global.window.wcNavigation = {};
+global.window.wcAdminFeatures = { 'activity-panels': false };
 
 const encodedBreadcrumb = [
 	[ 'admin.php?page=wc-settings', 'Settings' ],
@@ -56,11 +59,6 @@ describe( 'Header', () => {
 				cb();
 			}
 		);
-
-		// Mock user preferences to avoid testing the MobileAppBanner here
-
-		// Disable the ActivityPanel so it isn't tested here
-		window.wcAdminFeatures = { 'activity-panels': false };
 	} );
 
 	afterEach( () => {

--- a/plugins/woocommerce/client/admin/client/header/test/index.test.js
+++ b/plugins/woocommerce/client/admin/client/header/test/index.test.js
@@ -15,6 +15,32 @@ jest.mock( '@woocommerce/settings', () => ( {
 	},
 } ) );
 
+// Mock dependencies
+jest.mock( '../../launch-your-store', () => ( {
+	LaunchYourStoreStatus: () => <div data-testid="launch-your-store-status" />,
+	useLaunchYourStore: () => ( {
+		isLoading: false,
+		launchYourStoreEnabled: true,
+	} ),
+} ) );
+
+jest.mock( '~/order-attribution-install-banner', () => ( {
+	OrderAttributionInstallBanner: () => (
+		<div data-testid="order-attribution-install-banner" />
+	),
+	BANNER_TYPE_HEADER: 'header',
+} ) );
+
+jest.mock( '~/hooks/use-tasklists-state', () => ( {
+	isTaskListActive: () => false,
+} ) );
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	isWCAdmin: () => true,
+	getScreenFromPath: () => 'homescreen',
+	getPath: () => '/analytics/overview',
+} ) );
+
 global.window.wcNavigation = {};
 
 const encodedBreadcrumb = [
@@ -34,7 +60,7 @@ describe( 'Header', () => {
 		// Mock user preferences to avoid testing the MobileAppBanner here
 
 		// Disable the ActivityPanel so it isn't tested here
-		window.wcAdminFeatures[ 'activity-panels' ] = false;
+		window.wcAdminFeatures = { 'activity-panels': false };
 	} );
 
 	afterEach( () => {
@@ -43,7 +69,7 @@ describe( 'Header', () => {
 
 	it( 'should render decoded breadcrumb name', () => {
 		const { queryByText } = render(
-			<Header sections={ encodedBreadcrumb } isEmbedded={ true } />
+			<Header sections={ encodedBreadcrumb } query={ {} } />
 		);
 		expect( queryByText( 'Accounts &amp; Privacy' ) ).toBe( null );
 		expect( queryByText( 'Accounts & Privacy' ) ).not.toBe( null );
@@ -51,7 +77,7 @@ describe( 'Header', () => {
 
 	it( 'should only have the is-scrolled class if the page is scrolled', () => {
 		const { container } = render(
-			<Header sections={ encodedBreadcrumb } isEmbedded={ false } />
+			<Header sections={ encodedBreadcrumb } query={ {} } />
 		);
 
 		const topLevelElement = container.firstChild;
@@ -69,12 +95,24 @@ describe( 'Header', () => {
 	} );
 
 	it( 'correctly updates the document title to reflect the navigation state', () => {
-		render(
-			<Header sections={ encodedBreadcrumb } isEmbedded={ false } />
-		);
+		render( <Header sections={ encodedBreadcrumb } query={ {} } /> );
 
 		expect( document.title ).toBe(
 			'Accounts & Privacy ‹ Settings ‹ Fake Site Title — WooCommerce'
 		);
+	} );
+
+	it( 'should render LaunchYourStoreStatus and OrderAttributionInstallBanner only once', () => {
+		const { getAllByTestId } = render(
+			<Header sections={ encodedBreadcrumb } query={ {} } />
+		);
+
+		// Verify that each component is rendered exactly once
+		expect( getAllByTestId( 'launch-your-store-status' ) ).toHaveLength(
+			1
+		);
+		expect(
+			getAllByTestId( 'order-attribution-install-banner' )
+		).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue where the LaunchYourStoreStatus and OrderAttributionInstallBanner components were being rendered twice in the WooCommerce admin header. Redundant JSX caused the duplicate rendering in the Header component's return statement. 

This was caused by a previous PR  https://github.com/woocommerce/woocommerce/pull/55822/files#diff-6a1bc52b8f749c7ca3b8ee1ecba814a6dd8e46a3bf9f48e6c1f50b1731362325R79-R98

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Do not install woocommerce-analytics plugin
2. Set `woocommerce_remote_variant_assignment` option to `1` (`wp option set woocommerce_remote_variant_assignment 1`)
3. Go to `Analytics -> Overview`
4. It should show only one order attribution install banner in header 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>



#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fix duplicate component rendering in WooCommerce admin header

</details>
