### PR TITLE
Fix color scheme inconsistency between core profiler and Jetpack connection screens

### DIFF
--- a/plugins/woocommerce/changelog/fix-jpc-connection-default-color-schema
+++ b/plugins/woocommerce/changelog/fix-jpc-connection-default-color-schema
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures the correct color scheme is passed to JPC connection screen

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -248,13 +248,14 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 
 		$color_scheme = get_user_option( 'admin_color', get_current_user_id() );
 		if ( ! $color_scheme ) {
-			$color_scheme = 'default';
+			// The default Core color schema is 'fresh'.
+			$color_scheme = 'fresh';
 		}
 
 		return array(
 			'success'      => ! $errors->has_errors(),
 			'errors'       => $errors->get_error_messages(),
-			'color_scheme' => 'fresh' === $color_scheme ? 'default' : $color_scheme,
+			'color_scheme' => $color_scheme,
 			'url'          => add_query_arg(
 				array(
 					'from'        => $request->get_param( 'from' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/Automattic/wp-calypso/issues/99578

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Currently, the color schemes used on the core profiler and Jetpack connection screens are inconsistent, creating a disjointed user experience during the onboarding process.

This PR addresses the color scheme inconsistency issue by properly handling the color scheme in the onboarding plugins API. The calypso default color schema is not the same as the default color schema of WP Core. We should use `fresh` as the default color scheme and don't need to convert it to `default`.

| Before | After |
| ------ | ----- |
|   ![Screenshot 2025-03-10 at 14 40 16](https://github.com/user-attachments/assets/04244bc9-5e77-4f61-ba10-658f2a2509d3) |   ![Screenshot 2025-03-10 at 14 40 10](https://github.com/user-attachments/assets/29373f45-d8c2-4b57-a657-3c19d762aceb)  |



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Created a fresh store and went through core profiler
2. Ensure Jetpack or any Woo plugins are selected
3. In connection screen, verified color scheme consistency between core profiler and Jetpack connection screens (The primary button color should be `#2271b1`)


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
