### PR TITLE
@wordpress/data: Improve documentation

### DIFF
--- a/packages/js/data/README.md
+++ b/packages/js/data/README.md
@@ -24,8 +24,8 @@ function MySettings() {
 	} );
 	return (
 		<ul>
-			{ Object.keys( list ?? {} ).map( setting => (
-				<li>{ setting.name }</li>
+			{ Object.keys( settings ?? {} ).map( setting => (
+				<li key={setting}>{ setting }</li>
 			) ) }
 		</ul>
 	);

--- a/packages/js/data/README.md
+++ b/packages/js/data/README.md
@@ -20,11 +20,11 @@ import { useSelect } from '@wordpress/data';
 
 function MySettings() {
 	const settings = useSelect( select => {
-		return select( settingsStore ).getSettings();
+		return select( settingsStore ).getSettings('general').general;
 	} );
 	return (
 		<ul>
-			{ settings.map( setting => (
+			{ Object.keys( list ?? {} ).map( setting => (
 				<li>{ setting.name }</li>
 			) ) }
 		</ul>

--- a/packages/js/data/changelog/56067-39298-woocommercedata-readmes-example-is-invalid
+++ b/packages/js/data/changelog/56067-39298-woocommercedata-readmes-example-is-invalid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+@wordpress/data: Improve documentation.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fixes the `@wordpress/data` documentation. As the reporter mentioned, the current README isn't a valid example because:

- The return value of getSettings is an object with keys/values, not an array that can be mapped over.
- The current getSettings selector requires a group name.

This is a real use of `getSettings` selector:

https://github.com/woocommerce/woocommerce/blob/fa114ceecf394ace93207ed167d5aa84e68fd8ca/plugins/woocommerce/client/admin/client/shipping/experimental-shipping-recommendations.tsx#L21-L45

Closes #39298.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. N/A
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

@wordpress/data: Improve documentation.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
