### PR TITLE
Use more specific selectors in `product/product-create-simple` E2E test

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-create-simple.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-create-simple.spec.js
@@ -194,7 +194,7 @@ for ( const productType of Object.keys( productData ) ) {
 						page.getByText( 'Shipping class', { exact: true } )
 					).toBeVisible();
 					await page
-						.getByPlaceholder( '0' )
+						.locator('#_weight')
 						.fill( productData[ productType ].shipping.weight );
 					await page
 						.getByPlaceholder( 'Length', { exact: true } )
@@ -211,8 +211,8 @@ for ( const productType of Object.keys( productData ) ) {
 			// eslint-disable-next-line playwright/no-conditional-in-test
 			if ( productData[ productType ].virtual ) {
 				await test.step( 'add virtual product details', async () => {
-					await page.getByLabel( 'Virtual' ).check();
-					await expect( page.getByLabel( 'Virtual' ) ).toBeChecked();
+					await page.getByRole('checkbox', { name: 'Virtual' }).check();
+					await expect(page.getByRole('checkbox', { name: 'Virtual' })).toBeChecked();
 				} );
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR updates some of the selector used in the `product/product-create-simple` E2E test as they were very generic and were causing failures when being ran with canonical extensions. 

This PR addresses these failures: 

(1)

```
Error: locator.fill: Error: strict mode violation: getByPlaceholder('0') resolved to 3 elements:
    1) <input min="0" value="" step="any" type="text" placeholder="e.g. 5.90" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price"/> aka getByPlaceholder('e.g. 5.90')
    2) <input min="0" value="" step="any" type="text" placeholder="e.g. 9.90" id="_subscription_sign_up_fee" name="_subscription_sign_up_fee" class="wc_input_subscription_intial_price wc_input_subscription_initial_price wc_input_price  short wc_input_price"/> aka getByPlaceholder('e.g. 9.90')
    3) <input value="" type="text" id="_weight" name="_weight" placeholder="0" class="short wc_input_decimal"/> aka getByRole('textbox', { name: 'Weight (lbs)' })

Call log:
  - waiting for getByPlaceholder('0')

```

which searches for the Weight field using `getByPlaceholder('0')`, instead of its ID

and; 

(2)

```
Error: locator.check: Error: strict mode violation: getByLabel('Virtual') resolved to 3 elements:
    1) <input type="checkbox" id="_virtual_composite" name="_virtual_composite" data-product-type-option-id="_virtual_composite"/> aka locator('[id="_virtual_composite"]')
    2) <input id="_virtual" type="checkbox" name="_virtual" data-product-type-option-id="_virtual"/> aka getByRole('checkbox', { name: 'Virtual' })
    3) <span tabindex="-1" class="woocommerce-help-tip" aria-label="Unassembled – Component selections preserve their individual dimensions, weight and shipping classes. A virtual container item keeps them grouped together in the cart."></span> aka getByLabel('Unassembled – Component')

Call log:
  - waiting for getByLabel('Virtual')

```

which searches for the Virtual field using the Label instead of the specific name. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

No manual tests required for E2E changes. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR fixes an E2E test.

</details>
