### PR TITLE
Introduce _wc_delete_transients

### DIFF
--- a/plugins/woocommerce/changelog/add-wc-delete-transients
+++ b/plugins/woocommerce/changelog/add-wc-delete-transients
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add wc_delete_transients for batch transient deletion

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2751,8 +2751,8 @@ function wc_delete_transients( $transients ) {
 			// Use a single query for better performance.
 			$result = $wpdb->query(
 				$wpdb->prepare(
-					'DELETE FROM ' . $wpdb->options . ' WHERE option_name IN ( ' . implode( ', ', array_fill( 0, count( $transient_names ), '%s' ) ) . ' )',
-					$transient_names
+					'DELETE FROM ' . $wpdb->options . ' WHERE option_name IN ( ' . implode( ', ', array_fill( 0, count( $options_to_clear ), '%s' ) ) . ' )',
+					$options_to_clear
 				)
 			);
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2723,7 +2723,7 @@ function _wc_delete_transients( $transients ) {
 		}
 
 		// Limit the number of items in a single query to avoid exceeding database query parameter limits.
-		if ( count( $transient_names ) > 999 ) {
+		if ( count( $transient_names ) > 499 ) {
 			// Process in smaller chunks of 200 option names (100 transients) to reduce memory usage.
 			$chunks  = array_chunk( $transients, 100 );
 			$success = true;

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2796,7 +2796,7 @@ function _wc_delete_transients( $transients ) {
 		} catch ( Exception $e ) {
 			wc_get_logger()->error(
 				sprintf( 'Exception when deleting transients: %s', $e->getMessage() ),
-				array( 'source' => 'wc_delete_transients' )
+				array( 'source' => '_wc_delete_transients' )
 			);
 			return false;
 		}

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2723,8 +2723,8 @@ function _wc_delete_transients( $transients ) {
 		}
 
 		// Limit the number of items in a single query to avoid exceeding database query parameter limits.
-		if ( count( $transient_names ) > 499 ) {
-			// Process in smaller chunks of 200 option names (100 transients) to reduce memory usage.
+		if ( count( $transients) > 199 ) {
+			// Process in smaller chunks to reduce memory usage.
 			$chunks  = array_chunk( $transients, 100 );
 			$success = true;
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2690,14 +2690,18 @@ function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
 /**
  * Delete multiple transients in a single operation.
  *
+ * IMPORTANT: This is a private function (internal use ONLY).
+ *
  * This function efficiently deletes multiple transients at once, using a direct
  * database query when possible for better performance.
+ *
+ * @internal
  *
  * @since 9.8.0
  * @param array $transients Array of transient names to delete (without the '_transient_' prefix).
  * @return bool True on success, false on failure.
  */
-function wc_delete_transients( $transients ) {
+function _wc_delete_transients( $transients ) {
 	global $wpdb;
 
 	if ( empty( $transients ) || ! is_array( $transients ) ) {

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2693,7 +2693,7 @@ function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
  * This function efficiently deletes multiple transients at once, using a direct
  * database query when possible for better performance.
  *
- * @since 9.9.0
+ * @since 9.8.0
  * @param array $transients Array of transient names to delete (without the '_transient_' prefix).
  * @return bool True on success, false on failure.
  */

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -243,9 +243,6 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		// Delete the transients.
 		wc_delete_transients( array( $transient_name1, $transient_name2 ) );
 
-		// Force WordPress to refresh its memory cache.
-		wp_cache_flush();
-
 		// Verify transients are deleted.
 		$this->assertFalse( get_transient( $transient_name1 ) );
 		$this->assertFalse( get_transient( $transient_name2 ) );
@@ -257,9 +254,6 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 
 		// Pass the transient name as an array element
 		wc_delete_transients( array( $transient_name3 ) );
-
-		// Force WordPress to refresh its memory cache.
-		wp_cache_flush();
 
 		$this->assertFalse( get_transient( $transient_name3 ) );
 

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -262,6 +262,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertFalse( wc_delete_transients( '' ) );
 
 		// Test with other non-array arguments.
+		$this->assertFalse( wc_delete_transients( 'test' ) );
 		$this->assertFalse( wc_delete_transients( null ) );
 		$this->assertFalse( wc_delete_transients( 123 ) );
 		$this->assertFalse( wc_delete_transients( true ) );

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -224,4 +224,53 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( '', $result['state'] );
 		remove_all_filters( 'woocommerce_geolocate_ip' );
 	}
+
+	/**
+	 * Test wc_delete_transients() function.
+	 */
+	public function test_wc_delete_transients() {
+		// Set up test transients.
+		$transient_name1 = 'wc_test_transient_1';
+		$transient_name2 = 'wc_test_transient_2';
+
+		set_transient( $transient_name1, 'test_value_1', HOUR_IN_SECONDS );
+		set_transient( $transient_name2, 'test_value_2', HOUR_IN_SECONDS );
+
+		// Verify transients exist before deletion.
+		$this->assertEquals( 'test_value_1', get_transient( $transient_name1 ) );
+		$this->assertEquals( 'test_value_2', get_transient( $transient_name2 ) );
+
+		// Delete the transients.
+		wc_delete_transients( array( $transient_name1, $transient_name2 ) );
+
+		// Force WordPress to refresh its memory cache.
+		wp_cache_flush();
+
+		// Verify transients are deleted.
+		$this->assertFalse( get_transient( $transient_name1 ) );
+		$this->assertFalse( get_transient( $transient_name2 ) );
+
+		// Test with a single transient name (string instead of array).
+		$transient_name3 = 'wc_test_transient_3';
+		set_transient( $transient_name3, 'test_value_3', HOUR_IN_SECONDS );
+		$this->assertEquals( 'test_value_3', get_transient( $transient_name3 ) );
+
+		// Pass the transient name as an array element
+		wc_delete_transients( array( $transient_name3 ) );
+
+		// Force WordPress to refresh its memory cache.
+		wp_cache_flush();
+
+		$this->assertFalse( get_transient( $transient_name3 ) );
+
+		// Test with empty input.
+		$this->assertFalse( wc_delete_transients( array() ) );
+		$this->assertFalse( wc_delete_transients( '' ) );
+
+		// Test with other non-array arguments.
+		$this->assertFalse( wc_delete_transients( null ) );
+		$this->assertFalse( wc_delete_transients( 123 ) );
+		$this->assertFalse( wc_delete_transients( true ) );
+		$this->assertFalse( wc_delete_transients( new stdClass() ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -241,7 +241,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'test_value_2', get_transient( $transient_name2 ) );
 
 		// Delete the transients.
-		wc_delete_transients( array( $transient_name1, $transient_name2 ) );
+		_wc_delete_transients( array( $transient_name1, $transient_name2 ) );
 
 		// Verify transients are deleted.
 		$this->assertFalse( get_transient( $transient_name1 ) );
@@ -253,19 +253,19 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'test_value_3', get_transient( $transient_name3 ) );
 
 		// Pass the transient name as an array element
-		wc_delete_transients( array( $transient_name3 ) );
+		_wc_delete_transients( array( $transient_name3 ) );
 
 		$this->assertFalse( get_transient( $transient_name3 ) );
 
 		// Test with empty input.
-		$this->assertFalse( wc_delete_transients( array() ) );
-		$this->assertFalse( wc_delete_transients( '' ) );
+		$this->assertFalse( _wc_delete_transients( array() ) );
+		$this->assertFalse( _wc_delete_transients( '' ) );
 
 		// Test with other non-array arguments.
-		$this->assertFalse( wc_delete_transients( 'test' ) );
-		$this->assertFalse( wc_delete_transients( null ) );
-		$this->assertFalse( wc_delete_transients( 123 ) );
-		$this->assertFalse( wc_delete_transients( true ) );
-		$this->assertFalse( wc_delete_transients( new stdClass() ) );
+		$this->assertFalse( _wc_delete_transients( 'test' ) );
+		$this->assertFalse( _wc_delete_transients( null ) );
+		$this->assertFalse( _wc_delete_transients( 123 ) );
+		$this->assertFalse( _wc_delete_transients( true ) );
+		$this->assertFalse( _wc_delete_transients( new stdClass() ) );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This utility function was inspired by this PR https://github.com/woocommerce/woocommerce/pull/55843 by @cpapazoglou whereby sometimes we need to delete a batch of transient data associated with a product.

Looping through and using `delete_transient` isn't always the most performant for batch deletion. This takes the original implementation of [delete_transient](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/option.php) and re-implements it for batch deletion.

### Performance Benefits

I benchmarked this function deleting 500 transients vs using `delete_transient` on each transient individually. The results show that `wc_delete_transients` is over 100% more performant.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. This comes with unit tests. Review these tests and ensure they are passing as expected.
2. For batch deletion logic, enable Query Monitor and go to your sites homepage.
3. Go to Database Queries tab and filter by "DELETE"
4. Add the below code to your themes `function.php` file
5. Reload the page, and check that the transients are processed in batches.

```php
/**
 * Creates test transients and deletes them to test batch deletion logic.
 * 
 * This function creates 501 test transients with a specific prefix,
 * then uses wc_delete_transients() to delete them all at once.
 * 
 * @return void
 */
function test_transient_batch_deletion() {   
    // Create a unique prefix for our test transients
    $prefix = 'test_transient_batch_';
    
    // Create transients in smaller batches to avoid memory issues
    $batch_size = 50;
    $total_transients = 300;
    $transient_names = array();
    
    for ($batch = 0; $batch < ceil($total_transients / $batch_size); $batch++) {
        $batch_transients = array();
        $start = $batch * $batch_size + 1;
        $end = min(($batch + 1) * $batch_size, $total_transients);
        
        for ($i = $start; $i <= $end; $i++) {
            $transient_name = $prefix . $i;
            set_transient($transient_name, "Test value $i", HOUR_IN_SECONDS);
            $batch_transients[] = $transient_name;
        }
        
        // Add batch to the full list
        $transient_names = array_merge($transient_names, $batch_transients);
        
        // Free memory
        unset($batch_transients);
    }

	_wc_delete_transients($transient_names);
}
add_action('init', 'test_transient_batch_deletion');

```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
