### PR TITLE
Email Editor - Fix saving non public emails

### DIFF
--- a/packages/php/email-editor/changelog/improve-allowed-templates-check-on-save
+++ b/packages/php/email-editor/changelog/improve-allowed-templates-check-on-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use email templates registry when listing allowed templates for association with an email post

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -155,11 +155,18 @@ class Templates {
 		if ( $post_type && ! in_array( $post_type, $this->post_types, true ) ) {
 			return $templates;
 		}
-		$block_templates = get_block_templates();
+		$block_templates       = get_block_templates();
+		$email_templates_slugs = array_map(
+			function ( Template $template ) {
+				return $template->get_slug();
+			},
+			$this->templates_registry->get_all()
+		);
 		foreach ( $block_templates as $block_template ) {
-			// Ideally we could check for supported post_types but there seems to be a bug and once a template has some edits and is stored in DB
-			// the core returns null for post_types.
-			if ( $block_template->plugin !== $this->template_prefix ) {
+			if ( ! in_array( $block_template->slug, $email_templates_slugs, true ) ) {
+				continue;
+			}
+			if ( isset( $templates[ $block_template->slug ] ) ) {
 				continue;
 			}
 			$templates[ $block_template->slug ] = $block_template;

--- a/plugins/woocommerce/changelog/fix-error-saving-non-public-emails
+++ b/plugins/woocommerce/changelog/fix-error-saving-non-public-emails
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Switch woo_email custom post type added for transactional emails to non-public. This was previously not possible due an issue in the email editor package.
+
+

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -95,7 +95,7 @@ class Integration {
 				),
 				'rewrite'      => array( 'slug' => self::EMAIL_POST_TYPE ),
 				'supports'     => array( 'title', 'editor' ),
-				'public'       => true,
+				'public'       => false,
 				'show_ui'      => true,  // Showing in the admin UI is temporary, it will be removed in the future.
 				'show_in_menu' => true,
 				'show_in_rest' => true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #55862

This PR improves the code that adds email related tempaltes to list of allowed templates when saving an email. When a template is not in the list the REST API can't save the email - template association. Previous code was relying on the template prefix, but in case the extender used a different prefix it didn't worked and email couldn't be saved.

Note: We have this workaround in place to allow having emails set as non public (see [register_post_type](https://developer.wordpress.org/reference/functions/register_post_type/)). Alternatively we could drop this code and force all emails to be set as public and use other arguments to specify the behaviour. I chose to keep it for now.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See that the woo_email post_type is configured with `public` => `false`
2. Create a new email in the block editor and make some edits
3. Save the email
4. Observe that email was properly saved

Note: In case you want to replicate the issue. The issue was easily replicable by switching the woo_email [CPT to public](https://github.com/woocommerce/woocommerce/blob/be742f8fd2d496b176bdccbc6e8b808c73405e31/plugins/woocommerce/src/Internal/EmailEditor/Integration.php#L98). The [new template prefix we added in Woo](https://github.com/woocommerce/woocommerce/blob/be742f8fd2d496b176bdccbc6e8b808c73405e31/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplatesController.php#L25) was different from the prefix used [in the package](https://github.com/woocommerce/woocommerce/blob/be742f8fd2d496b176bdccbc6e8b808c73405e31/packages/php/email-editor/src/Engine/Templates/class-templates.php#L23). The package prefix used to be `mailpoet` and we changed that in https://github.com/woocommerce/woocommerce/pull/55938 to `woocommerce` so currently the issue is not replicable just by swtiching CPT to public. To replicate it you need to change one of the prefixes to emulate that and integrator uses a different prefix.

<!-- End testing instructions -->

### Testing that has already taken place:

The issue was causing that it was not possible to save the email. I replicated the issue locally and after the change I was able to save emails as expected.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
