### PR TITLE
[dev] Monorepo: fix broken E2E JS packages builds.

### DIFF
--- a/packages/js/e2e-core-tests/package.json
+++ b/packages/js/e2e-core-tests/package.json
@@ -49,7 +49,7 @@
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-e2e-builds": "workspace:*",
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
-		"@wordpress/babel-preset-default": "3.0.2",
+		"@wordpress/babel-preset-default": "7.28.0",
 		"@wordpress/browserslist-config": "wp-6.6",
 		"eslint": "^8.55.0",
 		"eslint-plugin-jest": "23.20.0",

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -77,7 +77,7 @@
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-e2e-builds": "workspace:*",
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
-		"@wordpress/babel-preset-default": "3.0.2",
+		"@wordpress/babel-preset-default": "7.28.0",
 		"@wordpress/browserslist-config": "wp-6.6",
 		"ndb": "^1.1.5",
 		"semver": "^7.5.4",

--- a/packages/js/e2e-utils-playwright/changelog/dev-fix-bronken-e2e-packages-build
+++ b/packages/js/e2e-utils-playwright/changelog/dev-fix-bronken-e2e-packages-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: fix broken E2E packages builds

--- a/packages/js/e2e-utils-playwright/package.json
+++ b/packages/js/e2e-utils-playwright/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@babel/cli": "^7.25.9",
 		"@babel/core": "^7.26.0",
-		"@wordpress/babel-preset-default": "^8.13.0",
+		"@wordpress/babel-preset-default": "7.28.0",
 		"jest": "27.5.x"
 	},
 	"publishConfig": {

--- a/packages/js/e2e-utils/package.json
+++ b/packages/js/e2e-utils/package.json
@@ -46,7 +46,7 @@
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-e2e-builds": "workspace:*",
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
-		"@wordpress/babel-preset-default": "3.0.2",
+		"@wordpress/babel-preset-default": "7.28.0",
 		"@wordpress/browserslist-config": "wp-6.6",
 		"eslint": "^8.55.0",
 		"eslint-plugin-jest": "23.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1461,8 +1461,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3(@babel/core@7.12.9)
       '@wordpress/babel-preset-default':
-        specifier: 3.0.2
-        version: 3.0.2(@babel/core@7.12.9)
+        specifier: 7.28.0
+        version: 7.28.0
       '@wordpress/browserslist-config':
         specifier: wp-6.6
         version: 6.0.1
@@ -1561,8 +1561,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3(@babel/core@7.12.9)
       '@wordpress/babel-preset-default':
-        specifier: 3.0.2
-        version: 3.0.2(@babel/core@7.12.9)
+        specifier: 7.28.0
+        version: 7.28.0
       '@wordpress/browserslist-config':
         specifier: wp-6.6
         version: 6.0.1
@@ -1634,8 +1634,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3(@babel/core@7.12.9)
       '@wordpress/babel-preset-default':
-        specifier: 3.0.2
-        version: 3.0.2(@babel/core@7.12.9)
+        specifier: 7.28.0
+        version: 7.28.0
       '@wordpress/browserslist-config':
         specifier: wp-6.6
         version: 6.0.1
@@ -1658,8 +1658,8 @@ importers:
         specifier: ^7.26.0
         version: 7.26.0
       '@wordpress/babel-preset-default':
-        specifier: ^8.13.0
-        version: 8.13.0
+        specifier: 7.28.0
+        version: 7.28.0
       jest:
         specifier: 27.5.x
         version: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
@@ -1810,7 +1810,7 @@ importers:
         version: 2.17.0(wp-prettier@3.0.3)
       '@wordpress/scripts':
         specifier: wp-6.6
-        version: 28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(eslint-import-resolver-typescript@3.8.3)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
+        version: 28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(encoding@0.1.13)(eslint-import-resolver-typescript@3.8.3)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
       core-js:
         specifier: ^3.37.1
         version: 3.40.0
@@ -40668,7 +40668,7 @@ snapshots:
       '@types/node': 20.17.8
     optional: true
 
-  '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)':
+  '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
@@ -44562,14 +44562,14 @@ snapshots:
   '@wordpress/eslint-plugin@9.3.0(@babel/core@7.26.0)(eslint@7.32.0)(typescript@5.7.2)':
     dependencies:
       '@babel/eslint-parser': 7.23.3(@babel/core@7.26.0)(eslint@7.32.0)
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       '@wordpress/prettier-config': 1.4.0(wp-prettier@2.2.1-beta-1)
       cosmiconfig: 7.1.0
       eslint: 7.32.0
       eslint-config-prettier: 7.2.0(eslint@7.32.0)
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)
-      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
       eslint-plugin-jsdoc: 36.1.1(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@7.2.0(eslint@7.32.0))(eslint@7.32.0)(wp-prettier@2.2.1-beta-1)
@@ -46076,13 +46076,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@wordpress/scripts@28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(eslint-import-resolver-typescript@3.8.3)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)':
+  '@wordpress/scripts@28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(encoding@0.1.13)(eslint-import-resolver-typescript@3.8.3)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/core': 7.26.0
       '@playwright/test': 1.50.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.25.4)(webpack@5.91.0)
       '@svgr/webpack': 8.1.0(typescript@5.7.2)
-      '@wordpress/babel-preset-default': 8.13.0
+      '@wordpress/babel-preset-default': 8.0.1
       '@wordpress/browserslist-config': 6.0.1
       '@wordpress/dependency-extraction-webpack-plugin': 6.16.0(webpack@5.91.0)
       '@wordpress/e2e-test-utils-playwright': 1.16.0(@playwright/test@1.50.1)
@@ -46174,7 +46174,7 @@ snapshots:
       '@playwright/test': 1.50.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.91.0))(webpack-hot-middleware@2.25.4)(webpack@5.97.1)
       '@svgr/webpack': 8.1.0(typescript@5.7.2)
-      '@wordpress/babel-preset-default': 8.13.0
+      '@wordpress/babel-preset-default': 8.0.1
       '@wordpress/browserslist-config': 6.0.1
       '@wordpress/dependency-extraction-webpack-plugin': 3.7.0(webpack@5.97.1)
       '@wordpress/e2e-test-utils-playwright': 1.16.0(@playwright/test@1.50.1)
@@ -46266,7 +46266,7 @@ snapshots:
       '@playwright/test': 1.50.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.2)(type-fest@3.13.1)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.25.4)(webpack@5.97.1)
       '@svgr/webpack': 8.1.0(typescript@5.7.2)
-      '@wordpress/babel-preset-default': 8.13.0
+      '@wordpress/babel-preset-default': 8.0.1
       '@wordpress/browserslist-config': 6.0.1
       '@wordpress/dependency-extraction-webpack-plugin': 3.7.0(webpack@5.97.1)
       '@wordpress/e2e-test-utils-playwright': 1.16.0(@playwright/test@1.50.1)
@@ -51495,12 +51495,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2):
+  eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2):
     dependencies:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       eslint: 7.32.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Repair the E2E JS package builds that are broken in https://github.com/woocommerce/woocommerce/pull/55861.

### How to test the changes in this Pull Request:

For each affected package run pnpm build command.
