### PR TITLE
Block Templates: Ensure loading of critical template parts after theme switch

### DIFF
--- a/plugins/woocommerce/changelog/fix-modified-template-parts-not-loading-on-theme-switch
+++ b/plugins/woocommerce/changelog/fix-modified-template-parts-not-loading-on-theme-switch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensures correct themes header renders after switching theme

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -168,8 +168,9 @@ class BlockTemplatesController {
 			$template_id = "{$theme}//{$slug}";
 			$template    = get_block_template( $template_id, 'wp_template_part' );
 
-			// Render the template part content.
-			$block_content = do_blocks( $template->content );
+			if ( $template && ! empty( $template->content ) ) {
+				$block_content = do_blocks( $template->content );
+			}
 		}
 
 		return $block_content;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the issue where header and footer template parts fail to render on the frontend after editing them in the Site Editor and switching themes with WooCommerce using block themes. The solution updates BlockTemplatesController to add `render_block` filter method to ensure frontend rendering for critical template parts

Closes https://github.com/woocommerce/woocommerce/issues/42181

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify the bug on `trunk`
2. Enable TT5 with WooCommerce and edit the header, save it.
3. Check the updates are reflected on the frontend
4. Switch theme to TT4. Check on the frontend that the header renders correctly
5. Edit the header via the Site Editor and check they are also reflected on the frontend and editor
6. Reset the header template part and check they reset correctly
7. Switch back to TT4, check your old updates are back on the frontend
8. Reset the TT4 header edits, check they clear as expected and you see the default header.
9. Perform same tests with the footer

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
