### PR TITLE
Improve messaging when email preview rendering fails

### DIFF
--- a/plugins/woocommerce/changelog/56241-email-preview-error-messaging
+++ b/plugins/woocommerce/changelog/56241-email-preview-error-messaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve messaging when email preview rendering fails

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -207,22 +207,27 @@ class WC_Admin {
 				}
 			}
 
-			// Start output buffering to prevent partial renders with PHP notices or warnings.
-			ob_start();
-			try {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				$message = $email_preview->render();
 				$message = $email_preview->ensure_links_open_in_new_tab( $message );
-			} catch ( Throwable $e ) {
+			} else {
+				// Start output buffering to prevent partial renders with PHP notices or warnings.
+				ob_start();
+				try {
+					$message = $email_preview->render();
+					$message = $email_preview->ensure_links_open_in_new_tab( $message );
+				} catch ( Throwable $e ) {
+					ob_end_clean();
+					wp_die(
+						esc_html__(
+							'There was an error rendering the email preview. This doesn\'t affect actual email delivery. Please contact the extension author for assistance.',
+							'woocommerce'
+						),
+						404
+					);
+				}
 				ob_end_clean();
-				wp_die(
-					esc_html__(
-						'There was an error rendering the email preview. This doesn’t affect actual email delivery. Please contact the extension author for assistance.',
-						'woocommerce'
-					),
-					404
-				);
 			}
-			ob_end_clean();
 
 			// print the preview email.
 			// phpcs:ignore WordPress.Security.EscapeOutput

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -214,7 +214,13 @@ class WC_Admin {
 				$message = $email_preview->ensure_links_open_in_new_tab( $message );
 			} catch ( Throwable $e ) {
 				ob_end_clean();
-				wp_die( esc_html__( 'There was an error rendering an email preview.', 'woocommerce' ), 404 );
+				wp_die(
+					esc_html__(
+						'There was an error rendering the email preview. This doesn’t affect actual email delivery. Please contact the extension author for assistance.',
+						'woocommerce'
+					),
+					404
+				);
 			}
 			ob_end_clean();
 

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 9.9.0
  */
 
 use Automattic\WooCommerce\Internal\Email\EmailFont;
@@ -305,7 +305,7 @@ body {
 
 #body_content td ul.wc-item-meta {
 	font-size: small;
-	margin: 1em 0 0>;
+	margin: 1em 0 0;
 	padding: 0;
 	list-style: none;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

1. Error message when email preview fails to render is improved to clarify, that actual emails continue to work and to contact extension author to fix the issue. 
    - Before: `There was an error rendering an email preview.`
    - After: `There was an error rendering the email preview. This doesn’t affect actual email delivery. Please contact the extension author for assistance.`
2. When `WP_DEBUG` is enabled, an actual error message is shown to help extension authors better debug and fix the issue. 

Closes #56241.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| `WP_DEBUG` disabled | `WP_DEBUG` enabled |
| ------ | ----- |
|    <img width="637" alt="Screenshot 2025-03-08 at 22 08 24" src="https://github.com/user-attachments/assets/e6ba4c47-5105-449e-9a6e-d759c572c75c" />    |   <img width="636" alt="Screenshot 2025-03-08 at 22 08 35" src="https://github.com/user-attachments/assets/5e0fdbe7-7783-4539-92c7-fa0d8983a78e" />    |

Sending email preview will always show human-friendly error message:

<img width="432" alt="Screenshot 2025-03-08 at 22 08 43" src="https://github.com/user-attachments/assets/ca8f6fb4-e2c9-4604-999c-ffd27cce91ff" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Disable `WP_DEBUG`. 
2. Manually edit any email template file, e.g. [`templates/emails/customer-processing-order.php`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/emails/customer-processing-order.php), and create any error in there (the easier is syntax error just by typing gibersh). 
3. Go to **WooCommerce > Settings > Emails** and observe that the email you edited shows a human-friendly error message.
4. Enable `WP_DEBUG`.
5. Go to **WooCommerce > Settings > Emails** and observe that the email you edited shows the actual PHP error.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
