### PR TITLE
Add initial product reviews block

### DIFF
--- a/plugins/woocommerce/changelog/add-initial-product-reviews-block
+++ b/plugins/woocommerce/changelog/add-initial-product-reviews-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new experimental product reviews block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -36,13 +36,7 @@ const additionalInformationAccordion = createAccordionItem(
 );
 
 const reviewsAccordion = createAccordionItem( 'Reviews', [
-	[
-		'core/paragraph',
-		{
-			content:
-				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget turpis eget nunc fermentum ultricies. Nullam nec sapien nec0',
-		},
-	],
+	[ 'woocommerce/blockified-product-reviews', {} ],
 ] );
 
 const TEMPLATE: InnerBlockTemplate[] = [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/blockified-product-reviews",
+	"version": "1.0.0",
+	"icon": "admin-comments",
+	"title": "Blockified Product Reviews",
+	"description": "Display a product's reviews",
+	"category": "woocommerce",
+	"textdomain": "woocommerce",
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "div"
+		}
+	},
+	"supports": {
+			"align": [ "wide", "full" ],
+			"html": false,
+			"color": {
+				"gradients": true,
+				"heading": true,
+				"link": true,
+				"__experimentalDefaultControls": {
+					"background": true,
+					"text": true,
+					"link": true
+				}
+			},
+			"spacing": {
+				"margin": true,
+				"padding": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true,
+				"__experimentalFontFamily": true,
+				"__experimentalFontWeight": true,
+				"__experimentalFontStyle": true,
+				"__experimentalTextTransform": true,
+				"__experimentalTextDecoration": true,
+				"__experimentalLetterSpacing": true,
+				"__experimentalDefaultControls": {
+					"fontSize": true
+				}
+			},
+			"__experimentalBorder": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true,
+				"__experimentalDefaultControls": {
+					"radius": true,
+					"color": true,
+					"width": true,
+					"style": true
+				}
+			}
+	},
+	"usesContext": [ "postId", "postType", "productId" ]
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
@@ -57,5 +57,5 @@
 				}
 			}
 	},
-	"usesContext": [ "postId", "postType", "productId" ]
+	"usesContext": [ "postId", "postType" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
@@ -57,5 +57,10 @@
 				}
 			}
 	},
-	"usesContext": [ "postId", "postType" ]
+	"usesContext": [ "postId", "postType" ],
+	"ancestor": [
+		"woocommerce/single-product",
+		"woocommerce/product-template",
+		"core/post-template"
+	]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
@@ -50,7 +50,7 @@ const Edit = ( { attributes, setAttributes }: ProductReviewsEditProps ) => {
 					/>
 				</InspectorControls>
 			</InspectorControls>
-			<TagName { ...innerBlocksProps } />;
+			<TagName { ...innerBlocksProps } />
 		</>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import TEMPLATE from './template';
+
+const Edit = () => {
+	return <InnerBlocks template={ TEMPLATE } />;
+};
+
+export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
@@ -1,15 +1,58 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	InspectorControls,
+	useBlockProps,
+	// @ts-expect-error missing types.
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import TEMPLATE from './template';
+import { ProductReviewsEditProps } from './types';
+import { htmlElementMessages } from '../../utils/messages';
 
-const Edit = () => {
-	return <InnerBlocks template={ TEMPLATE } />;
+const Edit = ( { attributes, setAttributes }: ProductReviewsEditProps ) => {
+	const { tagName: TagName } = attributes;
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+	} );
+
+	return (
+		<>
+			<InspectorControls>
+				{ /* @ts-expect-error missing types */ }
+				<InspectorControls group="advanced">
+					<SelectControl
+						// @ts-expect-error missing types.
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'HTML element', 'woocommerce' ) }
+						options={ [
+							{
+								label: __( 'Default (<div>)', 'woocommerce' ),
+								value: 'div',
+							},
+							{ label: '<section>', value: 'section' },
+							{ label: '<aside>', value: 'aside' },
+						] }
+						value={ TagName }
+						onChange={ ( value: 'div' | 'section' | 'aside' ) =>
+							setAttributes( { tagName: value } )
+						}
+						help={ htmlElementMessages[ TagName ] }
+					/>
+				</InspectorControls>
+			</InspectorControls>
+			<TagName { ...innerBlocksProps } />;
+		</>
+	);
 };
 
 export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
@@ -70,29 +70,27 @@ const Edit = ( {
 
 	return (
 		<>
-			<InspectorControls>
-				{ /* @ts-expect-error missing types */ }
-				<InspectorControls group="advanced">
-					<SelectControl
-						// @ts-expect-error missing types.
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-						label={ __( 'HTML element', 'woocommerce' ) }
-						options={ [
-							{
-								label: __( 'Default (<div>)', 'woocommerce' ),
-								value: 'div',
-							},
-							{ label: '<section>', value: 'section' },
-							{ label: '<aside>', value: 'aside' },
-						] }
-						value={ TagName }
-						onChange={ ( value: 'div' | 'section' | 'aside' ) =>
-							setAttributes( { tagName: value } )
-						}
-						help={ htmlElementMessages[ TagName ] }
-					/>
-				</InspectorControls>
+			{ /* @ts-expect-error missing types */ }
+			<InspectorControls group="advanced">
+				<SelectControl
+					// @ts-expect-error missing types.
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'HTML element', 'woocommerce' ) }
+					options={ [
+						{
+							label: __( 'Default (<div>)', 'woocommerce' ),
+							value: 'div',
+						},
+						{ label: '<section>', value: 'section' },
+						{ label: '<aside>', value: 'aside' },
+					] }
+					value={ TagName }
+					onChange={ ( value: 'div' | 'section' | 'aside' ) =>
+						setAttributes( { tagName: value } )
+					}
+					help={ htmlElementMessages[ TagName ] }
+				/>
 			</InspectorControls>
 			<TagName { ...innerBlocksProps } />
 		</>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/edit.tsx
@@ -1,11 +1,16 @@
 /**
  * External dependencies
  */
+
 import { SelectControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	InspectorControls,
 	useBlockProps,
+	Warning,
+	store as blockEditorStore,
 	// @ts-expect-error missing types.
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
@@ -17,12 +22,51 @@ import TEMPLATE from './template';
 import { ProductReviewsEditProps } from './types';
 import { htmlElementMessages } from '../../utils/messages';
 
-const Edit = ( { attributes, setAttributes }: ProductReviewsEditProps ) => {
+/**
+ * Check if block is inside a Query Loop with non-product post type
+ *
+ * @param {string} clientId The block's client ID
+ * @param {string} postType The current post type
+ * @return {boolean} Whether the block is in an invalid Query Loop context
+ */
+const useIsInvalidQueryLoopContext = ( clientId: string, postType: string ) => {
+	const { getBlockParentsByBlockName } = useSelect( blockEditorStore, [] );
+	const blockParents = useMemo( () => {
+		return getBlockParentsByBlockName( clientId, 'core/post-template' );
+	}, [ getBlockParentsByBlockName, clientId ] );
+
+	return blockParents.length > 0 && postType !== 'product';
+};
+
+const Edit = ( {
+	attributes,
+	setAttributes,
+	clientId,
+	context,
+}: ProductReviewsEditProps ) => {
 	const { tagName: TagName } = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 	} );
+
+	const { postType: contextPostType } = context;
+	const isInvalidQueryLoopContext = useIsInvalidQueryLoopContext(
+		clientId,
+		contextPostType
+	);
+	if ( isInvalidQueryLoopContext ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __(
+						'The Product Reviews block requires a product context. When used in a Query Loop, the Query Loop must be configured to display products.',
+						'woocommerce'
+					) }
+				</Warning>
+			</div>
+		);
+	}
 
 	return (
 		<>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import save from './save';
+import edit from './edit';
+
+if ( isExperimentalBlocksEnabled() ) {
+	// @ts-expect-error metadata is not typed.
+	registerBlockType( metadata, {
+		edit,
+		save,
+	} );
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+import { registerProductBlockType } from '@woocommerce/atomic-utils';
 
 /**
  * Internal dependencies
@@ -12,9 +12,13 @@ import save from './save';
 import edit from './edit';
 
 if ( isExperimentalBlocksEnabled() ) {
-	// @ts-expect-error metadata is not typed.
-	registerBlockType( metadata, {
+	const blockConfig = {
+		...metadata,
 		edit,
 		save,
+	};
+	// @ts-expect-error metadata is not typed.
+	registerProductBlockType( blockConfig, {
+		isAvailableOnPostEditor: true,
 	} );
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/save.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import {
+	// @ts-expect-error Missing types for this package.
+	useInnerBlocksProps,
+	useBlockProps,
+} from '@wordpress/block-editor';
+
+export default function Save( {
+	attributes: { tagName: Tag },
+}: {
+	attributes: { tagName: string };
+} ) {
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <Tag { ...innerBlocksProps } />;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { InnerBlockTemplate } from '@wordpress/blocks';
+
+const TEMPLATE: InnerBlockTemplate[] = [
+	[ 'core/comments-title' ],
+	[
+		'core/comment-template',
+		{},
+		[
+			[
+				'core/columns',
+				{},
+				[
+					[
+						'core/column',
+						{ width: '40px' },
+						[
+							[
+								'core/avatar',
+								{
+									size: 40,
+									style: {
+										border: { radius: '20px' },
+									},
+								},
+							],
+						],
+					],
+					[
+						'core/column',
+						{},
+						[
+							[
+								'core/comment-author-name',
+								{
+									fontSize: 'small',
+								},
+							],
+							[
+								'core/group',
+								{
+									layout: { type: 'flex' },
+									style: {
+										spacing: {
+											margin: {
+												top: '0px',
+												bottom: '0px',
+											},
+										},
+									},
+								},
+								[
+									[
+										'core/comment-date',
+										{
+											fontSize: 'small',
+										},
+									],
+									[
+										'core/comment-edit-link',
+										{
+											fontSize: 'small',
+										},
+									],
+								],
+							],
+							[ 'core/comment-content' ],
+						],
+					],
+				],
+			],
+		],
+	],
+	[ 'core/comments-pagination' ],
+	[ 'core/post-comments-form' ],
+];
+
+export default TEMPLATE;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/types.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { BlockEditProps } from '@wordpress/blocks';
+
+type Attributes = {
+	tagName: 'div' | 'section' | 'aside';
+};
+
+type Context = {
+	context: { postId: string; postType: string };
+};
+
+export type ProductReviewsEditProps = BlockEditProps< Attributes > & Context;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/constants.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/constants.tsx
@@ -80,5 +80,6 @@ export const ALLOWED_INNER_BLOCKS = [
 	'woocommerce/add-to-cart-with-options',
 	'woocommerce/product-meta',
 	'woocommerce/product-gallery',
+	'woocommerce/blockified-product-reviews',
 	...Object.keys( getBlockMap( metadata.name ) ),
 ];

--- a/plugins/woocommerce/client/blocks/assets/js/utils/messages.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/messages.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const htmlElementMessages = {
+	article: __(
+		'The <article> element should represent a self-contained, syndicatable portion of the document.',
+		'woocommerce'
+	),
+	aside: __(
+		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content.",
+		'woocommerce'
+	),
+	div: __(
+		'The <div> element should only be used if the block is a design element with no semantic meaning.',
+		'woocommerce'
+	),
+	footer: __(
+		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).',
+		'woocommerce'
+	),
+	header: __(
+		'The <header> element should represent introductory content, typically a group of introductory or navigational aids.',
+		'woocommerce'
+	),
+	main: __(
+		'The <main> element should be used for the primary content of your document only.',
+		'woocommerce'
+	),
+	nav: __(
+		'The <nav> element should be used to identify groups of links that are intended to be used for website or page content navigation.',
+		'woocommerce'
+	),
+	section: __(
+		"The <section> element should represent a standalone portion of the document that can't be better represented by another element.",
+		'woocommerce'
+	),
+};

--- a/plugins/woocommerce/client/blocks/assets/js/utils/messages.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/messages.ts
@@ -3,6 +3,20 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Messages providing guidance for HTML element usage in block editor controls.
+ * These messages help developers and users choose the appropriate semantic HTML elements
+ * for their blocks.
+ *
+ * @example
+ * ```tsx
+ * <SelectControl
+ *   value={ TagName }
+ *   onChange={ (value) => setAttributes({ tagName: value }) }
+ *   help={ htmlElementMessages[TagName] }
+ * />
+ * ```
+ */
 export const htmlElementMessages = {
 	article: __(
 		'The <article> element should represent a self-contained, syndicatable portion of the document.',

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -218,6 +218,10 @@ const blocks = {
 		customDir: 'order-confirmation/create-account',
 		isExperimental: true,
 	},
+	'blockified-product-reviews': {
+		isExperimental: true,
+		customDir: 'product-reviews',
+	},
 };
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductReviews.php
@@ -1,5 +1,4 @@
 <?php
-declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductReviews.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
@@ -1,0 +1,25 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+
+/**
+ * ProductReviews class.
+ */
+class ProductReviews extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'blockified-product-reviews';
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return string[]|null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -531,6 +531,8 @@ final class BlockTypesController {
 			$block_types[] = 'Accordion\AccordionHeader';
 			$block_types[] = 'BlockifiedProductDetails';
 			$block_types[] = 'ProductDescription';
+
+			$block_types[] = 'Reviews\ProductReviews';
 		}
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds the initial **Blockified Product Reviews** block, under the experimental feature flag. Currently this acts mostly as a template wrapper and contains all the blocks used in the WP comments block.
This is based off of this experimental PR: https://github.com/woocommerce/woocommerce/pull/55881

And will require follow up tasks to replace the inner blocks with either variations of the comments block or new custom blocks.

Initial part of #55729
Closes WOOPLUG-3848

### Screenshots or screen recordings:

<img width="1255" alt="Screenshot 2025-03-11 at 10 07 44 AM" src="https://github.com/user-attachments/assets/44f6f6bc-8213-47bb-a9f6-184238757bea" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and have the **WooCommerce Beta Tester** plugin activated
2. Go to **Tools > WCA Test Helper > Features** and enable the **experimental blocks** feature flag
3. Go to **Appearance > Editor > Templates** and edit the **Single Product** template
4. Add the **Blockified Product Details** block ( an accordion )
5. The third accordion ( Reviews ) should contain the **Blockified Product Reviews** block as its child
6. Save the template
7. Visit a product with and without reviews, if reviews exist, it should correctly render them, if no reviews exist, it shouldn't render anything aside from the form. **Note:** this is using the comments block so instead of **reviews** it will say **Responses** or **Leave a reply** ( the form also doesn't contain the rating field at this time ), this will all be follow up.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
