### PR TITLE
[dev] Remove unused @woocommerce/woocommerce-rest-api dev dependency

### DIFF
--- a/plugins/woocommerce/changelog/e2e-remove-rest-api-dependency
+++ b/plugins/woocommerce/changelog/e2e-remove-rest-api-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+dev: remove unused dev depencency @woocommerce/woocommerce-rest-api

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -161,7 +161,6 @@
 		"@woocommerce/data": "workspace:*",
 		"@woocommerce/e2e-utils": "workspace:*",
 		"@woocommerce/eslint-plugin": "workspace:*",
-		"@woocommerce/woocommerce-rest-api": "1.0.1",
 		"@wordpress/api-fetch": "6.21.0",
 		"@wordpress/babel-preset-default": "7.28.0",
 		"@wordpress/base-styles": "4.35.0",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -261,7 +261,9 @@
 					"changes": [
 						"tests/e2e-pw/**"
 					],
-					"onlyForDependencies": ["@woocommerce/e2e-utils-playwright"],
+					"onlyForDependencies": [
+						"@woocommerce/e2e-utils-playwright"
+					],
 					"events": [
 						"pull_request",
 						"daily-checks",
@@ -290,7 +292,9 @@
 					"changes": [
 						"tests/e2e-pw/**"
 					],
-					"onlyForDependencies": ["@woocommerce/e2e-utils-playwright"],
+					"onlyForDependencies": [
+						"@woocommerce/e2e-utils-playwright"
+					],
 					"events": [
 						"pull_request",
 						"daily-checks",
@@ -314,7 +318,9 @@
 					"changes": [
 						"tests/e2e-pw/**"
 					],
-					"onlyForDependencies": ["@woocommerce/e2e-utils-playwright"],
+					"onlyForDependencies": [
+						"@woocommerce/e2e-utils-playwright"
+					],
 					"events": [
 						"pull_request",
 						"daily-checks",
@@ -344,7 +350,9 @@
 					"changes": [
 						"tests/e2e-pw/**"
 					],
-					"onlyForDependencies": ["@woocommerce/e2e-utils-playwright"],
+					"onlyForDependencies": [
+						"@woocommerce/e2e-utils-playwright"
+					],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -377,7 +385,9 @@
 					"changes": [
 						"tests/e2e-pw/**"
 					],
-					"onlyForDependencies": ["@woocommerce/e2e-utils-playwright"],
+					"onlyForDependencies": [
+						"@woocommerce/e2e-utils-playwright"
+					],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -410,7 +420,9 @@
 					"changes": [
 						"tests/e2e-pw/**"
 					],
-					"onlyForDependencies": ["@woocommerce/e2e-utils-playwright"],
+					"onlyForDependencies": [
+						"@woocommerce/e2e-utils-playwright"
+					],
 					"testEnv": {
 						"start": "env:test",
 						"config": {
@@ -703,7 +715,6 @@
 		"@woocommerce/api": "workspace:*",
 		"@woocommerce/e2e-utils-playwright": "workspace:*",
 		"@woocommerce/eslint-plugin": "workspace:*",
-		"@woocommerce/woocommerce-rest-api": "^1.0.1",
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
 		"@wordpress/babel-preset-default": "3.0.2",
 		"@wordpress/e2e-test-utils-playwright": "^1.15.0",
@@ -784,15 +795,15 @@
 				"node_modules/@woocommerce/block-library/blocks.ini",
 				"node_modules/@woocommerce/classic-assets/build",
 				"node_modules/@woocommerce/api/dist/",
-				"node_modules/@woocommerce/eslint-plugin/configs",
-				"node_modules/@woocommerce/eslint-plugin/rules",
-				"node_modules/@woocommerce/eslint-plugin/index.js",
 				"!node_modules/@woocommerce/api/*.ts.map",
 				"!node_modules/@woocommerce/api/*.tsbuildinfo",
 				"!node_modules/@woocommerce/api/dist/**/__tests__/",
 				"!node_modules/@woocommerce/api/dist/**/__mocks__/",
 				"!node_modules/@woocommerce/api/dist/**/__snapshops__/",
-				"!node_modules/@woocommerce/api/dist/**/__test_data__/"
+				"!node_modules/@woocommerce/api/dist/**/__test_data__/",
+				"node_modules/@woocommerce/eslint-plugin/configs",
+				"node_modules/@woocommerce/eslint-plugin/rules",
+				"node_modules/@woocommerce/eslint-plugin/index.js"
 			]
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3528,9 +3528,6 @@ importers:
       '@woocommerce/eslint-plugin':
         specifier: workspace:*
         version: link:../../packages/js/eslint-plugin
-      '@woocommerce/woocommerce-rest-api':
-        specifier: ^1.0.1
-        version: 1.0.1
       '@wordpress/babel-plugin-import-jsx-pragma':
         specifier: 1.1.3
         version: 1.1.3(@babel/core@7.12.9)
@@ -3748,650 +3745,6 @@ importers:
       wireit:
         specifier: 0.14.10
         version: 0.14.10
-
-  plugins/woocommerce/client/blocks:
-    dependencies:
-      '@ariakit/react':
-        specifier: ^0.4.5
-        version: 0.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/core':
-        specifier: 6.1.0
-        version: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/modifiers':
-        specifier: 7.0.0
-        version: 7.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/sortable':
-        specifier: 8.0.0
-        version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/utilities':
-        specifier: 3.2.2
-        version: 3.2.2(react@18.3.1)
-      '@emotion/styled':
-        specifier: ^11.11.0
-        version: 11.11.0(@emotion/react@11.11.1(@types/react@18.3.16)(react@18.3.1))(@types/react@18.3.16)(react@18.3.1)
-      '@preact/signals':
-        specifier: ^1.3.0
-        version: 1.3.1(preact@10.25.1)
-      '@woocommerce/tracks':
-        specifier: workspace:*
-        version: link:../../../../packages/js/tracks
-      '@wordpress/autop':
-        specifier: 3.16.0
-        version: 3.16.0
-      '@wordpress/compose':
-        specifier: 5.5.0
-        version: 5.5.0(react@18.3.1)
-      '@wordpress/data':
-        specifier: wp-6.6
-        version: 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
-      '@wordpress/deprecated':
-        specifier: 3.41.0
-        version: 3.41.0
-      '@wordpress/icons':
-        specifier: 9.36.0
-        version: 9.36.0
-      '@wordpress/notices':
-        specifier: 5.15.1
-        version: 5.15.1(react@18.3.1)
-      '@wordpress/plugins':
-        specifier: 4.10.0
-        version: 4.10.0(react@18.3.1)
-      '@wordpress/primitives':
-        specifier: 4.11.0
-        version: 4.11.0(react@18.3.1)
-      '@wordpress/server-side-render':
-        specifier: 3.10.0
-        version: 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@wordpress/style-engine':
-        specifier: ^1.30.0
-        version: 1.30.0
-      '@wordpress/url':
-        specifier: 3.13.0
-        version: 3.13.0
-      '@wordpress/wordcount':
-        specifier: 3.47.0
-        version: 3.47.0
-      ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
-      ajv-errors:
-        specifier: ^3.0.0
-        version: 3.0.0(ajv@8.17.1)
-      ajv-formats:
-        specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
-      change-case:
-        specifier: ^4.1.2
-        version: 4.1.2
-      check-password-strength:
-        specifier: ^2.0.10
-        version: 2.0.10
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      compare-versions:
-        specifier: 4.1.3
-        version: 4.1.3
-      config:
-        specifier: 3.3.7
-        version: 3.3.7
-      dataloader:
-        specifier: 2.2.2
-        version: 2.2.2
-      deepsignal:
-        specifier: 1.3.6
-        version: 1.3.6(@preact/signals-core@1.8.0)(@preact/signals@1.3.1(preact@10.25.1))(preact@10.25.1)
-      dinero.js:
-        specifier: 1.9.1
-        version: 1.9.1
-      dompurify:
-        specifier: ^2.5.7
-        version: 2.5.7
-      downshift:
-        specifier: 6.1.7
-        version: 6.1.7(react@18.3.1)
-      fast-deep-equal:
-        specifier: ^3.1.3
-        version: 3.1.3
-      fast-sort:
-        specifier: ^3.4.0
-        version: 3.4.0
-      html-react-parser:
-        specifier: 3.0.4
-        version: 3.0.4(react@18.3.1)
-      postcode-validator:
-        specifier: 3.9.2
-        version: 3.9.2
-      preact:
-        specifier: ^10.24.2
-        version: 10.25.1
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
-      react:
-        specifier: 18.3.x
-        version: 18.3.1
-      react-dom:
-        specifier: 18.3.x
-        version: 18.3.1(react@18.3.1)
-      react-number-format:
-        specifier: 4.9.3
-        version: 4.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-transition-group:
-        specifier: ^4.4.5
-        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      request:
-        specifier: 2.88.2
-        version: 2.88.2
-      trim-html:
-        specifier: 0.1.9
-        version: 0.1.9
-      use-debounce:
-        specifier: 9.0.4
-        version: 9.0.4(react@18.3.1)
-      usehooks-ts:
-        specifier: ^2.9.1
-        version: 2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      wordpress-components:
-        specifier: npm:@wordpress/components@14.2.0
-        version: '@wordpress/components@14.2.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(reakit-utils@0.15.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))'
-      wordpress-components-slotfill:
-        specifier: npm:@wordpress/components@wp-6.5
-        version: '@wordpress/components@26.0.6(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@types/react@18.3.16)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
-    optionalDependencies:
-      ndb:
-        specifier: 1.1.5
-        version: 1.1.5
-    devDependencies:
-      '@automattic/color-studio':
-        specifier: 4.0.0
-        version: 4.0.0
-      '@babel/cli':
-        specifier: 7.23.0
-        version: 7.23.0(@babel/core@7.23.2)
-      '@babel/core':
-        specifier: 7.23.2
-        version: 7.23.2
-      '@babel/plugin-syntax-jsx':
-        specifier: 7.22.5
-        version: 7.22.5(@babel/core@7.23.2)
-      '@babel/plugin-transform-class-properties':
-        specifier: ^7.23.3
-        version: 7.25.9(@babel/core@7.23.2)
-      '@babel/plugin-transform-optional-chaining':
-        specifier: ^7.23.4
-        version: 7.25.9(@babel/core@7.23.2)
-      '@babel/polyfill':
-        specifier: 7.12.1
-        version: 7.12.1
-      '@babel/preset-react':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.2)
-      '@babel/preset-typescript':
-        specifier: 7.23.3
-        version: 7.23.3(@babel/core@7.23.2)
-      '@bartekbp/typescript-checkstyle':
-        specifier: 5.0.0
-        version: 5.0.0
-      '@playwright/test':
-        specifier: ^1.50.1
-        version: 1.50.1
-      '@storybook/addon-a11y':
-        specifier: 7.5.2
-        version: 7.5.2(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/addon-actions':
-        specifier: ^7.6.4
-        version: 7.6.4
-      '@storybook/addon-docs':
-        specifier: ^7.6.4
-        version: 7.6.4(@types/react-dom@18.0.10)(@types/react@18.3.16)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/addon-essentials':
-        specifier: 7.5.2
-        version: 7.5.2(@types/react-dom@18.0.10)(@types/react@18.3.16)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/addon-links':
-        specifier: 7.5.2
-        version: 7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/addon-storysource':
-        specifier: 7.5.2
-        version: 7.5.2(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/addon-styling-webpack':
-        specifier: ^0.0.5
-        version: 0.0.5(webpack@5.91.0)
-      '@storybook/addons':
-        specifier: 7.5.2
-        version: 7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/client-api':
-        specifier: 7.5.2
-        version: 7.5.2
-      '@storybook/preview-api':
-        specifier: ^7.6.4
-        version: 7.6.4
-      '@storybook/react':
-        specifier: 7.5.2
-        version: 7.5.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.2)
-      '@storybook/react-webpack5':
-        specifier: ^7.6.4
-        version: 7.6.4(@babel/core@7.23.2)(@swc/core@1.3.100)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@3.13.1)(typescript@5.7.2)(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.25.4)
-      '@testing-library/dom':
-        specifier: 9.3.3
-        version: 9.3.3
-      '@testing-library/jest-dom':
-        specifier: 6.4.5
-        version: 6.4.5(@jest/globals@29.7.0)(@types/jest@27.5.2)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))
-      '@testing-library/react':
-        specifier: 15.0.7
-        version: 15.0.7(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@testing-library/user-event':
-        specifier: 14.5.2
-        version: 14.5.2(@testing-library/dom@9.3.3)
-      '@types/dinero.js':
-        specifier: 1.9.0
-        version: 1.9.0
-      '@types/dompurify':
-        specifier: 2.3.4
-        version: 2.3.4
-      '@types/gtag.js':
-        specifier: 0.0.10
-        version: 0.0.10
-      '@types/jest':
-        specifier: 27.5.2
-        version: 27.5.2
-      '@types/jest-environment-puppeteer':
-        specifier: 5.0.2
-        version: 5.0.2
-      '@types/jquery':
-        specifier: 3.5.14
-        version: 3.5.14
-      '@types/lodash':
-        specifier: 4.14.182
-        version: 4.14.182
-      '@types/prop-types':
-        specifier: ^15.7.11
-        version: 15.7.11
-      '@types/puppeteer':
-        specifier: 5.4.6
-        version: 5.4.6
-      '@types/react':
-        specifier: 18.3.x
-        version: 18.3.16
-      '@types/react-dom':
-        specifier: 18.0.10
-        version: 18.0.10
-      '@types/react-transition-group':
-        specifier: ^4.4.10
-        version: 4.4.10
-      '@types/wordpress__block-editor':
-        specifier: 6.0.6
-        version: 6.0.6(@emotion/is-prop-valid@1.2.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__block-library':
-        specifier: 2.6.3
-        version: 2.6.3
-      '@types/wordpress__blocks':
-        specifier: 11.0.9
-        version: 11.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__components':
-        specifier: ^23.0.10
-        version: 23.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__core-data':
-        specifier: ^2.4.5
-        version: 2.4.5
-      '@types/wordpress__data':
-        specifier: ^6.0.2
-        version: 6.0.2
-      '@types/wordpress__data-controls':
-        specifier: 2.2.0
-        version: 2.2.0
-      '@types/wordpress__editor':
-        specifier: ^13.6.7
-        version: 13.6.7(@emotion/is-prop-valid@1.2.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__notices':
-        specifier: 3.3.0
-        version: 3.3.0
-      '@types/wordpress__rich-text':
-        specifier: 6.10.0
-        version: 6.10.0(react@18.3.1)
-      '@types/wordpress__wordcount':
-        specifier: ^2.4.5
-        version: 2.4.5
-      '@typescript-eslint/eslint-plugin':
-        specifier: 5.56.0
-        version: 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)
-      '@typescript-eslint/parser':
-        specifier: 5.56.0
-        version: 5.56.0(eslint@8.55.0)(typescript@5.7.2)
-      '@woocommerce/customer-effort-score':
-        specifier: workspace:*
-        version: link:../../packages/js/customer-effort-score
-      '@woocommerce/data':
-        specifier: workspace:*
-        version: link:../../packages/js/data
-      '@woocommerce/e2e-utils':
-        specifier: workspace:*
-        version: link:../../packages/js/e2e-utils
-      '@woocommerce/eslint-plugin':
-        specifier: workspace:*
-        version: link:../../packages/js/eslint-plugin
-      '@woocommerce/woocommerce-rest-api':
-        specifier: 1.0.1
-        version: 1.0.1
-      '@wordpress/api-fetch':
-        specifier: 6.21.0
-        version: 6.21.0
-      '@wordpress/babel-preset-default':
-        specifier: 7.28.0
-        version: 7.28.0
-      '@wordpress/base-styles':
-        specifier: 4.35.0
-        version: 4.35.0
-      '@wordpress/block-editor':
-        specifier: wp-6.6
-        version: 13.0.7(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/block-library':
-        specifier: wp-6.6
-        version: 9.0.8(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks':
-        specifier: wp-6.6
-        version: 13.0.3(react@18.3.1)
-      '@wordpress/browserslist-config':
-        specifier: 6.16.0
-        version: 6.16.0
-      '@wordpress/components':
-        specifier: 19.17.0
-        version: 19.17.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@wordpress/core-data':
-        specifier: 5.5.0
-        version: 5.5.0(react@18.3.1)
-      '@wordpress/data-controls':
-        specifier: 2.2.7
-        version: 2.2.7(react@18.3.1)
-      '@wordpress/date':
-        specifier: 4.44.0
-        version: 4.44.0
-      '@wordpress/dependency-extraction-webpack-plugin':
-        specifier: next
-        version: 6.13.1-next.a9f418477.0(webpack@5.91.0)
-      '@wordpress/dom':
-        specifier: 3.27.0
-        version: 3.27.0
-      '@wordpress/dom-ready':
-        specifier: 3.27.0
-        version: 3.27.0
-      '@wordpress/e2e-test-utils':
-        specifier: 10.12.0
-        version: 10.12.0(encoding@0.1.13)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(puppeteer-core@23.11.1)
-      '@wordpress/e2e-test-utils-playwright':
-        specifier: ^1.15.0
-        version: 1.16.0(@playwright/test@1.50.1)
-      '@wordpress/e2e-tests':
-        specifier: ^4.9.2
-        version: 4.9.2(@swc/core@1.3.100)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(file-loader@6.2.0(webpack@5.91.0))(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(node-notifier@8.0.2)(puppeteer-core@23.11.1)(puppeteer@17.1.3(encoding@0.1.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
-      '@wordpress/editor':
-        specifier: wp-6.7
-        version: 14.8.19(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element':
-        specifier: 5.22.0
-        version: 5.22.0
-      '@wordpress/env':
-        specifier: 10.17.0
-        version: 10.17.0(patch_hash=ovltjfwrjswkqlvmxt7r5kywn4)(@types/node@20.17.8)
-      '@wordpress/format-library':
-        specifier: wp-6.6
-        version: 5.0.7(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/hooks':
-        specifier: wp-6.6
-        version: 4.0.1
-      '@wordpress/html-entities':
-        specifier: 3.24.0
-        version: 3.24.0
-      '@wordpress/i18n':
-        specifier: 4.45.0
-        version: 4.45.0
-      '@wordpress/interactivity':
-        specifier: ^6.16.0
-        version: 6.18.0
-      '@wordpress/interactivity-router':
-        specifier: ^2.17.0
-        version: 2.18.0
-      '@wordpress/is-shallow-equal':
-        specifier: 4.24.0
-        version: 4.24.0
-      '@wordpress/jest-preset-default':
-        specifier: 8.5.2
-        version: 8.5.2(@babel/core@7.23.2)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/postcss-plugins-preset':
-        specifier: 1.6.0
-        version: 1.6.0
-      '@wordpress/postcss-themes':
-        specifier: 1.0.5
-        version: 1.0.5
-      '@wordpress/prettier-config':
-        specifier: 1.4.0
-        version: 1.4.0(wp-prettier@2.8.5)
-      '@wordpress/private-apis':
-        specifier: 1.16.0
-        version: 1.16.0
-      '@wordpress/rich-text':
-        specifier: wp-6.6
-        version: 7.0.2(react@18.3.1)
-      '@wordpress/scripts':
-        specifier: 30.6.0
-        version: 30.6.0(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/node@20.17.8)(@types/webpack@4.41.38)(babel-plugin-macros@3.1.0)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
-      '@wordpress/stylelint-config':
-        specifier: ^21.36.0
-        version: 21.36.0(postcss@8.4.32)(stylelint@14.16.1)
-      ajv-cli:
-        specifier: 3.3.x
-        version: 3.3.0
-      allure-playwright:
-        specifier: ^2.9.2
-        version: 2.9.2
-      autoprefixer:
-        specifier: 10.4.14
-        version: 10.4.14(postcss@8.4.32)
-      babel-jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@babel/core@7.23.2)
-      babel-plugin-explicit-exports-references:
-        specifier: ^1.0.2
-        version: 1.0.2
-      babel-plugin-react-docgen:
-        specifier: 4.2.1
-        version: 4.2.1
-      babel-plugin-transform-react-remove-prop-types:
-        specifier: 0.4.24
-        version: 0.4.24
-      buildkite-test-collector:
-        specifier: ^1.7.1
-        version: 1.7.1
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
-      circular-dependency-plugin:
-        specifier: 5.2.2
-        version: 5.2.2(webpack@5.91.0)
-      copy-webpack-plugin:
-        specifier: 11.0.0
-        version: 11.0.0(webpack@5.91.0)
-      core-js:
-        specifier: 3.25.0
-        version: 3.25.0
-      create-file-webpack:
-        specifier: 1.0.2
-        version: 1.0.2
-      cross-env:
-        specifier: 7.0.3
-        version: 7.0.3
-      css-loader:
-        specifier: ^6.8.1
-        version: 6.8.1(webpack@5.91.0)
-      cssnano:
-        specifier: 5.1.12
-        version: 5.1.12(postcss@8.4.32)
-      deep-freeze:
-        specifier: 0.0.1
-        version: 0.0.1
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
-      eslint-import-resolver-typescript:
-        specifier: 3.6.1
-        version: 3.6.1(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-webpack@0.13.2)(eslint-plugin-import@2.28.1)(eslint@8.55.0)
-      eslint-import-resolver-webpack:
-        specifier: 0.13.2
-        version: 0.13.2(eslint-plugin-import@2.28.1)(webpack@5.91.0)
-      eslint-plugin-import:
-        specifier: 2.28.1
-        version: 2.28.1(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.55.0)
-      eslint-plugin-playwright:
-        specifier: 1.6.0
-        version: 1.6.0(eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(typescript@5.7.2))(eslint@8.55.0)
-      eslint-plugin-rulesdir:
-        specifier: ^0.2.2
-        version: 0.2.2
-      eslint-plugin-storybook:
-        specifier: ^0.6.15
-        version: 0.6.15(eslint@8.55.0)(typescript@5.7.2)
-      eslint-plugin-woocommerce:
-        specifier: file:bin/eslint-plugin-woocommerce
-        version: link:bin/eslint-plugin-woocommerce
-      eslint-plugin-you-dont-need-lodash-underscore:
-        specifier: 6.12.0
-        version: 6.12.0
-      fs-extra:
-        specifier: 11.1.1
-        version: 11.1.1
-      gh-pages:
-        specifier: 5.0.0
-        version: 5.0.0
-      github-label-sync:
-        specifier: ^2.3.1
-        version: 2.3.1
-      glob:
-        specifier: 7.2.3
-        version: 7.2.3
-      glob-promise:
-        specifier: 4.2.2
-        version: 4.2.2(glob@7.2.3)
-      handlebars:
-        specifier: ^4.7.8
-        version: 4.7.8
-      ignore-loader:
-        specifier: 0.1.2
-        version: 0.1.2
-      jest:
-        specifier: 29.7.x
-        version: 29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))
-      jest-circus:
-        specifier: 29.7.x
-        version: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-puppeteer:
-        specifier: 6.1.1
-        version: 6.1.1
-      jest-fetch-mock:
-        specifier: 3.0.3
-        version: 3.0.3(encoding@0.1.13)
-      jest-html-reporters:
-        specifier: 3.0.10
-        version: 3.0.10
-      json2md:
-        specifier: 1.12.0
-        version: 1.12.0
-      lint-staged:
-        specifier: 13.2.0
-        version: 13.2.0(enquirer@2.4.1)
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
-      markdown-it:
-        specifier: 13.0.1
-        version: 13.0.1
-      mini-css-extract-plugin:
-        specifier: 2.7.6
-        version: 2.7.6(webpack@5.91.0)
-      postcss:
-        specifier: 8.4.32
-        version: 8.4.32
-      postcss-color-function:
-        specifier: 4.1.0
-        version: 4.1.0
-      postcss-loader:
-        specifier: 4.3.0
-        version: 4.3.0(postcss@8.4.32)(webpack@5.91.0)
-      prettier:
-        specifier: npm:wp-prettier@^2.8.5
-        version: wp-prettier@2.8.5
-      progress-bar-webpack-plugin:
-        specifier: 2.1.0
-        version: 2.1.0(webpack@5.91.0)
-      puppeteer:
-        specifier: 17.1.3
-        version: 17.1.3(encoding@0.1.13)
-      react-docgen:
-        specifier: 5.4.3
-        version: 5.4.3
-      react-docgen-typescript-plugin:
-        specifier: ^1.0.5
-        version: 1.0.5(typescript@5.7.2)(webpack@5.91.0)
-      react-test-renderer:
-        specifier: 18.3.x
-        version: 18.3.1(react@18.3.1)
-      redux:
-        specifier: 4.2.1
-        version: 4.2.1
-      request-promise:
-        specifier: 4.2.6
-        version: 4.2.6(request@2.88.2)
-      rimraf:
-        specifier: 5.0.5
-        version: 5.0.5
-      rtlcss:
-        specifier: ^4.1.1
-        version: 4.1.1
-      sass-loader:
-        specifier: ^10.5.0
-        version: 10.5.0(sass@1.69.5)(webpack@5.91.0)
-      storybook:
-        specifier: ^7.6.4
-        version: 7.6.4(encoding@0.1.13)
-      storybook-addon-react-docgen:
-        specifier: 1.2.44
-        version: 1.2.44(@storybook/addons@7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@7.6.19(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.19)(react@18.3.1)
-      stylelint:
-        specifier: ^14.16.1
-        version: 14.16.1
-      terser-webpack-plugin:
-        specifier: 5.3.11
-        version: 5.3.11(@swc/core@1.3.100)(esbuild@0.18.20)(webpack@5.91.0)
-      typescript:
-        specifier: 5.7.x
-        version: 5.7.2
-      utility-types:
-        specifier: 3.10.0
-        version: 3.10.0
-      webpack:
-        specifier: 5.91.0
-        version: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-bundle-analyzer:
-        specifier: 4.7.0
-        version: 4.7.0
-      webpack-cli:
-        specifier: 5.1.4
-        version: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
-      wireit:
-        specifier: 0.14.10
-        version: 0.14.10
-      wordpress-data-wp-6-7:
-        specifier: npm:@wordpress/data@wp-6.7
-        version: '@wordpress/data@10.8.3(react@18.3.1)'
-      wp-types:
-        specifier: 3.63.0
-        version: 3.63.0
-
-  plugins/woocommerce/client/blocks/bin/eslint-plugin-woocommerce:
-    devDependencies:
-      eslint:
-        specifier: ^8.55.0
-        version: 8.55.0
 
   plugins/woocommerce/client/admin:
     dependencies:
@@ -4963,6 +4316,647 @@ importers:
       wireit:
         specifier: 0.14.10
         version: 0.14.10
+
+  plugins/woocommerce/client/blocks:
+    dependencies:
+      '@ariakit/react':
+        specifier: ^0.4.5
+        version: 0.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/core':
+        specifier: 6.1.0
+        version: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/modifiers':
+        specifier: 7.0.0
+        version: 7.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: 8.0.0
+        version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@18.3.1)
+      '@emotion/styled':
+        specifier: ^11.11.0
+        version: 11.11.0(@emotion/react@11.11.1(@types/react@18.3.16)(react@18.3.1))(@types/react@18.3.16)(react@18.3.1)
+      '@preact/signals':
+        specifier: ^1.3.0
+        version: 1.3.1(preact@10.25.1)
+      '@woocommerce/tracks':
+        specifier: workspace:*
+        version: link:../../../../packages/js/tracks
+      '@wordpress/autop':
+        specifier: 3.16.0
+        version: 3.16.0
+      '@wordpress/compose':
+        specifier: 5.5.0
+        version: 5.5.0(react@18.3.1)
+      '@wordpress/data':
+        specifier: wp-6.6
+        version: 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
+      '@wordpress/deprecated':
+        specifier: 3.41.0
+        version: 3.41.0
+      '@wordpress/icons':
+        specifier: 9.36.0
+        version: 9.36.0
+      '@wordpress/notices':
+        specifier: 5.15.1
+        version: 5.15.1(react@18.3.1)
+      '@wordpress/plugins':
+        specifier: 4.10.0
+        version: 4.10.0(react@18.3.1)
+      '@wordpress/primitives':
+        specifier: 4.11.0
+        version: 4.11.0(react@18.3.1)
+      '@wordpress/server-side-render':
+        specifier: 3.10.0
+        version: 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@wordpress/style-engine':
+        specifier: ^1.30.0
+        version: 1.30.0
+      '@wordpress/url':
+        specifier: 3.13.0
+        version: 3.13.0
+      '@wordpress/wordcount':
+        specifier: 3.47.0
+        version: 3.47.0
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-errors:
+        specifier: ^3.0.0
+        version: 3.0.0(ajv@8.17.1)
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
+      change-case:
+        specifier: ^4.1.2
+        version: 4.1.2
+      check-password-strength:
+        specifier: ^2.0.10
+        version: 2.0.10
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      compare-versions:
+        specifier: 4.1.3
+        version: 4.1.3
+      config:
+        specifier: 3.3.7
+        version: 3.3.7
+      dataloader:
+        specifier: 2.2.2
+        version: 2.2.2
+      deepsignal:
+        specifier: 1.3.6
+        version: 1.3.6(@preact/signals-core@1.8.0)(@preact/signals@1.3.1(preact@10.25.1))(preact@10.25.1)
+      dinero.js:
+        specifier: 1.9.1
+        version: 1.9.1
+      dompurify:
+        specifier: ^2.5.7
+        version: 2.5.7
+      downshift:
+        specifier: 6.1.7
+        version: 6.1.7(react@18.3.1)
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
+      fast-sort:
+        specifier: ^3.4.0
+        version: 3.4.0
+      html-react-parser:
+        specifier: 3.0.4
+        version: 3.0.4(react@18.3.1)
+      postcode-validator:
+        specifier: 3.9.2
+        version: 3.9.2
+      preact:
+        specifier: ^10.24.2
+        version: 10.25.1
+      prop-types:
+        specifier: ^15.8.1
+        version: 15.8.1
+      react:
+        specifier: 18.3.x
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.x
+        version: 18.3.1(react@18.3.1)
+      react-number-format:
+        specifier: 4.9.3
+        version: 4.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-transition-group:
+        specifier: ^4.4.5
+        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      request:
+        specifier: 2.88.2
+        version: 2.88.2
+      trim-html:
+        specifier: 0.1.9
+        version: 0.1.9
+      use-debounce:
+        specifier: 9.0.4
+        version: 9.0.4(react@18.3.1)
+      usehooks-ts:
+        specifier: ^2.9.1
+        version: 2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      wordpress-components:
+        specifier: npm:@wordpress/components@14.2.0
+        version: '@wordpress/components@14.2.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(reakit-utils@0.15.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))'
+      wordpress-components-slotfill:
+        specifier: npm:@wordpress/components@wp-6.5
+        version: '@wordpress/components@26.0.6(@babel/helper-module-imports@7.25.9)(@babel/types@7.26.0)(@types/react@18.3.16)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
+    optionalDependencies:
+      ndb:
+        specifier: 1.1.5
+        version: 1.1.5
+    devDependencies:
+      '@automattic/color-studio':
+        specifier: 4.0.0
+        version: 4.0.0
+      '@babel/cli':
+        specifier: 7.23.0
+        version: 7.23.0(@babel/core@7.23.2)
+      '@babel/core':
+        specifier: 7.23.2
+        version: 7.23.2
+      '@babel/plugin-syntax-jsx':
+        specifier: 7.22.5
+        version: 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.23.3
+        version: 7.25.9(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-chaining':
+        specifier: ^7.23.4
+        version: 7.25.9(@babel/core@7.23.2)
+      '@babel/polyfill':
+        specifier: 7.12.1
+        version: 7.12.1
+      '@babel/preset-react':
+        specifier: 7.23.3
+        version: 7.23.3(@babel/core@7.23.2)
+      '@babel/preset-typescript':
+        specifier: 7.23.3
+        version: 7.23.3(@babel/core@7.23.2)
+      '@bartekbp/typescript-checkstyle':
+        specifier: 5.0.0
+        version: 5.0.0
+      '@playwright/test':
+        specifier: ^1.50.1
+        version: 1.50.1
+      '@storybook/addon-a11y':
+        specifier: 7.5.2
+        version: 7.5.2(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-actions':
+        specifier: ^7.6.4
+        version: 7.6.4
+      '@storybook/addon-docs':
+        specifier: ^7.6.4
+        version: 7.6.4(@types/react-dom@18.0.10)(@types/react@18.3.16)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-essentials':
+        specifier: 7.5.2
+        version: 7.5.2(@types/react-dom@18.0.10)(@types/react@18.3.16)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-links':
+        specifier: 7.5.2
+        version: 7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-storysource':
+        specifier: 7.5.2
+        version: 7.5.2(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-styling-webpack':
+        specifier: ^0.0.5
+        version: 0.0.5(webpack@5.91.0)
+      '@storybook/addons':
+        specifier: 7.5.2
+        version: 7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-api':
+        specifier: 7.5.2
+        version: 7.5.2
+      '@storybook/preview-api':
+        specifier: ^7.6.4
+        version: 7.6.4
+      '@storybook/react':
+        specifier: 7.5.2
+        version: 7.5.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.2)
+      '@storybook/react-webpack5':
+        specifier: ^7.6.4
+        version: 7.6.4(@babel/core@7.23.2)(@swc/core@1.3.100)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@3.13.1)(typescript@5.7.2)(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack-hot-middleware@2.25.4)
+      '@testing-library/dom':
+        specifier: 9.3.3
+        version: 9.3.3
+      '@testing-library/jest-dom':
+        specifier: 6.4.5
+        version: 6.4.5(@jest/globals@29.7.0)(@types/jest@27.5.2)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))
+      '@testing-library/react':
+        specifier: 15.0.7
+        version: 15.0.7(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: 14.5.2
+        version: 14.5.2(@testing-library/dom@9.3.3)
+      '@types/dinero.js':
+        specifier: 1.9.0
+        version: 1.9.0
+      '@types/dompurify':
+        specifier: 2.3.4
+        version: 2.3.4
+      '@types/gtag.js':
+        specifier: 0.0.10
+        version: 0.0.10
+      '@types/jest':
+        specifier: 27.5.2
+        version: 27.5.2
+      '@types/jest-environment-puppeteer':
+        specifier: 5.0.2
+        version: 5.0.2
+      '@types/jquery':
+        specifier: 3.5.14
+        version: 3.5.14
+      '@types/lodash':
+        specifier: 4.14.182
+        version: 4.14.182
+      '@types/prop-types':
+        specifier: ^15.7.11
+        version: 15.7.11
+      '@types/puppeteer':
+        specifier: 5.4.6
+        version: 5.4.6
+      '@types/react':
+        specifier: 18.3.x
+        version: 18.3.16
+      '@types/react-dom':
+        specifier: 18.0.10
+        version: 18.0.10
+      '@types/react-transition-group':
+        specifier: ^4.4.10
+        version: 4.4.10
+      '@types/wordpress__block-editor':
+        specifier: 6.0.6
+        version: 6.0.6(@emotion/is-prop-valid@1.2.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/wordpress__block-library':
+        specifier: 2.6.3
+        version: 2.6.3
+      '@types/wordpress__blocks':
+        specifier: 11.0.9
+        version: 11.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/wordpress__components':
+        specifier: ^23.0.10
+        version: 23.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/wordpress__core-data':
+        specifier: ^2.4.5
+        version: 2.4.5
+      '@types/wordpress__data':
+        specifier: ^6.0.2
+        version: 6.0.2
+      '@types/wordpress__data-controls':
+        specifier: 2.2.0
+        version: 2.2.0
+      '@types/wordpress__editor':
+        specifier: ^13.6.7
+        version: 13.6.7(@emotion/is-prop-valid@1.2.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/wordpress__notices':
+        specifier: 3.3.0
+        version: 3.3.0
+      '@types/wordpress__rich-text':
+        specifier: 6.10.0
+        version: 6.10.0(react@18.3.1)
+      '@types/wordpress__wordcount':
+        specifier: ^2.4.5
+        version: 2.4.5
+      '@typescript-eslint/eslint-plugin':
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)
+      '@typescript-eslint/parser':
+        specifier: 5.56.0
+        version: 5.56.0(eslint@8.55.0)(typescript@5.7.2)
+      '@woocommerce/customer-effort-score':
+        specifier: workspace:*
+        version: link:../../../../packages/js/customer-effort-score
+      '@woocommerce/data':
+        specifier: workspace:*
+        version: link:../../../../packages/js/data
+      '@woocommerce/e2e-utils':
+        specifier: workspace:*
+        version: link:../../../../packages/js/e2e-utils
+      '@woocommerce/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../../../packages/js/eslint-plugin
+      '@wordpress/api-fetch':
+        specifier: 6.21.0
+        version: 6.21.0
+      '@wordpress/babel-preset-default':
+        specifier: 7.28.0
+        version: 7.28.0
+      '@wordpress/base-styles':
+        specifier: 4.35.0
+        version: 4.35.0
+      '@wordpress/block-editor':
+        specifier: wp-6.6
+        version: 13.0.7(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/block-library':
+        specifier: wp-6.6
+        version: 9.0.8(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks':
+        specifier: wp-6.6
+        version: 13.0.3(react@18.3.1)
+      '@wordpress/browserslist-config':
+        specifier: 6.16.0
+        version: 6.16.0
+      '@wordpress/components':
+        specifier: 19.17.0
+        version: 19.17.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@wordpress/core-data':
+        specifier: 5.5.0
+        version: 5.5.0(react@18.3.1)
+      '@wordpress/data-controls':
+        specifier: 2.2.7
+        version: 2.2.7(react@18.3.1)
+      '@wordpress/date':
+        specifier: 4.44.0
+        version: 4.44.0
+      '@wordpress/dependency-extraction-webpack-plugin':
+        specifier: next
+        version: 6.13.1-next.a9f418477.0(webpack@5.91.0)
+      '@wordpress/dom':
+        specifier: 3.27.0
+        version: 3.27.0
+      '@wordpress/dom-ready':
+        specifier: 3.27.0
+        version: 3.27.0
+      '@wordpress/e2e-test-utils':
+        specifier: 10.12.0
+        version: 10.12.0(encoding@0.1.13)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(puppeteer-core@23.11.1)
+      '@wordpress/e2e-test-utils-playwright':
+        specifier: ^1.15.0
+        version: 1.16.0(@playwright/test@1.50.1)
+      '@wordpress/e2e-tests':
+        specifier: ^4.9.2
+        version: 4.9.2(@swc/core@1.3.100)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(file-loader@6.2.0(webpack@5.91.0))(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(node-notifier@8.0.2)(puppeteer-core@23.11.1)(puppeteer@17.1.3(encoding@0.1.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
+      '@wordpress/editor':
+        specifier: wp-6.7
+        version: 14.8.19(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element':
+        specifier: 5.22.0
+        version: 5.22.0
+      '@wordpress/env':
+        specifier: 10.17.0
+        version: 10.17.0(patch_hash=ovltjfwrjswkqlvmxt7r5kywn4)(@types/node@20.17.8)
+      '@wordpress/format-library':
+        specifier: wp-6.6
+        version: 5.0.7(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/hooks':
+        specifier: wp-6.6
+        version: 4.0.1
+      '@wordpress/html-entities':
+        specifier: 3.24.0
+        version: 3.24.0
+      '@wordpress/i18n':
+        specifier: 4.45.0
+        version: 4.45.0
+      '@wordpress/interactivity':
+        specifier: ^6.16.0
+        version: 6.18.0
+      '@wordpress/interactivity-router':
+        specifier: ^2.17.0
+        version: 2.18.0
+      '@wordpress/is-shallow-equal':
+        specifier: 4.24.0
+        version: 4.24.0
+      '@wordpress/jest-preset-default':
+        specifier: 8.5.2
+        version: 8.5.2(@babel/core@7.23.2)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/postcss-plugins-preset':
+        specifier: 1.6.0
+        version: 1.6.0
+      '@wordpress/postcss-themes':
+        specifier: 1.0.5
+        version: 1.0.5
+      '@wordpress/prettier-config':
+        specifier: 1.4.0
+        version: 1.4.0(wp-prettier@2.8.5)
+      '@wordpress/private-apis':
+        specifier: 1.16.0
+        version: 1.16.0
+      '@wordpress/rich-text':
+        specifier: wp-6.6
+        version: 7.0.2(react@18.3.1)
+      '@wordpress/scripts':
+        specifier: 30.6.0
+        version: 30.6.0(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/node@20.17.8)(@types/webpack@4.41.38)(babel-plugin-macros@3.1.0)(esbuild@0.18.20)(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(file-loader@6.2.0(webpack@5.91.0))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
+      '@wordpress/stylelint-config':
+        specifier: ^21.36.0
+        version: 21.36.0(postcss@8.4.32)(stylelint@14.16.1)
+      ajv-cli:
+        specifier: 3.3.x
+        version: 3.3.0
+      allure-playwright:
+        specifier: ^2.9.2
+        version: 2.9.2
+      autoprefixer:
+        specifier: 10.4.14
+        version: 10.4.14(postcss@8.4.32)
+      babel-jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@babel/core@7.23.2)
+      babel-plugin-explicit-exports-references:
+        specifier: ^1.0.2
+        version: 1.0.2
+      babel-plugin-react-docgen:
+        specifier: 4.2.1
+        version: 4.2.1
+      babel-plugin-transform-react-remove-prop-types:
+        specifier: 0.4.24
+        version: 0.4.24
+      buildkite-test-collector:
+        specifier: ^1.7.1
+        version: 1.7.1
+      chalk:
+        specifier: 4.1.2
+        version: 4.1.2
+      circular-dependency-plugin:
+        specifier: 5.2.2
+        version: 5.2.2(webpack@5.91.0)
+      copy-webpack-plugin:
+        specifier: 11.0.0
+        version: 11.0.0(webpack@5.91.0)
+      core-js:
+        specifier: 3.25.0
+        version: 3.25.0
+      create-file-webpack:
+        specifier: 1.0.2
+        version: 1.0.2
+      cross-env:
+        specifier: 7.0.3
+        version: 7.0.3
+      css-loader:
+        specifier: ^6.8.1
+        version: 6.8.1(webpack@5.91.0)
+      cssnano:
+        specifier: 5.1.12
+        version: 5.1.12(postcss@8.4.32)
+      deep-freeze:
+        specifier: 0.0.1
+        version: 0.0.1
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
+      eslint-import-resolver-typescript:
+        specifier: 3.6.1
+        version: 3.6.1(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-webpack@0.13.2)(eslint-plugin-import@2.28.1)(eslint@8.55.0)
+      eslint-import-resolver-webpack:
+        specifier: 0.13.2
+        version: 0.13.2(eslint-plugin-import@2.28.1)(webpack@5.91.0)
+      eslint-plugin-import:
+        specifier: 2.28.1
+        version: 2.28.1(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.1)(eslint-import-resolver-webpack@0.13.2)(eslint@8.55.0)
+      eslint-plugin-playwright:
+        specifier: 1.6.0
+        version: 1.6.0(eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(jest@29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))(typescript@5.7.2))(eslint@8.55.0)
+      eslint-plugin-rulesdir:
+        specifier: ^0.2.2
+        version: 0.2.2
+      eslint-plugin-storybook:
+        specifier: ^0.6.15
+        version: 0.6.15(eslint@8.55.0)(typescript@5.7.2)
+      eslint-plugin-woocommerce:
+        specifier: file:bin/eslint-plugin-woocommerce
+        version: link:bin/eslint-plugin-woocommerce
+      eslint-plugin-you-dont-need-lodash-underscore:
+        specifier: 6.12.0
+        version: 6.12.0
+      fs-extra:
+        specifier: 11.1.1
+        version: 11.1.1
+      gh-pages:
+        specifier: 5.0.0
+        version: 5.0.0
+      github-label-sync:
+        specifier: ^2.3.1
+        version: 2.3.1
+      glob:
+        specifier: 7.2.3
+        version: 7.2.3
+      glob-promise:
+        specifier: 4.2.2
+        version: 4.2.2(glob@7.2.3)
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      ignore-loader:
+        specifier: 0.1.2
+        version: 0.1.2
+      jest:
+        specifier: 29.7.x
+        version: 29.7.0(@types/node@20.17.8)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))
+      jest-circus:
+        specifier: 29.7.x
+        version: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-puppeteer:
+        specifier: 6.1.1
+        version: 6.1.1
+      jest-fetch-mock:
+        specifier: 3.0.3
+        version: 3.0.3(encoding@0.1.13)
+      jest-html-reporters:
+        specifier: 3.0.10
+        version: 3.0.10
+      json2md:
+        specifier: 1.12.0
+        version: 1.12.0
+      lint-staged:
+        specifier: 13.2.0
+        version: 13.2.0(enquirer@2.4.1)
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      markdown-it:
+        specifier: 13.0.1
+        version: 13.0.1
+      mini-css-extract-plugin:
+        specifier: 2.7.6
+        version: 2.7.6(webpack@5.91.0)
+      postcss:
+        specifier: 8.4.32
+        version: 8.4.32
+      postcss-color-function:
+        specifier: 4.1.0
+        version: 4.1.0
+      postcss-loader:
+        specifier: 4.3.0
+        version: 4.3.0(postcss@8.4.32)(webpack@5.91.0)
+      prettier:
+        specifier: npm:wp-prettier@^2.8.5
+        version: wp-prettier@2.8.5
+      progress-bar-webpack-plugin:
+        specifier: 2.1.0
+        version: 2.1.0(webpack@5.91.0)
+      puppeteer:
+        specifier: 17.1.3
+        version: 17.1.3(encoding@0.1.13)
+      react-docgen:
+        specifier: 5.4.3
+        version: 5.4.3
+      react-docgen-typescript-plugin:
+        specifier: ^1.0.5
+        version: 1.0.5(typescript@5.7.2)(webpack@5.91.0)
+      react-test-renderer:
+        specifier: 18.3.x
+        version: 18.3.1(react@18.3.1)
+      redux:
+        specifier: 4.2.1
+        version: 4.2.1
+      request-promise:
+        specifier: 4.2.6
+        version: 4.2.6(request@2.88.2)
+      rimraf:
+        specifier: 5.0.5
+        version: 5.0.5
+      rtlcss:
+        specifier: ^4.1.1
+        version: 4.1.1
+      sass-loader:
+        specifier: ^10.5.0
+        version: 10.5.0(sass@1.69.5)(webpack@5.91.0)
+      storybook:
+        specifier: ^7.6.4
+        version: 7.6.4(encoding@0.1.13)
+      storybook-addon-react-docgen:
+        specifier: 1.2.44
+        version: 1.2.44(@storybook/addons@7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@7.6.19(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.6.19)(react@18.3.1)
+      stylelint:
+        specifier: ^14.16.1
+        version: 14.16.1
+      terser-webpack-plugin:
+        specifier: 5.3.11
+        version: 5.3.11(@swc/core@1.3.100)(esbuild@0.18.20)(webpack@5.91.0)
+      typescript:
+        specifier: 5.7.x
+        version: 5.7.2
+      utility-types:
+        specifier: 3.10.0
+        version: 3.10.0
+      webpack:
+        specifier: 5.91.0
+        version: 5.91.0(@swc/core@1.3.100)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-bundle-analyzer:
+        specifier: 4.7.0
+        version: 4.7.0
+      webpack-cli:
+        specifier: 5.1.4
+        version: 5.1.4(webpack-bundle-analyzer@4.7.0)(webpack-dev-server@4.15.1)(webpack@5.91.0)
+      wireit:
+        specifier: 0.14.10
+        version: 0.14.10
+      wordpress-data-wp-6-7:
+        specifier: npm:@wordpress/data@wp-6.7
+        version: '@wordpress/data@10.8.3(react@18.3.1)'
+      wp-types:
+        specifier: 3.63.0
+        version: 3.63.0
+
+  plugins/woocommerce/client/blocks/bin/eslint-plugin-woocommerce:
+    devDependencies:
+      eslint:
+        specifier: ^8.55.0
+        version: 8.55.0
 
   plugins/woocommerce/client/legacy:
     dependencies:
@@ -11724,10 +11718,6 @@ packages:
 
   '@woocommerce/settings@1.0.0':
     resolution: {integrity: sha512-BjrT56Cz8XTRHw2JNPmANRkYh2rzdF33wOa56lah1qb/MjHUKuVJ0PTSZ19S5Trb92IkxfcIVB26CSdxXnf5Og==}
-
-  '@woocommerce/woocommerce-rest-api@1.0.1':
-    resolution: {integrity: sha512-YBk3EEYE0zax/egx6Rhpbu6hcCFyZpYQrjH9JO4NUGU3n3T0W9Edn7oAUbjL/c7Oezcg+UaQluCaKjY/B3zwxg==}
-    engines: {node: '>=8.0.0'}
 
   '@wordpress/a11y@3.57.0':
     resolution: {integrity: sha512-paf4pp+ze6zk47jDStE1AyO61USvAioIi+gy4lEBKv8LI6LapdYFWR4c/Lta5/aeHPlIHi6J5DkYZpPyVXFueA==}
@@ -34307,10 +34297,7 @@ snapshots:
       jest-runner: 25.5.4
       jest-runtime: 25.5.4
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - utf-8-validate
 
   '@jest/test-sequencer@26.6.3':
     dependencies:
@@ -41546,15 +41533,6 @@ snapshots:
   '@woocommerce/settings@1.0.0':
     dependencies:
       '@babel/runtime-corejs2': 7.5.5
-
-  '@woocommerce/woocommerce-rest-api@1.0.1':
-    dependencies:
-      axios: 0.19.2
-      create-hmac: 1.1.7
-      oauth-1.0a: 2.2.6
-      url-parse: 1.5.10
-    transitivePeerDependencies:
-      - supports-color
 
   '@wordpress/a11y@3.57.0':
     dependencies:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following up on #56156, the `@woocommerce/woocommerce-rest-api` dependency is no longer in use.

### How to test the changes in this Pull Request:

CI needs to be green.

### Testing that has already taken place:

CI green.