### PR TITLE
Enable auto-sync theme styles with email styles by default for new installations

### DIFF
--- a/plugins/woocommerce/changelog/55997-email-styles-auto-sync
+++ b/plugins/woocommerce/changelog/55997-email-styles-auto-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Enable auto-sync theme styles with email styles by default for new installations

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
@@ -56,6 +56,7 @@ export const ResetStylesControl: React.FC< ResetStylesControlProps > = ( {
 		setColors( defaultColors );
 		setIsResetShown( false );
 		setChanged( areColorsChanged( initialValue ) );
+		setIsAutoSyncEnabled( true );
 	};
 
 	const handleUndo = () => {

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-control.tsx
@@ -56,7 +56,7 @@ export const ResetStylesControl: React.FC< ResetStylesControlProps > = ( {
 		setColors( defaultColors );
 		setIsResetShown( false );
 		setChanged( areColorsChanged( initialValue ) );
-		setIsAutoSyncEnabled( true );
+		handleAutoSyncToggle( true );
 	};
 
 	const handleUndo = () => {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1025,6 +1025,7 @@ class WC_Install {
 	public static function enable_email_improvements() {
 		update_option( 'woocommerce_feature_email_improvements_enabled', 'yes' );
 		update_option( 'woocommerce_email_improvements_default_enabled', 'yes' );
+		update_option( 'woocommerce_email_auto_sync_with_theme', 'yes' );
 		update_option( 'woocommerce_email_improvements_first_enabled_at', gmdate( 'Y-m-d H:i:s' ) );
 		update_option( 'woocommerce_email_improvements_last_enabled_at', gmdate( 'Y-m-d H:i:s' ) );
 		update_option( 'woocommerce_email_improvements_enabled_count', 1 );

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -1452,6 +1452,7 @@ class WC_Tracker {
 		return array(
 			'enabled'                        => get_option( 'woocommerce_feature_email_improvements_enabled', 'no' ),
 			'default_enabled'                => get_option( 'woocommerce_email_improvements_default_enabled', 'no' ),
+			'auto_sync_enabled'              => get_option( 'woocommerce_email_auto_sync_with_theme', 'no' ),
 			'first_enabled_at'               => get_option( 'woocommerce_email_improvements_first_enabled_at', null ),
 			'last_enabled_at'                => get_option( 'woocommerce_email_improvements_last_enabled_at', null ),
 			'enabled_count'                  => get_option( 'woocommerce_email_improvements_enabled_count', 0 ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -357,7 +357,7 @@ class FeaturesController {
 				'email_improvements'     => array(
 					'name'            => __( 'Email improvements', 'woocommerce' ),
 					'description'     => __(
-						'Enable modern email design and live preview for transactional emails',
+						'Enable modern email design for transactional emails',
 						'woocommerce'
 					),
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1552,7 +1552,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#720eec',
 						tip: 'The base color for WooCommerce email templates. Default <code>#720eec</code>.',
-						value: '#720eec',
+						value: '#000000',
 					} ),
 				] )
 			);
@@ -1566,7 +1566,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#f7f7f7',
 						tip: 'The background color for WooCommerce email templates. Default <code>#f7f7f7</code>.',
-						value: '#f7f7f7',
+						value: '#ffffff',
 					} ),
 				] )
 			);
@@ -1594,7 +1594,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#3c3c3c',
 						tip: 'The main body text color. Default <code>#3c3c3c</code>.',
-						value: '#3c3c3c',
+						value: '#000000',
 					} ),
 				] )
 			);
@@ -1702,7 +1702,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#000000',
 						tip: 'Customize the color of your buttons and links. Default <code>#000000</code>.',
-						value: '#720eec',
+						value: '#000000',
 					} ),
 				] )
 			);
@@ -1716,7 +1716,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#ffffff',
 						tip: 'Select a color for the background of your emails. Default <code>#ffffff</code>.',
-						value: '#f7f7f7',
+						value: '#ffffff',
 					} ),
 				] )
 			);
@@ -1744,7 +1744,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#000000',
 						tip: 'Set the color of your headings and text. Default <code>#000000</code>.',
-						value: '#3c3c3c',
+						value: '#000000',
 					} ),
 				] )
 			);
@@ -1758,7 +1758,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#787c82',
 						tip: 'Choose a color for your secondary text, such as your footer content. Default <code>#787c82</code>.',
-						value: '#3c3c3c',
+						value: '#787c82',
 					} ),
 				] )
 			);

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -39,7 +39,7 @@ test.describe( 'Email Style Sync', () => {
 		// Enable email improvements feature
 		await setFeatureFlag( baseURL, 'yes' );
 		// Ensure auto-sync is disabled by default
-		await setAutoSyncFlag( baseURL, 'no' );
+		await setAutoSyncFlag( baseURL, 'yes' );
 		// Ensure color palette is not synced with theme
 		await setOption(
 			request,
@@ -71,12 +71,8 @@ test.describe( 'Email Style Sync', () => {
 		// Sync color palette with theme
 		await page.getByRole( 'button', { name: 'Sync with theme' } ).click();
 
-		// Check initial state (should be disabled by default)
+		// Check initial state (should be enabled by default)
 		await expect( autoSyncToggle ).toBeVisible();
-		await expect( autoSyncToggle ).not.toBeChecked();
-
-		// Toggle it on
-		await autoSyncToggle.click();
 		await expect( autoSyncToggle ).toBeChecked();
 
 		// Save settings
@@ -87,7 +83,7 @@ test.describe( 'Email Style Sync', () => {
 		await expect( autoSyncToggle ).toBeVisible();
 		await expect( autoSyncToggle ).toBeChecked();
 
-		// Toggle it back off
+		// Toggle it off
 		await autoSyncToggle.click();
 		await expect( autoSyncToggle ).not.toBeChecked();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Email Style Sync', () => {
 	test.beforeEach( async ( { baseURL } ) => {
 		// Enable email improvements feature
 		await setFeatureFlag( baseURL, 'yes' );
-		// Ensure auto-sync is disabled by default
+		// Ensure auto-sync is enabled by default
 		await setAutoSyncFlag( baseURL, 'yes' );
 		// Ensure color palette is not synced with theme
 		await setOption(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Enable auto-syncing theme styles with email styles by default for new installations. Existing merchants can manually sync email styles with theme styles which then enables auto-sync by default (which can be disabled).

Closes #55997. 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="509" alt="Screenshot 2025-03-02 at 14 30 53" src="https://github.com/user-attachments/assets/42789716-adb7-4ac1-b472-ec698a88ab1e" />    |    <img width="529" alt="Screenshot 2025-03-02 at 14 30 27" src="https://github.com/user-attachments/assets/5eaf9927-cdb4-49ad-b82d-f96d13f46744" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install on a new website with a block-based theme
2. Go to **WooCommerce > Settings > Emails**.
3. Check that the email color palette is synced with the theme and that the auto-sync is enabled. 
4. On an existing website with a block-based theme, update to this PR.
5. Go to **WooCommerce > Settings > Emails**.
6. Click `Sync with theme` and observe that the auto-sync is also enabled.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
