### PR TITLE
[Experimental] Move useProductTypeSelector() into the shared folder

### DIFF
--- a/plugins/woocommerce/changelog/update-move-use-product-type-selector-hook
+++ b/plugins/woocommerce/changelog/update-move-use-product-type-selector-hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Move useProductTypeSelector into the shared folder
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/block.tsx
@@ -28,7 +28,7 @@ import type {
 	AddToCartButtonPlaceholderAttributes,
 	AddToCartProductDetails,
 } from './types';
-import useProductTypeSelector from '../../../../blocks/add-to-cart-with-options/hooks/use-product-type-selector';
+import { useProductTypeSelector } from '../../../../shared/stores/product-type-template-state';
 
 const getButtonText = ( {
 	cartQuantity,

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/stock-indicator/block.tsx
@@ -12,12 +12,11 @@ import { withProductDataContext } from '@woocommerce/shared-hocs';
 import type { HTMLAttributes } from 'react';
 import { ProductResponseItem } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { store as productTypeTemplateStateStore } from '../../../../shared/stores/product-type-template-state';
+import { useProductTypeSelector } from '../../../../shared/stores/product-type-template-state';
 import type { BlockAttributes } from './types';
 import './style.scss';
 
@@ -59,20 +58,13 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	const { text: availabilityText, class: availabilityClass } =
 		product.stock_availability;
 
-	const { selectedProductType } = useSelect( ( select ) => {
-		const { getCurrentProductType } = select(
-			productTypeTemplateStateStore
-		);
-		return {
-			selectedProductType: getCurrentProductType(),
-		};
-	}, [] );
+	const { current: currentProductType } = useProductTypeSelector();
 
 	if (
 		! isStockIndicatorVisible(
 			product,
 			availabilityText,
-			selectedProductType?.slug
+			currentProductType?.slug
 		)
 	) {
 		return null;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/toolbar-type-product-selector-group/index.tsx
@@ -16,7 +16,7 @@ import {
 /**
  * Internal dependencies
  */
-import useProductTypeSelector from '../../hooks/use-product-type-selector';
+import { useProductTypeSelector } from '../../../../shared/stores/product-type-template-state';
 
 export default function ToolbarProductTypeGroup() {
 	const {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/index.tsx
@@ -18,7 +18,7 @@ import {
  */
 import ToolbarProductTypeGroup from '../components/toolbar-type-product-selector-group';
 import { DowngradeNotice } from '../components/downgrade-notice';
-import useProductTypeSelector from '../hooks/use-product-type-selector';
+import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import type { Attributes } from '../types';
 import { AddToCartWithOptionsEditTemplatePart } from './edit-template-part';
 import '../edit.scss';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/edit.tsx
@@ -8,7 +8,7 @@ import { type BlockEditProps } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import useProductTypeSelector from '../hooks/use-product-type-selector';
+import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import { GROUPED_PRODUCT_ITEM_TEMPLATE } from './product-item-template/constants';
 
 interface Attributes {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/plugins/index.tsx
@@ -13,7 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import useProductTypeSelector from '../hooks/use-product-type-selector';
+import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 
 function ProductTypeSwitcher() {
 	const { productTypes, current, set } = useProductTypeSelector();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/types.ts
@@ -1,8 +1,3 @@
-export type ProductTypeProps = {
-	slug: string;
-	label: string;
-};
-
 export type QuantitySelectorStyleProps = 'input' | 'stepper';
 
 export interface Attributes {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/edit.tsx
@@ -8,7 +8,7 @@ import { useProductDataContext } from '@woocommerce/shared-context';
 /**
  * Internal dependencies
  */
-import useProductTypeSelector from '../hooks/use-product-type-selector';
+import { useProductTypeSelector } from '../../../shared/stores/product-type-template-state';
 import { ATTRIBUTE_ITEM_TEMPLATE } from './attribute-item-template/constants';
 
 interface Attributes {

--- a/plugins/woocommerce/client/blocks/assets/js/shared/stores/product-type-template-state/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/stores/product-type-template-state/index.ts
@@ -13,10 +13,8 @@ import {
 	ACTION_UNREGISTER_LISTENER,
 	STORE_NAME,
 } from './constants';
-import {
-	getProductTypeOptions,
-	type ProductTypeProps,
-} from '../../../utils/get-product-type-options';
+import { getProductTypeOptions } from '../../../utils/get-product-type-options';
+import type { ProductTypeProps } from './types';
 
 type StoreState = {
 	productTypes: {
@@ -139,3 +137,6 @@ export const store = createReduxStore( STORE_NAME, {
 if ( ! select( STORE_NAME ) ) {
 	register( store );
 }
+
+export { default as useProductTypeSelector } from './use-product-type-selector';
+export type { ProductTypeProps } from './types';

--- a/plugins/woocommerce/client/blocks/assets/js/shared/stores/product-type-template-state/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/stores/product-type-template-state/types.ts
@@ -1,0 +1,4 @@
+export type ProductTypeProps = {
+	slug: string;
+	label: string;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/shared/stores/product-type-template-state/use-product-type-selector.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/stores/product-type-template-state/use-product-type-selector.ts
@@ -5,8 +5,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { store as productTypeTemplateStateStore } from '../../../../shared/stores/product-type-template-state';
-import type { ProductTypeProps } from '../../types';
+import { store as productTypeTemplateStateStore } from '../product-type-template-state';
+import type { ProductTypeProps } from './types';
 
 type ProductTypeSelector = {
 	productTypes: ProductTypeProps[];

--- a/plugins/woocommerce/client/blocks/assets/js/utils/get-product-type-options.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/get-product-type-options.ts
@@ -3,10 +3,10 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
-export type ProductTypeProps = {
-	slug: string;
-	label: string;
-};
+/**
+ * Internal dependencies
+ */
+import type { ProductTypeProps } from '../shared/stores/product-type-template-state';
 
 const productTypes = getSetting< Record< string, string > >(
 	'productTypes',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since https://github.com/woocommerce/woocommerce/pull/56263, `useProductTypeSelector()` is used by _Add to Cart with Options_ and _Add to Cart Button_ blocks, so it makes sense to move it to a shared folder. This way, we can also update _Stock Indicator_ to use this shared hook instead of its own implementation.

This PR also unifies the `ProductTypeProps` type, which until now was declared in two different places.

### How to test the changes in this Pull Request:

Testing this PR means making sure there are no regressions:

0. Install and activate the WooCommerce Beta Tester plugin
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.

#### Single Product block

1. Create a post or page, add the _Single product_ block and select an external product.
2. Add the Product Stock Indicator block. Verify the block renders nothing.
3. Update the _Add to Cart with Options_ block to the blockified version and verify the quantity selector isn't rendered and the button says _Buy product_ (or whatever is defined for that specific product).

![imatge](https://github.com/user-attachments/assets/d8388324-644c-411b-8f5c-deaa6a368254)

4. Now, edit the _Single product_ block and select a simple product out of stock.
5. Verify the Add to Cart button now says _Add to cart_ and the _Product Stock Indicator_ is rendered:

![imatge](https://github.com/user-attachments/assets/1cae8c57-7ef3-4194-a927-1e35262371c7)

#### Single Product template

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_ and update the _Add to Cart with Options_ block to the blockified version.
2. Switch product types and verify the form is updated, including the text displayed in the button (it should say _Add to cart_ for simple products and _Buy product_ for external products).
3. Verify you can also switch product types from the sidebar:

[Enregistrament de pantalla del 2025-03-13 14-17-46.webm](https://github.com/user-attachments/assets/f2bb031e-ab71-4a23-8273-8177a0a21e1a)
