### PR TITLE
Add product review title and rating blocks

### DIFF
--- a/packages/js/data/changelog/add-55729-product-review-title-and-rating-blocks
+++ b/packages/js/data/changelog/add-55729-product-review-title-and-rating-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a getReview selector and resolver to the reviews data store.

--- a/packages/js/data/src/reviews/resolvers.ts
+++ b/packages/js/data/src/reviews/resolvers.ts
@@ -7,7 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { NAMESPACE } from '../constants';
-import { setError, updateReviews } from './actions';
+import { setError, setReview, updateReviews } from './actions';
 import { fetchWithHeaders } from '../controls';
 import { ReviewObject, ReviewsQueryParams } from './types';
 
@@ -33,6 +33,23 @@ export function* getReviews( query: ReviewsQueryParams ) {
 		yield updateReviews( query, response.data, totalCount );
 	} catch ( error ) {
 		yield setError( JSON.stringify( query ), error );
+	}
+}
+
+export function* getReview( id: number ) {
+	try {
+		const url = addQueryArgs( `${ NAMESPACE }/products/reviews/${ id }` );
+		const response: {
+			headers: Map< string, string >;
+			data: ReviewObject;
+		} = yield fetchWithHeaders( {
+			path: url,
+			method: 'GET',
+		} );
+
+		yield setReview( id, response.data );
+	} catch ( error ) {
+		yield setError( JSON.stringify( id ), error );
 	}
 }
 

--- a/packages/js/data/src/reviews/resolvers.ts
+++ b/packages/js/data/src/reviews/resolvers.ts
@@ -38,7 +38,7 @@ export function* getReviews( query: ReviewsQueryParams ) {
 
 export function* getReview( id: number ) {
 	try {
-		const url = addQueryArgs( `${ NAMESPACE }/products/reviews/${ id }` );
+		const url = addQueryArgs( `wc/v3/products/reviews/${ id }` );
 		const response: {
 			headers: Map< string, string >;
 			data: ReviewObject;

--- a/packages/js/data/src/reviews/selectors.ts
+++ b/packages/js/data/src/reviews/selectors.ts
@@ -15,6 +15,10 @@ export const getReviews = (
 	return ids.map( ( id ) => state.data[ id ] );
 };
 
+export const getReview = ( state: ReviewsState, id: number ) => {
+	return state.data[ id ];
+};
+
 export const getReviewsTotalCount = (
 	state: ReviewsState,
 	query: ReviewsQueryParams
@@ -32,4 +36,8 @@ export const getReviewsError = (
 ) => {
 	const stringifiedQuery = JSON.stringify( query );
 	return state.errors[ stringifiedQuery ];
+};
+
+export const getReviewError = ( state: ReviewsState, id: number ) => {
+	return state.errors[ id ];
 };

--- a/plugins/woocommerce/changelog/add-55729-product-review-title-and-rating-blocks
+++ b/plugins/woocommerce/changelog/add-55729-product-review-title-and-rating-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Product Review and Product Reviews Title experimental blocks for use within the blockified product reviews block.

--- a/plugins/woocommerce/client/blocks/assets/css/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/style.scss
@@ -99,10 +99,11 @@ body.wc-block-product-gallery-modal-open {
 	}
 }
 
-.wc-block-grid__product-rating {
+.wc-block-grid__product-rating, .wp-block-woocommerce-product-review-rating {
 	display: block;
 
 	.wc-block-grid__product-rating__stars,
+	.wc-block-components-product-review-rating__stars,
 	.star-rating {
 		overflow: hidden;
 		position: relative;

--- a/plugins/woocommerce/client/blocks/assets/css/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/style.scss
@@ -33,7 +33,9 @@ body.wc-block-product-gallery-modal-open {
 		}
 	}
 }
-.edit-post-visual-editor .editor-block-list__block .wc-block-grid__product-title,
+.edit-post-visual-editor
+	.editor-block-list__block
+	.wc-block-grid__product-title,
 .editor-styles-wrapper .wc-block-grid__product-title,
 .wc-block-grid__product-title {
 	font-family: inherit;
@@ -93,7 +95,8 @@ body.wc-block-product-gallery-modal-open {
 .has-7-columns,
 .has-8-columns,
 .has-9-columns {
-	.wc-block-grid__product-add-to-cart.wp-block-button .wp-block-button__link::after {
+	.wc-block-grid__product-add-to-cart.wp-block-button
+		.wp-block-button__link::after {
 		content: "";
 		margin: 0;
 	}
@@ -104,7 +107,7 @@ body.wc-block-product-gallery-modal-open {
 	display: block;
 
 	.wc-block-grid__product-rating__stars,
-	.wc-block-components-product-review-rating__stars,
+	.wc-block-product-review-rating__stars,
 	.star-rating {
 		overflow: hidden;
 		position: relative;
@@ -207,7 +210,9 @@ body.wc-block-product-gallery-modal-open {
 	.wc-block-grid__product-onsale,
 	.wc-block-components-product-title,
 	.wc-block-components-product-sale-badge {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+			Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",
+			"Helvetica Neue", sans-serif;
 	}
 	.wc-block-grid__product-title::before {
 		display: none;
@@ -216,13 +221,16 @@ body.wc-block-product-gallery-modal-open {
 	.wc-block-components-product-sale-badge {
 		line-height: 1;
 	}
-	.editor-styles-wrapper .wp-block-button .wp-block-button__link:not(.has-text-color) {
+	.editor-styles-wrapper
+		.wp-block-button
+		.wp-block-button__link:not(.has-text-color) {
 		color: #fff;
 	}
 }
 
 .theme-twentytwenty {
-	$twentytwenty-headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-serif;
+	$twentytwenty-headings: -apple-system, blinkmacsystemfont, "Helvetica Neue",
+		helvetica, sans-serif;
 	$twentytwenty-highlights-color: #cd2653;
 
 	.wc-block-grid__product-link {
@@ -288,12 +296,17 @@ body.wc-block-product-gallery-modal-open {
 	.wc-block-grid__products .wc-block-components-product-sale-badge {
 		position: static;
 	}
-	.wc-block-grid__products .wc-block-grid__product-image .wc-block-components-product-sale-badge {
+	.wc-block-grid__products
+		.wc-block-grid__product-image
+		.wc-block-components-product-sale-badge {
 		position: absolute;
 	}
 
 	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
-	.wc-block-grid__products .wc-block-grid__product-onsale:not(.wc-block-components-product-sale-badge) {
+	.wc-block-grid__products
+		.wc-block-grid__product-onsale:not(
+			.wc-block-components-product-sale-badge
+		) {
 		position: absolute;
 		right: 4px;
 		top: 4px;

--- a/plugins/woocommerce/client/blocks/assets/css/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/style.scss
@@ -99,7 +99,8 @@ body.wc-block-product-gallery-modal-open {
 	}
 }
 
-.wc-block-grid__product-rating, .wp-block-woocommerce-product-review-rating {
+.wc-block-grid__product-rating,
+.wp-block-woocommerce-product-review-rating {
 	display: block;
 
 	.wc-block-grid__product-rating__stars,

--- a/plugins/woocommerce/client/blocks/assets/css/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/style.scss
@@ -33,9 +33,7 @@ body.wc-block-product-gallery-modal-open {
 		}
 	}
 }
-.edit-post-visual-editor
-	.editor-block-list__block
-	.wc-block-grid__product-title,
+.edit-post-visual-editor .editor-block-list__block .wc-block-grid__product-title,
 .editor-styles-wrapper .wc-block-grid__product-title,
 .wc-block-grid__product-title {
 	font-family: inherit;
@@ -95,8 +93,7 @@ body.wc-block-product-gallery-modal-open {
 .has-7-columns,
 .has-8-columns,
 .has-9-columns {
-	.wc-block-grid__product-add-to-cart.wp-block-button
-		.wp-block-button__link::after {
+	.wc-block-grid__product-add-to-cart.wp-block-button .wp-block-button__link::after {
 		content: "";
 		margin: 0;
 	}
@@ -210,9 +207,7 @@ body.wc-block-product-gallery-modal-open {
 	.wc-block-grid__product-onsale,
 	.wc-block-components-product-title,
 	.wc-block-components-product-sale-badge {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-			Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",
-			"Helvetica Neue", sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	}
 	.wc-block-grid__product-title::before {
 		display: none;
@@ -221,16 +216,13 @@ body.wc-block-product-gallery-modal-open {
 	.wc-block-components-product-sale-badge {
 		line-height: 1;
 	}
-	.editor-styles-wrapper
-		.wp-block-button
-		.wp-block-button__link:not(.has-text-color) {
+	.editor-styles-wrapper .wp-block-button .wp-block-button__link:not(.has-text-color) {
 		color: #fff;
 	}
 }
 
 .theme-twentytwenty {
-	$twentytwenty-headings: -apple-system, blinkmacsystemfont, "Helvetica Neue",
-		helvetica, sans-serif;
+	$twentytwenty-headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-serif;
 	$twentytwenty-highlights-color: #cd2653;
 
 	.wc-block-grid__product-link {
@@ -296,17 +288,12 @@ body.wc-block-product-gallery-modal-open {
 	.wc-block-grid__products .wc-block-components-product-sale-badge {
 		position: static;
 	}
-	.wc-block-grid__products
-		.wc-block-grid__product-image
-		.wc-block-components-product-sale-badge {
+	.wc-block-grid__products .wc-block-grid__product-image .wc-block-components-product-sale-badge {
 		position: absolute;
 	}
 
 	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
-	.wc-block-grid__products
-		.wc-block-grid__product-onsale:not(
-			.wc-block-components-product-sale-badge
-		) {
+	.wc-block-grid__products .wc-block-grid__product-onsale:not(.wc-block-components-product-sale-badge) {
 		position: absolute;
 		right: 4px;
 		top: 4px;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
@@ -5,7 +5,7 @@
 	"title": "Product Review Rating",
 	"category": "woocommerce",
 	"description": "Displays the rating of a product review.",
-	"textdomain": "default",
+	"textdomain": "woocommerce",
 	"usesContext": [ "commentId" ],
 	"attributes": {
 		"textAlign": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-review-rating",
+	"title": "Product Review Rating",
+	"category": "woocommerce",
+	"description": "Displays the rating of a product review.",
+	"textdomain": "default",
+	"usesContext": [ "commentId" ],
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"color": {
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
@@ -4,6 +4,7 @@
 	"name": "woocommerce/product-review-rating",
 	"title": "Product Review Rating",
 	"category": "woocommerce",
+	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"description": "Displays the rating of a product review.",
 	"textdomain": "woocommerce",
 	"usesContext": [ "commentId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/edit.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { __, sprintf } from '@wordpress/i18n';
+import { useEntityProp } from '@wordpress/core-data';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { useStyleProps } from '@woocommerce/base-hooks';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+/**
+ * Renders the `woocommerce/product-review-rating` block on the editor.
+ *
+ * @param   {Object}  props                    React props.
+ * @param   {Object}  props.attributes         Block attributes.
+ * @param   {Object}  props.setAttributes      Function to set block attributes.
+ * @param   {Object}  props.context           Inherited context.
+ * @param   {string}  props.context.commentId The comment ID.
+ *
+ * @return {JSX.Element} React element.
+ */
+export default function Edit( {
+	context: { commentId },
+	attributes,
+	setAttributes,
+}: BlockEditProps< {
+	textAlign: string;
+} > & {
+	context: { commentId: string };
+} ) {
+	const { textAlign } = attributes;
+	const styleProps = useStyleProps( attributes );
+	const className = clsx(
+		styleProps.className,
+		'wc-block-components-product-review-rating',
+		{
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		}
+	);
+	const blockProps = useBlockProps( {
+		className,
+	} );
+	let [ rating ] = useEntityProp( 'root', 'comment', 'rating', commentId );
+	rating = rating ?? 4;
+
+	const starStyle = {
+		width: ( rating / 5 ) * 100 + '%',
+	};
+
+	const ratingText = sprintf(
+		/* translators: %f is referring to the average rating value */
+		__( 'Rated %f out of 5', 'woocommerce' ),
+		rating
+	);
+
+	const ratingHTML = {
+		__html: sprintf(
+			/* translators: %s is the rating value wrapped in HTML strong tags. */
+			__( 'Rated %s out of 5', 'woocommerce' ),
+			sprintf( '<strong class="rating">%f</strong>', rating )
+		),
+	};
+
+	return (
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ attributes.textAlign }
+					onChange={ ( newAlign ) => {
+						setAttributes( { textAlign: newAlign || '' } );
+					} }
+				/>
+			</BlockControls>
+			<div { ...blockProps }>
+				<div
+					className={
+						'wc-block-components-product-review-rating__stars'
+					}
+					role="img"
+					aria-label={ ratingText }
+				>
+					<span
+						style={ starStyle }
+						dangerouslySetInnerHTML={ ratingHTML }
+					/>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/edit.tsx
@@ -9,20 +9,8 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { useStyleProps } from '@woocommerce/base-hooks';
 import type { BlockEditProps } from '@wordpress/blocks';
 
-/**
- * Renders the `woocommerce/product-review-rating` block on the editor.
- *
- * @param   {Object}  props                    React props.
- * @param   {Object}  props.attributes         Block attributes.
- * @param   {Object}  props.setAttributes      Function to set block attributes.
- * @param   {Object}  props.context           Inherited context.
- * @param   {string}  props.context.commentId The comment ID.
- *
- * @return {JSX.Element} React element.
- */
 export default function Edit( {
 	context: { commentId },
 	attributes,
@@ -33,14 +21,9 @@ export default function Edit( {
 	context: { commentId: string };
 } ) {
 	const { textAlign } = attributes;
-	const styleProps = useStyleProps( attributes );
-	const className = clsx(
-		styleProps.className,
-		'wc-block-components-product-review-rating',
-		{
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		}
-	);
+	const className = clsx( 'wc-block-product-review-rating', {
+		[ `has-text-align-${ textAlign }` ]: textAlign,
+	} );
 	const blockProps = useBlockProps( {
 		className,
 	} );
@@ -77,9 +60,7 @@ export default function Edit( {
 			</BlockControls>
 			<div { ...blockProps }>
 				<div
-					className={
-						'wc-block-components-product-review-rating__stars'
-					}
+					className="wc-block-product-review-rating__stars"
 					role="img"
 					aria-label={ ratingText }
 				>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/edit.tsx
@@ -3,16 +3,18 @@
  */
 import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEntityProp } from '@wordpress/core-data';
 import {
 	AlignmentToolbar,
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { REVIEWS_STORE_NAME } from '@woocommerce/data';
 
 export default function Edit( {
-	context: { commentId },
+	// commentId is the ID of the review.
+	context: { commentId: reviewId },
 	attributes,
 	setAttributes,
 }: BlockEditProps< {
@@ -27,8 +29,14 @@ export default function Edit( {
 	const blockProps = useBlockProps( {
 		className,
 	} );
-	let [ rating ] = useEntityProp( 'root', 'comment', 'rating', commentId );
-	rating = rating ?? 4;
+	const rating = useSelect(
+		( select ) => {
+			const { getReview } = select( REVIEWS_STORE_NAME );
+			const review = reviewId ? getReview( Number( reviewId ) ) : null;
+			return review?.rating ?? 4;
+		},
+		[ reviewId ]
+	);
 
 	const starStyle = {
 		width: ( rating / 5 ) * 100 + '%',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+import { Icon, starHalf } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+if ( isExperimentalBlocksEnabled() ) {
+	// @ts-expect-error metadata is not typed.
+	registerBlockType( metadata, {
+		edit,
+		icon: {
+			src: (
+				<Icon
+					icon={ starHalf }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+	} );
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
-import { Icon, starHalf } from '@wordpress/icons';
+import { starHalf } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -15,13 +15,6 @@ if ( isExperimentalBlocksEnabled() ) {
 	// @ts-expect-error metadata is not typed.
 	registerBlockType( metadata, {
 		edit,
-		icon: {
-			src: (
-				<Icon
-					icon={ starHalf }
-					className="wc-block-editor-components-block-icon"
-				/>
-			),
-		},
+		icon: starHalf,
 	} );
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/block.json
@@ -1,0 +1,72 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-reviews-title",
+	"title": "Product Reviews Title",
+	"category": "woocommerce",
+	"ancestor": [ "woocommerce/blockified-product-reviews" ],
+	"description": "Displays a title with the number of reviews.",
+	"textdomain": "woocommerce",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		},
+		"showProductTitle": {
+			"type": "boolean",
+			"default": true
+		},
+		"showReviewsCount": {
+			"type": "boolean",
+			"default": true
+		},
+		"level": {
+			"type": "number",
+			"default": 2
+		},
+		"levelOptions": {
+			"type": "array"
+		}
+	},
+	"supports": {
+		"anchor": false,
+		"align": true,
+		"html": false,
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
+		},
+		"color": {
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true,
+				"__experimentalFontFamily": true,
+				"__experimentalFontStyle": true,
+				"__experimentalFontWeight": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useEntityProp } from '@wordpress/core-data';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { resolveSelect } from '@wordpress/data';
+import { reviewsStore } from '@woocommerce/data';
+import {
+	// @ts-expect-error AlignmentControl is not exported from @wordpress/block-editor
+	AlignmentControl,
+	BlockControls,
+	useBlockProps,
+	InspectorControls,
+	// @ts-expect-error HeadingLevelDropdown is not exported from @wordpress/block-editor
+	HeadingLevelDropdown,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductReviewsTitleEditProps } from './types';
+
+export default function Edit( {
+	attributes: {
+		textAlign,
+		showProductTitle,
+		showReviewsCount,
+		level,
+		levelOptions,
+	},
+	setAttributes,
+	context: { postType, postId },
+}: ProductReviewsTitleEditProps ) {
+	const TagName = 'h' + level;
+	const [ reviewsCount, setReviewsCount ] = useState< number >( 3 );
+	const [ rawTitle ] = useEntityProp( 'postType', postType, 'title', postId );
+	const isSiteEditor = typeof postId === 'undefined';
+	const blockProps = useBlockProps( {
+		className: clsx( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
+	useEffect( () => {
+		if ( isSiteEditor ) {
+			setReviewsCount( 3 );
+			return;
+		}
+		resolveSelect( reviewsStore )
+			.getReviewsTotalCount( {
+				product: [ Number( postId ) ],
+			} )
+			.then( ( totalCount: number ) => {
+				setReviewsCount( totalCount );
+			} )
+			.catch( () => {
+				setReviewsCount( 0 );
+			} );
+	}, [ postId, isSiteEditor ] );
+
+	const blockControls = (
+		// @ts-expect-error BlockControls is not typed.
+		<BlockControls group="block">
+			<AlignmentControl
+				value={ textAlign }
+				onChange={ ( newAlign: string ) =>
+					setAttributes( { textAlign: newAlign } )
+				}
+			/>
+			<HeadingLevelDropdown
+				value={ level }
+				options={ levelOptions }
+				onChange={ ( newLevel: number ) =>
+					setAttributes( { level: newLevel } )
+				}
+			/>
+		</BlockControls>
+	);
+
+	const inspectorControls = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+				<ToggleControl
+					// @ts-expect-error ToggleControl is not typed.
+					__nextHasNoMarginBottom
+					label={ __( 'Show Product Title', 'woocommerce' ) }
+					checked={ showProductTitle }
+					onChange={ ( value ) =>
+						setAttributes( { showProductTitle: value } )
+					}
+				/>
+				<ToggleControl
+					// @ts-expect-error ToggleControl is not typed.
+					__nextHasNoMarginBottom
+					label={ __( 'Show Reviews Count', 'woocommerce' ) }
+					checked={ showReviewsCount }
+					onChange={ ( value ) =>
+						setAttributes( { showReviewsCount: value } )
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	const postTitle = isSiteEditor
+		? __( '“Product Title”', 'woocommerce' )
+		: `"${ rawTitle }"`;
+
+	let placeholder;
+	if ( showReviewsCount && reviewsCount !== undefined ) {
+		if ( showProductTitle ) {
+			if ( reviewsCount === 1 ) {
+				placeholder = sprintf(
+					/* translators: %s: Post title. */
+					__( 'One review for %s', 'woocommerce' ),
+					postTitle
+				);
+			} else {
+				placeholder = sprintf(
+					/* translators: 1: Number of comments, 2: Post title. */
+					_n(
+						'%1$s review for %2$s',
+						'%1$s reviews for %2$s',
+						reviewsCount,
+						'woocommerce'
+					),
+					reviewsCount,
+					postTitle
+				);
+			}
+		} else if ( reviewsCount === 1 ) {
+			placeholder = __( 'One review', 'woocommerce' );
+		} else {
+			placeholder = sprintf(
+				/* translators: %s: Number of reviews. */
+				_n( '%s review', '%s reviews', reviewsCount, 'woocommerce' ),
+				reviewsCount
+			);
+		}
+	} else if ( showProductTitle ) {
+		if ( reviewsCount === 1 ) {
+			placeholder = sprintf(
+				/* translators: %s: Post title. */
+				__( 'Review for %s', 'woocommerce' ),
+				postTitle
+			);
+		} else {
+			placeholder = sprintf(
+				/* translators: %s: Post title. */
+				__( 'Reviews for %s', 'woocommerce' ),
+				postTitle
+			);
+		}
+	} else if ( reviewsCount === 1 ) {
+		placeholder = __( 'Review', 'woocommerce' );
+	} else {
+		placeholder = __( 'Reviews', 'woocommerce' );
+	}
+
+	return (
+		<>
+			{ blockControls }
+			{ inspectorControls }
+			<TagName { ...blockProps }>{ placeholder }</TagName>
+		</>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
@@ -32,12 +32,12 @@ function getProductReviewsTitle(
 	if ( showReviewsCount && showProductTitle ) {
 		return reviewsCount === 1
 			? sprintf(
-					/* translators: %s: Post title. */
+					/* translators: %s: Product title. */
 					__( 'One review for %s', 'woocommerce' ),
 					productTitle
 			  )
 			: sprintf(
-					/* translators: 1: Number of comments, 2: Post title. */
+					/* translators: 1: Number of comments, 2: Product title. */
 					_n(
 						'%1$s review for %2$s',
 						'%1$s reviews for %2$s',
@@ -52,12 +52,12 @@ function getProductReviewsTitle(
 	if ( ! showReviewsCount && showProductTitle ) {
 		return reviewsCount === 1
 			? sprintf(
-					/* translators: %s: Post title. */
+					/* translators: %s: Product title. */
 					__( 'Review for %s', 'woocommerce' ),
 					productTitle
 			  )
 			: sprintf(
-					/* translators: %s: Post title. */
+					/* translators: %s: Product title. */
 					__( 'Reviews for %s', 'woocommerce' ),
 					productTitle
 			  );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
@@ -23,6 +23,67 @@ import {
  */
 import type { ProductReviewsTitleEditProps } from './types';
 
+function getProductReviewsTitle(
+	showReviewsCount: boolean,
+	reviewsCount: number,
+	showProductTitle: boolean,
+	productTitle: string
+) {
+	if ( showReviewsCount && showProductTitle ) {
+		return reviewsCount === 1
+			? sprintf(
+					/* translators: %s: Post title. */
+					__( 'One review for %s', 'woocommerce' ),
+					productTitle
+			  )
+			: sprintf(
+					/* translators: 1: Number of comments, 2: Post title. */
+					_n(
+						'%1$s review for %2$s',
+						'%1$s reviews for %2$s',
+						reviewsCount,
+						'woocommerce'
+					),
+					reviewsCount,
+					productTitle
+			  );
+	}
+
+	if ( ! showReviewsCount && showProductTitle ) {
+		return reviewsCount === 1
+			? sprintf(
+					/* translators: %s: Post title. */
+					__( 'Review for %s', 'woocommerce' ),
+					productTitle
+			  )
+			: sprintf(
+					/* translators: %s: Post title. */
+					__( 'Reviews for %s', 'woocommerce' ),
+					productTitle
+			  );
+	}
+
+	if ( showReviewsCount && ! showProductTitle ) {
+		return reviewsCount === 1
+			? __( 'One review', 'woocommerce' )
+			: sprintf(
+					/* translators: %s: Number of reviews. */
+					_n(
+						'%s review',
+						'%s reviews',
+						reviewsCount,
+						'woocommerce'
+					),
+					reviewsCount
+			  );
+	}
+
+	if ( reviewsCount === 1 ) {
+		return __( 'Review', 'woocommerce' );
+	}
+	return __( 'Reviews', 'woocommerce' );
+}
+
 export default function Edit( {
 	attributes: {
 		textAlign,
@@ -105,60 +166,16 @@ export default function Edit( {
 		</InspectorControls>
 	);
 
-	const postTitle = isSiteEditor
-		? __( '“Product Title”', 'woocommerce' )
+	const productTitle = isSiteEditor
+		? __( '"Product Title"', 'woocommerce' )
 		: `"${ rawTitle }"`;
 
-	let placeholder;
-	if ( showReviewsCount && reviewsCount !== undefined ) {
-		if ( showProductTitle ) {
-			if ( reviewsCount === 1 ) {
-				placeholder = sprintf(
-					/* translators: %s: Post title. */
-					__( 'One review for %s', 'woocommerce' ),
-					postTitle
-				);
-			} else {
-				placeholder = sprintf(
-					/* translators: 1: Number of comments, 2: Post title. */
-					_n(
-						'%1$s review for %2$s',
-						'%1$s reviews for %2$s',
-						reviewsCount,
-						'woocommerce'
-					),
-					reviewsCount,
-					postTitle
-				);
-			}
-		} else if ( reviewsCount === 1 ) {
-			placeholder = __( 'One review', 'woocommerce' );
-		} else {
-			placeholder = sprintf(
-				/* translators: %s: Number of reviews. */
-				_n( '%s review', '%s reviews', reviewsCount, 'woocommerce' ),
-				reviewsCount
-			);
-		}
-	} else if ( showProductTitle ) {
-		if ( reviewsCount === 1 ) {
-			placeholder = sprintf(
-				/* translators: %s: Post title. */
-				__( 'Review for %s', 'woocommerce' ),
-				postTitle
-			);
-		} else {
-			placeholder = sprintf(
-				/* translators: %s: Post title. */
-				__( 'Reviews for %s', 'woocommerce' ),
-				postTitle
-			);
-		}
-	} else if ( reviewsCount === 1 ) {
-		placeholder = __( 'Review', 'woocommerce' );
-	} else {
-		placeholder = __( 'Reviews', 'woocommerce' );
-	}
+	const placeholder = getProductReviewsTitle(
+		showReviewsCount,
+		reviewsCount,
+		showProductTitle,
+		productTitle
+	);
 
 	return (
 		<>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/editor.scss
@@ -1,0 +1,4 @@
+
+.wp-block-product-reviews-title.has-background {
+	padding: inherit;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/editor.scss
@@ -1,4 +1,0 @@
-
-.wp-block-product-reviews-title.has-background {
-	padding: inherit;
-}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/index.ts
@@ -10,7 +10,7 @@ import { title as icon } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
-import './editor.scss';
+import './style.scss';
 
 if ( isExperimentalBlocksEnabled() ) {
 	// @ts-expect-error metadata is not typed.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/index.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+import { title as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import './editor.scss';
+
+if ( isExperimentalBlocksEnabled() ) {
+	// @ts-expect-error metadata is not typed.
+	registerBlockType( metadata, {
+		edit,
+		icon,
+	} );
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/style.scss
@@ -1,0 +1,4 @@
+
+.wp-block-woocommerce-product-reviews-title.has-background {
+	padding: inherit;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/types.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { BlockEditProps } from '@wordpress/blocks';
+
+type Attributes = {
+	textAlign: string;
+	showProductTitle: boolean;
+	showReviewsCount: boolean;
+	level: number;
+	levelOptions: { label: string; value: number }[];
+};
+
+type Context = {
+	context: { postId: string; postType: string };
+};
+
+export type ProductReviewsTitleEditProps = BlockEditProps< Attributes > &
+	Context;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
@@ -4,7 +4,7 @@
 import { InnerBlockTemplate } from '@wordpress/blocks';
 
 const TEMPLATE: InnerBlockTemplate[] = [
-	[ 'core/comments-title' ],
+	[ 'woocommerce/product-reviews-title' ],
 	[
 		'core/comment-template',
 		{},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
@@ -69,6 +69,11 @@ const TEMPLATE: InnerBlockTemplate[] = [
 							[ 'core/comment-content' ],
 						],
 					],
+					[
+						'core/column',
+						{ width: '80px' },
+						[ [ 'woocommerce/product-review-rating' ] ],
+					],
 				],
 			],
 		],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
@@ -33,10 +33,24 @@ const TEMPLATE: InnerBlockTemplate[] = [
 						{},
 						[
 							[
-								'core/comment-author-name',
+								'core/group',
 								{
-									fontSize: 'small',
+									tagName: 'div',
+									layout: {
+										type: 'flex',
+										flexWrap: 'nowrap',
+										justifyContent: 'space-between',
+									},
 								},
+								[
+									[
+										'core/comment-author-name',
+										{
+											fontSize: 'small',
+										},
+									],
+									[ 'woocommerce/product-review-rating' ],
+								],
 							],
 							[
 								'core/group',
@@ -68,11 +82,6 @@ const TEMPLATE: InnerBlockTemplate[] = [
 							],
 							[ 'core/comment-content' ],
 						],
-					],
-					[
-						'core/column',
-						{ width: '80px' },
-						[ [ 'woocommerce/product-review-rating' ] ],
 					],
 				],
 			],

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -222,6 +222,10 @@ const blocks = {
 		isExperimental: true,
 		customDir: 'product-reviews',
 	},
+	'product-review-rating': {
+		customDir: 'product-reviews/inner-blocks/review-rating',
+		isExperimental: true,
+	},
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -226,6 +226,10 @@ const blocks = {
 		customDir: 'product-reviews/inner-blocks/review-rating',
 		isExperimental: true,
 	},
+	'product-reviews-title': {
+		customDir: 'product-reviews/inner-blocks/reviews-title',
+		isExperimental: true,
+	},
 };
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
@@ -1,0 +1,71 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+
+/**
+ * ProductReviewRating class.
+ */
+class ProductReviewRating extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-review-rating';
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return string[]|null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered block content.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( ! isset( $block->context['commentId'] ) ) {
+			return '';
+		}
+
+		$rating = intval( get_comment_meta( $block->context['commentId'], 'rating', true ) );
+
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
+
+		$html = '';
+
+		if ( 0 < $rating ) {
+			$label = sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating );
+			$html  = sprintf(
+				'<div class="wc-block-components-product-review-rating__container">
+					<div class="wc-block-components-product-review-rating__stars" role="img" aria-label="%1$s">
+						%2$s
+					</div>
+				</div>
+				',
+				esc_attr( $label ),
+				wc_get_star_rating_html( $rating )
+			);
+		}
+
+		return sprintf(
+			'<div %1$s>
+				%2$s
+			</div>',
+			get_block_wrapper_attributes(
+				array(
+					'class' => esc_attr( $classes_and_styles['classes'] ),
+					'style' => $classes_and_styles['styles'],
+				)
+			),
+			$html
+		);
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
@@ -47,8 +47,8 @@ class ProductReviewRating extends AbstractBlock {
 			// translators: %s: Rating.
 			$label = sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating );
 			$html  = sprintf(
-				'<div class="wc-block-components-product-review-rating__container">
-					<div class="wc-block-components-product-review-rating__stars" role="img" aria-label="%1$s">
+				'<div class="wc-block-product-review-rating__container">
+					<div class="wc-block-product-review-rating__stars" role="img" aria-label="%1$s">
 						%2$s
 					</div>
 				</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
@@ -27,8 +27,8 @@ class ProductReviewRating extends AbstractBlock {
 	/**
 	 * Render the block.
 	 *
-	 * @param array $attributes Block attributes.
-	 * @param string $content Block content.
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
 	 * @param WP_Block $block Block instance.
 	 * @return string Rendered block content.
 	 */
@@ -44,6 +44,7 @@ class ProductReviewRating extends AbstractBlock {
 		$html = '';
 
 		if ( 0 < $rating ) {
+			// translators: %s: Rating.
 			$label = sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating );
 			$html  = sprintf(
 				'<div class="wc-block-components-product-review-rating__container">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
@@ -2,7 +2,6 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
  * ProductReviewRating class.
@@ -39,8 +38,6 @@ class ProductReviewRating extends AbstractBlock {
 
 		$rating = intval( get_comment_meta( $block->context['commentId'], 'rating', true ) );
 
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
-
 		$html = '';
 
 		if ( 0 < $rating ) {
@@ -62,12 +59,7 @@ class ProductReviewRating extends AbstractBlock {
 			'<div %1$s>
 				%2$s
 			</div>',
-			get_block_wrapper_attributes(
-				array(
-					'class' => esc_attr( $classes_and_styles['classes'] ),
-					'style' => $classes_and_styles['styles'],
-				)
-			),
+			get_block_wrapper_attributes(),
 			$html
 		);
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
@@ -71,4 +71,15 @@ class ProductReviewRating extends AbstractBlock {
 			$html
 		);
 	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewRating.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
@@ -28,6 +28,8 @@ class ProductReviewRating extends AbstractBlock {
 	 * Render the block.
 	 *
 	 * @param array $attributes Block attributes.
+	 * @param string $content Block content.
+	 * @param WP_Block $block Block instance.
 	 * @return string Rendered block content.
 	 */
 	protected function render( $attributes, $content, $block ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
@@ -23,4 +23,15 @@ class ProductReviews extends AbstractBlock {
 	protected function get_block_type_style() {
 		return null;
 	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -1,0 +1,107 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+
+/**
+ * ProductReviewsTitle class.
+ */
+class ProductReviewsTitle extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-reviews-title';
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return string[]|null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered block content.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( post_password_required() ) {
+			return;
+		}
+		$post_id = $block->context['postId'];
+		$product = wc_get_product( $post_id );
+
+		if ( ! $product ) {
+			return '';
+		}
+	
+		$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+		$show_product_title = ! empty( $attributes['showProductTitle'] ) && $attributes['showProductTitle'];
+		$show_reviews_count = ! empty( $attributes['showReviewsCount'] ) && $attributes['showReviewsCount'];
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+		$reviews_count      = $product->get_review_count();
+		/* translators: %s: Product title. */
+		$product_title = sprintf( __( '&#8220;%s&#8221;', 'woocommerce' ), $product->get_title() );
+		$tag_name   = 'h2';
+		if ( isset( $attributes['level'] ) ) {
+			$tag_name = 'h' . $attributes['level'];
+		}
+	
+		if ( '0' === $reviews_count ) {
+			return;
+		}
+	
+		if ( $show_reviews_count ) {
+			if ( $show_product_title ) {
+				if ( '1' === $reviews_count ) {
+					/* translators: %s: Post title. */
+					$reviews_title = sprintf( __( 'One review for %s', 'woocommerce' ), $product_title );
+				} else {
+					$reviews_title = sprintf(
+						/* translators: 1: Number of reviews, 2: Product title. */
+						_n(
+							'%1$s review for %2$s',
+							'%1$s reviews for %2$s',
+							$reviews_count,
+							'woocommerce'
+						),
+						number_format_i18n( $reviews_count ),
+						$product_title
+					);
+				}
+			} elseif ( '1' === $reviews_count ) {
+				$reviews_title = __( 'One review', 'woocommerce' );
+			} else {
+				$reviews_title = sprintf(
+					/* translators: %s: Number of reviews. */
+					_n( '%s review', '%s reviews', $reviews_count, 'woocommerce' ),
+					number_format_i18n( $reviews_count )
+				);
+			}
+		} elseif ( $show_product_title ) {
+			if ( '1' === $reviews_count ) {
+				/* translators: %s: Product title. */
+				$reviews_title = sprintf( __( 'Review for %s', 'woocommerce' ), $product_title );
+			} else {
+				/* translators: %s: Product title. */
+				$reviews_title = sprintf( __( 'Reviews for %s', 'woocommerce' ), $product_title );
+			}
+		} elseif ( '1' === $reviews_count ) {
+			$reviews_title = __( 'Review', 'woocommerce' );
+		} else {
+			$reviews_title = __( 'Reviews', 'woocommerce' );
+		}
+	
+		return sprintf(
+			'<%1$s id="reviews" %2$s>%3$s</%1$s>',
+			$tag_name,
+			$wrapper_attributes,
+			$reviews_title
+		);
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -15,15 +15,6 @@ class ProductReviewsTitle extends AbstractBlock {
 	protected $block_name = 'product-reviews-title';
 
 	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return string[]|null
-	 */
-	protected function get_block_type_style() {
-		return null;
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array $attributes Block attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -15,6 +15,66 @@ class ProductReviewsTitle extends AbstractBlock {
 	protected $block_name = 'product-reviews-title';
 
 	/**
+	 * Get the reviews title.
+	 *
+	 * @param array      $attributes Block attributes.
+	 * @param WC_Product $product Product instance.
+	 * @return string
+	 */
+	private function get_reviews_title( $attributes, $product ) {
+		$show_product_title = ! empty( $attributes['showProductTitle'] ) && $attributes['showProductTitle'];
+		$show_reviews_count = ! empty( $attributes['showReviewsCount'] ) && $attributes['showReviewsCount'];
+		$reviews_count      = $product->get_review_count();
+		/* translators: %s: Product title. */
+		$product_title = sprintf( __( '&#8220;%s&#8221;', 'woocommerce' ), $product->get_title() );
+
+		if ( $show_reviews_count && $show_product_title ) {
+			return 1 === $reviews_count
+				/* translators: %s: Product title. */
+				? sprintf( __( 'One review for %s', 'woocommerce' ), $product_title )
+				: sprintf(
+					/* translators: 1: Number of reviews, 2: Product title. */
+					_n(
+						'%1$s review for %2$s',
+						'%1$s reviews for %2$s',
+						$reviews_count,
+						'woocommerce'
+					),
+					number_format_i18n( $reviews_count ),
+					$product_title
+				);
+		}
+
+		if ( ! $show_reviews_count && $show_product_title ) {
+			return 1 === $reviews_count
+				/* translators: %s: Product title. */
+				? sprintf( __( 'Review for %s', 'woocommerce' ), $product_title )
+				: sprintf(
+					/* translators: %s: Product title. */
+					__( 'Reviews for %s', 'woocommerce' ),
+					$product_title
+				);
+		}
+
+		if ( $show_reviews_count && ! $show_product_title ) {
+			return 1 === $reviews_count
+				/* translators: %s: Number of reviews. */
+				? __( 'One review', 'woocommerce' )
+				: sprintf(
+					/* translators: %s: Number of reviews. */
+					_n( '%s review', '%s reviews', $reviews_count, 'woocommerce' ),
+					number_format_i18n( $reviews_count )
+				);
+		}
+
+		if ( 1 === $reviews_count ) {
+			return __( 'Review', 'woocommerce' );
+		}
+
+		return __( 'Reviews', 'woocommerce' );
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -34,61 +94,18 @@ class ProductReviewsTitle extends AbstractBlock {
 		}
 
 		$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
-		$show_product_title = ! empty( $attributes['showProductTitle'] ) && $attributes['showProductTitle'];
-		$show_reviews_count = ! empty( $attributes['showReviewsCount'] ) && $attributes['showReviewsCount'];
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 		$reviews_count      = $product->get_review_count();
-		/* translators: %s: Product title. */
-		$product_title = sprintf( __( '&#8220;%s&#8221;', 'woocommerce' ), $product->get_title() );
-		$tag_name      = 'h2';
+		$tag_name           = 'h2';
 		if ( isset( $attributes['level'] ) ) {
 			$tag_name = 'h' . $attributes['level'];
 		}
 
-		if ( '0' === $reviews_count ) {
+		if ( 0 === $reviews_count ) {
 			return;
 		}
 
-		if ( $show_reviews_count ) {
-			if ( $show_product_title ) {
-				if ( '1' === $reviews_count ) {
-					/* translators: %s: Post title. */
-					$reviews_title = sprintf( __( 'One review for %s', 'woocommerce' ), $product_title );
-				} else {
-					$reviews_title = sprintf(
-						/* translators: 1: Number of reviews, 2: Product title. */
-						_n(
-							'%1$s review for %2$s',
-							'%1$s reviews for %2$s',
-							$reviews_count,
-							'woocommerce'
-						),
-						number_format_i18n( $reviews_count ),
-						$product_title
-					);
-				}
-			} elseif ( '1' === $reviews_count ) {
-				$reviews_title = __( 'One review', 'woocommerce' );
-			} else {
-				$reviews_title = sprintf(
-					/* translators: %s: Number of reviews. */
-					_n( '%s review', '%s reviews', $reviews_count, 'woocommerce' ),
-					number_format_i18n( $reviews_count )
-				);
-			}
-		} elseif ( $show_product_title ) {
-			if ( '1' === $reviews_count ) {
-				/* translators: %s: Product title. */
-				$reviews_title = sprintf( __( 'Review for %s', 'woocommerce' ), $product_title );
-			} else {
-				/* translators: %s: Product title. */
-				$reviews_title = sprintf( __( 'Reviews for %s', 'woocommerce' ), $product_title );
-			}
-		} elseif ( '1' === $reviews_count ) {
-			$reviews_title = __( 'Review', 'woocommerce' );
-		} else {
-			$reviews_title = __( 'Reviews', 'woocommerce' );
-		}
+		$reviews_title = $this->get_reviews_title( $attributes, $product );
 
 		return sprintf(
 			'<%1$s id="reviews" %2$s>%3$s</%1$s>',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -97,4 +97,15 @@ class ProductReviewsTitle extends AbstractBlock {
 			$reviews_title
 		);
 	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -17,8 +17,8 @@ class ProductReviewsTitle extends AbstractBlock {
 	/**
 	 * Render the block.
 	 *
-	 * @param array $attributes Block attributes.
-	 * @param string $content Block content.
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
 	 * @param WP_Block $block Block instance.
 	 * @return string Rendered block content.
 	 */
@@ -32,7 +32,7 @@ class ProductReviewsTitle extends AbstractBlock {
 		if ( ! $product ) {
 			return '';
 		}
-	
+
 		$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 		$show_product_title = ! empty( $attributes['showProductTitle'] ) && $attributes['showProductTitle'];
 		$show_reviews_count = ! empty( $attributes['showReviewsCount'] ) && $attributes['showReviewsCount'];
@@ -40,15 +40,15 @@ class ProductReviewsTitle extends AbstractBlock {
 		$reviews_count      = $product->get_review_count();
 		/* translators: %s: Product title. */
 		$product_title = sprintf( __( '&#8220;%s&#8221;', 'woocommerce' ), $product->get_title() );
-		$tag_name   = 'h2';
+		$tag_name      = 'h2';
 		if ( isset( $attributes['level'] ) ) {
 			$tag_name = 'h' . $attributes['level'];
 		}
-	
+
 		if ( '0' === $reviews_count ) {
 			return;
 		}
-	
+
 		if ( $show_reviews_count ) {
 			if ( $show_product_title ) {
 				if ( '1' === $reviews_count ) {
@@ -89,7 +89,7 @@ class ProductReviewsTitle extends AbstractBlock {
 		} else {
 			$reviews_title = __( 'Reviews', 'woocommerce' );
 		}
-	
+
 		return sprintf(
 			'<%1$s id="reviews" %2$s>%3$s</%1$s>',
 			$tag_name,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -101,10 +101,6 @@ class ProductReviewsTitle extends AbstractBlock {
 			$tag_name = 'h' . $attributes['level'];
 		}
 
-		if ( 0 === $reviews_count ) {
-			return;
-		}
-
 		$reviews_title = $this->get_reviews_title( $attributes, $product );
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
@@ -18,6 +18,8 @@ class ProductReviewsTitle extends AbstractBlock {
 	 * Render the block.
 	 *
 	 * @param array $attributes Block attributes.
+	 * @param string $content Block content.
+	 * @param WP_Block $block Block instance.
 	 * @return string Rendered block content.
 	 */
 	protected function render( $attributes, $content, $block ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -534,6 +534,7 @@ final class BlockTypesController {
 
 			$block_types[] = 'Reviews\ProductReviews';
 			$block_types[] = 'Reviews\ProductReviewRating';
+			$block_types[] = 'Reviews\ProductReviewsTitle';
 		}
 
 		/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -533,6 +533,7 @@ final class BlockTypesController {
 			$block_types[] = 'ProductDescription';
 
 			$block_types[] = 'Reviews\ProductReviews';
+			$block_types[] = 'Reviews\ProductReviewRating';
 		}
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR builds on top of the initial product reviews PR ( #56276 ) and adds two new blocks:
- **Product Review Rating** - A block to display the **star** rating of an individual review.
- **Product Reviews Title** - A block to replace the **Post Comments Title**, which updates the wording to use reviews, but also makes use of the WC Reviews REST endpoint within context aware blocks.

Part of https://github.com/woocommerce/woocommerce/issues/55729

Closes WOOPLUG-3849

### Screenshots or screen recordings:

<img width="1512" alt="Screenshot 2025-03-13 at 1 44 09 PM" src="https://github.com/user-attachments/assets/c16d54fd-6056-4640-8a07-1a6b19eab9c4" />

https://github.com/user-attachments/assets/54af7715-51aa-4262-aaeb-fc781981b59a

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Note:** These tests will be focused towards the two new blocks, the reviews title and the review rating. Meaning that the review block still contains other blocks that pertain to comments specifically. These will be addressed in follow up PRs.

1. Load this branch and have the **WooCommerce Beta Tester** plugin activated
2. Go to **Tools > WCA Test Helper > Features** and enable the **experimental blocks** feature flag
3. Go to **Appearance > Editor > Templates** and edit the **Single Product** template
4. Add the **Blockified Product Details** block ( an accordion )
5. The third accordion ( Reviews ) should contain the **Blockified Product Reviews** block as its child
6. It should include the **Product Reviews Title** as the first nested block that uses the "product reviews" copy and allows you toggle the review count and product title ( this should also be reflected correctly on the front-end ).
7. The comment template will have a third column that contains the product rating ( the 5 stars )
8. Save the template
9. Visit a product with and without reviews, if reviews exist, it should correctly render the title with the correct number and show the correct star rating for each review, if no reviews exist, it shouldn't render any review and render "0 reviews for ..." as the title. ( We may want to create a follow up to have an explicit "No review" title block, as in the current block it displays "There are no reviews yet." and "Be the first to review “Black and White”" )

**Test areas with context**

Follow the tests below either within a page where you use either the **Single product** or **product collection** block.

1. Add the **Blockified Product Reviews** block as a child of one of the above blocks ( make sure you have a product with and without reviews displayed )
2. If the parent block has reviews it should show the correct number in the **Product Reviews Title** block. Ratings will unfortunately not be shown yet, because we still make use of the **Comments Template** which uses the comments endpoint.
3. If the parent block does not have reviews, it should show the correct number of zero reviews in the title.
4. Save the page and preview it, it should render the title correctly and also the reviews that include the star rating.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
