### PR TITLE
[e2e tests] Fix install plugins and site reset setup steps

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-install-wc
+++ b/plugins/woocommerce/changelog/e2e-fix-install-wc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix install wc and reset site setup steps

--- a/plugins/woocommerce/tests/e2e-pw/fixtures/reset.setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/fixtures/reset.setup.js
@@ -12,15 +12,15 @@ setup( 'reset site', async ( { restApi } ) => {
 	try {
 		const response = await restApi.get( `wc-cleanup/v1/reset` );
 
-		if ( response.ok() ) {
-			console.log( 'Site reset successful:', response.status() );
+		if ( response.statusCode === 200 ) {
+			console.log( 'Site reset successful', response.statusCode );
 		} else {
-			console.error( 'ERROR! Site reset failed:', response.status() );
+			console.error( 'ERROR! Site reset failed:', response.statusCode );
 		}
 	} catch ( error ) {
 		console.error(
-			'Site reset failed:',
-			error.response ? error.response.status() : error.message
+			'ERROR! Site reset failed:',
+			error.data?.message || error
 		);
 	}
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix install-wc and site reset global setup steps, broken by #56156.

### How to test the changes in this Pull Request:

```
WC_VERSION=latest pnpm e2e:pressable basic
WC_VERSION=nightly pnpm e2e:pressable basic
```

