### PR TITLE
[dev] CI: fix CI-workflow failures on tagging caused by wp-env overrides.

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -32,6 +32,7 @@
 			},
 			"mappings": {
 				"wp-cli.yml": "./tests/wp-cli.yml",
+				"test-env-setup.sh": "./tests/e2e-pw/bin/test-env-setup.sh",
 				"wp-content/plugins/filter-setter.php": "./tests/e2e-pw/bin/filter-setter.php",
 				"wp-content/plugins/process-waiting-actions.php": "./tests/e2e-pw/bin/process-waiting-actions.php",
 				"wp-content/plugins/test-helper-apis.php": "./tests/e2e-pw/bin/test-helper-apis.php",

--- a/plugins/woocommerce/changelog/fix-ci-workflow-on-tagging
+++ b/plugins/woocommerce/changelog/fix-ci-workflow-on-tagging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: fix CI-workflow failures on tagging caused by wp-env overrides.

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -4,7 +4,7 @@ if [ ! -z ${CI+y} ]; then
     # In CI we want to execute the setup behind single container call, while in dev-environments we use the script as it is.
     # Inside the container the command executed from /var/www/html path as pwd
     echo -e '--> Dispatching script execution into tests-cli\n'
-    wp-env run --debug tests-cli cp wp-content/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh test-env-setup-ci.sh
+    wp-env run --debug tests-cli cp test-env-setup.sh test-env-setup-ci.sh
     wp-env run --debug tests-cli sed -i -e 's/wp-env run tests-cli //' test-env-setup-ci.sh
     wp-env run --debug tests-cli bash test-env-setup-ci.sh
     exit $?


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes failing CI-workflow on tagging event ([example](https://github.com/woocommerce/woocommerce/actions/runs/13655956509/job/38218706009)).

The root cause is that some of the jobs will override the wp-env config and use the core zip file and ignore the checked-out codebase, causing the test environment provisioning failures. We link the necessary script separately in wp-env configuration to fix this.

### How to test the changes in this Pull Request:

- CI-checks shall pass
