### PR TITLE
[e2e-utils] Update editor-canvas locator to support updates in Gutenberg nightly

### DIFF
--- a/packages/js/e2e-utils-playwright/changelog/e2e-utils-playwright-fix-editor-canvas-locator-gb-20.6
+++ b/packages/js/e2e-utils-playwright/changelog/e2e-utils-playwright-fix-editor-canvas-locator-gb-20.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updated the editor canvas frame locator to support changes in Gutenberg 20.6

--- a/packages/js/e2e-utils-playwright/src/editor.js
+++ b/packages/js/e2e-utils-playwright/src/editor.js
@@ -36,8 +36,20 @@ export const openEditorSettings = async ( { page } ) => {
 	}
 };
 
+/**
+ * Returns the editor canvas frame for Gutenberg interactions.
+ *
+ * The Gutenberg editor content can be contained within an iframe in some contexts.
+ * This helper function returns the content frame of the editor canvas iframe if it exists,
+ * or falls back to the main page if the iframe isn't present.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page object
+ * @return {Promise<import('@playwright/test').FrameLocator|import('@playwright/test').Page>} The editor canvas frame or the original page
+ */
 export const getCanvas = async ( page ) => {
-	return page.frame( 'editor-canvas' ) || page;
+	return (
+		page.locator( 'iframe[name="editor-canvas"]' ).contentFrame() || page
+	);
 };
 
 export const goToPageEditor = async ( { page } ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

3 tests started failing with Gutenberg Nightly in [the daily runs](https://github.com/woocommerce/woocommerce/actions/runs/13645680320/job/38153297083#step:9:318):
```
- editor/create-woocommerce-blocks.spec.js:155:3 › Add WooCommerce Blocks Into Page › can insert all WooCommerce blocks into page
- editor/create-woocommerce-patterns.spec.js:44:3 › Add WooCommerce Patterns Into Page › can insert WooCommerce patterns into page
- wp-core/create-page.spec.js:28:3 › Can create a new page › can create new page
```

all in the same place:

```
TimeoutError: locator.click: Timeout 20000ms exceeded.
Call log:
  - waiting for getByLabel(/Add title|Block: Title/)
```

Updating the locator for the canvas frame in the e2e-utils-playwright packages fixed it. Not yet sure why, it looks to me the old locator should have worked as well...

### How to test the changes in this Pull Request:

Build the utils package:

```
pnpm --filter="@woocommerce/e2e-utils-playwright" build
```

Run the 3 tests:

1. Without Gutenberg
```
pnpm test:e2e create-woocommerce-blocks create-woocommerce-patterns create-page.spec
```
3. With Gutenberg stable
```
pnpm test:e2e:gb-stable create-woocommerce-blocks create-woocommerce-patterns create-page.spec
```
5. With Gutenberg nightly
```
pnpm test:e2e:gb-nightly create-woocommerce-blocks create-woocommerce-patterns create-page.spec
```

### Testing that has already taken place:

- ✅ Ran the above tests locally
- ✅ Tests without Gutenberg should be validated in CI
- ✅ Tests with Gutenberg ran on demand: [here](https://github.com/woocommerce/woocommerce/actions/runs/13659480916)
