### PR TITLE
Remove pending sync order count when no sync is in progress

### DIFF
--- a/plugins/woocommerce/changelog/update-54860
+++ b/plugins/woocommerce/changelog/update-54860
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Remove pending sync order count when no sync is in progress

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -460,7 +460,7 @@ class CustomOrdersTableController {
 			return 'no';
 		}
 
-		$sync_is_pending = 0 !== $this->data_synchronizer->get_current_orders_pending_sync_count();
+		$sync_is_pending = $this->data_synchronizer->has_orders_pending_sync();
 		if ( $sync_is_pending && ! $this->changing_data_source_with_sync_pending_is_allowed() ) {
 			throw new \Exception( "The authoritative table for orders storage can't be changed while there are orders out of sync" );
 		}
@@ -612,7 +612,7 @@ class CustomOrdersTableController {
 
 		$get_disabled = function () {
 			$compatibility_info = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
-			$sync_complete      = 0 === $this->data_synchronizer->get_current_orders_pending_sync_count();
+			$sync_complete      = ! $this->data_synchronizer->has_orders_pending_sync();
 			$disabled           = array();
 			// Changing something here? You might also want to look at `enable|disable` functions in Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner.
 			$incompatible_plugins = $this->plugin_util->get_items_considered_incompatible( 'custom_order_tables', $compatibility_info );
@@ -658,22 +658,15 @@ class CustomOrdersTableController {
 		};
 
 		$get_sync_message = function () {
-			$orders_pending_sync_count = $this->data_synchronizer->get_current_orders_pending_sync_count( true );
-			$sync_in_progress          = $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) );
-			$sync_enabled              = $this->data_synchronizer->data_sync_is_enabled();
-			$sync_is_pending           = $orders_pending_sync_count > 0;
-			$sync_message              = array();
-
-			$is_dangerous = $sync_is_pending && $this->changing_data_source_with_sync_pending_is_allowed();
+			$sync_in_progress = $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) );
+			$sync_enabled     = $this->data_synchronizer->data_sync_is_enabled();
+			$sync_is_pending  = $this->data_synchronizer->has_orders_pending_sync( true );
+			$sync_message     = array();
+			$is_dangerous     = $sync_is_pending && $this->changing_data_source_with_sync_pending_is_allowed();
 
 			if ( $is_dangerous ) {
 				$sync_message[] = wp_kses_data(
-					sprintf(
-						// translators: %s: number of pending orders.
-						_n( "There's %s order pending sync.", 'There are %s orders pending sync.', $orders_pending_sync_count, 'woocommerce' ),
-						number_format_i18n( $orders_pending_sync_count ),
-					)
-					. ' '
+					__( "There are orders pending sync.", 'woocommerce' )
 					. '<strong>'
 					. __( 'Switching data storage while sync is incomplete is dangerous and can lead to order data corruption or loss!', 'woocommerce' )
 					. '</strong>'
@@ -685,6 +678,8 @@ class CustomOrdersTableController {
 			}
 
 			if ( $sync_in_progress && $sync_is_pending ) {
+				$orders_pending_sync_count = $this->data_synchronizer->get_current_orders_pending_sync_count( true );
+
 				$sync_message[] = sprintf(
 					// translators: %s: number of pending orders.
 					__( 'Currently syncing orders... %s pending', 'woocommerce' ),
@@ -721,16 +716,7 @@ class CustomOrdersTableController {
 
 				if ( ! $is_dangerous ) {
 					$sync_message[] = wp_kses_data(
-						sprintf(
-							// translators: %s: number of pending orders.
-							_n(
-								"You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>. There's currently %s order out of sync.",
-								'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>. There are currently %s orders out of sync. ',
-								$orders_pending_sync_count,
-								'woocommerce'
-							),
-							number_format_i18n( $orders_pending_sync_count )
-						)
+						__( "You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>. There are currently orders out of sync.", 'woocommerce' ),
 					);
 				}
 
@@ -745,7 +731,7 @@ class CustomOrdersTableController {
 		};
 
 		$get_description_is_error = function () {
-			$sync_is_pending = $this->data_synchronizer->get_current_orders_pending_sync_count( true ) > 0;
+			$sync_is_pending = $this->data_synchronizer->has_orders_pending_sync();
 
 			return $sync_is_pending && $this->changing_data_source_with_sync_pending_is_allowed();
 		};

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -78,7 +78,7 @@ class COTMigrationUtil {
 			return false;
 		}
 
-		return 0 === $this->data_synchronizer->get_total_pending_count();
+		return 0 === $this->data_synchronizer->has_orders_pending_sync();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -78,7 +78,7 @@ class COTMigrationUtil {
 			return false;
 		}
 
-		return 0 === $this->data_synchronizer->has_orders_pending_sync();
+		return ! $this->data_synchronizer->has_orders_pending_sync();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
@@ -92,10 +92,10 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_is_custom_order_tables_in_sync_is_true() {
 		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
-			->setMethods( array( 'get_current_orders_pending_sync_count', 'data_sync_is_enabled' ) )
+			->setMethods( array( 'has_orders_pending_sync', 'data_sync_is_enabled' ) )
 			->getMock();
 
-		$data_sync_mock->method( 'get_current_orders_pending_sync_count' )->willReturn( 0 );
+		$data_sync_mock->method( 'has_orders_pending_sync' )->willReturn( false );
 		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( true );
 
 		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.
@@ -113,10 +113,10 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_is_custom_order_tables_in_sync_is_false() {
 		$data_sync_mock = $this->getMockBuilder( DataSynchronizer::class )
-							->setMethods( array( 'get_current_orders_pending_sync_count', 'data_sync_is_enabled' ) )
+							->setMethods( array( 'has_orders_pending_sync', 'data_sync_is_enabled' ) )
 							->getMock();
 
-		$data_sync_mock->method( 'get_current_orders_pending_sync_count' )->willReturn( 0 );
+		$data_sync_mock->method( 'has_orders_pending_sync' )->willReturn( false );
 		$data_sync_mock->method( 'data_sync_is_enabled' )->willReturn( false );
 
 		// This is needed to prevent "Call to private method Mock_DataSynchronizer_xxxx::process_added_option" errors.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the ability to check for the existence of any pending sync orders instead of forcing a count on all rows.  Because this query needs to run on almost every page load for this feature page, this significantly reduces the load time.  On a testing site with ~178k orders, the previous query typically clocked in around ~400ms and the new query takes approximately ~1.5ms.  This will have an even larger impact as the site scales.

The trade-off here is that we will not have access to the pending sync order count until the process has begun, but after some discussion on Slack, while I believe this information is nice to have, it does not ultimately affect the decision of whether or not to begin the sync.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #54860 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1322" alt="Screenshot 2025-03-06 at 12 17 19 PM" src="https://github.com/user-attachments/assets/b8c842b9-6ca7-4303-aa2d-ae862d7f1a13" />  |   <img width="1281" alt="Screenshot 2025-03-06 at 2 45 52 PM" src="https://github.com/user-attachments/assets/89662465-4d5d-46ac-b1bd-5a389ab5cc87" /> |

Note that by default, order count is no longer shown, but instead a message indicating that pending orders do exist.
<img width="1124" alt="Screenshot 2025-03-06 at 12 17 44 PM" src="https://github.com/user-attachments/assets/0790ea33-74a3-454f-9f2d-bb9a7ae5de08" />

When a sync has begun, you will still see the total count pending sync.
<img width="1089" alt="Screenshot 2025-03-06 at 12 14 46 PM" src="https://github.com/user-attachments/assets/32656e37-3efb-48ba-b9e8-c029b42178fd" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Navigate to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure that the option to keep orders in sync is disabled
3. Create some orders
4. Navigate to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` again
5. Note that the text "There are currently orders out of sync." is shown next to the "Order data storage" description.
6. Click "Sync orders now"
7. Note that the number of pending sync orders is now shown
8. When complete, note that the message "There are currently orders out of sync" is no longer shown and you can switch between storage options.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
