### PR TITLE
Email Editor: Update package initialization to fix loading issues

### DIFF
--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -768,7 +768,8 @@
 			"node_modules/@woocommerce/block-library/build",
 			"node_modules/@woocommerce/block-library/blocks.ini",
 			"node_modules/@woocommerce/classic-assets/build",
-			"node_modules/@woocommerce/admin-library/build"
+			"node_modules/@woocommerce/admin-library/build",
+			"client/admin/node_modules/@woocommerce/email-editor/build/"
 		],
 		"ext": "js,css,php,json",
 		"ignoreRoot": []

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -50,7 +50,7 @@ class Integration {
 			return;
 		}
 
-		add_action( 'init', array( $this, 'initialize' ) );
+		add_action( 'woocommerce_init', array( $this, 'initialize' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/Package.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Package.php
@@ -40,8 +40,8 @@ class Package {
 			return;
 		}
 
-		\Automattic\WooCommerce\EmailEditor\Package::init();
 		self::initialize();
+		\Automattic\WooCommerce\EmailEditor\Package::init();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

**Important**: This PR fixes a regression caused by the recent [9.8 → trunk sync](https://github.com/woocommerce/woocommerce/pull/56201).

Closes #56251 

#### Email Editor: Fix Package Initialization and Loading Issues

This PR addresses initialization issues with the WooCommerce Email Editor by making the following changes:

1. Reorders the initialization sequence in `Package.php` to ensure proper loading:
   - Now calls `self::initialize()` before `EmailEditor\Package::init()`
   - This ensures proper dependency initialization order

2. Updates the initialization hook in `Integration.php`:
   - Changes from `init` to `woocommerce_init` hook
   - Ensures WooCommerce core is fully loaded before initializing the email editor

3. Updates package.json to include email editor build files in the Nodemon watch list:
   - Adds `client/admin/node_modules/@woocommerce/email-editor/build/` to watched paths
   - Improves development workflow for email editor changes

These changes resolve issues where the email editor was not loading properly due to initialization timing and dependency loading order.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block email editor feature flag (in DB, set `woocommerce_feature_block_email_editor_enabled` option to `yes`)
2. Navigate to `WP Admin > Woo Emails`
3. Verify the email editor loads correctly
4. Test editing and saving email templates
5. Verify changes persist after page reload

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Minor dev update
</details>
