### PR TITLE
Add/email editor sending transactional emails

### DIFF
--- a/plugins/woocommerce/changelog/add-email-editor-sending-transactional-emails
+++ b/plugins/woocommerce/changelog/add-email-editor-sending-transactional-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the base functionality for replacing Woo transactional emails with emails created via the block email editor

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/constants.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/constants.ts
@@ -1,0 +1,1 @@
+export const NAME_SPACE = 'woocommerce/email-editor-integration';

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
@@ -1,5 +1,5 @@
 interface Window {
-	MailPoetEmailEditor: {
+	WooCommerceEmailEditor: {
 		current_post_type: string;
 		current_post_id: string;
 		email_types: {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
@@ -1,0 +1,10 @@
+interface Window {
+	MailPoetEmailEditor: {
+		current_post_type: string;
+		current_post_id: string;
+		email_types: {
+			value: string;
+			label: string;
+		}[];
+	};
+}

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -10,8 +10,8 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { wooContentBlock } from './woo_content_placeholder_block';
-
-const NAME_SPACE = 'woocommerce/email-editor-integration';
+import { NAME_SPACE } from './constants';
+import { modifySidebar } from './sidebar_extension';
 
 addFilter(
 	'woocommerce_email_editor_send_button_label',
@@ -20,3 +20,4 @@ addFilter(
 );
 
 registerBlockType( 'woo/email-content', wooContentBlock );
+modifySidebar();

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -4,6 +4,12 @@
  * External dependencies
  */
 import { addFilter } from '@wordpress/hooks';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { wooContentBlock } from './woo_content_placeholder_block';
 
 const NAME_SPACE = 'woocommerce/email-editor-integration';
 
@@ -12,3 +18,5 @@ addFilter(
 	NAME_SPACE,
 	() => 'Save WooCommerce email template' // This is a temporary label to confirm the integration works, it will be updated in the future.
 );
+
+registerBlockType( 'woo/email-content', wooContentBlock );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_extension.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_extension.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	useEntityRecord,
+	store as coreDataStore,
+	Post,
+} from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { EntityRecordResolution } from '@wordpress/core-data/build-types/hooks/use-entity-record';
+
+/**
+ * Internal dependencies
+ */
+import { NAME_SPACE } from './constants';
+
+const SidebarExtensionComponent = () => {
+	const { current_post_id, current_post_type, email_types } =
+		window.MailPoetEmailEditor;
+	const email = useEntityRecord(
+		'postType',
+		current_post_type,
+		current_post_id
+	) as EntityRecordResolution< Post >;
+	const { editEntityRecord } = useDispatch( coreDataStore );
+	const email_type_options = [ { value: '', label: '---' }, ...email_types ];
+
+	return (
+		<SelectControl
+			label={ __( 'Email type', 'woocommerce' ) }
+			options={ email_type_options }
+			value={ email.editedRecord.slug }
+			onChange={ ( value ) => {
+				editEntityRecord(
+					'postType',
+					current_post_type,
+					current_post_id,
+					{ slug: value }
+				);
+			} }
+			__nextHasNoMarginBottom
+		/>
+	);
+};
+
+export function modifySidebar() {
+	addFilter(
+		'mailpoet_email_editor_setting_sidebar_extension_component',
+		NAME_SPACE,
+		() => SidebarExtensionComponent
+	);
+}

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_extension.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_extension.tsx
@@ -19,7 +19,7 @@ import { NAME_SPACE } from './constants';
 
 const SidebarExtensionComponent = () => {
 	const { current_post_id, current_post_type, email_types } =
-		window.MailPoetEmailEditor;
+		window.WooCommerceEmailEditor;
 	const email = useEntityRecord(
 		'postType',
 		current_post_type,
@@ -48,7 +48,7 @@ const SidebarExtensionComponent = () => {
 
 export function modifySidebar() {
 	addFilter(
-		'mailpoet_email_editor_setting_sidebar_extension_component',
+		'woocommerce_email_editor_setting_sidebar_extension_component',
 		NAME_SPACE,
 		() => SidebarExtensionComponent
 	);

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/woo_content_placeholder_block.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/woo_content_placeholder_block.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const wooContentBlock = {
+	title: __( 'Woo Email Content', 'woocommerce' ),
+	category: 'text',
+	attributes: {},
+	edit: () => (
+		<p>
+			<strong>This will be replaced by WooCommerce Content</strong>
+		</p>
+	),
+	save: () => <div>##WOO_CONTENT##</div>,
+};

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Emails
  */
 
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Pelago\Emogrifier\CssInliner;
 use Pelago\Emogrifier\HtmlProcessor\CssToAttributeConverter;
@@ -258,10 +259,18 @@ class WC_Email extends WC_Settings_API {
 	public $email_improvements_enabled;
 
 	/**
+	 * Whether email block editor feature is enabled.
+	 *
+	 * @var bool
+	 */
+	public $block_email_editor_enabled;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		$this->email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+		$this->block_email_editor_enabled = FeaturesUtil::feature_is_enabled( 'block_email_editor' );
 
 		// Find/replace.
 		$this->placeholders = array_merge(
@@ -706,6 +715,11 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function get_content() {
 		$this->sending = true;
+
+		$block_email_content = $this->get_block_email_html_content();
+		if ( $block_email_content ) {
+			return $block_email_content;
+		}
 
 		if ( 'plain' === $this->get_email_type() ) {
 			$email_content = wordwrap( preg_replace( $this->plain_search, $this->plain_replace, wp_strip_all_tags( $this->get_content_plain() ) ), 70 );
@@ -1388,5 +1402,54 @@ class WC_Email extends WC_Settings_API {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * This method checks if there is email created in the block editor associated with this WC_Email
+	 * and if so, it renders the block email content.
+	 *
+	 * @return string|null
+	 */
+	private function get_block_email_html_content(): ?string {
+		if ( ! $this->block_email_editor_enabled ) {
+			return null;
+		}
+
+		/** Service for rendering emails from block content @var BlockEmailRenderer $renderer */
+		$renderer   = wc_get_container()->get( BlockEmailRenderer::class );
+		$email_post = $renderer->get_email_post_by_wc_email( $this );
+
+		if ( ! $email_post ) {
+			return null;
+		}
+
+		// Get the Woo content excluding headers and footers.
+		// Store the existing header and footer callbacks.
+		global $wp_filter;
+		$original_header_filters = isset( $wp_filter['woocommerce_email_header'] ) ? clone $wp_filter['woocommerce_email_header'] : null;
+		$original_footer_filters = isset( $wp_filter['woocommerce_email_footer'] ) ? clone $wp_filter['woocommerce_email_header'] : null;
+
+		// Remove header and footer filters because we want to get only the main content.
+		remove_all_filters( 'woocommerce_email_header' );
+		remove_all_filters( 'woocommerce_email_footer' );
+
+		$woo_content = $this->get_content_html();
+
+		// Restore the original header and footer filters.
+		if ( $original_header_filters ) {
+			foreach ( $original_header_filters->callbacks as $priority => $callbacks ) {
+				foreach ( $callbacks as $filter ) {
+					add_filter( 'woocommerce_email_header', $filter['function'], $priority, $filter['accepted_args'] );
+				}
+			}
+		}
+		if ( $original_footer_filters ) {
+			foreach ( $original_footer_filters->callbacks as $priority => $callbacks ) {
+				foreach ( $callbacks as $filter ) {
+					add_filter( 'woocommerce_email_footer', $filter['function'], $priority, $filter['accepted_args'] );
+				}
+			}
+		}
+		return $renderer->render_block_email( $email_post, $woo_content, $this );
 	}
 }

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -718,6 +718,7 @@ class WC_Email extends WC_Settings_API {
 
 		$block_email_content = $this->get_block_email_html_content();
 		if ( $block_email_content ) {
+			$this->email_type = 'plain' === $this->email_type ? 'html' : $this->email_type;
 			return $block_email_content;
 		}
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailEditorServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailEditorServiceProvider.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\EmailEditor\PageRenderer;
 use Automattic\WooCommerce\Internal\EmailEditor\PersonalizationTagManager;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController;
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 /**
  * Service provider for the EmailEditor namespace.
@@ -26,6 +27,7 @@ class EmailEditorServiceProvider extends AbstractInterfaceServiceProvider {
 		PersonalizationTagManager::class,
 		PatternsController::class,
 		TemplatesController::class,
+		BlockEmailRenderer::class,
 	);
 
 	/**
@@ -37,5 +39,6 @@ class EmailEditorServiceProvider extends AbstractInterfaceServiceProvider {
 		$this->share( PersonalizationTagManager::class );
 		$this->share( PatternsController::class );
 		$this->share( TemplatesController::class );
+		$this->share( BlockEmailRenderer::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -44,7 +44,7 @@ class BlockEmailRenderer {
 	/**
 	 * Initialize the renderer.
 	 */
-	public function register_hooks(): void {
+	public function init(): void {
 		add_action( 'mailpoet_blocks_renderer_initialized', array( $this, 'register_block_renderers' ) );
 	}
 

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -112,6 +112,8 @@ class BlockEmailRenderer {
 	private function prepare_context_data( \WC_Email $wc_email ): array {
 		$context                    = array();
 		$context['recipient_email'] = $wc_email->get_recipient();
+		$context['order']           = $wc_email->object instanceof \WC_Order ? $wc_email->object : null;
+		$context['wp_user']         = $wc_email->object instanceof \WP_User ? $wc_email->object : null;
 		return $context;
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -4,11 +4,11 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\EmailEditor;
 
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Personalizer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Blocks_Registry;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer as EmailRenderer;
 use Automattic\WooCommerce\Internal\EmailEditor\Renderer\Blocks\WooContent;
-use MailPoet\EmailEditor\Engine\Personalizer;
-use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Blocks_Registry;
-use MailPoet\EmailEditor\Engine\Renderer\Renderer as MailPoetRenderer;
-use MailPoet\EmailEditor\EmailEditorContainer;
 
 /**
  * Class responsible for rendering block-based emails.
@@ -20,7 +20,7 @@ class BlockEmailRenderer {
 	/**
 	 * Service for rendering block emails
 	 *
-	 * @var MailPoetRenderer
+	 * @var EmailRenderer
 	 */
 	private $renderer;
 
@@ -36,16 +36,18 @@ class BlockEmailRenderer {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$editor_container   = EmailEditorContainer::container();
-		$this->renderer     = $editor_container->get( MailPoetRenderer::class );
+		$editor_container   = Email_Editor_Container::container();
+		$this->renderer     = $editor_container->get( EmailRenderer::class );
 		$this->personalizer = $editor_container->get( Personalizer::class );
 	}
 
 	/**
 	 * Initialize the renderer.
+	 *
+	 * @internal
 	 */
-	public function init(): void {
-		add_action( 'mailpoet_blocks_renderer_initialized', array( $this, 'register_block_renderers' ) );
+	final public function init(): void {
+		add_action( 'woocommerce_blocks_renderer_initialized', array( $this, 'register_block_renderers' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\EmailEditor;
+
+use Automattic\WooCommerce\Internal\EmailEditor\Renderer\Blocks\WooContent;
+use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Blocks_Registry;
+
+/**
+ * Class responsible for rendering block-based emails.
+ */
+class BlockEmailRenderer {
+	const WOO_EMAIL_CONTENT_PLACEHOLDER_BLOCK = 'woo/email-content';
+	const WOO_EMAIL_CONTENT_PLACEHOLDER       = '##WOO_CONTENT##';
+
+	/**
+	 * Initialize the renderer.
+	 */
+	public function register_hooks(): void {
+		add_action( 'mailpoet_blocks_renderer_initialized', array( $this, 'register_block_renderers' ) );
+	}
+
+	/**
+	 * Callback for registering WooCommerce email block renderers.
+	 *
+	 * @param Blocks_Registry $blocks_registry Block renderer registry.
+	 */
+	public function register_block_renderers( $blocks_registry ): void {
+		$blocks_registry->add_block_renderer( self::WOO_EMAIL_CONTENT_PLACEHOLDER_BLOCK, new WooContent() );
+	}
+	}
+}

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\Internal\EmailEditor;
 
 use Automattic\WooCommerce\Internal\EmailEditor\Renderer\Blocks\WooContent;
 use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Blocks_Registry;
+use MailPoet\EmailEditor\Engine\Renderer\Renderer as MailPoetRenderer;
+use MailPoet\EmailEditor\EmailEditorContainer;
 
 /**
  * Class responsible for rendering block-based emails.
@@ -13,6 +15,21 @@ use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Blocks_Registry;
 class BlockEmailRenderer {
 	const WOO_EMAIL_CONTENT_PLACEHOLDER_BLOCK = 'woo/email-content';
 	const WOO_EMAIL_CONTENT_PLACEHOLDER       = '##WOO_CONTENT##';
+
+	/**
+	 * Service for rendering block emails
+	 *
+	 * @var MailPoetRenderer
+	 */
+	private $renderer;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$editor_container = EmailEditorContainer::container();
+		$this->renderer   = $editor_container->get( MailPoetRenderer::class );
+	}
 
 	/**
 	 * Initialize the renderer.
@@ -29,5 +46,48 @@ class BlockEmailRenderer {
 	public function register_block_renderers( $blocks_registry ): void {
 		$blocks_registry->add_block_renderer( self::WOO_EMAIL_CONTENT_PLACEHOLDER_BLOCK, new WooContent() );
 	}
+
+	/**
+	 * Maybe render block-based email content.
+	 *
+	 * @param \WP_Post  $email_post Email post.
+	 * @param string    $woo_content WooCommerce email content.
+	 * @param \WC_Email $wc_email WooCommerce email.
+	 * @return string Modified email content
+	 */
+	public function render_block_email( \WP_Post $email_post, string $woo_content, \WC_Email $wc_email ): ?string {
+		$subject   = $wc_email->get_subject(); // We will get subject from $email_post after we add it to the editor.
+		$preheader = ''; // We will get the preheader from $email_post after we add it to the editor.
+		try {
+			$rendered_email_data = $this->renderer->render( $email_post, $subject, $preheader, 'en' );
+			$rendered_email      = str_replace( self::WOO_EMAIL_CONTENT_PLACEHOLDER, $woo_content, $rendered_email_data['html'] );
+			return $rendered_email;
+		} catch ( \Exception $e ) {
+			wc_caught_exception( $e, __METHOD__, array( $email_post, $woo_content, $wc_email ) );
+			return null;
+		}
+	}
+
+	/**
+	 * Get the email post for a given WC_Email.
+	 * Temporarily using the email ID as the post title for storing the association.
+	 *
+	 * @param \WC_Email $email WooCommerce email.
+	 * @return \WP_Post|null
+	 */
+	public function get_email_post_by_wc_email( \WC_Email $email ): ?\WP_Post {
+		$args = array(
+			'post_type'      => Integration::EMAIL_POST_TYPE,
+			'title'          => $email->id,
+			'post_status'    => 'draft', // Temporarily use draft status we will change it to publish or custom active later.
+			'posts_per_page' => 1,
+		);
+
+		$posts = get_posts( $args );
+		if ( empty( $posts ) ) {
+			return null;
+		}
+
+		return $posts[0];
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/BlockEmailRenderer.php
@@ -92,7 +92,7 @@ class BlockEmailRenderer {
 	public function get_email_post_by_wc_email( \WC_Email $email ): ?\WP_Post {
 		$args = array(
 			'post_type'      => Integration::EMAIL_POST_TYPE,
-			'title'          => $email->id,
+			'name'           => $email->id,
 			'post_status'    => 'draft', // Temporarily use draft status we will change it to publish or custom active later.
 			'posts_per_page' => 1,
 		);

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailPatterns/WooEmailContentPattern.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailPatterns/WooEmailContentPattern.php
@@ -60,6 +60,10 @@ class WooEmailContentPattern extends Abstract_Pattern {
 <p>Here comes content composed of supported core blocks and Woo transactional email block(s).</p>
 <!-- /wp:paragraph -->
 
+<!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woo-email-content">##WOO_CONTENT##</div>
+<!-- /wp:woo/email-content -->
+
 <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button {"style":{"color":{"background":"#873eff"}}} -->
 <div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button" style="background-color:#873eff">Shop now</a></div>

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -32,13 +32,6 @@ class Integration {
 	private Dependency_Check $dependency_check;
 
 	/**
-	 * Renderer for block emails.
-	 *
-	 * @var BlockEmailRenderer
-	 */
-	private BlockEmailRenderer $block_email_renderer;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -68,8 +61,8 @@ class Integration {
 		$container->get( PatternsController::class );
 		$container->get( TemplatesController::class );
 		$container->get( PersonalizationTagManager::class );
+		$container->get( BlockEmailRenderer::class );
 		$this->editor_page_renderer = $container->get( PageRenderer::class );
-		$this->block_email_renderer = $container->get( BlockEmailRenderer::class );
 	}
 
 	/**
@@ -79,7 +72,6 @@ class Integration {
 		add_filter( 'woocommerce_email_editor_post_types', array( $this, 'add_email_post_type' ) );
 		add_filter( 'woocommerce_is_email_editor_page', array( $this, 'is_editor_page' ), 10, 1 );
 		add_filter( 'replace_editor', array( $this, 'replace_editor' ), 10, 2 );
-		$this->block_email_renderer->register_hooks();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -32,6 +32,13 @@ class Integration {
 	private Dependency_Check $dependency_check;
 
 	/**
+	 * Renderer for block emails.
+	 *
+	 * @var BlockEmailRenderer
+	 */
+	private BlockEmailRenderer $block_email_renderer;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -62,6 +69,7 @@ class Integration {
 		$container->get( TemplatesController::class );
 		$container->get( PersonalizationTagManager::class );
 		$this->editor_page_renderer = $container->get( PageRenderer::class );
+		$this->block_email_renderer = $container->get( BlockEmailRenderer::class );
 	}
 
 	/**
@@ -71,6 +79,7 @@ class Integration {
 		add_filter( 'woocommerce_email_editor_post_types', array( $this, 'add_email_post_type' ) );
 		add_filter( 'woocommerce_is_email_editor_page', array( $this, 'is_editor_page' ), 10, 1 );
 		add_filter( 'replace_editor', array( $this, 'replace_editor' ), 10, 2 );
+		$this->block_email_renderer->register_hooks();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -119,6 +119,17 @@ class PageRenderer {
 		);
 
 		$current_user_email = wp_get_current_user()->user_email;
+		
+		// Fetch all email types from WooCommerce including those added by other plugins.
+		$wc_emails = \WC_Emails::instance();
+		$email_types = $wc_emails->get_emails();
+		$email_types = array_values( array_map( function( $email ) {
+			return array(
+				'value' => $email->id,
+				'label' => $email->title,
+			);
+		}, $email_types ) );
+
 		wp_localize_script(
 			'woocommerce_email_editor',
 			'WooCommerceEmailEditor',
@@ -133,6 +144,7 @@ class PageRenderer {
 					'listings' => admin_url( 'edit.php?post_type=' . Integration::EMAIL_POST_TYPE ),
 					'send'     => admin_url( 'edit.php?post_type=' . Integration::EMAIL_POST_TYPE ),
 				),
+				'email_types' => $email_types,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/EmailEditor/Renderer/Blocks/WooContent.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Renderer/Blocks/WooContent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\EmailEditor\Renderer\Blocks;
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+use MailPoet\EmailEditor\Engine\Settings_Controller;
+use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+
+/**
+ * Renders a list item block.
+ */
+class WooContent extends Abstract_Block_Renderer {
+	/**
+	 * Renders Woo content placeholder to be replaced by content during sending.
+	 *
+	 * @param string              $block_content Block content.
+	 * @param array               $parsed_block Parsed block.
+	 * @param Settings_Controller $settings_controller Settings controller.
+	 * @return string
+	 */
+	protected function render_content( $block_content, array $parsed_block, Settings_Controller $settings_controller ): string {
+		return BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER;
+	}
+}

--- a/plugins/woocommerce/src/Internal/EmailEditor/Renderer/Blocks/WooContent.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Renderer/Blocks/WooContent.php
@@ -4,9 +4,9 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\EmailEditor\Renderer\Blocks;
 
+use Automattic\WooCommerce\EmailEditor\Engine\Settings_Controller;
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
-use MailPoet\EmailEditor\Engine\Settings_Controller;
-use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
 
 /**
  * Renders a list item block.

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 use Automattic\WooCommerce\Internal\EmailEditor\Package;
 use MailPoet\EmailEditor\Bootstrap;
 use MailPoet\EmailEditor\EmailEditorContainer;
+use MailPoet\EmailEditor\Engine\Dependency_Check;
 
 /**
  * Tests for the BlockEmailRenderer class.
@@ -66,6 +67,8 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 	 * Test that the BlockEmailRenderer can render email and replaces Woo Content.
 	 */
 	public function testItRendersAnEmail(): void {
+		$this->skip_if_unsupported_environment();
+
 		$test_woo_content        = 'Test Woo Content';
 		$wc_mail_mock            = new \WC_Email();
 		$wc_mail_mock->id        = 'test_email';
@@ -85,5 +88,14 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		parent::tearDown();
 		update_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
+	}
+
+	/**
+	 * Skip test if the environment doesn't fulfill minimal requirements.
+	 */
+	private function skip_if_unsupported_environment() {
+		if ( ! EmailEditorContainer::container()->get( Dependency_Check::class )->are_dependencies_met() ) {
+			$this->markTestSkipped( 'This test because the test environment does not fulfill minimal requirements for the block email editor.' );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
@@ -53,7 +53,8 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 
 		$this->email_post = $this->factory()->post->create_and_get(
 			array(
-				'post_title'   => 'test_email',
+				'post_title'   => 'Test email',
+				'post_name'    => 'test_email',
 				'post_type'    => Integration::EMAIL_POST_TYPE,
 				'post_content' => $this->email_post_content,
 				'post_status'  => 'draft',

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+use Automattic\WooCommerce\Internal\EmailEditor\Integration;
+use Automattic\WooCommerce\Internal\EmailEditor\Package;
+use MailPoet\EmailEditor\Bootstrap;
+use MailPoet\EmailEditor\EmailEditorContainer;
+
+/**
+ * Tests for the BlockEmailRenderer class.
+ */
+class BlockEmailRendererTest extends \WC_Unit_Test_Case {
+	/**
+	 * @var BlockEmailRenderer $block_email_renderer
+	 */
+	private BlockEmailRenderer $block_email_renderer;
+
+	/**
+	 * @var string $email_post_content
+	 */
+	private $email_post_content = '<!-- wp:paragraph -->
+<p>Test Paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woo-email-content">##WOO_CONTENT##</div>
+<!-- /wp:woo/email-content -->';
+
+	/**
+	 * @var \WP_Post $email_post
+	 */
+	private \WP_Post $email_post;
+
+	/**
+	 * Setup test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Make sure WC_Email class exists.
+		if ( ! class_exists( \WC_Email::class ) ) {
+			require_once WC_ABSPATH . 'includes/emails/class-wc-email.php';
+		}
+
+		add_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
+		wc_get_container()->get( Package::class )->init();
+		EmailEditorContainer::container()->get( Bootstrap::class )->initialize();
+
+		$this->email_post = $this->factory()->post->create_and_get(
+			array(
+				'post_title'   => 'test_email',
+				'post_type'    => Integration::EMAIL_POST_TYPE,
+				'post_content' => $this->email_post_content,
+				'post_status'  => 'draft',
+			)
+		);
+
+		$this->block_email_renderer = wc_get_container()->get( BlockEmailRenderer::class );
+	}
+
+	/**
+	 * Test that the BlockEmailRenderer can render email and replaces Woo Content.
+	 */
+	public function testItRendersAnEmail(): void {
+		$test_woo_content = 'Test Woo Content';
+		$wc_mail_mock     = new \WC_Email();
+		$wc_mail_mock->id = 'test_email';
+		$rendered_email   = $this->block_email_renderer->render_block_email( $this->email_post, $test_woo_content, $wc_mail_mock );
+		$this->assertStringContainsString( $test_woo_content, $rendered_email );
+		$this->assertStringContainsString( 'Test Paragraph.', $rendered_email );
+	}
+
+	/**
+	 * Cleanup after test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		update_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
@@ -4,12 +4,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
 
+use Automattic\WooCommerce\EmailEditor\Bootstrap;
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Dependency_Check;
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 use Automattic\WooCommerce\Internal\EmailEditor\Package;
-use MailPoet\EmailEditor\Bootstrap;
-use MailPoet\EmailEditor\EmailEditorContainer;
-use MailPoet\EmailEditor\Engine\Dependency_Check;
 
 /**
  * Tests for the BlockEmailRenderer class.
@@ -49,7 +49,7 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 
 		add_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
 		wc_get_container()->get( Package::class )->init();
-		EmailEditorContainer::container()->get( Bootstrap::class )->initialize();
+		Email_Editor_Container::container()->get( Bootstrap::class )->initialize();
 
 		$this->email_post = $this->factory()->post->create_and_get(
 			array(
@@ -94,7 +94,7 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 	 * Skip test if the environment doesn't fulfill minimal requirements.
 	 */
 	private function skip_if_unsupported_environment() {
-		if ( ! EmailEditorContainer::container()->get( Dependency_Check::class )->are_dependencies_met() ) {
+		if ( ! Email_Editor_Container::container()->get( Dependency_Check::class )->are_dependencies_met() ) {
 			$this->markTestSkipped( 'This test because the test environment does not fulfill minimal requirements for the block email editor.' );
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/BlockEmailRendererTest.php
@@ -23,7 +23,7 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 	 * @var string $email_post_content
 	 */
 	private $email_post_content = '<!-- wp:paragraph -->
-<p>Test Paragraph.</p>
+<p>Test Paragraph. <!--[woocommerce/shopper-email]--></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
@@ -66,12 +66,17 @@ class BlockEmailRendererTest extends \WC_Unit_Test_Case {
 	 * Test that the BlockEmailRenderer can render email and replaces Woo Content.
 	 */
 	public function testItRendersAnEmail(): void {
-		$test_woo_content = 'Test Woo Content';
-		$wc_mail_mock     = new \WC_Email();
-		$wc_mail_mock->id = 'test_email';
-		$rendered_email   = $this->block_email_renderer->render_block_email( $this->email_post, $test_woo_content, $wc_mail_mock );
+		$test_woo_content        = 'Test Woo Content';
+		$wc_mail_mock            = new \WC_Email();
+		$wc_mail_mock->id        = 'test_email';
+		$wc_mail_mock->recipient = 'customer@test.com';
+		$rendered_email          = $this->block_email_renderer->render_block_email( $this->email_post, $test_woo_content, $wc_mail_mock );
+		// Check that the Woo content placeholder was replaced.
 		$this->assertStringContainsString( $test_woo_content, $rendered_email );
+		// Check that the email standard block content was rendered correctly.
 		$this->assertStringContainsString( 'Test Paragraph.', $rendered_email );
+		// Check that the personalized tag was replaced.
+		$this->assertStringContainsString( 'customer@test.com', $rendered_email );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #55674, Closes #55801.

This PR adds the initial implementation of replacing Woo transactional emails with emails created in the email block editor.

I've provided more details in a GH discussion: https://github.com/woocommerce/woocommerce/discussions/55965

**Do not merge immediately. I would like to get feedback on the approach**

There will be follow-up tasks. Also mentioned in  https://github.com/woocommerce/woocommerce/discussions/55965

![Screenshot 2025-02-28 at 9 25 55](https://github.com/user-attachments/assets/9cf9b99a-88ea-48f2-83d0-024656dad51b)
![Screenshot 2025-02-28 at 9 30 50](https://github.com/user-attachments/assets/748a33ec-a40f-4088-b9cb-3dbcd0194fb9)

### Key Changes

- Added simple placeholder block for WooCommerce content
- Transactional emails that are associated with an email created in the block editor are replaced by the block based emails  during the sending
- The WooCommerce content placeholder is replaced by a content captured from the associated WC_Email during the 
sending
- Currently supported personalized tags are also processed and replaced in the sent email

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `block_email_editor` experimental flag (in DB, set `woocommerce_feature_block_email_editor_enabled` option to yes).
2. Navigate to WP Admin > Woo Emails
3. Create or edit an email template
4. Use an id of WC_Email you want to replace as the email title/campaign name. This is editable in the component in the center of the header in the editor. The list of WC_Emails can be found [here](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/includes/emails) and you can grab the id from the constructor ([example](https://github.com/woocommerce/woocommerce/blob/65be92caa43dcad3c61b2b1319a2116e748db35b/plugins/woocommerce/includes/emails/class-wc-email-customer-processing-order.php#L30)). This is a temporary way of setting the association.
5. Do the action that triggers the email. For example, for `customer_processing_order` you need to create a new order.
6. You should receive the email created in the block editor and it should contain the main content from the WC_Email. Note: you can use [WP Mail Logging plugin](https://wordpress.org/plugins/wp-mail-logging/) to capture the emails

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
