### PR TITLE
Updates to address caching when API is inaccesible

### DIFF
--- a/plugins/woocommerce/changelog/dev-failed-abtest-requests
+++ b/plugins/woocommerce/changelog/dev-failed-abtest-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixes performance impact on failed API request for A/B test assignments.

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -119,24 +119,6 @@ final class Experimental_Abtest {
 	}
 
 	/**
-	 * Returns true if the current user is in the treatment group of the given experiment.
-	 *
-	 * If an exception occurs, it will be handled and false will be returned.
-	 *
-	 * @param string $experiment_name Name of the experiment.
-	 * @param bool   $as_auth_wpcom_user Request variation as an auth wp user or not.
-	 *
-	 * @return bool True if the user is in the treatment group, false otherwise (including if an exception is thrown).
-	 */
-	public static function in_treatment_handled_exception( string $experiment_name, bool $as_auth_wpcom_user = false ) {
-		try {
-			return self::in_treatment( $experiment_name, $as_auth_wpcom_user );
-		} catch ( \Exception $e ) {
-			return false;
-		}
-	}
-
-	/**
 	 * Retrieve the test variation for a provided A/B test.
 	 *
 	 * @param string $test_name Name of the A/B test.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #55939 .

(For Bug Fixes) Bug introduced in PR #55646 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Update your `/etc/hosts` file to point `public-api.wordpress.com` to an inaccessible address (for example `1.1.1.1 public-api.wordpress.com`
2. Using debug bar or query monitor, load a page on the store.
3. Verify the request mentioned in #55939 only occurs once. The result should be stored in the transient for 1 hour before another request is made.
4. Check that folllowing the instructions in #55646 related to testing with the experiment on/off still works. If in experiment and the flag is on, the NOX should be visible. If not in the experiment, or the flag is off, the NOX won't be visible.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
