### PR TITLE
Fix Total Payments Volume Processor validation and schema handling

### DIFF
--- a/packages/php/remote-specs-validation/bundles/obw-free-extensions.json
+++ b/packages/php/remote-specs-validation/bundles/obw-free-extensions.json
@@ -482,12 +482,65 @@
               ]
             },
             "value": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ]
             },
             "operation": {
               "$ref": "#/definitions/operations"
             }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "const": "range"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "not": {
+                      "const": "range"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
           "type": "object",

--- a/packages/php/remote-specs-validation/bundles/payment-gateway-suggestions.json
+++ b/packages/php/remote-specs-validation/bundles/payment-gateway-suggestions.json
@@ -466,12 +466,65 @@
                           ]
                         },
                         "value": {
-                          "type": "integer"
+                          "oneOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          ]
                         },
                         "operation": {
                           "$ref": "#/definitions/operations"
                         }
-                      }
+                      },
+                      "allOf": [
+                        {
+                          "if": {
+                            "properties": {
+                              "operation": {
+                                "const": "range"
+                              }
+                            }
+                          },
+                          "then": {
+                            "properties": {
+                              "value": {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "operation": {
+                                "not": {
+                                  "const": "range"
+                                }
+                              }
+                            }
+                          },
+                          "then": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      ]
                     },
                     {
                       "type": "object",
@@ -1157,12 +1210,65 @@
               ]
             },
             "value": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ]
             },
             "operation": {
               "$ref": "#/definitions/operations"
             }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "const": "range"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "not": {
+                      "const": "range"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
           "type": "object",

--- a/packages/php/remote-specs-validation/bundles/remote-inbox-notification.json
+++ b/packages/php/remote-specs-validation/bundles/remote-inbox-notification.json
@@ -570,12 +570,65 @@
               ]
             },
             "value": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ]
             },
             "operation": {
               "$ref": "#/definitions/operations"
             }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "const": "range"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "not": {
+                      "const": "range"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
           "type": "object",

--- a/packages/php/remote-specs-validation/bundles/shipping-partner-suggestions.json
+++ b/packages/php/remote-specs-validation/bundles/shipping-partner-suggestions.json
@@ -460,12 +460,65 @@
                           ]
                         },
                         "value": {
-                          "type": "integer"
+                          "oneOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          ]
                         },
                         "operation": {
                           "$ref": "#/definitions/operations"
                         }
-                      }
+                      },
+                      "allOf": [
+                        {
+                          "if": {
+                            "properties": {
+                              "operation": {
+                                "const": "range"
+                              }
+                            }
+                          },
+                          "then": {
+                            "properties": {
+                              "value": {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "operation": {
+                                "not": {
+                                  "const": "range"
+                                }
+                              }
+                            }
+                          },
+                          "then": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      ]
                     },
                     {
                       "type": "object",
@@ -1140,12 +1193,65 @@
               ]
             },
             "value": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ]
             },
             "operation": {
               "$ref": "#/definitions/operations"
             }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "const": "range"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "not": {
+                      "const": "range"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
           "type": "object",

--- a/packages/php/remote-specs-validation/bundles/wc-pay-promotions.json
+++ b/packages/php/remote-specs-validation/bundles/wc-pay-promotions.json
@@ -463,12 +463,65 @@
                           ]
                         },
                         "value": {
-                          "type": "integer"
+                          "oneOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          ]
                         },
                         "operation": {
                           "$ref": "#/definitions/operations"
                         }
-                      }
+                      },
+                      "allOf": [
+                        {
+                          "if": {
+                            "properties": {
+                              "operation": {
+                                "const": "range"
+                              }
+                            }
+                          },
+                          "then": {
+                            "properties": {
+                              "value": {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "operation": {
+                                "not": {
+                                  "const": "range"
+                                }
+                              }
+                            }
+                          },
+                          "then": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      ]
                     },
                     {
                       "type": "object",
@@ -1137,12 +1190,65 @@
               ]
             },
             "value": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ]
             },
             "operation": {
               "$ref": "#/definitions/operations"
             }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "const": "range"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation": {
+                    "not": {
+                      "const": "range"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
           "type": "object",

--- a/packages/php/remote-specs-validation/changelog/56384-fix-total-payments-volume-processor
+++ b/packages/php/remote-specs-validation/changelog/56384-fix-total-payments-volume-processor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Total Payments Volume Processor validation logic and improved schema definitions

--- a/packages/php/remote-specs-validation/schemas/shared/rules/total_payments_value.json
+++ b/packages/php/remote-specs-validation/schemas/shared/rules/total_payments_value.json
@@ -11,10 +11,63 @@
 			"enum": ["last_week", "last_month", "last_quarter", "last_6_months","last_year"]
 		},
 		"value": {
-			"type": "integer"
+			"oneOf": [
+				{
+					"type": "number"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "number"
+					},
+					"minItems": 2,
+					"maxItems": 2
+				}
+			]
 		},
 		"operation": {
 			"$ref": "#/definitions/operations"
 		}
-	}
+	},
+	"allOf": [
+		{
+			"if": {
+				"properties": {
+					"operation": {
+						"const": "range"
+					}
+				}
+			},
+			"then": {
+				"properties": {
+					"value": {
+						"type": "array",
+						"items": {
+							"type": "number"
+						},
+						"minItems": 2,
+						"maxItems": 2
+					}
+				}
+			}
+		},
+		{
+			"if": {
+				"properties": {
+					"operation": {
+						"not": {
+							"const": "range"
+						}
+					}
+				}
+			},
+			"then": {
+				"properties": {
+					"value": {
+						"type": "number"
+					}
+				}
+			}
+		}
+	]
 }

--- a/plugins/woocommerce/changelog/56384-fix-total-payments-volume-processor
+++ b/plugins/woocommerce/changelog/56384-fix-total-payments-volume-processor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Total Payments Volume Processor validation logic and improved schema definitions

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/TotalPaymentsVolumeProcessor.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Rule processor that passes when a store's payments volume exceeds a provided amount.
  */
@@ -67,12 +69,21 @@ class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
 			return false;
 		}
 
-		if ( ! isset( $rule->value ) || ! is_numeric( $rule->value ) ) {
+		if ( ! isset( $rule->value ) ) {
 			return false;
 		}
 
-		if ( ! isset( $rule->operation ) ) {
-			return false;
+		// If the operation is range, the value must be an array of two numbers.
+		if ( 'range' === $rule->operation ) {
+			if ( ! is_array( $rule->value ) || count( $rule->value ) !== 2 ) {
+				return false;
+			}
+
+			if ( ! is_numeric( $rule->value[0] ) || ! is_numeric( $rule->value[1] ) ) {
+				return false;
+			}
+		} elseif ( ! is_numeric( $rule->value ) ) {
+				return false;
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/TotalPaymentsVolumeProcessor.php
@@ -73,6 +73,10 @@ class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
 			return false;
 		}
 
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
 		// If the operation is range, the value must be an array of two numbers.
 		if ( 'range' === $rule->operation ) {
 			if ( ! is_array( $rule->value ) || count( $rule->value ) !== 2 ) {

--- a/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteSpecs/RuleProcessors/TotalPaymentsVolumeProcessor.php
@@ -1,9 +1,9 @@
 <?php
-declare(strict_types=1);
-
 /**
  * Rule processor that passes when a store's payments volume exceeds a provided amount.
  */
+
+declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Admin\RemoteSpecs\RuleProcessors;
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/total-payments-volume-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/total-payments-volume-processor.php
@@ -138,110 +138,122 @@ class WC_Admin_Tests_RemoteSpecs_RuleProcessors_TotalPaymentsVolumeProcessor ext
 	}
 
 	/**
-	 * Test validation with invalid data.
+	 * Test validation with invalid data using a data provider.
+	 *
+	 * @param array  $rule    The rule to validate.
+	 * @param string $message The message to display.
+	 *
+	 * @dataProvider data_provider_invalid_data
 	 */
-	public function test_validate_invalid_data() {
-		$mock = $this->getMockBuilder( TotalPaymentsVolumeProcessor::class )
-			->onlyMethods( array( 'get_reports_query' ) )
-			->getMock();
+	public function test_validate_invalid_data( $rule, $message ) {
+		$processor = new TotalPaymentsVolumeProcessor();
+		$this->assertFalse( $processor->validate( (object) $rule ), $message );
+	}
 
-		$this->assertFalse( $mock->validate( (object) array() ) );
-		$this->assertFalse(
-			$mock->validate(
-				(object) array(
+	/**
+	 * Data provider for invalid data validation tests.
+	 *
+	 * @return array
+	 */
+	public function data_provider_invalid_data() {
+		return array(
+			'empty_rule'                              => array(
+				array(),
+				'Validation should fail for an empty rule.',
+			),
+			'missing_value_and_operation'             => array(
+				array(
 					'timeframe' => 'last_week',
-				)
-			)
-		);
-
-		$this->assertFalse(
-			$mock->validate(
-				(object) array(
+				),
+				'Validation should fail when value and operation are missing.',
+			),
+			'invalid_timeframe'                       => array(
+				array(
 					'timeframe' => 'invalid',
 					'value'     => 100,
 					'operation' => '=',
-				)
-			)
-		);
-
-		// Test invalid range operation cases.
-		$this->assertFalse(
-			$mock->validate(
-				(object) array(
+				),
+				'Validation should fail for an invalid timeframe.',
+			),
+			'range_operation_with_non_array_value'    => array(
+				array(
 					'timeframe' => 'last_week',
-					'value'     => 100, // Should be array for range.
+					'value'     => 100,
 					'operation' => 'range',
-				)
-			)
-		);
-		$this->assertFalse(
-			$mock->validate(
-				(object) array(
+				),
+				'Validation should fail when range operation is used with non-array value.',
+			),
+			'range_operation_with_short_array'        => array(
+				array(
 					'timeframe' => 'last_week',
-					'value'     => array( 100 ), // Array too short.
+					'value'     => array( 100 ),
 					'operation' => 'range',
-				)
-			)
-		);
-		$this->assertFalse(
-			$mock->validate(
-				(object) array(
+				),
+				'Validation should fail when range operation is used with an array that is too short.',
+			),
+			'range_operation_with_long_array'         => array(
+				array(
 					'timeframe' => 'last_week',
-					'value'     => array( 100, 200, 300 ), // Array too long.
+					'value'     => array( 100, 200, 300 ),
 					'operation' => 'range',
-				)
-			)
-		);
-		$this->assertFalse(
-			$mock->validate(
-				(object) array(
+				),
+				'Validation should fail when range operation is used with an array that is too long.',
+			),
+			'range_operation_with_non_numeric_values' => array(
+				array(
 					'timeframe' => 'last_week',
-					'value'     => array( 'invalid', 200 ), // Non-numeric values.
+					'value'     => array( 'invalid', 200 ),
 					'operation' => 'range',
-				)
-			)
+				),
+				'Validation should fail when range operation is used with non-numeric values.',
+			),
 		);
 	}
 
 	/**
 	 * Test validation with valid data.
+	 *
+	 * @param object $rule    The rule to validate.
+	 * @param string $message The message to display.
+	 *
+	 * @dataProvider data_provider_valid_data
 	 */
-	public function test_validate_valid_data() {
-		$mock = $this->getMockBuilder( TotalPaymentsVolumeProcessor::class )
-			->onlyMethods( array( 'get_reports_query' ) )
-			->getMock();
+	public function test_validate_valid_data( $rule, $message ) {
+		$processor = new TotalPaymentsVolumeProcessor();
+		$this->assertTrue( $processor->validate( $rule ), $message );
+	}
 
-		// Test regular comparison operation.
-		$this->assertTrue(
-			$mock->validate(
+	/**
+	 * Data provider for test_validate_valid_data.
+	 *
+	 * @return array
+	 */
+	public function data_provider_valid_data() {
+		return array(
+			'regular_comparison_operation'        => array(
 				(object) array(
 					'timeframe' => 'last_week',
 					'value'     => 100,
 					'operation' => '=',
-				)
-			)
-		);
-
-		// Test range operation.
-		$this->assertTrue(
-			$mock->validate(
+				),
+				'Validation should pass for regular comparison operation.',
+			),
+			'range_operation'                     => array(
 				(object) array(
 					'timeframe' => 'last_week',
 					'value'     => array( 0, 5000000 ),
 					'operation' => 'range',
-				)
-			)
-		);
-
-		// Test range operation with decimal values.
-		$this->assertTrue(
-			$mock->validate(
+				),
+				'Validation should pass for range operation with integer values.',
+			),
+			'range_operation_with_decimal_values' => array(
 				(object) array(
 					'timeframe' => 'last_week',
 					'value'     => array( 0.5, 5000000.50 ),
 					'operation' => 'range',
-				)
-			)
+				),
+				'Validation should pass for range operation with decimal values.',
+			),
 		);
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/total-payments-volume-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-specs/rule-processors/total-payments-volume-processor.php
@@ -136,4 +136,151 @@ class WC_Admin_Tests_RemoteSpecs_RuleProcessors_TotalPaymentsVolumeProcessor ext
 
 		$this->assertEquals( false, $result );
 	}
+
+	/**
+	 * Test validation with invalid data.
+	 */
+	public function test_validate_invalid_data() {
+		$mock = $this->getMockBuilder( TotalPaymentsVolumeProcessor::class )
+			->onlyMethods( array( 'get_reports_query' ) )
+			->getMock();
+
+		$this->assertFalse( $mock->validate( (object) array() ) );
+		$this->assertFalse(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+				)
+			)
+		);
+
+		$this->assertFalse(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'invalid',
+					'value'     => 100,
+					'operation' => '=',
+				)
+			)
+		);
+
+		// Test invalid range operation cases.
+		$this->assertFalse(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => 100, // Should be array for range.
+					'operation' => 'range',
+				)
+			)
+		);
+		$this->assertFalse(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => array( 100 ), // Array too short.
+					'operation' => 'range',
+				)
+			)
+		);
+		$this->assertFalse(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => array( 100, 200, 300 ), // Array too long.
+					'operation' => 'range',
+				)
+			)
+		);
+		$this->assertFalse(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => array( 'invalid', 200 ), // Non-numeric values.
+					'operation' => 'range',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test validation with valid data.
+	 */
+	public function test_validate_valid_data() {
+		$mock = $this->getMockBuilder( TotalPaymentsVolumeProcessor::class )
+			->onlyMethods( array( 'get_reports_query' ) )
+			->getMock();
+
+		// Test regular comparison operation.
+		$this->assertTrue(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => 100,
+					'operation' => '=',
+				)
+			)
+		);
+
+		// Test range operation.
+		$this->assertTrue(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => array( 0, 5000000 ),
+					'operation' => 'range',
+				)
+			)
+		);
+
+		// Test range operation with decimal values.
+		$this->assertTrue(
+			$mock->validate(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => array( 0.5, 5000000.50 ),
+					'operation' => 'range',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test process with range operation.
+	 */
+	public function test_process_range_operation() {
+		$mock = $this->getMockBuilder( TotalPaymentsVolumeProcessor::class )
+			->onlyMethods( array( 'get_reports_query' ) )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'get_reports_query' )
+			->willReturn(
+				new class() {
+					/**
+					 * Get the report data.
+					 *
+					 * @return object The report data.
+					 */
+					public function get_data() {
+						return (object) array(
+							'totals' => (object) array(
+								'total_sales' => 3000000,
+							),
+						);
+					}
+				}
+			);
+
+		$this->assertTrue(
+			$mock->process(
+				(object) array(
+					'timeframe' => 'last_week',
+					'value'     => array( 0, 5000000 ),
+					'operation' => 'range',
+				),
+				(object) array()
+			)
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/54683

This PR fixes the validation logic and schema handling for the Total Payments Volume Processor. 

Key changes include:

- Allowed `range` type operation for Total Payments Volume Processor
- Updated schema definitions to support both single numbers and arrays for 'value' field
- Added unit tests for both valid and invalid scenarios

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Test schema**

1. Open `./packages/php/remote-specs-validation/bundles/remote-inbox-notification.json` and copy the content.
2. Open [https://www.jsonschemavalidator.net/ ](https://www.jsonschemavalidator.net/)and paste the schema on the left panel.
3. Paste the following content on the right panel.

```
[
  {
    "slug": "wayflyer_bnpl_q4_2021",
    "type": "marketing",
    "status": "unactioned",
    "is_snoozable": 0,
    "source": "woocommerce.com",
    "locales": [
      {
        "locale": "en_US",
        "title": "Grow your business with funding through Wayflyer",
        "content": "Test"
      }
    ],
    "actions": [
      {
        "name": "wayflyer_bnpl_q4_2021",
        "locales": [
          {
            "locale": "en_US",
            "label": "Level up with funding"
          }
        ],
        "url": "https://woocommerce.com/products/wayflyer/?utm_source=inbox_note&utm_medium=product&utm_campaign=wayflyer_bnpl_q4_2021",
        "url_is_admin_query": false,
        "is_primary": true,
        "status": "actioned"
      }
    ],
    "rules": [
      {
        "type": "total_payments_value",
        "timeframe": "last_year",
        "value": [ 0, 5000000 ],
        "operation": "range"
      }
    ]
  }
]
```

4. Validation should pass.
5. Change the value to a single number, and validation should fail.
6. Change the operation to `=` and validation should pass.
7. Change the value back to `[ 0, 5000000 ]` and validation should fail.

**Test Total Payments Volume Processor runtime validation**

1. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=remote-inbox-notifications`
2. Import remote spect from URL https://gist.githubusercontent.com/chihsuan/e93faecc359fed65e4d865fd20d3eaf3/raw/5bc946a15adfb26eb7e8f495512d5467ffff1b80/inbox-note
3. `total-payments-volume-processor-test` should be imported successfully.
4. Click on Run button.
5. `total-payments-volume-processor-test: All rules passed successfully` notice should be shown.

<img width="1035" alt="Screenshot 2025-03-14 at 14 16 01" src="https://github.com/user-attachments/assets/ead68f25-de83-401e-9bfc-ebf70637f941" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Total Payments Volume Processor validation logic and improved schema definitions

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
