### PR TITLE
[e2e-tests] Improve flaky verifyAdditionalFieldsDetails helper

### DIFF
--- a/plugins/woocommerce/changelog/fix-flaky-verifyAdditionalFieldsDetails
+++ b/plugins/woocommerce/changelog/fix-flaky-verifyAdditionalFieldsDetails
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update flaky e2e test helper.
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -186,7 +186,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Test required checkbox' )
 				.check();
 
-			await checkoutPageObject.waitForCheckoutToFinishUpdating();
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.placeOrder();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -22,15 +22,21 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 	test.describe( 'Guest shopper', () => {
 		test.use( { storageState: guestFile } );
 
-		test.beforeEach( async ( { frontendUtils, requestUtils } ) => {
-			await requestUtils.activatePlugin(
-				'woocommerce-blocks-test-additional-checkout-fields'
-			);
+		test.beforeEach(
+			async ( { frontendUtils, requestUtils, checkoutPageObject } ) => {
+				await requestUtils.activatePlugin(
+					'woocommerce-blocks-test-additional-checkout-fields'
+				);
 
-			await frontendUtils.goToShop();
-			await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
-			await frontendUtils.goToCheckout();
-		} );
+				await frontendUtils.goToShop();
+				await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
+				await frontendUtils.goToCheckout();
+				// Wait for the email field to be visible before filling in the form.
+				await checkoutPageObject.page
+					.locator( '#email' )
+					.waitFor( { state: 'visible' } );
+			}
+		);
 
 		test( 'Shopper can see an error message when a required field is not filled in the checkout form', async ( {
 			checkoutPageObject,
@@ -161,7 +167,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
-
 			await checkoutPageObject.page
 				.getByRole( 'group', {
 					name: 'Billing address',

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -186,8 +186,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Test required checkbox' )
 				.check();
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
-
 			await checkoutPageObject.placeOrder();
 
 			expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -178,12 +178,16 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
 
+			await checkoutPageObject.waitForCustomerDataUpdate();
+
+			await checkoutPageObject.waitForCheckoutToFinishUpdating();
+
 			await checkoutPageObject.page
 				.getByLabel( 'Test required checkbox' )
 				.check();
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
 			await checkoutPageObject.waitForCheckoutToFinishUpdating();
+
 			await checkoutPageObject.placeOrder();
 
 			expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -178,14 +178,12 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
-
-			await checkoutPageObject.waitForCheckoutToFinishUpdating();
-
 			await checkoutPageObject.page
 				.getByLabel( 'Test required checkbox' )
 				.check();
 
+			await checkoutPageObject.waitForCustomerDataUpdate();
+			await checkoutPageObject.waitForCheckoutToFinishUpdating();
 			await checkoutPageObject.placeOrder();
 
 			expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -624,11 +624,15 @@ export class CheckoutPage {
 	}
 
 	async syncBillingWithShipping() {
-		await this.page.getByLabel( 'Use same address for billing' ).check();
+		const checkbox = this.page.getByLabel( 'Use same address for billing' );
+		await checkbox.waitFor( { state: 'visible' } );
+		await checkbox.check();
 	}
 
 	async unsyncBillingWithShipping() {
-		await this.page.getByLabel( 'Use same address for billing' ).uncheck();
+		const checkbox = this.page.getByLabel( 'Use same address for billing' );
+		await checkbox.waitFor( { state: 'visible' } );
+		await checkbox.uncheck();
 	}
 
 	getOrderId() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -68,6 +68,9 @@ export class CheckoutPage {
 			contact: {},
 		}
 	) {
+		// Wait for the email field to be visible before filling in the form.
+		await this.page.locator( '#email' ).waitFor( { state: 'visible' } );
+
 		const isShippingOpen = await this.page
 			.getByRole( 'group', {
 				name: 'Shipping address',
@@ -224,7 +227,13 @@ export class CheckoutPage {
 				// your road?" field.
 			} );
 		await this.waitForCheckoutToFinishUpdating();
-		await this.page.getByText( 'Place Order', { exact: true } ).click();
+
+		const placeOrderButton = this.page.getByText( 'Place Order', {
+			exact: true,
+		} );
+		await placeOrderButton.waitFor( { state: 'visible' } );
+		await placeOrderButton.click();
+
 		if ( waitForRedirect ) {
 			await this.page.waitForURL( /order-received/ );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -227,6 +227,11 @@ export class CheckoutPage {
 		await this.page.getByText( 'Place Order', { exact: true } ).click();
 		if ( waitForRedirect ) {
 			await this.page.waitForURL( /order-received/ );
+
+			// Wait for order confirmation page to be fully rendered.
+			await this.page
+				.getByText( 'Thank you. Your order has been received.' )
+				.waitFor( { state: 'visible' } );
 		}
 	}
 
@@ -235,13 +240,13 @@ export class CheckoutPage {
 	 */
 	async verifyAdditionalFieldsDetails( values: [ string, string ][] ) {
 		for ( const [ label, value ] of values ) {
-			const visible = await this.page
-				.getByText(
-					`${ label }${ value }` // No space between these due to the way the markup is output on the confirmation page.
-				)
-				.isVisible();
-
-			if ( ! visible ) {
+			try {
+				await this.page
+					.getByText(
+						`${ label }${ value }` // No space between these due to the way the markup is output on the confirmation page.
+					)
+					.waitFor( { state: 'visible' } );
+			} catch {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -68,9 +68,6 @@ export class CheckoutPage {
 			contact: {},
 		}
 	) {
-		// Wait for the email field to be visible before filling in the form.
-		await this.page.locator( '#email' ).waitFor( { state: 'visible' } );
-
 		const isShippingOpen = await this.page
 			.getByRole( 'group', {
 				name: 'Shipping address',

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -240,17 +240,12 @@ export class CheckoutPage {
 	 */
 	async verifyAdditionalFieldsDetails( values: [ string, string ][] ) {
 		for ( const [ label, value ] of values ) {
-			try {
-				await this.page
-					.getByText(
-						`${ label }${ value }` // No space between these due to the way the markup is output on the confirmation page.
-					)
-					.waitFor( { state: 'visible' } );
-			} catch {
-				return false;
-			}
+			await this.page
+				.getByText(
+					`${ label }${ value }` // No space between these due to the way the markup is output on the confirmation page.
+				)
+				.waitFor( { state: 'visible' } );
 		}
-		// If one of the fields above is false the function would have returned early.
 		return true;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Attempts to fix the flaky test:

> 1) [chromium] › tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts:119:3 › Shopper → Additional Checkout Fields › Guest shopper › Shopper can fill in the checkout form with additional fields and can have different value for same field in shipping and billing address 

By waiting for the confirmation page to render before checking text visibility.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

N/A. This change is for e2e tests.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Improves flaky e2e tests.

</details>
