### PR TITLE
[e2e tests] Fix flakiness in product reviews checks

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-product-review
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-product-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: stabilize product review checks

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -295,7 +295,7 @@ test.describe( 'Product Reviews', () => {
 				.locator( 'a.comments-view-item-link' )
 				.getAttribute( 'href' );
 			await page.goto( productLink );
-			await page.click( '#tab-reviews' );
+			await page.getByRole( 'tab', { name: 'Reviews' } ).click();
 
 			const replyReviews = page.locator(
 				`div.comment_container:has-text("${ replyText }")`

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -9,21 +9,17 @@ import { faker } from '@faker-js/faker';
 import { test as baseTest, expect } from '../../fixtures/fixtures';
 import { WC_API_PATH } from '../../utils/api-client';
 import { ADMIN_STATE_PATH, CUSTOMER_STATE_PATH } from '../../playwright.config';
+import { getFakeProduct } from '../../utils/data';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
 	products: async ( { restApi }, use ) => {
-		const timestamp = Date.now().toString();
 		const products = [];
 
 		// Create the products
 		for ( let i = 0; i < 2; i++ ) {
 			await restApi
-				.post( `${ WC_API_PATH }/products`, {
-					name: `Product ${ i } ${ timestamp }`,
-					type: 'simple',
-					regular_price: '9.99',
-				} )
+				.post( `${ WC_API_PATH }/products`, getFakeProduct() )
 				.then( ( response ) => {
 					products.push( response.data );
 				} );
@@ -45,8 +41,10 @@ const test = baseTest.extend( {
 				.post( `${ WC_API_PATH }/products/reviews`, {
 					product_id: product.id,
 					review: `Nice product ${ product.name }, at ${ timestamp }`,
-					reviewer: 'John Doe',
-					reviewer_email: `john.doe.${ timestamp }@example.com`,
+					reviewer: faker.person.fullName(),
+					reviewer_email: faker.internet.email( {
+						provider: 'example.fakerjs.dev',
+					} ),
 					rating: ( Math.random() * ( 5 - 1 ) + 1 ).toFixed( 0 ),
 				} )
 				.then( ( response ) => {
@@ -120,21 +118,20 @@ test.describe( 'Product Reviews', () => {
 				.fill( review.product_name );
 			await page
 				.getByRole( 'option', { name: review.product_name } )
+				.first()
 				.click();
 			await page.getByRole( 'button', { name: 'Filter' } ).click();
 
-			// Flakiness warning: if the filtering is too slow, some other reviews might still be displayed
-			// We need to find something to assess filtering is ready
-			const rows = await page.locator( '#the-comment-list tr' ).all();
+			await expect( page.locator( '#the-comment-list tr' ) ).toHaveCount(
+				1
+			);
 
-			for ( const reviewRow of rows ) {
-				await expect(
-					reviewRow
-						.locator( '[data-colname="Product"]' )
-						.getByRole( 'link' )
-						.first()
-				).toContainText( review.product_name );
-			}
+			await expect(
+				page
+					.locator( '[data-colname="Product"]' )
+					.getByRole( 'link' )
+					.filter( { hasText: review.product_name } )
+			).toBeVisible();
 		} );
 
 		test( 'can quick edit a product review', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -187,6 +187,7 @@ test.describe( 'Product Reviews', () => {
 				value: updatedRating.toString(),
 			} );
 			await page.getByRole( 'button', { name: 'Update' } ).click();
+			await page.waitForURL( '**/edit-comments.php?**' );
 
 			await page.goto(
 				`wp-admin/edit.php?post_type=product&page=product-reviews`
@@ -202,7 +203,7 @@ test.describe( 'Product Reviews', () => {
 			).toBeVisible();
 
 			await reviewRow.locator( 'a.comments-view-item-link' ).click();
-			await page.click( '#tab-reviews' );
+			await page.getByRole( 'tab', { name: 'Reviews' } ).click();
 			await expect(
 				page.locator( '.comment_container' ).first()
 			).toContainText( updatedReview );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A few product review tests became very unstable lately. 
Context: p1741801572373359-slack-C03CPM3UXDJ

Attempt to stabilize these, with good results in my local tests:
- use [web first assertion](https://playwright.dev/docs/test-assertions#auto-retrying-assertions) toHaveCount to wait for the expected result.
- use faker to generate unique product and reviews data
- wait for navigation to complete
- updated locator for review tab

Closes # .

### How to test the changes in this Pull Request:

```
pnpm test:e2e -g "can filter the reviews by product" --repeat-each=100 --max-failures=1
```

Notes: 
- customize-store tests with WP6.8 beta 2 are expected to fail and are not related to this PR (p1741767118325399-slack-C02FL3X7KR6)
- monitor js files failures is also not related (p1741856129878359-slack-C03CPM3UXDJ)