### PR TITLE
[dev] CI: cap E2E testing jobs execution time for PRs to 25 minutes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
           pattern: 'last-run__${{ strategy.job-index }}'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && '25' ) || 360 }}
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && '25' ) || '360' }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_CORE_E2E_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
           pattern: 'last-run__${{ strategy.job-index }}'
 
       - name: 'Run tests (${{ matrix.testType }})'
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && '25' ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_CORE_E2E_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
           pattern: 'last-run__${{ strategy.job-index }}'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && '25' ) || '360' }}
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && 25 ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_CORE_E2E_TOKEN }}

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@woocommerce/plugin-woocommerce",
 	"private": true,
-	"title": "WooCommerce",
+	"title": "WooCommerce...",
 	"version": "9.9.0",
 	"homepage": "https://woocommerce.com/",
 	"repository": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@woocommerce/plugin-woocommerce",
 	"private": true,
-	"title": "WooCommerce...",
+	"title": "WooCommerce",
 	"version": "9.9.0",
 	"homepage": "https://woocommerce.com/",
 	"repository": {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Due to retries E2E tests for some PRs will keep running for over 30 minutes while still failing. In this PR we cap the execution time to 25 minutes for PRs.

### How to test the changes in this Pull Request:

- CI-checks shall pass
- [Example run
](https://github.com/woocommerce/woocommerce/actions/runs/13831592277/job/38696957124?pr=56352)