### PR TITLE
Fix classic shortcode block is_cart/is_checkout page detection

### DIFF
--- a/plugins/woocommerce/changelog/fix-classic-cart-block-page-detection-56041
+++ b/plugins/woocommerce/changelog/fix-classic-cart-block-page-detection-56041
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix is_cart/is_checkout detection when using classic shortcode block

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -6,6 +6,20 @@ namespace Automattic\WooCommerce\Blocks\Utils;
  */
 class CartCheckoutUtils {
 	/**
+	 * Caches if we're on the cart page.
+	 *
+	 * @var bool
+	 */
+	private static $is_cart_page = null;
+
+	/**
+	 * Caches if we're on the checkout page.
+	 *
+	 * @var bool
+	 */
+	private static $is_checkout_page = null;
+
+	/**
 	 * Returns true if:
 	 * - The cart page is being viewed.
 	 * - The page contains a cart block, cart shortcode or classic shortcode block with the cart attribute.
@@ -13,17 +27,22 @@ class CartCheckoutUtils {
 	 * @return bool
 	 */
 	public static function is_cart_page() {
-		global $post;
+		if ( null !== self::$is_cart_page ) {
+			return self::$is_cart_page;
+		}
 
 		$page_id      = wc_get_page_id( 'cart' );
 		$is_cart_page = $page_id && is_page( $page_id );
 
 		if ( $is_cart_page ) {
-			return true;
+			self::$is_cart_page = true;
+		} else {
+			global $post;
+			// Check page contents for block/shortcode.
+			self::$is_cart_page = is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_cart' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart', $post->post_content ) );
 		}
 
-		// Check page contents for block/shortcode.
-		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_cart' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart', $post->post_content ) );
+		return self::$is_cart_page;
 	}
 
 	/**
@@ -54,17 +73,22 @@ class CartCheckoutUtils {
 	 * @return bool
 	 */
 	public static function is_checkout_page() {
-		global $post;
+		if ( null !== self::$is_checkout_page ) {
+			return self::$is_checkout_page;
+		}
 
 		$page_id          = wc_get_page_id( 'checkout' );
 		$is_checkout_page = $page_id && is_page( $page_id );
 
 		if ( $is_checkout_page ) {
-			return true;
+			self::$is_checkout_page = true;
+		} else {
+			global $post;
+			// Check page contents for block/shortcode.
+			self::$is_checkout_page = is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_checkout' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout', $post->post_content ) );
 		}
 
-		// Check page contents for block/shortcode.
-		return is_a( $post, 'WP_Post' ) && ( wc_post_content_has_shortcode( 'woocommerce_checkout' ) || self::has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout', $post->post_content ) );
+		return self::$is_checkout_page;
 	}
 
 	/**
@@ -331,7 +355,6 @@ class CartCheckoutUtils {
 	/**
 	 * Removes accents from an array of values, sorts by the values, then returns the original array values sorted.
 	 *
-	 * @param array $array Array of values to sort.
 	 * @param array $sort_array Array of values to sort.
 	 * @return array Sorted array.
 	 */

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -94,7 +94,6 @@ class CartCheckoutUtils {
 				if ( isset( $block['attrs'][ $attribute ] ) && $value === $block['attrs'][ $attribute ] ) {
 					return true;
 				}
-				// Cart is default so it will be empty.
 
 				// `Cart` is default for `woocommerce/classic-shortcode` so it will be empty in the block attributes.
 				if ( 'woocommerce/classic-shortcode' === $block_id && 'shortcode' === $attribute && 'cart' === $value && ! isset( $block['attrs']['shortcode'] ) ) {
@@ -333,11 +332,12 @@ class CartCheckoutUtils {
 	 * Removes accents from an array of values, sorts by the values, then returns the original array values sorted.
 	 *
 	 * @param array $array Array of values to sort.
+	 * @param array $sort_array Array of values to sort.
 	 * @return array Sorted array.
 	 */
-	protected static function deep_sort_with_accents( $array ) {
-		if ( ! is_array( $array ) || empty( $array ) ) {
-			return $array;
+	protected static function deep_sort_with_accents( $sort_array ) {
+		if ( ! is_array( $sort_array ) || empty( $sort_array ) ) {
+			return $sort_array;
 		}
 
 		$array_without_accents = array_map(
@@ -346,11 +346,11 @@ class CartCheckoutUtils {
 					? self::deep_sort_with_accents( $value )
 					: remove_accents( wc_strtolower( html_entity_decode( $value ) ) );
 			},
-			$array
+			$sort_array
 		);
 
 		asort( $array_without_accents );
-		return array_replace( $array_without_accents, $array );
+		return array_replace( $array_without_accents, $sort_array );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -73,6 +73,7 @@ class CartCheckoutUtils {
 	 * @param string $block_id The block ID to check for.
 	 * @param string $attribute The attribute to check.
 	 * @param string $value The value to check for.
+	 * @param string $post_content The post content to check.
 	 * @return boolean
 	 */
 	public static function has_block_variation( $block_id, $attribute, $value, $post_content ) {
@@ -84,10 +85,18 @@ class CartCheckoutUtils {
 			$blocks = (array) parse_blocks( $post_content );
 
 			foreach ( $blocks as $block ) {
+				$block_name = $block['blockName'] ?? '';
+
+				if ( $block_name !== $block_id ) {
+					continue;
+				}
+
 				if ( isset( $block['attrs'][ $attribute ] ) && $value === $block['attrs'][ $attribute ] ) {
 					return true;
 				}
 				// Cart is default so it will be empty.
+
+				// `Cart` is default for `woocommerce/classic-shortcode` so it will be empty in the block attributes.
 				if ( 'woocommerce/classic-shortcode' === $block_id && 'shortcode' === $attribute && 'cart' === $value && ! isset( $block['attrs']['shortcode'] ) ) {
 					return true;
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using the `woocommerce/classic-shortcode` block, `is_cart_page()` and `is_checkout_page` detect will be broken if the page contains additional content, meaning they always return true. This doesn't break functionality but it can lead to unwanted scripts being loaded when they are not needed.

The problem was in the `has_block_variation` method which was not checking if the currently parsed block is the block being detected.

While looking into this I noticed that we would be parsing block several times throughout a single request, so in order to optimise performance I've introduced a cache so that `is_cart_page()` and `is_checkout_page()` only parse blocks once per request.

Closes #56041

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

To test this you'll need a snippet to see what conditionals are returning true.

```
function test_cart_conditionals() {
	var_dump( 'is_checkout() -> ' . json_encode( is_checkout() ) );
	var_dump( 'is_cart() -> ' . json_encode( is_cart() ) );
}
add_action( 'wp_head', 'test_cart_conditionals' );
```

1. Setup three new pages. 
    1. Page containing `classic cart` block
    2. Page containing `classic checkout` block
    3. Page containing `classic checkout` block and other content such as images and headings
2. View the created pages, as well as the block cart and checkout pages, and confirm the conditionals reflect the page contents. Any page with a checkout block or classic checkout block should return `is_checkout()` true and `is_cart()` false. They should never both be true, and vice versa for cart pages.

<!-- End testing instructions -->

### Testing that has already taken place:

The above steps including a classic checkout with headings. 

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
