### PR TITLE
Update Block Templates Package for React 18

### DIFF
--- a/packages/js/block-templates/changelog/56341-update-register-woo-block-type-util-react-18
+++ b/packages/js/block-templates/changelog/56341-update-register-woo-block-type-util-react-18
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Cleanup task: Fix TypeScript error in block templates package from React 18 upgrade.
+

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -57,8 +57,7 @@ function getEdit<
 		const { getEvaluationContext } = useEvaluationContext( context );
 
 		const { shouldHide, shouldDisable } = useSelect(
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			( select: any ) => {
+			( select: SelectType ) => {
 				const evaluationContext = getEvaluationContext( select );
 
 				return {

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -11,11 +11,6 @@ import { createElement } from '@wordpress/element';
 import { evaluate } from '@woocommerce/expression-evaluation';
 import { isWpVersion, getSetting } from '@woocommerce/settings';
 import { ComponentType } from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet, natively (not until 7.0.0).
-// Including `@types/wordpress__data` as a devDependency causes build issues,
-// so just going type-free for now.
-// eslint-disable-next-line @woocommerce/dependency-group
 import { useSelect } from '@wordpress/data';
 
 // Define a more generic type for the select function to avoid TypeScript errors

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -19,7 +19,6 @@ import { ComponentType } from 'react';
 import { useSelect } from '@wordpress/data';
 
 // Define a more generic type for the select function to avoid TypeScript errors
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SelectType = ( store: string ) => Record< string, unknown >;
 
 interface BlockRepresentation< T extends Record< string, object > > {

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -34,8 +34,7 @@ type UseEvaluationContext = ( context: Record< string, unknown > ) => {
 
 function defaultUseEvaluationContext( context: Record< string, unknown > ) {
 	return {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-		getEvaluationContext: ( select: any ) => context,
+		getEvaluationContext: () => context,
 	};
 }
 

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -16,7 +16,11 @@ import { ComponentType } from 'react';
 // Including `@types/wordpress__data` as a devDependency causes build issues,
 // so just going type-free for now.
 // eslint-disable-next-line @woocommerce/dependency-group
-import { useSelect, select as WPSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+
+// Define a more generic type for the select function to avoid TypeScript errors
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SelectType = ( store: string ) => Record< string, unknown >;
 
 interface BlockRepresentation< T extends Record< string, object > > {
 	name?: string;
@@ -25,14 +29,13 @@ interface BlockRepresentation< T extends Record< string, object > > {
 }
 
 type UseEvaluationContext = ( context: Record< string, unknown > ) => {
-	getEvaluationContext: (
-		select: typeof WPSelect
-	) => Record< string, unknown >;
+	getEvaluationContext: ( select: SelectType ) => Record< string, unknown >;
 };
 
 function defaultUseEvaluationContext( context: Record< string, unknown > ) {
 	return {
-		getEvaluationContext: () => context,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+		getEvaluationContext: ( select: any ) => context,
 	};
 }
 
@@ -55,8 +58,8 @@ function getEdit<
 		const { getEvaluationContext } = useEvaluationContext( context );
 
 		const { shouldHide, shouldDisable } = useSelect(
-			// @ts-expect-error TODO: react-18-upgrade
-			( select: typeof WPSelect ) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( select: any ) => {
 				const evaluationContext = getEvaluationContext( select );
 
 				return {

--- a/packages/js/product-editor/changelog/56341-update-register-woo-block-type-util-react-18
+++ b/packages/js/product-editor/changelog/56341-update-register-woo-block-type-util-react-18
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Cleanup task: Fix TypeScript error in block templates package from React 18 upgrade.
+

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -15,7 +15,6 @@ interface BlockRepresentation< T extends Record< string, object > > {
 }
 
 // Define a more generic type for the select function to avoid TypeScript errors
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SelectType = ( store: string ) => Record< string, unknown >;
 
 export function useEvaluationContext( context: Record< string, unknown > ) {
@@ -23,7 +22,6 @@ export function useEvaluationContext( context: Record< string, unknown > ) {
 
 	const productId = useEntityId( 'postType', postType );
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const getEvaluationContext = ( select: SelectType ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -20,14 +20,20 @@ type SelectType = ( store: string ) => Record< string, unknown >;
 export function useEvaluationContext( context: Record< string, unknown > ) {
 	const { postType } = context;
 
-	const productId = useEntityId( 'postType', postType );
+	const productId = useEntityId( 'postType', postType as string );
 
 	const getEvaluationContext = ( select: SelectType ) => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		const editedProduct = select( 'core' ).getEditedEntityRecord(
+		const coreStore = select( 'core' ) as {
+			getEditedEntityRecord: (
+				kind: string,
+				name: string,
+				id: number
+			) => Record< string, unknown >;
+		};
+
+		const editedProduct = coreStore.getEditedEntityRecord(
 			'postType',
-			postType,
+			postType as string,
 			productId
 		);
 

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -14,13 +14,17 @@ interface BlockRepresentation< T extends Record< string, object > > {
 	settings: Partial< BlockConfiguration< T > >;
 }
 
+// Define a more generic type for the select function to avoid TypeScript errors
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SelectType = ( store: string ) => Record< string, unknown >;
+
 export function useEvaluationContext( context: Record< string, unknown > ) {
 	const { postType } = context;
 
 	const productId = useEntityId( 'postType', postType );
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const getEvaluationContext = ( select: any ) => {
+	const getEvaluationContext = ( select: SelectType ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		const editedProduct = select( 'core' ).getEditedEntityRecord(

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Block, BlockConfiguration } from '@wordpress/blocks';
-import { select as WPSelect } from '@wordpress/data';
 import { registerWooBlockType } from '@woocommerce/block-templates';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -20,7 +19,8 @@ export function useEvaluationContext( context: Record< string, unknown > ) {
 
 	const productId = useEntityId( 'postType', postType );
 
-	const getEvaluationContext = ( select: typeof WPSelect ) => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const getEvaluationContext = ( select: any ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		const editedProduct = select( 'core' ).getEditedEntityRecord(

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -3,9 +3,6 @@
  */
 import { Block, BlockConfiguration } from '@wordpress/blocks';
 import { registerWooBlockType } from '@woocommerce/block-templates';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
 import { useEntityId } from '@wordpress/core-data';
 
 interface BlockRepresentation< T extends Record< string, object > > {

--- a/packages/js/product-editor/src/wp-hooks/hide-inventory-advanced-collapsible.tsx
+++ b/packages/js/product-editor/src/wp-hooks/hide-inventory-advanced-collapsible.tsx
@@ -60,7 +60,6 @@ const maybeHideInventoryAdvancedCollapsible = createHigherOrderComponent(
 								advancedCollapsibleBlock?.innerBlocks[ 0 ];
 							allBlocksInvisible = areAllBlocksInvisible(
 								advancedSectionBlock?.innerBlocks,
-								// @ts-expect-error type is not correct
 								evalContext.getEvaluationContext( select )
 							);
 						}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fixes the TS error (post React 18 update) as follows:

1. Removed the unused `select as WPSelect` import since we're no longer using it directly.
2. Created a more generic `SelectType` type that's compatible with React 18.
3. Updated the `UseEvaluationContext` type to use this new `SelectType`.
4. Changed the `useSelect` hook to use `any` for the select parameter with appropriate ESLint comments.
5. Updated the `defaultUseEvaluationContext` function to match our new type definition.
6. Changed the `select` parameter type in `useEvaluationContext` from `typeof WPSelect` to `any` with appropriate ESLint comments.

These changes should bring the code up to compatibility with React 18 while maintaining the functionality of the code. The approach uses `any` in a controlled way with appropriate ESLint comments to acknowledge the type safety compromise, which is necessary given the comment about not being able to include proper type definitions.

This solution:

1. Fixes the immediate TypeScript error.
2. Maintains compatibility with React 18.
3. Preserves the existing functionality.
4. Follows the existing pattern of handling type issues in this file.

Sub-task of #55399.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the following files and confirm there are no TS errors introduced by this PR:
    - `packages/js/block-templates/src/utils/register-woo-block-type.ts`
    - `packages/js/product-editor/src/wp-hooks/hide-inventory-advanced-collapsible.tsx`
    - `packages/js/product-editor/src/utils/register-product-editor-block-type.ts`
2. Run tests from block-templates dir (`cd packages/js/block-templates && pnpm test:js`) and confirm all tests pass.
3. Run tests from product-editor dir (`cd packages/js/product-editor && pnpm test:js`) and confirm all tests pass.
4. Build the WooCommerce plugin via `pnpm --filter='@woocommerce/plugin-woocommerce' build` and confirm build succeeds without errors.

_Note: This PR only includes changes to types, there are no user-facing changes._

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

1. Ran tests from block-templates dir (`cd packages/js/block-templates && pnpm test:js`) and confirmed all tests pass.
2. Ran tests from product-editor dir (`cd packages/js/product-editor && pnpm test:js`) and confirmed all tests pass.
3. Built the WooCommerce plugin via `pnpm --filter='@woocommerce/plugin-woocommerce' build` and confirmed build succeeds without errors.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Cleanup task: Fix TypeScript error in block templates package from React 18 upgrade.

</details>
