### PR TITLE
Deprecate __internalSetExtensionData in favor of setExtensionData

### DIFF
--- a/plugins/woocommerce/changelog/update-expose-setExtensionData
+++ b/plugins/woocommerce/changelog/update-expose-setExtensionData
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Deprecate __internalSetExtensionData in favor of setExtensionData

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-checkout-extension-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-checkout-extension-data.ts
@@ -6,38 +6,26 @@ import { useCallback, useRef } from '@wordpress/element';
 import { checkoutStore } from '@woocommerce/block-data';
 
 /**
- * Internal dependencies
- */
-import type { CheckoutState } from '../../../data/checkout/default-state';
-
-/**
  * Custom hook for setting custom checkout data which is passed to the wc/store/checkout endpoint when processing orders.
  */
-export const useCheckoutExtensionData = (): {
-	extensionData: CheckoutState[ 'extensionData' ];
-	setExtensionData: (
-		namespace: string,
-		key: string,
-		value: unknown
-	) => void;
-} => {
-	const { __internalSetExtensionData } = useDispatch( checkoutStore );
+export const useCheckoutExtensionData = () => {
+	const { setExtensionData } = useDispatch( checkoutStore );
 	const extensionData = useSelect( ( select ) =>
 		select( checkoutStore ).getExtensionData()
 	);
 	const extensionDataRef = useRef( extensionData );
 
-	const setExtensionData = useCallback(
-		( namespace, key, value ) => {
-			__internalSetExtensionData( namespace, {
+	const setExtensionDataCallback = useCallback(
+		( namespace: string, key: string, value: unknown ) => {
+			setExtensionData( namespace, {
 				[ key ]: value,
 			} );
 		},
-		[ __internalSetExtensionData ]
+		[ setExtensionData ]
 	);
 
 	return {
 		extensionData: extensionDataRef.current,
-		setExtensionData,
+		setExtensionData: setExtensionDataCallback,
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/actions.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/actions.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { OrderFormValues } from '@woocommerce/settings';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -197,8 +198,9 @@ export const setExtensionData = (
 export const __internalSetExtensionData = (
 	...args: Parameters< typeof setExtensionData >
 ) => {
-	console.warn(
-		'Warning: __internalSetExtensionData is deprecated. Use setExtensionData instead.'
-	);
+	deprecated( '__internalSetExtensionData', {
+		alternative: 'setExtensionData',
+		plugin: 'WooCommerce',
+	} );
 	return setExtensionData( ...args );
 };

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/actions.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/actions.ts
@@ -177,7 +177,7 @@ export const setPrefersCollection = ( prefersCollection: boolean ) => ( {
 /**
  * Registers additional data under an extension namespace.
  */
-export const __internalSetExtensionData = (
+export const setExtensionData = (
 	// The namespace for the extension. Defaults to 'default'. Must be unique to prevent conflicts.
 	namespace: string,
 	// Data to register under the namespace.
@@ -190,3 +190,15 @@ export const __internalSetExtensionData = (
 	namespace,
 	replace,
 } );
+
+/**
+ * @deprecated Use setExtensionData instead
+ */
+export const __internalSetExtensionData = (
+	...args: Parameters< typeof setExtensionData >
+) => {
+	console.warn(
+		'Warning: __internalSetExtensionData is deprecated. Use setExtensionData instead.'
+	);
+	return setExtensionData( ...args );
+};

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/test/reducer.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/test/reducer.ts
@@ -226,7 +226,7 @@ describe.only( 'Checkout Store Reducer', () => {
 			expect(
 				reducer(
 					defaultState,
-					actions.__internalSetExtensionData(
+					actions.setExtensionData(
 						'extensionNamespace',
 						mockExtensionData.extensionNamespace
 					)
@@ -246,13 +246,13 @@ describe.only( 'Checkout Store Reducer', () => {
 			};
 			const firstState = reducer(
 				defaultState,
-				actions.__internalSetExtensionData( 'extensionNamespace', {
+				actions.setExtensionData( 'extensionNamespace', {
 					testKey: 'test-value',
 				} )
 			);
 			const secondState = reducer(
 				firstState,
-				actions.__internalSetExtensionData( 'extensionNamespace', {
+				actions.setExtensionData( 'extensionNamespace', {
 					testKey2: 'test-value-2',
 				} )
 			);
@@ -270,19 +270,48 @@ describe.only( 'Checkout Store Reducer', () => {
 			};
 			const firstState = reducer(
 				defaultState,
-				actions.__internalSetExtensionData( 'extensionNamespace', {
+				actions.setExtensionData( 'extensionNamespace', {
 					testKeyOld: 'test-value',
 				} )
 			);
 			const secondState = reducer(
 				firstState,
-				actions.__internalSetExtensionData(
+				actions.setExtensionData(
 					'extensionNamespace',
 					{ testKey: 'test-value' },
 					true
 				)
 			);
 			expect( secondState ).toEqual( expectedState );
+		} );
+		it( 'should work with deprecated __internalSetExtensionData and show deprecation warning', () => {
+			const consoleSpy = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation();
+			const mockExtensionData = {
+				extensionNamespace: {
+					testKey: 'test-value',
+				},
+			};
+			const expectedState = {
+				...defaultState,
+				extensionData: mockExtensionData,
+			};
+
+			const state = reducer(
+				defaultState,
+				actions.__internalSetExtensionData(
+					'extensionNamespace',
+					mockExtensionData.extensionNamespace
+				)
+			);
+
+			expect( state ).toEqual( expectedState );
+			expect( consoleSpy ).toHaveBeenCalledWith(
+				'Warning: __internalSetExtensionData is deprecated. Use setExtensionData instead.'
+			);
+
+			consoleSpy.mockRestore();
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/test/reducer.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/test/reducer.ts
@@ -308,7 +308,7 @@ describe.only( 'Checkout Store Reducer', () => {
 
 			expect( state ).toEqual( expectedState );
 			expect( consoleSpy ).toHaveBeenCalledWith(
-				'Warning: __internalSetExtensionData is deprecated. Use setExtensionData instead.'
+				'__internalSetExtensionData is deprecated. Please use setExtensionData instead.'
 			);
 
 			consoleSpy.mockRestore();

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/block-client-apis/checkout/checkout-api.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/block-client-apis/checkout/checkout-api.md
@@ -71,7 +71,7 @@ The following actions can be dispatched from the Checkout data store:
 -   `__internalSetUseShippingAsBilling( useShippingAsBilling: boolean )`: Set `state.useShippingAsBilling` to `useShippingAsBilling`
 -   `__internalSetShouldCreateAccount( shouldCreateAccount: boolean )`: Set `state.shouldCreateAccount` to `shouldCreateAccount`
 -   `__internalSetOrderNotes( orderNotes: string )`: Set `state.orderNotes` to `orderNotes`
--   `__internalSetExtensionData( namespace: string, extensionData: Record< string, unknown > )`: Set `state.extensionData` to `extensionData`
+-   `setExtensionData( namespace: string, extensionData: Record< string, unknown > )`: Set `state.extensionData` to `extensionData`
 
 ## Contexts
 

--- a/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/order-attribution.js
@@ -47,12 +47,20 @@
 	 */
 	function updateCheckoutBlockData( values ) {
 		// Update Checkout block data if available.
-		if ( window.wp && window.wp.data && window.wp.data.dispatch && window.wc && window.wc.wcBlocksData ) {
-			window.wp.data.dispatch( window.wc.wcBlocksData.CHECKOUT_STORE_KEY ).__internalSetExtensionData(
-				'woocommerce/order-attribution',
-				values,
-				true
-			);
+		if (
+			window.wp &&
+			window.wp.data &&
+			window.wp.data.dispatch &&
+			window.wc &&
+			window.wc.wcBlocksData
+		) {
+			window.wp.data
+				.dispatch( window.wc.wcBlocksData.CHECKOUT_STORE_KEY )
+				.setExtensionData(
+					'woocommerce/order-attribution',
+					values,
+					true
+				);
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #42214.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Test deprecated `__internalSetExtensionData()`

1. Add a product to the cart.
2. Go to the checkout page.
3. Open the console.
4. Add the following call:
```js
wp.data.dispatch('wc/store/checkout').__internalSetExtensionData(
    'test-namespace',
    {
        testKey: 'testValue'
    }
);
```
5. Verify that the call still works.
6. Verify that the deprecation message is visible.
7. Add the following call:
```js
wp.data.select('wc/store/checkout').getExtensionData();
```
8. Verify that the data was stored.

<img width="1071" alt="Screenshot 2025-03-12 at 15 22 12" src="https://github.com/user-attachments/assets/cb995e08-1284-4a5a-a794-196b7d61f912" />

#### Test new `setExtensionData()`

1. Refresh the checkout page from the previus test case.
2. Add the following call:
```js
wp.data.dispatch('wc/store/checkout').setExtensionData(
    'test-namespace',
    {
        testKey: 'testValue'
    }
);
```
3. Verify that the call works.
4. Add the following call:
```js
wp.data.select('wc/store/checkout').getExtensionData();
```
5. Verify that the data was stored.

<img width="1071" alt="Screenshot 2025-03-12 at 15 23 50" src="https://github.com/user-attachments/assets/6085fab4-3ccb-439b-9849-e751880bbb09" />

<!-- End testing instructions -->

### Testing that has already taken place:

I've tested the following two scenarios and added screenshots above:

1. Test deprecated `__internalSetExtensionData()`
3. Test new `setExtensionData()`

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
