### PR TITLE
Add disabled state examples to SelectControl stories

### DIFF
--- a/packages/js/components/src/select-control/stories/select-control.story.tsx
+++ b/packages/js/components/src/select-control/stories/select-control.story.tsx
@@ -71,6 +71,30 @@ const SelectControlExample = () => {
 		inlineSelected: [],
 		allOptionsIncludingSelected: options[ options.length - 1 ].key,
 		virtualScrollSelected: [],
+		disabledSelected: [
+			{
+				key: 'apple',
+				label: 'Apple',
+				value: { id: 'apple' },
+			},
+			{
+				key: 'banana',
+				label: 'Banana',
+				value: { id: 'banana' },
+			},
+		],
+		disabledInlineSelected: [
+			{
+				key: 'apple',
+				label: 'Apple',
+				value: { id: 'apple' },
+			},
+			{
+				key: 'banana',
+				label: 'Banana',
+				value: { id: 'banana' },
+			},
+		],
 	} );
 
 	const {
@@ -82,6 +106,8 @@ const SelectControlExample = () => {
 		inlineSelected,
 		allOptionsIncludingSelected,
 		virtualScrollSelected,
+		disabledSelected,
+		disabledInlineSelected,
 	} = state;
 
 	return (
@@ -186,6 +212,35 @@ const SelectControlExample = () => {
 				virtualScroll={ true }
 				virtualItemHeight={ 56 }
 				virtualListHeight={ 56 * 6 }
+			/>
+			<br />
+			<SelectControl
+				label="Disabled select control"
+				isSearchable
+				multiple
+				disabled
+				onChange={ ( selected ) =>
+					setState( { ...state, disabledSelected: selected } )
+				}
+				options={ options }
+				placeholder="Start typing to filter options..."
+				selected={ disabledSelected }
+				showClearButton
+			/>
+			<br />
+			<SelectControl
+				label="Disabled select control with inline tags"
+				isSearchable
+				multiple
+				disabled
+				inlineTags
+				onChange={ ( selected ) =>
+					setState( { ...state, disabledInlineSelected: selected } )
+				}
+				options={ options }
+				placeholder="Start typing to filter options..."
+				selected={ disabledInlineSelected }
+				showClearButton
 			/>
 		</div>
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR adds two new examples to the SelectControl component's story file to demonstrate the disabled state functionality:
1. A basic disabled select control with multiple selection.
2. A disabled select control with inline tags.

These examples help developers understand how the SelectControl component behaves when in a disabled state, both with regular multiple selection and with inline tag display.


These changes were used to reproduce #32340. Once this PR is merged, the testing instructions for #32340 will be updated.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/b5fb4fe9-057c-427f-beed-12ee52916fdd)| ![image](https://github.com/user-attachments/assets/4896d072-7c4a-4bd8-9373-03557789e22f)|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build storybook with `pnpm --filter=@woocommerce/storybook run watch:build` command
2. Visit `http://localhost:6007/?path=/docs/components-selectcontrol--docs`
3. Ensure that the new two stories are visible.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Add disabled state examples to SelectControl stories

</details>
