### PR TITLE
[Experimental] Fix errors due to missing stylesheets in Add to Cart with Options blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-missing-stylesheets
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-missing-stylesheets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix errors due to missing stylesheets in Add to Cart with Options blocks
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsGroupedProductSelectorItemTemplate.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use WP_Block;
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
- * CatalogSorting class.
+ * AddToCartWithOptionsQuantitySelector class.
  */
 class AddToCartWithOptionsQuantitySelector extends AbstractBlock {
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelector.php
@@ -3,9 +3,6 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
-
 /**
  * Block type for variation selector in add to cart with options.
  */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelectorAttributeName.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelectorAttributeName.php
@@ -14,4 +14,13 @@ class AddToCartWithOptionsVariationSelectorAttributeName extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'add-to-cart-with-options-variation-selector-attribute-name';
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelectorAttributeOptions.php
@@ -14,4 +14,13 @@ class AddToCartWithOptionsVariationSelectorAttributeOptions extends AbstractBloc
 	 * @var string
 	 */
 	protected $block_name = 'add-to-cart-with-options-variation-selector-attribute-options';
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsVariationSelectorItemTemplate.php
@@ -14,4 +14,13 @@ class AddToCartWithOptionsVariationSelectorItemTemplate extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'add-to-cart-with-options-variation-selector-item';
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There were some requests to missing stylesheets from some of the recently created blocks for the _Add to Cart with Options_ project.

![imatge](https://github.com/user-attachments/assets/52cd9940-75d2-462d-86fc-1ee8d1805605)

This PR fixes that (98b7f3e7ae789bfdd993e132e4a0e122331eb43c), it also fixes an incorrect comment (https://github.com/woocommerce/woocommerce/commit/3537c1465e4c349fee2a63d203494a29e1fc045f), and removes unnecessary imports (2175f7a2de47ad42912f6f718838394e8633c407).

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product (`/wp-admin/site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fsingle-product&canvas=edit`).
2. Verify there are no 404 requests for block stylesheets.