### PR TITLE
Marketplace: Add WMB subscriptions

### DIFF
--- a/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
@@ -14,14 +14,17 @@ import { ADMIN_URL } from '../../../../../utils/admin-settings';
 export default function ActionsDropdownMenu( props: {
 	subscription: Subscription;
 } ) {
-	const controls = [
-		{
+	const isWmb = props.subscription.is_wmb ?? false;
+	const controls = [];
+
+	if ( ! isWmb ) {
+		controls.push( {
 			title: __( 'Manage in Plugins', 'woocommerce' ),
 			onClick: () => {
 				window.location.href = ADMIN_URL + 'plugins.php';
 			},
-		},
-	];
+		} );
+	}
 
 	if ( ! props.subscription.is_shared ) {
 		controls.unshift( {

--- a/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -381,6 +381,7 @@ export function version(
 }
 
 export function actions( subscription: Subscription ): TableRow {
+	const isWmb = subscription.is_wmb ?? false;
 	let actionButton = null;
 	if ( subscription.product_key === '' ) {
 		actionButton = <SubscribeButton subscription={ subscription } />;
@@ -388,7 +389,8 @@ export function actions( subscription: Subscription ): TableRow {
 		actionButton = <RenewButton subscription={ subscription } />;
 	} else if (
 		subscription.local.installed === false &&
-		subscription.subscription_installed === false
+		subscription.subscription_installed === false &&
+		isWmb === false
 	) {
 		actionButton = <Install subscription={ subscription } />;
 	} else if (

--- a/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/types.ts
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/my-subscriptions/types.ts
@@ -33,6 +33,7 @@ export type Subscription = {
 	is_installable: boolean;
 	is_shared: boolean;
 	owner_email: boolean;
+	is_wmb?: boolean;
 };
 
 export interface SubscriptionLocal {

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-wmb-subscriptions.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-wmb-subscriptions.php
@@ -24,4 +24,27 @@ class WC_Helper_WMB_Subscriptions {
 	public static function is_wmb_subscription( $subscription ) {
 		return isset( $subscription['is_wmb'] ) && $subscription['is_wmb'];
 	}
+
+	/**
+	 * Check if a WMB subscription is installed.
+	 *
+	 * WMB subscriptions don't have a local file.
+	 * There are considered installed if the site is connected to the subscription.
+	 *
+	 * @param array $subscription The subscription to check.
+	 * @return bool True if the subscription is active on the site.
+	 */
+	public static function is_subscription_installed( $subscription ) {
+		$auth = WC_Helper_Options::get( 'auth' );
+		if ( empty( $auth['site_id'] ) ) {
+			return false;
+		}
+		$site_id = absint( $auth['site_id'] );
+
+		if ( in_array( $site_id, $subscription['connections'], true ) ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-wmb-subscriptions.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-wmb-subscriptions.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * WooCommerce WMB Subscriptions Helper
+ *
+ * @package WooCommerce\Admin\Helper
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Helper_WMB_Subscriptions Class
+ *
+ * Handles WMB subscription specific functionality.
+ */
+class WC_Helper_WMB_Subscriptions {
+	/**
+	 * Check if a subscription is a WMB subscription.
+	 *
+	 * @param array $subscription The subscription to check.
+	 * @return bool True if the subscription is a WMB subscription.
+	 */
+	public static function is_wmb_subscription( $subscription ) {
+		return isset( $subscription['is_wmb'] ) && $subscription['is_wmb'];
+	}
+}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -74,6 +74,7 @@ class WC_Helper {
 		include_once __DIR__ . '/class-wc-helper-admin.php';
 		include_once __DIR__ . '/class-wc-helper-subscriptions-api.php';
 		include_once __DIR__ . '/class-wc-helper-orders-api.php';
+		include_once __DIR__ . '/class-wc-helper-wmb-subscriptions.php';
 		include_once __DIR__ . '/class-wc-product-usage-notice.php';
 	}
 
@@ -1760,6 +1761,7 @@ class WC_Helper {
 				'sites_active'      => 0,
 				'autorenew'         => false,
 				'maxed'             => false,
+				'is_wmb'            => false, // Add is_wmb property for non-WMB subscriptions.
 			);
 		}
 
@@ -1785,6 +1787,9 @@ class WC_Helper {
 			if ( ! empty( $updates[ $subscription['product_id'] ]['url'] ) ) {
 				$subscription['product_url'] = $updates[ $subscription['product_id'] ]['url'];
 			}
+
+			// Add is_wmb property for existing subscriptions.
+			$subscription['is_wmb'] = WC_Helper_WMB_Subscriptions::is_wmb_subscription( $subscription );
 		}
 
 		// Sort subscriptions by name and expiration date.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1860,6 +1860,11 @@ class WC_Helper {
 	 * @return bool True if installed, false otherwise.
 	 */
 	public static function is_subscription_installed( $subscription, $subscriptions ) {
+		// WMB subscriptions are handled differently because they don't have a local install.
+		if ( WC_Helper_WMB_Subscriptions::is_wmb_subscription( $subscription ) ) {
+			return WC_Helper_WMB_Subscriptions::is_subscription_installed( $subscription );
+		}
+
 		if ( false === $subscription['local']['installed'] ) {
 			return false;
 		}


### PR DESCRIPTION
**DO NOT MERGE - Needs design**

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Add basic support for a new type of subscription (WMB) without installation file:
- Display 'Connect' instead of 'Install' for available WMB subscriptions
- Considered the WMB subscription as installed if connected to the site, without checking for local files
- Do not display 'Manage in Plugins' for WMB subscriptions

👉 See corresponding `PR 23212` in the marketplace repo.

### Screenshots or screen recordings:
Screenshot for an account with 3 subscriptions for product WMB A and 1 subscription for product WMB B
Before WMB subscriptions are connected to the site:
- Appear under Available to use
- Display Connect instead of Install
- Actions do not have Manage in Plugins
<img width="1953" alt="Screenshot 2025-03-05 at 1 13 19 PM" src="https://github.com/user-attachments/assets/949c936d-6b63-45c5-9ae4-fedd25babd6c" />
After connecting WMB A:
- WMB A appears under Installed on this Store list
- Additional WMB A subscriptions don't show the Connect button

<img width="1768" alt="Screenshot 2025-03-05 at 1 14 37 PM" src="https://github.com/user-attachments/assets/c04dbff4-b734-40ae-b3f5-4a10bee43400" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

⚠️ This type of subscription is not available yet. ⚠️ 
👉 See corresponding `PR 23212` in marketplace **to test the full flow**

For **partially** testing the UI (Link `Connect` **will not work**):
 - Go to WooCommerce > Extensions > My Subscriptions
 - Make sure your site is connected to WooCommerce.com
 - Apply this patch to add mock data (`git apply mocked-WMB.patch`):
[mocked-WMB.patch](https://github.com/user-attachments/files/19096206/mocked-WMB.patch)
 - Click on Refresh
 - Check that you see  one `WMB A` subscriptions under `Installed on this store` and another `WMB A` under `Available to use`. Both don't have buttons `Install` or `Connect`, there is no version data, there is no action `Manage in plugins`
 - Check that you see one `WMB B` subscriptions under `Available to use`. There is a link `Connect`, there is no version data.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Adding basic support for new type of subscriptions not yet available

</details>

contributes to WCCOM-1196