### PR TITLE
[Experimental] Product Filters - Fix deprecations

### DIFF
--- a/plugins/woocommerce/changelog/product-filters-fix-deprecations
+++ b/plugins/woocommerce/changelog/product-filters-fix-deprecations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Fix product filters deprecation warnings
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
@@ -75,6 +75,7 @@ export const Inspector = ( {
 			<InspectorControls key="inspector">
 				<PanelBody title={ __( 'Attribute', 'woocommerce' ) }>
 					<ComboboxControl
+						__nextHasNoMarginBottom
 						options={ ATTRIBUTES.map( ( item ) => ( {
 							value: item.attribute_id,
 							label: item.attribute_label,
@@ -123,6 +124,7 @@ export const Inspector = ( {
 							'Determine the order of filter options.',
 							'woocommerce'
 						) }
+						__nextHasNoMarginBottom
 					/>
 					<ToggleGroupControl
 						label={ __( 'Logic', 'woocommerce' ) }
@@ -131,6 +133,8 @@ export const Inspector = ( {
 						onChange={ ( value: BlockAttributes[ 'queryType' ] ) =>
 							setAttributes( { queryType: value } )
 						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						style={ { width: '100%' } }
 						help={
 							queryType === 'and'
@@ -165,6 +169,8 @@ export const Inspector = ( {
 					<ToggleGroupControl
 						value={ displayStyle }
 						isBlock
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 						onChange={ (
 							value: BlockAttributes[ 'displayStyle' ]
 						) => {
@@ -214,6 +220,7 @@ export const Inspector = ( {
 						onChange={ ( value ) =>
 							setAttributes( { showCounts: value } )
 						}
+						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Empty filter options', 'woocommerce' ) }
@@ -221,6 +228,7 @@ export const Inspector = ( {
 						onChange={ ( value ) =>
 							setAttributes( { hideEmpty: ! value } )
 						}
+						__nextHasNoMarginBottom
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-slider/edit.tsx
@@ -108,6 +108,7 @@ const PriceSliderEdit = ( {
 								showInputFields: ! showInputFields,
 							} )
 						}
+						__nextHasNoMarginBottom
 					/>
 
 					{ showInputFields && (
@@ -117,6 +118,7 @@ const PriceSliderEdit = ( {
 							onChange={ () =>
 								setAttributes( { inlineInput: ! inlineInput } )
 							}
+							__nextHasNoMarginBottom
 						/>
 					) }
 				</PanelBody>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/components/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/components/inspector.tsx
@@ -68,6 +68,7 @@ export const Inspector = ( {
 					label={ __( 'Display product count', 'woocommerce' ) }
 					checked={ showCounts }
 					onChange={ setCountVisibility }
+					__nextHasNoMarginBottom
 				/>
 			</PanelBody>
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
@@ -90,6 +90,8 @@ export const Inspector = ( {
 							setAttributes( { displayStyle: value } );
 						} }
 						style={ { width: '100%' } }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					>
 						{ displayStyleOptions.map( ( blockType ) => (
 							<ToggleGroupControlOption
@@ -105,6 +107,7 @@ export const Inspector = ( {
 						onChange={ ( value ) =>
 							setAttributes( { showCounts: value } )
 						}
+						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Empty filter options', 'woocommerce' ) }
@@ -112,6 +115,7 @@ export const Inspector = ( {
 						onChange={ ( value ) =>
 							setAttributes( { hideEmpty: ! value } )
 						}
+						__nextHasNoMarginBottom
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56181

This PR fixes the deprecation warnings for the styles used in the WP core inspector control components.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

> [!NOTE]  
> **Pre-requisite**
> - If you're using WC Beta Tester plugin, make sure the `experimental-blocks` feature is enabled (Tools > WCA Test Helper > Features).
> - Make sure to reset Product Catalog Template.

1. Navigate to Product Catalog template (Appearance > Editor > Templates > Product Catalog template.
2. Edit the template.
3. Add the Product Filters (Experimental) block to the page.
4. Have your browser console opened.
5. In the list view, click on each of the product filters block.
6. Ensure you don't see any warnings related to these blocks in the console when clicked on.

<!-- End testing instructions -->

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
