### PR TITLE
[Beta Tester] Fix TypeError when deleting the simulate WooCommerce JS error option

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-delete-option-error
+++ b/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-delete-option-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix TypeError when deleting the simulate WooCommerce JS error option

--- a/plugins/woocommerce-beta-tester/src/remote-logging/register-exception-filter.tsx
+++ b/plugins/woocommerce-beta-tester/src/remote-logging/register-exception-filter.tsx
@@ -7,14 +7,11 @@
 import { addFilter } from '@wordpress/hooks';
 
 import apiFetch from '@wordpress/api-fetch';
-// @ts-ignore no types
-import { dispatch } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
 import { API_NAMESPACE } from './constants';
-// @ts-ignore no types
-import { STORE_KEY as optionsStore } from '../options/data/constants';
 
 /**
  * Retrieves the options for simulating a WooCommerce JavaScript error.
@@ -48,9 +45,10 @@ const getSimulateErrorOptions = async () => {
  * Deletes the option used for simulating WooCommerce JavaScript errors.
  */
 const deleteSimulateErrorOption = async () => {
-	await dispatch( optionsStore ).deleteOption(
-		'wc_beta_tester_simulate_woocommerce_js_error'
-	);
+	await apiFetch( {
+		path: `${ API_NAMESPACE }/options/wc_beta_tester_simulate_woocommerce_js_error`,
+		method: 'DELETE',
+	} );
 };
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

While testing the remote logging feature, an error was encountered when deleting the simulated WooCommerce JS error option. 


![Screenshot 2025-03-04 at 17 30 34](https://github.com/user-attachments/assets/d5a2b1e4-99d4-409a-a11f-27bf1f017007)

This issue arises because the beta tester app script is only enqueued on WCA tester pages (https://github.com/woocommerce/woocommerce/pull/55553), making data stores unavailable on other pages, while the beta tester remote logging script is enqueued on all pages and attempts to use the option data store to delete the option. 

This PR resolves the issue using apiFetch instead of dispatching to the options store, thereby preventing the error.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `cd plugins/woocommerce-beta-tester`
2. Run `pnpm run build:zip`
3. Create a fresh JN site and upload the zip file to the site.
4. Activate the WooCommerce Beta Tester plugin.
5. Go to the `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=remote-logging`
6. Enable remote logging
7. Click on JavaScript Integration > `Simulate Core Exception` to simulate a JavaScript error.
8. Go to any WooCommerce Admin page
9. Confirm `Uncaught (in promise) TypeError: Cannot read properties of null (reading "deleteOption')` is not logged in the console
10. Go to `wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=options`
11. Search for `wc_beta_tester_simulate_woocommerce_js_error` option and confirm it's not found

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
