### PR TITLE
Fix rest API endpoint ( payment_gateway and tax_class)

### DIFF
--- a/plugins/woocommerce/changelog/55978-fix-endpoints
+++ b/plugins/woocommerce/changelog/55978-fix-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add support to `count` output format on `tax_class` and `payment_gateway` endpoints.

--- a/plugins/woocommerce/changelog/fix-cli-and-endpoints
+++ b/plugins/woocommerce/changelog/fix-cli-and-endpoints
@@ -1,0 +1,6 @@
+Significance: minor
+Type: fix
+
+- Adding header validation to prevent this error:
+`PHP Warning:  Undefined array key "X-WP-Total" in /app/wordpress/wp-content/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php on line 239`
+- Adding `X-WP-Total` and `X-WP-TotalPages` header on `tax_class` and `payment_gateway` endpoints.

--- a/plugins/woocommerce/changelog/fix-cli-and-endpoints
+++ b/plugins/woocommerce/changelog/fix-cli-and-endpoints
@@ -1,6 +1,4 @@
 Significance: minor
 Type: fix
 
-- Adding header validation to prevent this error:
-`PHP Warning:  Undefined array key "X-WP-Total" in /app/wordpress/wp-content/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php on line 239`
-- Adding `X-WP-Total` and `X-WP-TotalPages` header on `tax_class` and `payment_gateway` endpoints.
+Add validation to prevent PHP warning in CLI when using the 'count' format.

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -236,7 +236,11 @@ class WC_CLI_REST_Command {
 		}
 
 		if ( ! empty( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
-			echo (int) $headers['X-WP-Total'];
+			if ( isset( $headers['X-WP-Total'] ) ) {
+				echo (int) $headers['X-WP-Total'];
+			} else {
+				echo "Notice: Count format not implemented yet\n\r";
+			}
 		} elseif ( 'headers' === $assoc_args['format'] ) {
 			echo wp_json_encode( $headers );
 		} elseif ( 'body' === $assoc_args['format'] ) {

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -239,7 +239,7 @@ class WC_CLI_REST_Command {
 			if ( isset( $headers['X-WP-Total'] ) ) {
 				echo (int) $headers['X-WP-Total'];
 			} else {
-				echo "Notice: Count format not implemented yet\n\r";
+				WP_CLI::error( 'Count format not implemented yet.' );
 			}
 		} elseif ( 'headers' === $assoc_args['format'] ) {
 			echo wp_json_encode( $headers );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-tax-classes-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-tax-classes-v1-controller.php
@@ -160,7 +160,11 @@ class WC_REST_Tax_Classes_V1_Controller extends WC_REST_Controller {
 			$data[] = $class;
 		}
 
-		return rest_ensure_response( $data );
+		$total    = count( $data );
+		$response = rest_ensure_response( $data );
+		$response->header( 'X-WP-Total', (int) $total );
+		$response->header( 'X-WP-TotalPages', $total ? 1 : 0 );
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-payment-gateways-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-payment-gateways-v2-controller.php
@@ -121,14 +121,19 @@ class WC_REST_Payment_Gateways_V2_Controller extends WC_REST_Controller {
 	 */
 	public function get_items( $request ) {
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
-		$response         = array();
+		$data             = array();
 		foreach ( $payment_gateways as $payment_gateway_id => $payment_gateway ) {
 			$payment_gateway->id = $payment_gateway_id;
 			$gateway             = $this->prepare_item_for_response( $payment_gateway, $request );
 			$gateway             = $this->prepare_response_for_collection( $gateway );
-			$response[]          = $gateway;
+			$data[]              = $gateway;
 		}
-		return rest_ensure_response( $response );
+
+		$total    = count( $data );
+		$response = rest_ensure_response( $data );
+		$response->header( 'X-WP-Total', (int) $total );
+		$response->header( 'X-WP-TotalPages', $total ? 1 : 0 );
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

1. Implemented a conditional in the CLI to prevent the `Warning: Undefined array key "X-WP-Total"` error on endpoints that do not implement the `count` output format. If the `count` format is requested on an endpoint where it is not implemented, display the message: `Error: Count format not implemented yet.`

2. Implemented a `count` output format for `Payment gateway` and `tax classes` endpoints.

#### Current error
```bash
$ wp wc [payment_gateway|tax_class] list --user=admin --format=count
Warning: Undefined array key "X-WP-Total" in /var/www/html/wp-content/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php on line 239
```

### How to test the changes in this Pull Request:

#### CLI
**Requirement**: To run the following test, you need to have data in your WooCommerce installation. If you don't have data, you can use this command to install the `Smooth Generator` plugin and generate `products` and `orders`.

```bash
wp plugin install https://github.com/woocommerce/wc-smooth-generator/releases/download/1.2.1/wc-smooth-generator.zip --activate
wp wc generate orders 10 
wp wc generate products 10 --type=simple
```
*Test*
```bash
wp wc order_note list $(wp wc shop_order list --user=1 --format=ids --per_page=1) --user=1 --format=count
Error: Count format not implemented yet.
```
Or

```bash
wp wc product_review list $(wp wc product list --user=1 --per_page=1 --format=ids) --user=1 --format=count
Error: Count format not implemented yet.
```

#### Endpoint
1. Run the following commands using WP-CLI. No error should be logged or printed while doing so.
   ``` 
   wp> wp wc payment_gateway list --user=admin --format=count
   wp> wp wc tax_class list --user=admin --format=count
   ```
   In particular, error `Warning: Undefined array key "X-WP-Total"` should not appear.
2. (Optional)
   1. Use the request software of your choice to make GET requests to:
      - `<yoursite>/wp-json/wc/v3/payment_gateways/`
      - `<yoursite>/wp-json/wc/v3/taxes/classes/`
      Make sure the requests work correctly and that, in all cases, headers `X-WP-Total` (reflecting the number of items returned) and `X-WP-TotalPages` are set.

![Captura de pantalla de 2025-02-28 12-06-10](https://github.com/user-attachments/assets/c60125d8-8ff5-40fc-833e-2df7c4b10e6f)
![Captura de pantalla de 2025-02-28 12-09-22](https://github.com/user-attachments/assets/623016d7-12d9-4223-aca4-2cbb0af7b93f)