### PR TITLE
[dev] Update nightly tag and build workflow

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -20,32 +20,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.SOURCE_REF }}
-
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          pull-package-deps: '@woocommerce/plugin-woocommerce'
-
-      - name: Build zip
-        working-directory: plugins/woocommerce
-        run: bash bin/build-zip.sh
-
-      - name: Upload nightly build
-        uses: WebFreak001/deploy-nightly@46ecbabd7fad70d3e7d2c97fe8cd54e7a52e215b #v3.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets{?name,label}
-          release_id: ${{ env.RELEASE_ID }}
-          asset_path: plugins/woocommerce/woocommerce.zip
-          asset_name: woocommerce-${{ env.SOURCE_REF }}-nightly.zip
-          asset_content_type: application/zip
-          max_releases: 1
-
-      - name: Update nightly tag commit ref
-        uses: actions/github-script@v7
+      - name: 'Update nightly tag commit ref'
+        uses: 'actions/github-script@v7'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -61,3 +37,30 @@ jobs:
               ref: `tags/${ targetRef }`,
               sha: branchData.data.commit.sha,
             });
+
+      - name: 'Checkout ref'
+        uses: 'actions/checkout@v4'
+        with:
+          ref: ${{ env.TARGET_REF }}
+
+      - name: 'Setup WooCommerce Monorepo'
+        uses: './.github/actions/setup-woocommerce-monorepo'
+        with:
+          pull-package-deps: '@woocommerce/plugin-woocommerce'
+
+      - name: 'Build zip'
+        working-directory: plugins/woocommerce
+        run: bash bin/build-zip.sh
+
+      - name: 'Upload nightly build'
+        uses: 'WebFreak001/deploy-nightly@46ecbabd7fad70d3e7d2c97fe8cd54e7a52e215b' #v3.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets{?name,label}
+          release_id: ${{ env.RELEASE_ID }}
+          asset_path: plugins/woocommerce/woocommerce.zip
+          asset_name: woocommerce-${{ env.SOURCE_REF }}-nightly.zip
+          asset_content_type: application/zip
+          max_releases: 1
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Ground work for https://github.com/woocommerce/woocommerce/issues/51027

Updates the nightly build workflow:
- updates the nightly tag before creating the build zip
- checkout the recently updated nightly tag and build zip from it instead of trunk

### How to test the changes in this Pull Request:

Run the [nightly build workflow](https://github.com/woocommerce/woocommerce/actions/workflows/nightly-builds.yml) from this branch. Check the log and the [nightly release](https://github.com/woocommerce/woocommerce/releases/tag/nightly) after the workflow ran. The tag and the release should have been updated.

Tested with: https://github.com/woocommerce/woocommerce/actions/runs/13832770767/job/38700664242
