### PR TITLE
[NOX] Fix how we record onboarding state in the complete setup click event

### DIFF
--- a/plugins/woocommerce/changelog/fix-55921-complete-setup-event-property
+++ b/plugins/woocommerce/changelog/fix-55921-complete-setup-event-property
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix how we record onboarding state in the complete setup click event.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/complete-setup-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/complete-setup-button.tsx
@@ -75,7 +75,9 @@ export const CompleteSetupButton = ( {
 		// Record the click of this button.
 		recordEvent( 'settings_payments_provider_complete_setup_click', {
 			provider_id: gatewayId,
-			onboarding_state: onboardingState,
+			onboarding_started: onboardingState.started,
+			onboarding_completed: onboardingState.completed,
+			onboarding_test_mode: onboardingState.test_mode,
 		} );
 
 		setIsUpdating( true );

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/complete-setup-button.test.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/test/complete-setup-button.test.tsx
@@ -51,11 +51,9 @@ describe( 'CompleteSetupButton', () => {
 			'settings_payments_provider_complete_setup_click',
 			{
 				provider_id: 'test-gateway',
-				onboarding_state: {
-					started: true,
-					completed: false,
-					test_mode: false,
-				},
+				onboarding_started: true,
+				onboarding_completed: false,
+				onboarding_test_mode: false,
 			}
 		);
 	} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/55921.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

##### Local

1. Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );` on your site browser console. And look for verbose logs.
2. Enable the new Payment settings page by going to WP Admin > Tools > WCA Test Helper > Features and turning on the `reactify-classic-payments-settings` flag. (requires the WC Beta Tester plugin).
3. Go to WP Admin > WooCommerce > Settings > Payments.
5. Click the Enable button for PayPal provider.
6. Once PayPal is installed, click its Complete Setup button and verify `wcadmin_settings_payments_provider_complete_setup_click` is recorded.
7. Before: onboarding_state property was recorded with an object as its value
8. After: Onboarding state is recorded granularly as three separate properties - `onboarding_completed`, `onboarding_started`, and `onboarding_test_mode` - with boolean values.

<img width="825" alt="image" src="https://github.com/user-attachments/assets/361b9b45-d22e-4d84-9dcb-c22eeba422c4" />


##### JurassicNinja

1. Create a new JN site with WooCommerce on this PR's live branch and the WooCommerce Beta Tester plugin (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=fix/55921-complete-setup-event-property))
2. Go to WP Admin > WooCommerce menu item. You will be taken to the WooCommerce profiler. Click "Skip guided setup" and choose `US` as the store's base location country.
3. Go to WooCommerce > Settings > Advanced > WooCommerce.com and turn the `Enable tracking` flag on.
4. Install [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) browser extension and use its log of events.
13. Follow the steps in the Local section above. Instead of browser console, verify that correct events are recorded in Tracks Vigilante.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
