### PR TITLE
Fix menu icon active state when navigating between wc-admin pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-menu-item-active-status
+++ b/plugins/woocommerce/changelog/fix-menu-item-active-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix menu icon active state when navigating between wc-admin pages

--- a/plugins/woocommerce/client/admin/client/layout/controller.js
+++ b/plugins/woocommerce/client/admin/client/layout/controller.js
@@ -501,15 +501,11 @@ window.wpNavMenuUrlUpdate = function ( query ) {
 	);
 };
 
+// Cache custom SVG menu items to prevent repeated DOM queries. This is necessary to remove event handlers when the route changes in window.wpNavMenuClassChange.
 const customSVGMenuItems = [];
-// Get all menu items with SVG backgrounds
-// See: https://github.com/WordPress/wordpress-develop/blob/22bebd7de6681c673933953aab8c08802e7e3d4a/src/js/_enqueues/wp/svg-painter.js#L140-L148
-const initCustomSVGMenuItems = () => {
-	// Return the menu items if they have already been initialized, as the top menu item remains unchanged when the route changes
-	if ( customSVGMenuItems.length > 0 ) {
-		return customSVGMenuItems;
-	}
-
+const getCustomSVGMenuItems = () => {
+	// Get all menu items with SVG backgrounds
+	// See: https://github.com/WordPress/wordpress-develop/blob/22bebd7de6681c673933953aab8c08802e7e3d4a/src/js/_enqueues/wp/svg-painter.js#L140-L148
 	const menuItems = window.jQuery(
 		'#adminmenu .wp-menu-image, #wpadminbar .ab-item'
 	);
@@ -528,7 +524,9 @@ const initCustomSVGMenuItems = () => {
 
 // When the route changes, we need to update wp-admin's menu with the correct section & current link
 window.wpNavMenuClassChange = function ( page, url ) {
-	initCustomSVGMenuItems();
+	if ( customSVGMenuItems.length === 0 ) {
+		getCustomSVGMenuItems();
+	}
 
 	const wpNavMenu = document.querySelector( '#adminmenu' );
 
@@ -603,7 +601,7 @@ window.wpNavMenuClassChange = function ( page, url ) {
 
 	// 6. Attempt to re-color SVG icons used in the admin menu or the toolbar
 	if ( window.wp && window.wp.svgPainter ) {
-		// Remove the specific SVG painting event handlers to prevent incorrect painting. For more details, refer to: https://github.com/WordPress/wordpress-develop/blob/22bebd7de6681c673933953aab8c08802e7e3d4a/src/js/_enqueues/wp/svg-painter.js#L162C4-L170C10
+		// Detach SVG painting event handlers from menu items to prevent the active state from being reset on hover. For more information, see: https://github.com/WordPress/wordpress-develop/blob/22bebd7de6681c673933953aab8c08802e7e3d4a/src/js/_enqueues/wp/svg-painter.js#L162C4-L170C10
 		customSVGMenuItems.forEach( ( $menuItem ) => {
 			const events =
 				window.jQuery._data( $menuItem[ 0 ], 'events' ) || {};

--- a/plugins/woocommerce/client/admin/client/layout/controller.js
+++ b/plugins/woocommerce/client/admin/client/layout/controller.js
@@ -501,35 +501,69 @@ window.wpNavMenuUrlUpdate = function ( query ) {
 	);
 };
 
+const customSVGMenuItems = [];
+// Get all menu items with SVG backgrounds
+// See: https://github.com/WordPress/wordpress-develop/blob/22bebd7de6681c673933953aab8c08802e7e3d4a/src/js/_enqueues/wp/svg-painter.js#L140-L148
+const initCustomSVGMenuItems = () => {
+	// Return the menu items if they have already been initialized, as the top menu item remains unchanged when the route changes
+	if ( customSVGMenuItems.length > 0 ) {
+		return customSVGMenuItems;
+	}
+
+	const menuItems = window.jQuery(
+		'#adminmenu .wp-menu-image, #wpadminbar .ab-item'
+	);
+	menuItems.each( function () {
+		const $this = window.jQuery( this ),
+			bgImage = $this.css( 'background-image' );
+
+		if (
+			bgImage &&
+			bgImage.indexOf( 'data:image/svg+xml;base64' ) !== -1
+		) {
+			customSVGMenuItems.push( $this.parent().parent() );
+		}
+	} );
+};
+
 // When the route changes, we need to update wp-admin's menu with the correct section & current link
 window.wpNavMenuClassChange = function ( page, url ) {
-	const wpNavMenu = document.querySelector( '#adminmenu' );
-	Array.from( wpNavMenu.getElementsByClassName( 'current' ) ).forEach(
-		function ( item ) {
-			item.classList.remove( 'current' );
-		}
-	);
+	initCustomSVGMenuItems();
 
-	const submenu = Array.from(
-		wpNavMenu.querySelectorAll( '.wp-has-current-submenu' )
+	const wpNavMenu = document.querySelector( '#adminmenu' );
+
+	// 1. Remove all current states
+	const currentItems = Array.from(
+		wpNavMenu.getElementsByClassName( 'current' )
 	);
-	submenu.forEach( function ( element ) {
-		element.classList.remove( 'wp-has-current-submenu' );
-		element.classList.remove( 'wp-menu-open' );
-		element.classList.remove( 'selected' );
-		element.classList.add( 'wp-not-current-submenu' );
-		element.classList.add( 'menu-top' );
+	currentItems.forEach( ( item ) => {
+		item.classList.remove( 'current' );
 	} );
 
+	const submenuItems = Array.from(
+		wpNavMenu.querySelectorAll( '.wp-has-current-submenu' )
+	);
+	submenuItems.forEach( function ( element ) {
+		element.classList.remove(
+			'wp-has-current-submenu',
+			'selected',
+			'wp-menu-open'
+		);
+		element.classList.add( 'wp-not-current-submenu' );
+	} );
+
+	// 2. Get current page URL and item selector
 	const pageUrl =
 		url === '/'
 			? 'admin.php?page=wc-admin'
 			: 'admin.php?page=wc-admin&path=' + encodeURIComponent( url );
+
 	let currentItemsSelector =
 		url === '/'
 			? `li > a[href$="${ pageUrl }"], li > a[href*="${ pageUrl }?"]`
 			: `li > a[href*="${ pageUrl }"]`;
 
+	// 3. Handle parent paths with proper hierarchy
 	const parentPath = page.navArgs?.parentPath;
 	if ( parentPath ) {
 		const parentPageUrl =
@@ -540,22 +574,63 @@ window.wpNavMenuClassChange = function ( page, url ) {
 		currentItemsSelector += `, li > a[href*="${ parentPageUrl }"]`;
 	}
 
-	const currentItems = wpNavMenu.querySelectorAll( currentItemsSelector );
-
-	Array.from( currentItems ).forEach( function ( item ) {
+	// 4. Set current menu item to active
+	const newCurrentItems = Array.from(
+		wpNavMenu.querySelectorAll( currentItemsSelector )
+	);
+	newCurrentItems.forEach( ( item ) => {
 		item.parentElement.classList.add( 'current' );
 	} );
 
+	// 5. Handle explicit menu opening
 	if ( page.wpOpenMenu ) {
-		const currentMenu = wpNavMenu.querySelector( '#' + page.wpOpenMenu );
+		const currentMenu = wpNavMenu.querySelector( `#${ page.wpOpenMenu }` );
 		if ( currentMenu ) {
+			// Reset the margin-top immediately so menu can open smoothly without jumping
+			const allSubmenus = wpNavMenu.querySelectorAll( '.wp-submenu' );
+			allSubmenus.forEach( ( submenu ) => {
+				submenu.style.marginTop = ''; // Reset margin-top
+			} );
+
 			currentMenu.classList.remove( 'wp-not-current-submenu' );
-			currentMenu.classList.add( 'wp-has-current-submenu' );
-			currentMenu.classList.add( 'wp-menu-open' );
-			currentMenu.classList.add( 'current' );
+			currentMenu.classList.add(
+				'wp-has-current-submenu',
+				'wp-menu-open',
+				'current'
+			);
 		}
 	}
 
+	// 6. Attempt to re-color SVG icons used in the admin menu or the toolbar
+	if ( window.wp && window.wp.svgPainter ) {
+		// Remove the specific SVG painting event handlers to prevent incorrect painting. For more details, refer to: https://github.com/WordPress/wordpress-develop/blob/22bebd7de6681c673933953aab8c08802e7e3d4a/src/js/_enqueues/wp/svg-painter.js#L162C4-L170C10
+		customSVGMenuItems.forEach( ( $menuItem ) => {
+			const events =
+				window.jQuery._data( $menuItem[ 0 ], 'events' ) || {};
+
+			if ( events.mouseover ) {
+				events.mouseover.forEach( ( event ) => {
+					if ( event.handler.toString().includes( 'paintElement' ) ) {
+						$menuItem.off( 'mouseenter', event.handler );
+					}
+				} );
+			}
+
+			if ( events.mouseout ) {
+				events.mouseout.forEach( ( event ) => {
+					if ( event.handler.toString().includes( 'paintElement' ) ) {
+						$menuItem.off( 'mouseleave', event.handler );
+					}
+				} );
+			}
+		} );
+
+		window.wp.svgPainter.paint();
+	}
+
+	// 7. Close responsive menu if open
 	const wpWrap = document.querySelector( '#wpwrap' );
-	wpWrap.classList.remove( 'wp-responsive-open' );
+	if ( wpWrap && wpWrap.classList.contains( 'wp-responsive-open' ) ) {
+		wpWrap.classList.remove( 'wp-responsive-open' );
+	}
 };

--- a/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
+++ b/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
@@ -33,7 +33,7 @@
 
 	#adminmenu {
 		#toplevel_page_woocommerce.menu-top > a:focus,
-		#toplevel_page_woodash--analytics > a:focus {
+		#toplevel_page_wc-admin-path--analytics-overview > a:focus {
 			& + .wp-submenu {
 				top: auto;
 			}

--- a/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
+++ b/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
@@ -31,10 +31,12 @@
 		}
 	}
 
-	@include breakpoint( ">960px" ) {
+	#adminmenu {
 		#toplevel_page_woocommerce.menu-top > a:focus,
-		#toplevel_page_wcadmin--analytics.menu-top > a:focus {
-			padding-bottom: 1px;
+		#toplevel_page_woodash--analytics > a:focus {
+			& + .wp-submenu {
+				top: auto;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/55896

This PR fixes the WooCommerce menu icon's active state not updating correctly when navigating between wc-admin pages.

Two issues are fixed in this PR:

1. The WooCommerce menu icon's active state was not updating correctly when navigating between wc-admin pages.
2. Analytics menu doesn't slide up smoothly.

The first issue is fixed by calling `wp.svgPainter.paint()` after updating the menu state. This ensures the WooCommerce icon updates correctly. We also detach the SVG painting event handlers to prevent the active state from resetting on hover. The reason why only WooCommerce icon is affected is because it's a custom SVG icon and the rest of the icons are Dashicons that natively support the active state.

The second issue is fixed by resting the margin-top of the submenu to 0 before the menu is opened.

I've also made some other improvements to the codebase:

1. Added inline comments to explain the `wpNavMenuClassChange` function so that it's easier to understand.
2. Add checks before doing some DOM operations to reduce the number of operations that are performed.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before:

https://github.com/user-attachments/assets/356468d3-a835-4cdb-a4cc-bcd2bf17b4c7  

After:

https://github.com/user-attachments/assets/7da5da91-785a-45a5-b329-bd533f032f95  

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Home`
2. Navigate to `Analytics > Overview`
3. Verify that:
   - The Analytics menu slides up smoothly
   - The WooCommerce menu icon becomes inactive (grey)
4. Navigate to `WooCommerce > Home`
5. Verify that:
   - The WooCommerce menu icon becomes active (white)
   - The menu state correctly reflects the current page's conte
6. Navigate between other wc admin pages such as Marketing, Payments and ensure that the menu icon's active state is updated correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
