### PR TITLE
[e2e tests] Stablize product-tags-attributes spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-product-tag-attributes-flakyness
+++ b/plugins/woocommerce/changelog/e2e-fix-product-tag-attributes-flakyness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: stabilize product-tags-attributes spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
@@ -45,14 +45,6 @@ test.describe(
 		test.use( { storageState: ADMIN_STATE_PATH } );
 
 		test.beforeAll( async ( { restApi } ) => {
-			// make sure the attribute term page is visible in the shop
-			await restApi.put(
-				`${ WC_API_PATH }/settings/products/woocommerce_attribute_lookup_enabled`,
-				{
-					value: 'yes',
-				}
-			);
-
 			// add product tags
 			await restApi
 				.post( `${ WC_API_PATH }/products/tags`, {
@@ -171,12 +163,6 @@ test.describe(
 			await restApi.post( `${ WC_API_PATH }/products/attributes/batch`, {
 				delete: [ attributeId ],
 			} );
-			// await restApi.put(
-			// 	`${ WC_API_PATH }/settings/products/woocommerce_attribute_lookup_enabled`,
-			// 	{
-			// 		value: 'no',
-			// 	}
-			// );
 
 			const pages = await restApi.get( `${ WP_API_PATH }/pages` );
 
@@ -247,14 +233,28 @@ test.describe(
 			page,
 		} ) => {
 			// the api setting for enabling attribute term page doesn't apply for some reason
-			// but I could see it as checked/enabled in the settings
-			// workaround for the change to take effect is to just save the settings.
-			await page.goto( 'wp-admin/admin.php?page=wc-settings' );
-			// Modify a random unrelated settings so we can save the form.
-			await page
-				.locator( '#woocommerce_allowed_countries' )
-				.selectOption( 'all' );
-			await page.locator( 'text=Save changes' ).click();
+			// workaround for the change to take effect is to just update via the settings ui.
+			await page.goto(
+				'wp-admin/admin.php?page=wc-settings&tab=products&section=advanced'
+			);
+
+			const attributeLookupCheckbox = page.locator(
+				'#woocommerce_attribute_lookup_enabled'
+			);
+			await expect( attributeLookupCheckbox ).toBeVisible();
+
+			// eslint-disable-next-line playwright/no-conditional-in-test
+			if ( ! ( await attributeLookupCheckbox.isChecked() ) ) {
+				await attributeLookupCheckbox.click();
+				await page.locator( 'text=Save changes' ).click();
+				await expect(
+					page
+						.locator( '#message' )
+						.getByText( 'Your settings have been saved' )
+				).toBeVisible();
+			}
+
+			await expect( attributeLookupCheckbox ).toBeChecked();
 
 			const slug = simpleProductName.replace( / /gi, '-' ).toLowerCase();
 			await page.goto( `product/${ slug }` );

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
@@ -11,10 +11,9 @@ import {
 /**
  * Internal dependencies
  */
-import { tags, test, expect, request } from '../../fixtures/fixtures';
+import { tags, test, expect } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
-import { admin } from '../../test-data/data';
-import { WC_API_PATH } from '../../utils/api-client';
+import { WC_API_PATH, WP_API_PATH } from '../../utils/api-client';
 import { fillPageTitle } from '../../utils/editor';
 
 const pageTitle = 'Product Showcase';
@@ -162,7 +161,7 @@ test.describe(
 				} );
 		} );
 
-		test.afterAll( async ( { baseURL, restApi } ) => {
+		test.afterAll( async ( { restApi } ) => {
 			await restApi.post( `${ WC_API_PATH }/products/batch`, {
 				delete: [ product1Id, product2Id, product3Id ],
 			} );
@@ -172,32 +171,27 @@ test.describe(
 			await restApi.post( `${ WC_API_PATH }/products/attributes/batch`, {
 				delete: [ attributeId ],
 			} );
-			await restApi.put(
-				`${ WC_API_PATH }/settings/products/woocommerce_attribute_lookup_enabled`,
-				{
-					value: 'no',
-				}
-			);
-			const base64auth = Buffer.from(
-				`${ admin.username }:${ admin.password }`
-			).toString( 'base64' );
-			const wpApi = await request.newContext( {
-				baseURL: `${ baseURL }/wp-json/wp/v2/`,
-				extraHTTPHeaders: {
-					Authorization: `Basic ${ base64auth }`,
-				},
-			} );
-			let response = await wpApi.get( `pages` );
-			const allPages = await response.json();
-			await allPages.forEach( async ( page ) => {
+			// await restApi.put(
+			// 	`${ WC_API_PATH }/settings/products/woocommerce_attribute_lookup_enabled`,
+			// 	{
+			// 		value: 'no',
+			// 	}
+			// );
+
+			const pages = await restApi.get( `${ WP_API_PATH }/pages` );
+
+			for ( const page of pages.data ) {
 				if ( page.title.rendered === pageTitle ) {
-					response = await wpApi.delete( `pages/${ page.id }`, {
-						data: {
-							force: true,
-						},
-					} );
+					await restApi.delete(
+						`${ WP_API_PATH }/pages/${ page.id }`,
+						{
+							data: {
+								force: true,
+							},
+						}
+					);
 				}
-			} );
+			}
 		} );
 
 		test( 'should see shop catalog with all its products', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-tags-attributes.spec.js
@@ -233,7 +233,7 @@ test.describe(
 		test( 'should see and sort tags page with all the products', async ( {
 			page,
 		} ) => {
-			await page.goto( 'shop/' );
+			await page.goto( 'shop/?orderby=date' );
 			await page.locator( `text=${ simpleProductName } 1` ).click();
 			await page.getByRole( 'link', { name: productTagName1 } ).click();
 			await expect(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Tests in product-tags-attributes spec stared failing with `page.goto: net::ERR_ABORTED`. A goto action is performed before the previous page load triggered by a save/update button click was completed.

Fixed by making sure we wait for the initial save/update to complete. 
Other changes:
- used the restApi fixture instead of request to handle the test page
- the failing test required woocommerce_attribute_lookup_enabled setting to be enabled, but enabling it via the API was not enough, so a workaround to also change a random setting via the UI was performed. Instead of that, I changed the test to update via the UI the actual setting the test requires.

### How to test the changes in this Pull Request:

```
pnpm test:e2e product-tags-attributes.spec.js
```
Note: CYS failures with WP6.8 beta2 can be ignored.