### PR TITLE
Fix flakey additional fields e2e tests

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
@@ -164,8 +164,13 @@ export const __internalEmitAfterProcessingEvents: emitAfterProcessingEventsType 
 
 export const updateDraftOrder = ( data: CheckoutPutData ) => {
 	return async ( { registry } ) => {
-		const { receiveCart } = registry.dispatch( CART_STORE_KEY );
+		const {
+			receiveCart,
+			__internalIncrementCalculating,
+			__internalDecrementCalculating,
+		} = registry.dispatch( CART_STORE_KEY );
 		try {
+			__internalIncrementCalculating();
 			const response = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/checkout?__experimental_calc_totals=true',
 				method: 'PUT',
@@ -178,6 +183,8 @@ export const updateDraftOrder = ( data: CheckoutPutData ) => {
 			return response;
 		} catch ( error ) {
 			return Promise.reject( error );
+		} finally {
+			__internalDecrementCalculating();
 		}
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
@@ -164,13 +164,8 @@ export const __internalEmitAfterProcessingEvents: emitAfterProcessingEventsType 
 
 export const updateDraftOrder = ( data: CheckoutPutData ) => {
 	return async ( { registry } ) => {
-		const {
-			receiveCart,
-			__internalIncrementCalculating,
-			__internalDecrementCalculating,
-		} = registry.dispatch( CART_STORE_KEY );
+		const { receiveCartContents } = registry.dispatch( CART_STORE_KEY );
 		try {
-			__internalIncrementCalculating();
 			const response = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/checkout?__experimental_calc_totals=true',
 				method: 'PUT',
@@ -178,13 +173,11 @@ export const updateDraftOrder = ( data: CheckoutPutData ) => {
 				signal: CheckoutPutAbortController.signal,
 			} );
 			if ( response?.response?.__experimentalCart ) {
-				receiveCart( response.response.__experimentalCart );
+				receiveCartContents( response.response.__experimentalCart );
 			}
 			return response;
 		} catch ( error ) {
 			return Promise.reject( error );
-		} finally {
-			__internalDecrementCalculating();
 		}
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/thunks.ts
@@ -163,9 +163,10 @@ export const __internalEmitAfterProcessingEvents: emitAfterProcessingEventsType 
 	};
 
 export const updateDraftOrder = ( data: CheckoutPutData ) => {
-	return async ( { registry } ) => {
+	return async ( { registry, dispatch } ) => {
 		const { receiveCartContents } = registry.dispatch( CART_STORE_KEY );
 		try {
+			dispatch.__internalIncrementCalculating();
 			const response = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/checkout?__experimental_calc_totals=true',
 				method: 'PUT',
@@ -178,6 +179,8 @@ export const updateDraftOrder = ( data: CheckoutPutData ) => {
 			return response;
 		} catch ( error ) {
 			return Promise.reject( error );
+		} finally {
+			dispatch.__internalDecrementCalculating();
 		}
 	};
 };

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -149,6 +149,8 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
+			await checkoutPageObject.waitForCustomerDataUpdate();
+
 			await checkoutPageObject.page
 				.getByLabel( 'Would you like a free gift with your order?' )
 				.check();
@@ -169,7 +171,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
+			await Promise.all( [
+				checkoutPageObject.waitForCustomerDataUpdate(),
+				checkoutPageObject.waitForCheckoutDataUpdate(),
+			] );
 
 			await checkoutPageObject.page
 				.getByRole( 'group', {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -169,7 +169,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
+			await Promise.all( [
+				checkoutPageObject.waitForCustomerDataUpdate(),
+				checkoutPageObject.waitForCheckoutDataUpdate(),
+			] );
 
 			await checkoutPageObject.page
 				.getByRole( 'group', {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -148,9 +148,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 					},
 				}
 			);
-
-			await checkoutPageObject.waitForCustomerDataUpdate();
-
 			await checkoutPageObject.page
 				.getByLabel( 'Would you like a free gift with your order?' )
 				.check();
@@ -163,30 +160,18 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				} )
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
-
 			await checkoutPageObject.page
 				.getByRole( 'group', {
 					name: 'Billing address',
 				} )
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
-
-			await Promise.all( [
-				checkoutPageObject.waitForCustomerDataUpdate(),
-				checkoutPageObject.waitForCheckoutDataUpdate(),
-			] );
-
 			await checkoutPageObject.page
 				.getByRole( 'group', {
 					name: 'Billing address',
 				} )
 				.getByLabel( 'Can a truck fit down your road?' )
 				.uncheck();
-
-			await checkoutPageObject.waitForCustomerDataUpdate();
-
-			await checkoutPageObject.waitForCheckoutToFinishUpdating();
-
 			await checkoutPageObject.page
 				.getByLabel( 'Test required checkbox' )
 				.check();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -169,10 +169,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Can a truck fit down your road?' )
 				.check();
 
-			await Promise.all( [
-				checkoutPageObject.waitForCustomerDataUpdate(),
-				checkoutPageObject.waitForCheckoutDataUpdate(),
-			] );
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.page
 				.getByRole( 'group', {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
@@ -241,7 +241,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
+			await Promise.all( [
+				checkoutPageObject.waitForCustomerDataUpdate(),
+				checkoutPageObject.waitForCheckoutDataUpdate(),
+			] );
 
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.fillInCheckoutWithTestData(
@@ -325,7 +328,10 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Test required checkbox' )
 				.check();
 
-			await checkoutPageObject.waitForCustomerDataUpdate();
+			await Promise.all( [
+				checkoutPageObject.waitForCustomerDataUpdate(),
+				checkoutPageObject.waitForCheckoutDataUpdate(),
+			] );
 
 			await checkoutPageObject.placeOrder();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
@@ -241,11 +241,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
-			await Promise.all( [
-				checkoutPageObject.waitForCustomerDataUpdate(),
-				checkoutPageObject.waitForCheckoutDataUpdate(),
-			] );
-
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.fillInCheckoutWithTestData(
 				{},
@@ -260,8 +255,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 					},
 				}
 			);
-
-			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.page
 				.getByLabel( 'Would you like a free gift with your order?' )
@@ -327,12 +320,6 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 			await checkoutPageObject.page
 				.getByLabel( 'Test required checkbox' )
 				.check();
-
-			await Promise.all( [
-				checkoutPageObject.waitForCustomerDataUpdate(),
-				checkoutPageObject.waitForCheckoutDataUpdate(),
-			] );
-
 			await checkoutPageObject.placeOrder();
 
 			expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.shopper.block_theme.spec.ts
@@ -241,10 +241,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				}
 			);
 
-			await Promise.all( [
-				checkoutPageObject.waitForCustomerDataUpdate(),
-				checkoutPageObject.waitForCheckoutDataUpdate(),
-			] );
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			// Change the shipping and billing select fields again.
 			await checkoutPageObject.fillInCheckoutWithTestData(
@@ -328,10 +325,7 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 				.getByLabel( 'Test required checkbox' )
 				.check();
 
-			await Promise.all( [
-				checkoutPageObject.waitForCustomerDataUpdate(),
-				checkoutPageObject.waitForCheckoutDataUpdate(),
-			] );
+			await checkoutPageObject.waitForCustomerDataUpdate();
 
 			await checkoutPageObject.placeOrder();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -51,6 +51,15 @@ test.describe( 'Merchant → Checkout', () => {
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
+
+		// Dismiss the "Get started" modal if it appears.
+		const getStartedButton = admin.page.getByRole( 'button', {
+			name: 'Get started',
+		} );
+		if ( await getStartedButton.isVisible() ) {
+			await getStartedButton.click();
+		}
+
 		await editor.openDocumentSettingsSidebar();
 	} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -325,6 +325,10 @@ export class CheckoutPage {
 		} );
 	}
 
+	async waitForCheckoutDataUpdate() {
+		await this.page.waitForResponse( '**/wc/store/v1/checkout**' );
+	}
+
 	async editShippingDetails() {
 		const editButton = this.page.locator(
 			'.wc-block-checkout__shipping-fields .wc-block-components-address-address-wrapper:not(.is-editing) .wc-block-components-address-card__edit'

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -325,10 +325,6 @@ export class CheckoutPage {
 		} );
 	}
 
-	async waitForCheckoutDataUpdate() {
-		await this.page.waitForResponse( '**/wc/store/v1/checkout**' );
-	}
-
 	async editShippingDetails() {
 		const editButton = this.page.locator(
 			'.wc-block-checkout__shipping-fields .wc-block-components-address-address-wrapper:not(.is-editing) .wc-block-components-address-card__edit'

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -68,6 +68,15 @@ export class CheckoutPage {
 			contact: {},
 		}
 	) {
+		await Promise.race( [
+			this.page
+				.getByRole( 'group', { name: 'Shipping address' } )
+				.waitFor( { state: 'visible' } ),
+			this.page
+				.getByRole( 'group', { name: 'Billing address' } )
+				.waitFor( { state: 'visible' } ),
+		] );
+
 		const isShippingOpen = await this.page
 			.getByRole( 'group', {
 				name: 'Shipping address',

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -309,6 +309,10 @@ export class CheckoutPage {
 		}
 	}
 
+	/**
+	 * This waits for the batch request to /cart/update-customer
+	 * when updating address fields.
+	 */
 	async waitForCustomerDataUpdate() {
 		// Wait for data to start updating.
 		await this.page.waitForFunction( () => {
@@ -325,8 +329,24 @@ export class CheckoutPage {
 		} );
 	}
 
+	/**
+	 * This waits for the PUT request to /checkout
+	 * when updating additional fields, payment methods or order notes.
+	 */
 	async waitForCheckoutDataUpdate() {
-		await this.page.waitForResponse( '**/wc/store/v1/checkout**' );
+		// Wait for data to start updating.
+		await this.page.waitForFunction( () => {
+			return !! window.wp.data
+				.select( 'wc/store/checkout' )
+				.isCalculating();
+		} );
+
+		// Wait for data to finish updating
+		await this.page.waitForFunction( () => {
+			return ! window.wp.data
+				.select( 'wc/store/checkout' )
+				.isCalculating();
+		} );
 	}
 
 	async editShippingDetails() {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout.page.ts
@@ -211,19 +211,10 @@ export class CheckoutPage {
 	 *                        when testing for errors on the checkout page.
 	 */
 	async placeOrder( waitForRedirect = true ) {
-		await this.page
-			.waitForRequest(
-				( request ) => {
-					return request.url().includes( 'batch' );
-				},
-				{ timeout: 3000 }
-			)
-			.catch( () => {
-				// Do nothing. This is just in case there's a debounced request
-				// still to be made, e.g. from checking "Can a truck fit down
-				// your road?" field.
-			} );
 		await this.waitForCheckoutToFinishUpdating();
+		await expect(
+			this.page.getByText( 'Place Order', { exact: true } )
+		).toBeEnabled();
 		await this.page.getByText( 'Place Order', { exact: true } ).click();
 		if ( waitForRedirect ) {
 			await this.page.waitForURL( /order-received/ );
@@ -307,46 +298,6 @@ export class CheckoutPage {
 		if ( await editButton.isVisible() ) {
 			await editButton.click();
 		}
-	}
-
-	/**
-	 * This waits for the batch request to /cart/update-customer
-	 * when updating address fields.
-	 */
-	async waitForCustomerDataUpdate() {
-		// Wait for data to start updating.
-		await this.page.waitForFunction( () => {
-			return !! window.wp.data
-				.select( 'wc/store/cart' )
-				.isCustomerDataUpdating();
-		} );
-
-		// Wait for data to finish updating
-		await this.page.waitForFunction( () => {
-			return ! window.wp.data
-				.select( 'wc/store/cart' )
-				.isCustomerDataUpdating();
-		} );
-	}
-
-	/**
-	 * This waits for the PUT request to /checkout
-	 * when updating additional fields, payment methods or order notes.
-	 */
-	async waitForCheckoutDataUpdate() {
-		// Wait for data to start updating.
-		await this.page.waitForFunction( () => {
-			return !! window.wp.data
-				.select( 'wc/store/checkout' )
-				.isCalculating();
-		} );
-
-		// Wait for data to finish updating
-		await this.page.waitForFunction( () => {
-			return ! window.wp.data
-				.select( 'wc/store/checkout' )
-				.isCalculating();
-		} );
 	}
 
 	async editShippingDetails() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This attempts to fix some flakey e2e tests. The assumption is that they are failing because we have started persisting checkout fields, but we are only waiting for the customer data to update. This PR awaits the update of checkout data via the PUT endpoint when additional fields, payment methods or order notes are updated.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the Ci job with the [chromium] › tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts:119:3 › Shopper → Additional Checkout Fields › Guest shopper › Shopper can fill in the checkout form with additional fields and can have different value for same field in shipping and billing address test a few times and check for flakiness.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fixes e2e tests, no changelog needed

</details>
