### PR TITLE
Update the loading placeholder of the Reviews blocks so they are better aligned with the end content

### DIFF
--- a/plugins/woocommerce/changelog/fix-reviews-loading-placeholder-alignments
+++ b/plugins/woocommerce/changelog/fix-reviews-loading-placeholder-alignments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update the loading placeholder of the Reviews blocks so they are better aligned with the end content

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/reviews/review-list-item/style.scss
@@ -7,7 +7,7 @@
 	}
 
 	.wc-block-components-review-list-item__info {
-		margin-bottom: calc($gap-large + .25em);
+		margin-bottom: calc($gap-large + 0.25em);
 
 		.wc-block-components-review-list-item__image {
 			@include placeholder();
@@ -22,14 +22,14 @@
 				@include placeholder();
 				@include font-size(regular);
 				@include force-content();
-				margin: .25em #{$gap * 0.5} .25em 0;
+				margin: 0.25em #{$gap * 0.5} 0.25em 0;
 				width: 5em;
 			}
 
 			.wc-block-components-review-list-item__product {
 				@include placeholder();
 				@include force-content();
-				margin: .25em 0;
+				margin: 0.25em 0;
 				width: 6em;
 			}
 
@@ -44,7 +44,7 @@
 			@include placeholder();
 			@include force-content();
 			height: 1em;
-			margin: .25em 0;
+			margin: 0.25em 0;
 			width: 7em;
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/reviews/review-list-item/style.scss
@@ -22,7 +22,7 @@
 				@include placeholder();
 				@include font-size(regular);
 				@include force-content();
-				margin: .25em 0;
+				margin: .25em #{$gap * 0.5} .25em 0;
 				width: 5em;
 			}
 
@@ -44,7 +44,7 @@
 			@include placeholder();
 			@include force-content();
 			height: 1em;
-			margin: .25em 0 .25em $gap * 0.5;
+			margin: .25em 0;
 			width: 7em;
 		}
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/reviews/review-list-item/style.scss
@@ -7,9 +7,14 @@
 	}
 
 	.wc-block-components-review-list-item__info {
+		margin-bottom: calc($gap-large + .25em);
+
 		.wc-block-components-review-list-item__image {
 			@include placeholder();
 			@include force-content();
+			/* We assume the image will be a square */
+			aspect-ratio: 1/1;
+			width: auto;
 		}
 
 		.wc-block-components-review-list-item__meta {
@@ -17,11 +22,15 @@
 				@include placeholder();
 				@include font-size(regular);
 				@include force-content();
-				width: 80px;
+				margin: .25em 0;
+				width: 5em;
 			}
 
 			.wc-block-components-review-list-item__product {
-				display: none;
+				@include placeholder();
+				@include force-content();
+				margin: .25em 0;
+				width: 6em;
 			}
 
 			.wc-block-components-review-list-item__rating {
@@ -35,7 +44,8 @@
 			@include placeholder();
 			@include force-content();
 			height: 1em;
-			width: 120px;
+			margin: .25em 0 .25em $gap * 0.5;
+			width: 7em;
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the CSS code used by the placeholder elements of the Reviews blocks so they are more aligned with the rendered components.

### How to test the changes in this Pull Request:

1. Make sure you have at least one product and one review in your store.
2. Create a post or page and add the All Reviews, Reviews by Product or Reviews by Category blocks.
3. In the frontend, try changing the sorting option in the block and verify the placeholder gray boxes are aligned with the rendered components. You might want to throttle your _Network_ using the browser devtools to make it easier to see the difference.

Before:

[Enregistrament de pantalla del 2025-03-05 12-32-24.webm](https://github.com/user-attachments/assets/a79e24ac-dba9-45d5-9889-a897a77cfea7)

After:

[Enregistrament de pantalla del 2025-03-05 12-30-11.webm](https://github.com/user-attachments/assets/186c6e74-1f61-489b-b82e-f1baea6c328d)

4. In the editor, play around hiding some components from the block. In the frontend, verify the loading layout doesn't break.

![image](https://github.com/user-attachments/assets/85517341-06dc-463c-824b-5a87f45275af)