### PR TITLE
Update email editor WordPress Playground blueprint

### DIFF
--- a/packages/js/email-editor/blueprint.json
+++ b/packages/js/email-editor/blueprint.json
@@ -1,4 +1,5 @@
 {
+	"landingPage": "/wp-admin/edit.php?post_type=woo_email",
 	"preferredVersions": {
 		"php": "8.2",
 		"wp": "latest"
@@ -20,7 +21,7 @@
 		},
 		{
 			"step": "runPHP",
-			"code": "<?php include 'wordpress/wp-load.php'; delete_transient( '_wc_activation_redirect' );"
+			"code": "<?php include 'wordpress/wp-load.php'; delete_transient( '_wc_activation_redirect' ); update_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );"
 		}
 	]
 }

--- a/packages/js/email-editor/changelog/update-wordpress-playground-blueprint
+++ b/packages/js/email-editor/changelog/update-wordpress-playground-blueprint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add landingPage and block_email_editor feature flag

--- a/plugins/woocommerce/changelog/fix-remove-email-editor-php-package-before-composer-install
+++ b/plugins/woocommerce/changelog/fix-remove-email-editor-php-package-before-composer-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove email editor php package before composer install

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -33,7 +33,7 @@
 		"env:test": "pnpm env:dev",
 		"env:perf": "pnpm env:dev && pnpm env:performance-init",
 		"preinstall": "npx only-allow pnpm",
-		"postinstall": "rimraf -g vendor/woocommerce && XDEBUG_MODE=off composer install --quiet",
+		"postinstall": "rimraf -g vendor/woocommerce packages/email-editor && XDEBUG_MODE=off composer install --quiet",
 		"lint": "pnpm --if-present '/^lint:lang:.*$/'",
 		"lint:changes:branch": "pnpm '/^lint:changes:branch:.*$/'",
 		"lint:fix": "pnpm --if-present '/^lint:fix:lang:.*$/'",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A part of https://github.com/woocommerce/woocommerce/issues/55688
~This PR reduces the WooCommerce plugin size by removing unnecessary files, such as test files, from the email editor PHP package.~

~This will shrink the woocommerce plugin build by 3KB (compressed, more than 2.5MB uncompressed)~ 


This PR updates the WordPress playground blueprint for the email editor

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Test with https://playground.wordpress.net/builder/builder.html#{
2. Copy the blueprint or link the file directly to the Playground



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
