### PR TITLE
Add `woocommerce` as a dependency in WooCommerce Beta Tester plugin

### DIFF
--- a/plugins/woocommerce-beta-tester/.wp-env.json
+++ b/plugins/woocommerce-beta-tester/.wp-env.json
@@ -1,7 +1,4 @@
 {
 	"phpVersion": "7.4",
-	"plugins": [ 
-        ".",
-        "https://downloads.wordpress.org/plugin/woocommerce.zip"
-     ]
+	"plugins": [ "https://downloads.wordpress.org/plugin/woocommerce.zip", "." ]
 }

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -12,6 +12,7 @@
  * WC requires at least: 9.4
  * WC tested up to: 9.5
  * Text Domain: woocommerce-beta-tester
+ * Requires Plugins: woocommerce
  *
  * @package WC_Beta_Tester
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I suggest adding `woocommerce` as a required plugin for WooCommerce Beta Tester. As explained in [this article](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/), since WordPress 6.5 it is possible to define the dependencies in the plugin itself, which handles some workflows by default.

### Screenshots or screen recordings:

**Before**

https://github.com/user-attachments/assets/dfd13c36-591a-4a5e-9f86-36a79633130a

**After**

<img width="1323" alt="Screenshot 2025-03-05 at 09 17 09" src="https://github.com/user-attachments/assets/3f470b83-8511-48a9-93e6-a0e9068ae8b5" /> 