### PR TITLE
Cherry pick e2e test fixes 56083 and 56121 to 9.8

### DIFF
--- a/packages/js/e2e-utils-playwright/changelog/e2e-fix-tests-with-wpcore-6.8
+++ b/packages/js/e2e-utils-playwright/changelog/e2e-fix-tests-with-wpcore-6.8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updates to support WP6.8

--- a/packages/js/e2e-utils-playwright/changelog/e2e-utils-playwright-fix-editor-canvas-locator-gb-20.6
+++ b/packages/js/e2e-utils-playwright/changelog/e2e-utils-playwright-fix-editor-canvas-locator-gb-20.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updated the editor canvas frame locator to support changes in Gutenberg 20.6

--- a/packages/js/e2e-utils-playwright/src/editor.js
+++ b/packages/js/e2e-utils-playwright/src/editor.js
@@ -36,8 +36,20 @@ export const openEditorSettings = async ( { page } ) => {
 	}
 };
 
+/**
+ * Returns the editor canvas frame for Gutenberg interactions.
+ *
+ * The Gutenberg editor content can be contained within an iframe in some contexts.
+ * This helper function returns the content frame of the editor canvas iframe if it exists,
+ * or falls back to the main page if the iframe isn't present.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page object
+ * @return {Promise<import('@playwright/test').FrameLocator|import('@playwright/test').Page>} The editor canvas frame or the original page
+ */
 export const getCanvas = async ( page ) => {
-	return page.frame( 'editor-canvas' ) || page;
+	return (
+		page.locator( 'iframe[name="editor-canvas"]' ).contentFrame() || page
+	);
 };
 
 export const goToPageEditor = async ( { page } ) => {

--- a/packages/js/e2e-utils-playwright/src/editor.js
+++ b/packages/js/e2e-utils-playwright/src/editor.js
@@ -91,12 +91,13 @@ export const insertBlock = async ( page, blockName ) => {
 
 export const insertBlockByShortcut = async ( page, blockName ) => {
 	const canvas = await getCanvas( page );
-	await canvas.getByRole( 'button', { name: 'Add default block' } ).click();
-	await canvas
-		.getByRole( 'document', {
+	const emptyBlockField = canvas.getByText( 'Type / to choose a block' ).or(
+		canvas.getByRole( 'document', {
 			name: 'Empty block; start writing or type forward slash to choose a block',
 		} )
-		.pressSequentially( `/${ blockName }` );
+	);
+	await emptyBlockField.click();
+	await emptyBlockField.pressSequentially( `/${ blockName }` );
 	await page.getByRole( 'option', { name: blockName, exact: true } ).click();
 };
 

--- a/plugins/woocommerce/changelog/e2e-fix-tests-with-wpcore-6.8
+++ b/plugins/woocommerce/changelog/e2e-fix-tests-with-wpcore-6.8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: updates to support WP6.8

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/assembler.page.js
@@ -28,7 +28,7 @@ export class AssemblerPage {
 	 * @return {(Promise<import('playwright').Frame> | Promise<import('playwright').Page>)} The assembler page or the iframe where the assembler is loaded.
 	 */
 	async getAssembler() {
-		const selector = '.cys-fullscreen-iframe[style="opacity: 1;"]';
+		const selector = 'iframe[title="assembler-hub"]';
 
 		if ( await this.page.isVisible( selector ) ) {
 			return this.page.frameLocator( selector );

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/footer.spec.js
@@ -140,7 +140,6 @@ test.describe(
 			assemblerPage,
 		} ) => {
 			const assembler = await assemblerPage.getAssembler();
-			const editor = await assemblerPage.getEditor();
 
 			await assembler
 				.locator( '.block-editor-block-patterns-list__list-item' )
@@ -164,14 +163,28 @@ test.describe(
 				const expectedFooterClass =
 					extractFooterClass( footerPickerClass );
 
-				const footerPattern = editor.locator(
-					`footer div.wc-blocks-footer-pattern`
+				const editor = await assemblerPage.getEditor();
+				const footer = editor.getByRole( 'document', {
+					name: 'Footer',
+				} );
+
+				await expect(
+					footer,
+					'Footer should be visible'
+				).toBeVisible();
+
+				const footerPattern = footer.locator(
+					`div.wc-blocks-footer-pattern`
 				);
 
-				await footerPattern.waitFor();
 				await expect(
-					await footerPattern.getAttribute( 'class' )
-				).toContain( expectedFooterClass );
+					footerPattern,
+					'Footer pattern should be visible'
+				).toBeVisible();
+				await expect(
+					footerPattern,
+					`Footer should have class ${ expectedFooterClass }`
+				).toHaveClass( new RegExp( expectedFooterClass ) );
 			}
 		} );
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/header.spec.js
@@ -139,7 +139,6 @@ test.describe(
 			assemblerPage,
 		} ) => {
 			const assembler = await assemblerPage.getAssembler();
-			const editor = await assemblerPage.getEditor();
 
 			await assembler
 				.locator( '.block-editor-block-patterns-list__list-item' )
@@ -163,13 +162,28 @@ test.describe(
 				const expectedHeaderClass =
 					extractHeaderClass( headerPickerClass );
 
-				const headerPattern = editor.locator(
-					'header div.wc-blocks-header-pattern'
+				const editor = await assemblerPage.getEditor();
+				const header = editor.getByRole( 'document', {
+					name: 'Header',
+				} );
+
+				await expect(
+					header,
+					'Header should be visible'
+				).toBeVisible();
+
+				const headerPattern = header.locator(
+					`div.wc-blocks-header-pattern`
 				);
 
 				await expect(
-					await headerPattern.getAttribute( 'class' )
-				).toContain( expectedHeaderClass );
+					headerPattern,
+					'Header pattern should be visible'
+				).toBeVisible();
+				await expect(
+					headerPattern,
+					`Header should have class ${ expectedHeaderClass }`
+				).toHaveClass( new RegExp( expectedHeaderClass ) );
 			}
 		} );
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/logo-picker/logo-picker.spec.js
@@ -127,7 +127,9 @@ test.describe(
 				logoPickerPageObject.getLogoPickerLocator( assembler )
 			).toBeVisible();
 			await expect(
-				logoPickerPageObject.getLogoLocator( editor )
+				editor
+					.getByRole( 'document', { name: 'Header' } )
+					.locator( 'img.custom-logo' )
 			).toBeVisible();
 
 			await expect( imageWidth ).toBeVisible();

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
@@ -1,12 +1,18 @@
 /**
  * External dependencies
  */
-import { getCanvas, goToPageEditor } from '@woocommerce/e2e-utils-playwright';
+import {
+	getCanvas,
+	goToPageEditor,
+	insertBlockByShortcut,
+	publishPage,
+} from '@woocommerce/e2e-utils-playwright';
 /**
  * Internal dependencies
  */
 import { tags } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+import { fillPageTitle } from '../../utils/editor';
 const { test, expect, request } = require( '@playwright/test' );
 const { admin } = require( '../../test-data/data' );
 const pageTitle = 'Product Showcase';
@@ -288,23 +294,9 @@ test.describe(
 		test( 'can see products showcase', async ( { page } ) => {
 			// create as a merchant a new page with Product Collection block
 			await goToPageEditor( { page } );
-
+			await fillPageTitle( page, pageTitle );
+			await insertBlockByShortcut( page, 'Product Collection' );
 			const canvas = await getCanvas( page );
-
-			await canvas
-				.getByRole( 'textbox', { name: 'Add Title' } )
-				.fill( pageTitle );
-
-			await canvas
-				.getByRole( 'button', { name: 'Add default block' } )
-				.click();
-
-			await canvas
-				.getByRole( 'document', {
-					name: 'Empty block; start writing or type forward slash to choose a block',
-				} )
-				.pressSequentially( '/product collection' );
-			await page.keyboard.press( 'Enter' );
 
 			// Product Collection requires choosing some collection.
 			await canvas
@@ -316,24 +308,7 @@ test.describe(
 				} )
 				.click();
 
-			await page
-				.getByRole( 'button', { name: 'Publish', exact: true } )
-				.click();
-
-			await page
-				.getByRole( 'region', { name: 'Editor publish' } )
-				.getByRole( 'button', { name: 'Publish', exact: true } )
-				.click();
-
-			await expect(
-				// WP 6.6 updates the button text from "Update" to "Save", so we'll need to check for either.
-				page.getByRole( 'button', { name: 'Update', exact: true } ).or(
-					page.getByRole( 'button', {
-						name: 'Save',
-						exact: true,
-					} )
-				)
-			).toBeVisible();
+			await publishPage( page, pageTitle );
 
 			// go to created page with products showcase
 			await page.goto( 'product-showcase' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/user/users-create.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/user/users-create.spec.js
@@ -43,7 +43,10 @@ for ( const userData of users ) {
 			await page.getByLabel( 'Last Name' ).fill( userData.last_name );
 			await page.getByText( 'Send the new user an email' ).check();
 			await page.getByLabel( 'Role' ).selectOption( userData.role );
-			await page.getByRole( 'button', { name: 'Add New User' } ).click();
+			// WP 6.8 changed the button text from "Add New User" to "Add User"
+			await page
+				.getByRole( 'button', { name: /Add User|Add New User/ } )
+				.click();
 
 			await expect( page ).toHaveTitle( /Users/ );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Cherry pick e2e tests fixes from trunk to release 9.8 branch, addressing fixing issues caused by Gutenberg and WP Core 6.8.

[[e2e-utils] Update editor-canvas locator to support updates in Gutenberg nightly #56083](https://github.com/woocommerce/woocommerce/pull/56083)
[[e2e tests] Fixes to support WP core 6.8 #56121](https://github.com/woocommerce/woocommerce/pull/56121)

### How to test the changes in this Pull Request:

Core E2E tests pass in CI.
pre-release Core e2e checks pass against this branch: https://github.com/woocommerce/woocommerce/actions/runs/13699197266
Note that Blocks e2e checks are not related to this.
