### PR TITLE
Prevent product button loading unnecessary dependencies

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-button-dependencies
+++ b/plugins/woocommerce/changelog/fix-product-button-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent product button loading unnecessary dependencies
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
@@ -175,12 +175,10 @@ const AddToCartButtonPlaceholder = ( {
 	useEffect( () => {
 		if ( blockClientId ) {
 			registerListener( blockClientId );
-		}
-		return () => {
-			if ( blockClientId ) {
+			return () => {
 				unregisterListener( blockClientId );
-			}
-		};
+			};
+		}
 	}, [ blockClientId, registerListener, unregisterListener ] );
 
 	const buttonText =

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
@@ -17,7 +17,6 @@ import {
 	useProductDataContext,
 } from '@woocommerce/shared-context';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
-import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -165,10 +164,8 @@ const LoadingAddToCartButton = ( {
 const AddToCartButtonPlaceholder = ( {
 	className,
 	style,
+	blockClientId,
 }: AddToCartButtonPlaceholderAttributes ): JSX.Element => {
-	const blockProps = useBlockProps();
-	const blockClientId = blockProps?.id;
-
 	const {
 		current: currentProductType,
 		registerListener,
@@ -176,9 +173,13 @@ const AddToCartButtonPlaceholder = ( {
 	} = useProductTypeSelector();
 
 	useEffect( () => {
-		registerListener( blockClientId );
+		if ( blockClientId ) {
+			registerListener( blockClientId );
+		}
 		return () => {
-			unregisterListener( blockClientId );
+			if ( blockClientId ) {
+				unregisterListener( blockClientId );
+			}
 		};
 	}, [ blockClientId, registerListener, unregisterListener ] );
 
@@ -205,7 +206,7 @@ const AddToCartButtonPlaceholder = ( {
 };
 
 export const Block = ( props: BlockAttributes ): JSX.Element => {
-	const { className, textAlign } = props;
+	const { className, textAlign, blockClientId } = props;
 	const styleProps = useStyleProps( props );
 	const { parentClassName } = useInnerBlockLayoutContext();
 	const { isLoading, product } = useProductDataContext();
@@ -246,6 +247,7 @@ export const Block = ( props: BlockAttributes ): JSX.Element => {
 							style={ styleProps.style }
 							className={ styleProps.className }
 							isLoading={ isLoading }
+							blockClientId={ blockClientId }
 						/>
 					) }
 				</>

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/edit.tsx
@@ -99,6 +99,7 @@ const Edit = ( {
 				<Disabled>
 					<Block
 						{ ...{ ...attributes, ...context } }
+						blockClientId={ blockProps?.id }
 						className={ clsx( attributes.className, {
 							[ `has-custom-width wp-block-button__width-${ width }` ]:
 								width,

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/types.ts
@@ -14,6 +14,7 @@ export interface BlockAttributes {
 	width?: number | undefined;
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	'woocommerce/isDescendantOfAddToCartWithOptions'?: boolean | undefined;
+	blockClientId?: string;
 }
 
 export interface AddToCartProductDetails {
@@ -27,6 +28,7 @@ export interface AddToCartButtonPlaceholderAttributes {
 	className: string;
 	style: React.CSSProperties;
 	isLoading: boolean;
+	blockClientId?: string;
 }
 
 export interface AddToCartButtonAttributes {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/56263.

This PR moves the `useBlockProps()` usage and the `@wordpress/block-editor` import from the Product Button block component to the edit one, ensuring we get rid of the unnecessary dependencies in the frontend which were introduced in #56263.

### How to test the changes in this Pull Request:

1. Open the _Network_ tab of your browser devtools (<kbd>F12</kbd>).
2. Go the _Cart_ or _Checkout_ page.
3. In the _Network_ tab verify there are no scripts loaded like `/wp-content/plugins/gutenberg/build/block-editor/index.min.js` or `/wp-content/plugins/gutenberg/build/components/index.min.js`.

Also repeat the tests from https://github.com/woocommerce/woocommerce/pull/56263 to make sure there are no regressions.
