### PR TITLE
Fix email accent color causing invisible text in emails

### DIFF
--- a/plugins/woocommerce/changelog/56059-email-accent-color
+++ b/plugins/woocommerce/changelog/56059-email-accent-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email accent color causing invisible text in emails

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -40,8 +40,8 @@ class EmailColors {
 				&& function_exists( 'wp_get_global_styles' ) 
 			) {
 				$global_styles             = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
-				$base_color_global         = ! empty( $global_styles['elements']['button']['color']['text'] )
-					? sanitize_hex_color( $global_styles['elements']['button']['color']['text'] ) : '';
+				$base_color_global         = ! empty( $global_styles['elements']['button']['color']['background'] )
+					? sanitize_hex_color( $global_styles['elements']['button']['color']['background'] ) : '';
 				$bg_color_global           = ! empty( $global_styles['color']['background'] )
 					? sanitize_hex_color( $global_styles['color']['background'] ) : '';
 				$body_bg_color_global      = ! empty( $global_styles['color']['background'] )

--- a/plugins/woocommerce/src/Internal/Email/EmailStyleSync.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailStyleSync.php
@@ -152,8 +152,8 @@ class EmailStyleSync implements RegisterHooksInterface {
 		$body_text_color_default = $default_colors['body_text_color_default'];
 		$footer_text_color_default = $default_colors['footer_text_color_default'];
 
-		$base_color = ! empty( $global_styles['elements']['button']['color']['text'] )
-			? sanitize_hex_color( $global_styles['elements']['button']['color']['text'] )
+		$base_color = ! empty( $global_styles['elements']['button']['color']['background'] )
+			? sanitize_hex_color( $global_styles['elements']['button']['color']['background'] )
 			: $base_color_default;
 
 		$bg_color = ! empty( $global_styles['color']['background'] )

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1552,7 +1552,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						type: 'color',
 						default: '#720eec',
 						tip: 'The base color for WooCommerce email templates. Default <code>#720eec</code>.',
-						value: '#000000',
+						value: '#9DFF20',
 					} ),
 				] )
 			);
@@ -1698,11 +1698,11 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'woocommerce_email_base_color',
 						label: 'Accent',
 						description:
-							'Customize the color of your buttons and links. Default <code>#000000</code>.',
+							'Customize the color of your buttons and links. Default <code>#9DFF20</code>.',
 						type: 'color',
-						default: '#000000',
-						tip: 'Customize the color of your buttons and links. Default <code>#000000</code>.',
-						value: '#000000',
+						default: '#9DFF20',
+						tip: 'Customize the color of your buttons and links. Default <code>#9DFF20</code>.',
+						value: '#9DFF20',
 					} ),
 				] )
 			);

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
@@ -168,7 +168,7 @@ class EmailStyleSyncTest extends WC_Unit_Test_Case {
             'elements' => [
                 'button' => [
                     'color' => [
-                        'text' => '#ff0000'
+                        'background' => '#ff0000'
                     ]
                 ],
                 'caption' => [


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When syncing email styles with the theme styles, the accent color (used for text logo and links in the email) is taken from the theme's button styles. However, button color instead of button background was used, which caused that in most cases, it was the same as the email background, causing those elements to be invisible. 

This PR changes it so the email accent color is taken from the theme's button background. 

Closes #56059.

(For Bug Fixes) Bug introduced in PR #53209.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1363" alt="Screenshot 2025-03-04 at 13 21 22" src="https://github.com/user-attachments/assets/d18e4849-d7e2-47e5-9674-0038f26dae4a" />    |  <img width="1366" alt="Screenshot 2025-03-04 at 13 20 13" src="https://github.com/user-attachments/assets/615a0bbc-0b09-405f-94a0-23ea6dbe435e" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. New website installation.
2. Go to **WooCommerce > Settings > Emails**.
3. Remove the image logo (if present).
4. Sync the color palette with the theme (unless already synced).
5. Check that the text logo and links in email previews are visible. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
