### PR TITLE
Product Gallery: Fix variable product images on variation change

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/frontend.tsx
@@ -9,6 +9,11 @@ import {
 } from '@wordpress/interactivity';
 import type { StorePart } from '@woocommerce/utils';
 
+/**
+ * Internal dependencies
+ */
+import type { ImageDataObject } from './types';
+
 export interface ProductGalleryContext {
 	selectedImageId: string;
 	imageIds: string[];
@@ -20,12 +25,7 @@ export interface ProductGalleryContext {
 	touchCurrentX: number;
 	isDragging: boolean;
 	userHasInteracted: boolean;
-	imageData: {
-		id: string;
-		src: string;
-		srcSet: string;
-		sizes: string;
-	}[];
+	imageData: ImageDataObject;
 }
 
 const getContext = ( ns?: string ) =>
@@ -110,26 +110,32 @@ const productGallery = {
 				selectedImageId
 			);
 
-			return imageData.map( ( image, index ) => {
-				const isActive = selectedImageNumber === index + 1;
-				const tabIndex = isActive ? '0' : '-1';
+			const allProductImages = imageData?.all_images || [];
 
-				if ( ! userHasInteracted && index >= 2 ) {
-					// Return a copy with empty src and srcSet for images beyond the first two
+			const processedImageData = allProductImages.map(
+				( image, index ) => {
+					const isActive = selectedImageNumber === index + 1;
+					const tabIndex = isActive ? '0' : '-1';
+
+					if ( ! userHasInteracted && index >= 2 ) {
+						// Return a copy with empty src and srcSet for images beyond the first two
+						return {
+							...image,
+							isActive,
+							tabIndex,
+							src: '',
+							src_set: '',
+						};
+					}
 					return {
 						...image,
 						isActive,
 						tabIndex,
-						src: '',
-						srcSet: '',
 					};
 				}
-				return {
-					...image,
-					isActive,
-					tabIndex,
-				};
-			} );
+			);
+
+			return processedImageData;
 		},
 	},
 	actions: {
@@ -150,8 +156,9 @@ const productGallery = {
 			context.disableRight = disableRight;
 
 			const { imageData } = context;
+			const allProductImages = imageData?.all_images || [];
 			const imageIndex = newImageNumber - 1;
-			const imageId = imageData[ imageIndex ].id;
+			const imageId = allProductImages[ imageIndex ].id;
 			context.selectedImageId = imageId;
 			if ( imageIndex !== -1 ) {
 				scrollImageIntoView( imageId );

--- a/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/types.ts
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-gallery/types.ts
@@ -10,3 +10,16 @@ export interface ProductGallerySettingsProps {
 		attributes: Partial< ProductGalleryBlockAttributes >
 	) => void;
 }
+
+interface ImageDataItem {
+	id: string;
+	src: string;
+	srcSet: string;
+	sizes: string;
+}
+
+export interface ImageDataObject {
+	gallery_images: ImageDataItem[];
+	variation_images: ImageDataItem[];
+	all_images: ImageDataItem[];
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -111,7 +111,8 @@ class ProductGallery extends AbstractBlock {
 		$product_gallery_thumbnail_images = ProductGalleryUtils::get_product_gallery_images( $post_id, 'thumbnail', array() );
 		$product_gallery_full_images      = ProductGalleryUtils::get_product_gallery_images( $post_id, 'full', array() );
 		$image_src_data                   = ProductGalleryUtils::get_product_gallery_image_data( $product );
-		$image_id                         = count( $image_src_data ) > 0 ? $image_src_data[0]['id'] : -1;
+		$image_ids                        = array_column( $image_src_data['all_images'], 'id' );
+		$initial_image_id                 = count( $image_ids ) > 0 ? $image_ids[0] : -1;
 		$classname_single_image           = '';
 
 		if ( count( $product_gallery_thumbnail_images ) < 2 ) {
@@ -138,8 +139,8 @@ class ProductGallery extends AbstractBlock {
 						'touchStartX'       => 0,
 						'touchCurrentX'     => 0,
 						'productId'         => $product_id,
-						'imageIds'          => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
-						'selectedImageId'   => $image_id,
+						'imageIds'          => $image_ids,
+						'selectedImageId'   => $initial_image_id,
 						'userHasInteracted' => false,
 					),
 					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryPager.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryPager.php
@@ -61,8 +61,9 @@ class ProductGalleryPager extends AbstractBlock {
 			return '';
 		}
 
-		$product_gallery_images_ids = ProductGalleryUtils::get_product_gallery_image_ids( $product );
-		$total_images               = count( $product_gallery_images_ids );
+		$product_image_data = ProductGalleryUtils::get_product_gallery_image_data( $product );
+		$all_image_ids      = array_column( $product_image_data['all_images'], 'id' );
+		$total_images       = count( $all_image_ids );
 
 		if ( 0 === $total_images ) {
 			return '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If a product variant has a specific image which is not selected in the "Product gallery" metabox. When this variation is selected the image will not show. This PR fixes that by expanding the usage of the Product Gallery imageData object to house variation specific images also.

Closes

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
