### PR TITLE
[e2e-tests] improve cart-related frontend utils

### DIFF
--- a/plugins/woocommerce/changelog/fix-55953
+++ b/plugins/woocommerce/changelog/fix-55953
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix https://github.com/woocommerce/woocommerce/issues/55953

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -22,7 +22,15 @@ export class FrontendUtils {
 	}
 
 	async addToCart( itemName = '' ) {
-		await this.page.waitForLoadState( 'domcontentloaded' );
+		const cartResponsePromise = this.page.waitForResponse( ( response ) => {
+			const url = response.url();
+			return (
+				url.includes( 'cart/items' ) ||
+				url.includes( 'add_to_cart' ) ||
+				url.includes( 'batch' )
+			);
+		} );
+
 		if ( itemName !== '' ) {
 			// We can't use `getByRole()` here because the Add to Cart button
 			// might be a button (in blocks) or a link (in the legacy template).
@@ -33,14 +41,7 @@ export class FrontendUtils {
 			await this.page.click( 'text=Add to cart' );
 		}
 
-		await this.page.waitForResponse( ( response ) => {
-			const url = response.url();
-			return (
-				url.includes( 'cart/items' ) ||
-				url.includes( 'add_to_cart' ) ||
-				url.includes( 'batch' )
-			);
-		} );
+		await cartResponsePromise;
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -3,7 +3,6 @@
  */
 import { Page, Locator } from '@playwright/test';
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
-import { expect } from '@woocommerce/e2e-utils';
 
 export class FrontendUtils {
 	page: Page;
@@ -43,21 +42,6 @@ export class FrontendUtils {
 		}
 
 		await cartResponsePromise;
-
-		await expect.poll( async () => {
-			const cartResponse = await this.requestUtils.request.get(
-				'/wp-json/wc/store/cart'
-			);
-
-			const payload = await cartResponse.json();
-
-			if ( payload.items.length === 0 ) {
-				return '';
-			}
-
-			// The last item in the cart should be the one we added.
-			return payload.items.at( -1 ).name;
-		} ).toBe( itemName );
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -50,7 +50,7 @@ export class FrontendUtils {
 		 * the next test step.
 		 */
 		// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
-		await this.page.waitForTimeout( 1000 );
+		await this.page.waitForTimeout( 2000 );
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -23,10 +23,11 @@ export class FrontendUtils {
 
 	async addToCart( itemName = '' ) {
 		const cartResponsePromise = this.page.waitForResponse( ( response ) => {
+			const url = response.url();
 			return (
-				response.url().includes( 'wc/store/v1/cart' ) &&
-				response.status() === 200 &&
-				response.request().method() === 'GET'
+				url.includes( 'cart/items' ) ||
+				url.includes( 'add_to_cart' ) ||
+				url.includes( 'batch' )
 			);
 		} );
 
@@ -41,6 +42,15 @@ export class FrontendUtils {
 		}
 
 		await cartResponsePromise;
+
+		/**
+		 * There's a race condition where the cart is not fully updated
+		 * immediately when adding multiple items one by one, even though the
+		 * response is received. This timeout ensures the cart is updated before
+		 * the next test step.
+		 */
+		// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
+		await this.page.waitForTimeout( 2000 );
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -46,7 +46,6 @@ export class FrontendUtils {
 
 	async goToCheckout() {
 		await this.page.goto( '/checkout' );
-		await this.page.locator( '#email' ).waitFor();
 	}
 
 	async goToCart() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -3,6 +3,7 @@
  */
 import { Page, Locator } from '@playwright/test';
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+import { expect } from '@woocommerce/e2e-utils';
 
 export class FrontendUtils {
 	page: Page;
@@ -42,6 +43,21 @@ export class FrontendUtils {
 		}
 
 		await cartResponsePromise;
+
+		await expect.poll( async () => {
+			const cartResponse = await this.requestUtils.request.get(
+				'/wp-json/wc/store/cart'
+			);
+
+			const payload = await cartResponse.json();
+
+			if ( payload.items.length === 0 ) {
+				return '';
+			}
+
+			// The last item in the cart should be the one we added.
+			return payload.items.at( -1 ).name;
+		} ).toBe( itemName );
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -42,6 +42,15 @@ export class FrontendUtils {
 		}
 
 		await cartResponsePromise;
+
+		/**
+		 * There's a race condition where the cart is not fully updated
+		 * immediately when adding multiple items one by one, even though the
+		 * response is received. This timeout ensures the cart is updated before
+		 * the next test step.
+		 */
+		// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
+		await this.page.waitForTimeout( 1000 );
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -23,11 +23,10 @@ export class FrontendUtils {
 
 	async addToCart( itemName = '' ) {
 		const cartResponsePromise = this.page.waitForResponse( ( response ) => {
-			const url = response.url();
 			return (
-				url.includes( 'cart/items' ) ||
-				url.includes( 'add_to_cart' ) ||
-				url.includes( 'batch' )
+				response.url().includes( 'wc/store/v1/cart' ) &&
+				response.status() === 200 &&
+				response.request().method() === 'GET'
 			);
 		} );
 
@@ -42,15 +41,6 @@ export class FrontendUtils {
 		}
 
 		await cartResponsePromise;
-
-		/**
-		 * There's a race condition where the cart is not fully updated
-		 * immediately when adding multiple items one by one, even though the
-		 * response is received. This timeout ensures the cart is updated before
-		 * the next test step.
-		 */
-		// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
-		await this.page.waitForTimeout( 2000 );
 	}
 
 	async goToCheckout() {

--- a/plugins/woocommerce/client/woocommerce/changelog/fix-55953
+++ b/plugins/woocommerce/client/woocommerce/changelog/fix-55953
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix https://github.com/woocommerce/woocommerce/issues/55953

--- a/plugins/woocommerce/client/woocommerce/changelog/fix-55953
+++ b/plugins/woocommerce/client/woocommerce/changelog/fix-55953
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix https://github.com/woocommerce/woocommerce/issues/55953


### PR DESCRIPTION
## What?

Closes #55953 

There's a race condition where the cart isn't updated correctly when products are added in quick succession, as e2e automation can do. When two products are added back-to-back via `Add to cart` button clicks, one of two issues can occur:

1. The second product is not added at all, even though both buttons display `1 in cart`.
2. The second product replaces (?) the first, leaving only one item in the cart, despite both buttons showing `1 in cart`.

A potential workaround is implemented in this PR, but we'll need to monitor test stability over time to see if the issue persists. In general, waiting for the `cart/items` response should be enough for the automation to confirm the item is in the cart and proceed with the test.

This likely won’t affect real users, but perhaps someone from @woocommerce/rubik can pinpoint the root cause and determine if it's an easy fix. Ideally, addressing this at the application level would not only resolve the bug but also stabilize affected e2e tests automatically.

## How to test

Tests should pass.