### PR TITLE
[Experimental] Add to Cart Button: show single add to cart text when inside the Add to Cart with Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-56218-add-to-cart-with-options-button-text
+++ b/plugins/woocommerce/changelog/fix-56218-add-to-cart-with-options-button-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add to Cart Button: show single add to cart text when inside the Add to Cart with Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.json
@@ -9,7 +9,7 @@
 		"query",
 		"queryId",
 		"postId",
-		"woocommerce/isDescendentOfAddToCartWithOptions"
+		"woocommerce/isDescendantOfAddToCartWithOptions"
 	],
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.json
@@ -4,13 +4,12 @@
 	"title": "Add to Cart Button",
 	"description": "Display a call to action button which either adds the product to the cart, or links to the product page.",
 	"category": "woocommerce-product-elements",
-	"keywords": [
-		"WooCommerce"
-	],
+	"keywords": [ "WooCommerce" ],
 	"usesContext": [
 		"query",
 		"queryId",
-		"postId"
+		"postId",
+		"woocommerce/isDescendentOfAddToCartWithOptions"
 	],
 	"textdomain": "woocommerce",
 	"attributes": {
@@ -35,10 +34,7 @@
 		}
 	},
 	"supports": {
-		"align": [
-			"wide",
-			"full"
-		],
+		"align": [ "wide", "full" ],
 		"color": {
 			"background": false,
 			"link": true
@@ -67,9 +63,7 @@
 			"label": "Outline"
 		}
 	],
-	"viewScript": [
-		"wc-product-button-interactivity-frontend"
-	],
+	"viewScript": [ "wc-product-button-interactivity-frontend" ],
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
@@ -34,11 +34,11 @@ import useProductTypeSelector from '../../../../blocks/add-to-cart-with-options/
 const getButtonText = ( {
 	cartQuantity,
 	productCartDetails,
-	isDescendentOfAddToCartWithOptions,
+	isDescendantOfAddToCartWithOptions,
 }: {
 	cartQuantity: number;
 	productCartDetails: AddToCartProductDetails;
-	isDescendentOfAddToCartWithOptions: boolean | undefined;
+	isDescendantOfAddToCartWithOptions: boolean | undefined;
 } ) => {
 	const addedToCart = Number.isFinite( cartQuantity ) && cartQuantity > 0;
 
@@ -51,7 +51,7 @@ const getButtonText = ( {
 	}
 
 	if (
-		isDescendentOfAddToCartWithOptions &&
+		isDescendantOfAddToCartWithOptions &&
 		productCartDetails?.single_text
 	) {
 		return productCartDetails?.single_text;
@@ -62,7 +62,7 @@ const getButtonText = ( {
 
 const AddToCartButton = ( {
 	product,
-	isDescendentOfAddToCartWithOptions,
+	isDescendantOfAddToCartWithOptions,
 	className,
 	style,
 }: AddToCartButtonAttributes ): JSX.Element => {
@@ -84,7 +84,7 @@ const AddToCartButton = ( {
 	const buttonText = getButtonText( {
 		cartQuantity,
 		productCartDetails,
-		isDescendentOfAddToCartWithOptions,
+		isDescendantOfAddToCartWithOptions,
 	} );
 
 	const ButtonTag = allowAddToCart ? 'button' : 'a';
@@ -235,9 +235,9 @@ export const Block = ( props: BlockAttributes ): JSX.Element => {
 							product={ product }
 							style={ styleProps.style }
 							className={ styleProps.className }
-							isDescendentOfAddToCartWithOptions={
+							isDescendantOfAddToCartWithOptions={
 								props[
-									'woocommerce/isDescendentOfAddToCartWithOptions'
+									'woocommerce/isDescendantOfAddToCartWithOptions'
 								]
 							}
 						/>

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
@@ -12,6 +12,8 @@ export interface BlockAttributes {
 	isDescendentOfQueryLoop?: boolean | undefined;
 	isDescendentOfSingleProductBlock?: boolean | undefined;
 	width?: number | undefined;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'woocommerce/isDescendentOfAddToCartWithOptions'?: boolean | undefined;
 }
 
 export interface AddToCartButtonPlaceholderAttributes {
@@ -20,17 +22,21 @@ export interface AddToCartButtonPlaceholderAttributes {
 	isLoading: boolean;
 }
 
+export interface AddToCartProductDetails {
+	url: string;
+	description: string;
+	text: string;
+	single_text: string;
+}
+
 export interface AddToCartButtonAttributes {
 	className: string;
 	style: React.CSSProperties;
+	isDescendentOfAddToCartWithOptions: boolean | undefined;
 	product: {
 		id: number;
 		permalink: string;
-		add_to_cart: {
-			url: string;
-			description: string;
-			text: string;
-		};
+		add_to_cart: AddToCartProductDetails;
 		has_options: boolean;
 		is_purchasable: boolean;
 		is_in_stock: boolean;

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
@@ -13,7 +13,7 @@ export interface BlockAttributes {
 	isDescendentOfSingleProductBlock?: boolean | undefined;
 	width?: number | undefined;
 	// eslint-disable-next-line @typescript-eslint/naming-convention
-	'woocommerce/isDescendentOfAddToCartWithOptions'?: boolean | undefined;
+	'woocommerce/isDescendantOfAddToCartWithOptions'?: boolean | undefined;
 }
 
 export interface AddToCartProductDetails {
@@ -32,7 +32,7 @@ export interface AddToCartButtonPlaceholderAttributes {
 export interface AddToCartButtonAttributes {
 	className: string;
 	style: React.CSSProperties;
-	isDescendentOfAddToCartWithOptions: boolean | undefined;
+	isDescendantOfAddToCartWithOptions: boolean | undefined;
 	product: {
 		id: number;
 		type: string;

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
@@ -16,17 +16,17 @@ export interface BlockAttributes {
 	'woocommerce/isDescendentOfAddToCartWithOptions'?: boolean | undefined;
 }
 
-export interface AddToCartButtonPlaceholderAttributes {
-	className: string;
-	style: React.CSSProperties;
-	isLoading: boolean;
-}
-
 export interface AddToCartProductDetails {
 	url: string;
 	description: string;
 	text: string;
 	single_text: string;
+}
+
+export interface AddToCartButtonPlaceholderAttributes {
+	className: string;
+	style: React.CSSProperties;
+	isLoading: boolean;
 }
 
 export interface AddToCartButtonAttributes {
@@ -35,6 +35,7 @@ export interface AddToCartButtonAttributes {
 	isDescendentOfAddToCartWithOptions: boolean | undefined;
 	product: {
 		id: number;
+		type: string;
 		permalink: string;
 		add_to_cart: AddToCartProductDetails;
 		has_options: boolean;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -4,8 +4,16 @@
 	"title": "Add to Cart with Options (Experimental)",
 	"description": "Create an \"Add To Cart\" composition by using blocks",
 	"category": "woocommerce-product-elements",
-	"attributes": {},
+	"attributes": {
+		"isDescendentOfAddToCartWithOptions": {
+			"type": "boolean",
+			"default": true
+		}
+	},
 	"usesContext": [ "postId" ],
+	"providesContext": {
+		"woocommerce/isDescendentOfAddToCartWithOptions": "isDescendentOfAddToCartWithOptions"
+	},
 	"textdomain": "woocommerce",
 	"supports": {
 		"interactivity": true

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -5,14 +5,14 @@
 	"description": "Create an \"Add To Cart\" composition by using blocks",
 	"category": "woocommerce-product-elements",
 	"attributes": {
-		"isDescendentOfAddToCartWithOptions": {
+		"isDescendantOfAddToCartWithOptions": {
 			"type": "boolean",
 			"default": true
 		}
 	},
 	"usesContext": [ "postId" ],
 	"providesContext": {
-		"woocommerce/isDescendentOfAddToCartWithOptions": "isDescendentOfAddToCartWithOptions"
+		"woocommerce/isDescendantOfAddToCartWithOptions": "isDescendantOfAddToCartWithOptions"
 	},
 	"textdomain": "woocommerce",
 	"supports": {

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/product-response.ts
@@ -93,6 +93,7 @@ export interface ProductResponseItem {
 		minimum: number;
 		maximum: number;
 		multiple_of: number;
+		single_text: string;
 	};
 	slug: string;
 	grouped_products: Array< number >;

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -65,7 +65,7 @@ class AddToCartWithOptionsPage {
 		// Add to Cart is a dynamic block, so we need to wait for it to be
 		// ready. If we don't do that, it might clear the paragraph we're
 		// inserting below (depending on the test execution speed).
-		await parentBlock.getByText( 'Add to cart', { exact: true } ).waitFor();
+		await parentBlock.getByText( /^(Add to cart|Buy product)$/ ).waitFor();
 
 		await this.editor.insertBlock(
 			{

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -40,9 +40,9 @@ class AddToCartWithOptions extends AbstractBlock {
 	 * @param array $block   The parsed block.
 	 * @return array Modified block context.
 	 */
-	public function set_is_descendent_of_add_to_cart_with_options_context( $context, $block ) {
+	public function set_is_descendant_of_add_to_cart_with_options_context( $context, $block ) {
 		if ( 'woocommerce/product-button' === $block['blockName'] ) {
-			$context['woocommerce/isDescendentOfAddToCartWithOptions'] = true;
+			$context['woocommerce/isDescendantOfAddToCartWithOptions'] = true;
 		}
 
 		return $context;
@@ -210,10 +210,10 @@ class AddToCartWithOptions extends AbstractBlock {
 			}
 
 			// Because we are printing the template part using do_blocks, context from the outside is lost.
-			// This filter is used to add the isDescendentOfAddToCartWithOptions context back.
-			add_filter( 'render_block_context', array( $this, 'set_is_descendent_of_add_to_cart_with_options_context' ), 10, 2 );
+			// This filter is used to add the isDescendantOfAddToCartWithOptions context back.
+			add_filter( 'render_block_context', array( $this, 'set_is_descendant_of_add_to_cart_with_options_context' ), 10, 2 );
 			$template_part_blocks = do_blocks( $template_part_contents );
-			remove_filter( 'render_block_context', array( $this, 'set_is_descendent_of_add_to_cart_with_options_context' ) );
+			remove_filter( 'render_block_context', array( $this, 'set_is_descendant_of_add_to_cart_with_options_context' ) );
 
 			$form_html = sprintf(
 				'<form %1$s>%2$s%3$s%4$s</form>',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -42,7 +42,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	 */
 	public function set_is_descendent_of_add_to_cart_form_context( $context, $block ) {
 		if ( 'woocommerce/product-button' === $block['blockName'] ) {
-			$context['isDescendentOfAddToCartForm'] = true;
+			$context['woocommerce/isDescendentOfAddToCartForm'] = true;
 		}
 
 		return $context;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -34,15 +34,15 @@ class AddToCartWithOptions extends AbstractBlock {
 	}
 
 	/**
-	 * Modifies the block context for product button blocks when inside the add-to-cart-with-options block.
+	 * Modifies the block context for product button blocks when inside the Add to Cart with Options block.
 	 *
 	 * @param array $context The block context.
 	 * @param array $block   The parsed block.
 	 * @return array Modified block context.
 	 */
-	public function set_is_descendent_of_add_to_cart_form_context( $context, $block ) {
+	public function set_is_descendent_of_add_to_cart_with_options_context( $context, $block ) {
 		if ( 'woocommerce/product-button' === $block['blockName'] ) {
-			$context['woocommerce/isDescendentOfAddToCartForm'] = true;
+			$context['woocommerce/isDescendentOfAddToCartWithOptions'] = true;
 		}
 
 		return $context;
@@ -209,9 +209,11 @@ class AddToCartWithOptions extends AbstractBlock {
 				$hooks_after = ob_get_clean();
 			}
 
-			add_filter( 'render_block_context', array( $this, 'set_is_descendent_of_add_to_cart_form_context' ), 10, 2 );
+			// Because we are printing the template part using do_blocks, context from the outside is lost.
+			// This filter is used to add the isDescendentOfAddToCartWithOptions context back.
+			add_filter( 'render_block_context', array( $this, 'set_is_descendent_of_add_to_cart_with_options_context' ), 10, 2 );
 			$template_part_blocks = do_blocks( $template_part_contents );
-			remove_filter( 'render_block_context', array( $this, 'set_is_descendent_of_add_to_cart_form_context' ) );
+			remove_filter( 'render_block_context', array( $this, 'set_is_descendent_of_add_to_cart_with_options_context' ) );
 
 			$form_html = sprintf(
 				'<form %1$s>%2$s%3$s%4$s</form>',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -155,7 +155,7 @@ class ProductButton extends AbstractBlock {
 		*/
 		$quantity_to_add = apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() );
 
-		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendentOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendentOfAddToCartWithOptions'] : false;
+		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
 		$add_to_cart_text                  = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
 		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
 			$add_to_cart_text = $product->single_add_to_cart_text();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -155,7 +155,7 @@ class ProductButton extends AbstractBlock {
 		*/
 		$quantity_to_add = apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() );
 
-		$is_descendent_of_add_to_cart_form = isset( $block->context['isDescendentOfAddToCartForm'] ) ? $block->context['isDescendentOfAddToCartForm'] : false;
+		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendentOfAddToCartForm'] ) ? $block->context['woocommerce/isDescendentOfAddToCartForm'] : false;
 		$add_to_cart_text                  = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
 		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
 			$add_to_cart_text = $product->single_add_to_cart_text();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -155,10 +155,16 @@ class ProductButton extends AbstractBlock {
 		*/
 		$quantity_to_add = apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() );
 
+		$is_descendent_of_add_to_cart_form = isset( $block->context['isDescendentOfAddToCartForm'] ) ? $block->context['isDescendentOfAddToCartForm'] : false;
+		$add_to_cart_text                  = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
+		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
+			$add_to_cart_text = $product->single_add_to_cart_text();
+		}
+
 		$context = array(
 			'quantityToAdd'   => $quantity_to_add,
 			'productId'       => $product->get_id(),
-			'addToCartText'   => null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' ),
+			'addToCartText'   => $add_to_cart_text,
 			'tempQuantity'    => $number_of_items_in_cart,
 			'animationStatus' => 'IDLE',
 		);
@@ -253,7 +259,7 @@ class ProductButton extends AbstractBlock {
 					'{button_classes}'         => isset( $args['class'] ) ? esc_attr( $args['class'] . ' wc-interactive' ) : 'wc-interactive',
 					'{button_styles}'          => esc_attr( $styles_and_classes['styles'] ),
 					'{attributes}'             => isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
-					'{add_to_cart_text}'       => $is_ajax_button ? '' : $product->add_to_cart_text(),
+					'{add_to_cart_text}'       => $is_ajax_button ? '' : $add_to_cart_text,
 					'{div_directives}'         => $is_ajax_button ? $div_directives : '',
 					'{button_directives}'      => $is_ajax_button ? $button_directives : $anchor_directive,
 					'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -155,7 +155,7 @@ class ProductButton extends AbstractBlock {
 		*/
 		$quantity_to_add = apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() );
 
-		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendentOfAddToCartForm'] ) ? $block->context['woocommerce/isDescendentOfAddToCartForm'] : false;
+		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendentOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendentOfAddToCartWithOptions'] : false;
 		$add_to_cart_text                  = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
 		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
 			$add_to_cart_text = $product->single_add_to_cart_text();

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -506,6 +506,12 @@ class ProductSchema extends AbstractSchema {
 						'readonly'    => true,
 						'default'     => 1,
 					],
+					'single_text' => [
+						'description' => __( 'Button text in the single product page.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
 				],
 			],
 			self::EXTENDING_KEY   => $this->get_extended_schema( self::IDENTIFIER ),
@@ -558,6 +564,7 @@ class ProductSchema extends AbstractSchema {
 					'text'        => $this->prepare_html_response( $product->add_to_cart_text() ),
 					'description' => $this->prepare_html_response( $product->add_to_cart_description() ),
 					'url'         => $this->prepare_html_response( $product->add_to_cart_url() ),
+					'single_text' => $this->prepare_html_response( $product->single_add_to_cart_text() ),
 				],
 				( new QuantityLimits() )->get_add_to_cart_limits( $product )
 			),

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -65,6 +65,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		// Single Products contain the Add to Cart button and the quantity selector blocks.
 		$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The Simple Product Add to Cart with Options contains the product button block.' );
+		$this->assertStringContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button reads "Add to cart".' );
 		$this->assertStringContainsString( 'woocommerce/add-to-cart-with-options-quantity-selector', $markup, 'The Simple Product Add to Cart with Options contains the quantity selector block.' );
 
 		$product    = new \WC_Product_External();
@@ -73,6 +74,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		// External Products contain the Add to Cart button block but do not contain the quantity selector block.
 		$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The External Product Add to Cart with Options contains the product button block.' );
+		$this->assertStringContainsString( 'Buy product', $markup, 'The External Product Add to Cart Button reads "Buy product".' );
 		$this->assertStringNotContainsString( 'woocommerce/add-to-cart-with-options-quantity-selector', $markup, 'The External Product Add to Cart with Options does not contain the quantity selector block.' );
 
 		$product    = new WC_Product_Custom();

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Products.php
@@ -66,6 +66,7 @@ class Products extends ControllerTestCase {
 		$this->assertEquals( $this->products[0]->is_in_stock(), $data['is_in_stock'] );
 		$this->assertEquals( $this->products[0]->add_to_cart_text(), $data['add_to_cart']->text );
 		$this->assertEquals( $this->products[0]->add_to_cart_description(), $data['add_to_cart']->description );
+		$this->assertEquals( $this->products[0]->single_add_to_cart_text(), $data['add_to_cart']->single_text );
 		$this->assertEquals( $this->products[0]->is_on_sale(), $data['on_sale'] );
 		$this->assertCount( 0, $data['grouped_products'] );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/56218.

This PR updates the _Add to Cart Button_ block to display the single add to cart text when it's a descendant of the _Add to Cart with Options_ block.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_ and update the _Add to Cart with Options_ block to the blockified version.
2. Switch between product types and verify the button always says "Add to cart" except for external products, in which case it says "Buy product".

[Enregistrament de pantalla del 2025-03-10 15-43-38.webm](https://github.com/user-attachments/assets/f3dbe45d-6520-4860-90b6-5eade91ec793)


3. In the frontend, visit the page of a grouped product, verify the cart button says "Add to cart" instead of "View products".

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/62736329-627e-46da-bc32-64e22f8f2d53) | ![imatge](https://github.com/user-attachments/assets/fa2e3457-7dd7-46bc-b660-ccc0dbec5b75)

4. Visit the page of an external product and verify the button says "Buy product" (or whatever is defined in the product settings).
5. Verify there are no regressions in the Add to Cart Button in other contexts. For example, by going to the _Shop_ page and verifying the button of the grouped product says "View products" instead of "Add to cart".

![imatge](https://github.com/user-attachments/assets/ed341c18-4a9b-4507-8e2f-03ddf10a1aca)
