### PR TITLE
Fix: Imported CSV products not completing product task

### DIFF
--- a/plugins/woocommerce/changelog/fix-import-product-not-complete
+++ b/plugins/woocommerce/changelog/fix-import-product-not-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix import CSV products not completing product task

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -191,7 +191,7 @@ class Products extends Task {
 	/**
 	 * Set the has products transient if the product qualifies as a user created product.
 	 *
-	 * @param int $product_id Product ID.
+	 * @param int        $product_id Product ID.
 	 * @param WC_Product $product Product object.
 	 */
 	public function maybe_set_has_product_transient( $product_id, $product ) {
@@ -209,8 +209,8 @@ class Products extends Task {
 	 */
 	private function is_valid_product( $product ) {
 		return ProductStatus::PUBLISH === $product->get_status() &&
-			! $product->get_meta( '_headstart_post' ) &&
-			get_post_meta( $product->get_id(), '_edit_last', true );
+			( ! $product->get_meta( '_headstart_post' ) ||
+			get_post_meta( $product->get_id(), '_edit_last', true ) );
 	}
 
 	/**
@@ -234,7 +234,7 @@ class Products extends Task {
 				'relation' => 'OR',
 				array(
 					'key'     => '_headstart_post',
-					'compare' => 'NOT EXISTS',
+					'compare' => 'NOT NULL',
 				),
 				array(
 					'key'     => '_edit_last',

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -230,11 +230,20 @@ class Products extends Task {
 			'posts_per_page' => 1,
 			'no_found_rows'  => true,
 			'fields'         => 'ids',
-			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'     => array(
 				'relation' => 'OR',
 				array(
-					'key'     => '_headstart_post',
-					'compare' => 'NOT NULL',
+					'relation' => 'OR',
+					array(
+						'key'     => '_headstart_post',
+						'value'   => null,
+						'compare' => 'IS',
+					),
+					array(
+						'key'     => '_headstart_post',
+						'compare' => 'NOT EXISTS',
+					),
 				),
 				array(
 					'key'     => '_edit_last',

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -224,38 +224,56 @@ class Products extends Task {
 			return 'yes' === $product_exists;
 		}
 
-		// Query to determine if there are any published products that are either not headstart posts (sample products) or have been modified by a user.
-		$args = array(
-			'post_type'      => 'product',
-			'post_status'    => ProductStatus::PUBLISH,
-			'posts_per_page' => 1,
-			'no_found_rows'  => true,
-			'fields'         => 'ids',
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'     => array(
-				'relation' => 'OR',
-				array(
-					'relation' => 'OR',
-					array(
-						'key'     => '_headstart_post',
-						'value'   => null,
-						'compare' => 'IS',
+		global $wpdb;
+
+		/*
+		 * Check if any valid products exist and return 'yes' or 'no'
+		 * A valid product must:
+		 * 1. Be a published product post type
+		 * 2. Meet one of these conditions:
+		 *    - Have been edited by a user (_edit_last meta exists), OR
+		 *    - Not have _headstart_post meta, OR
+		 *    - Have _headstart_post meta but it's NULL
+		 */
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT IF(
+					EXISTS (
+						SELECT 1 FROM {$wpdb->posts} p
+						WHERE p.post_type = %s
+						AND p.post_status = %s
+						AND (
+							EXISTS (
+								SELECT 1 FROM {$wpdb->postmeta} pm
+								WHERE pm.post_id = p.ID
+								AND pm.meta_key = %s
+							)
+							OR
+							NOT EXISTS (
+								SELECT 1 FROM {$wpdb->postmeta} pm
+								WHERE pm.post_id = p.ID
+								AND pm.meta_key = %s
+							)
+							OR
+							EXISTS (
+								SELECT 1 FROM {$wpdb->postmeta} pm
+								WHERE pm.post_id = p.ID
+								AND pm.meta_key = %s
+								AND pm.meta_value = ''
+							)
+						)
+						LIMIT 1
 					),
-					array(
-						'key'     => '_headstart_post',
-						'compare' => 'NOT EXISTS',
-					),
-				),
-				array(
-					'key'     => '_edit_last',
-					'compare' => 'EXISTS',
-				),
-			),
+					'yes', 'no'
+				)",
+				'product',
+				ProductStatus::PUBLISH,
+				'_edit_last',
+				'_headstart_post',
+				'_headstart_post'
+			)
 		);
 
-		$products_query = new \WP_Query( $args );
-
-		$value = $products_query->post_count > 0 ? 'yes' : 'no';
 		set_transient( self::HAS_PRODUCT_TRANSIENT, $value );
 		return 'yes' === $value;
 	}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -224,6 +224,7 @@ class Products extends Task {
 			return 'yes' === $product_exists;
 		}
 
+		// Query to determine if there are any published products that are either not headstart posts (sample products) or have been modified by a user.
 		$args = array(
 			'post_type'      => 'product',
 			'post_status'    => ProductStatus::PUBLISH,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/53133

This PR fixes an issue where importing products via CSV (including any valid CSV, not just those with sample products) would fail to mark the product task as complete in the product task.

In https://github.com/woocommerce/woocommerce/pull/55872, we optimized the product query, but the `is_valid_product` function contains incorrect logic that prevents any CSV import from marking the product task as complete.

This PR corrects the logic in `is_valid_product` to ensure that CSV import marks the product task as complete and also updates the product count query to be more strict by including products where _headstart_post is empty/nulll as suggested in https://github.com/woocommerce/woocommerce/issues/53133


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**To reset the product completion state**

1. Delete transient `woocommerce_product_task_has_product_transient` (`wp transient delete woocommerce_product_task_has_product_transient`)
2. Delete option woocommerce_task_list_tracked_completed_tasks (`wp option delete woocommerce_task_list_tracked_completed_tasks`)

**Test importing csv with all sample products**

1. Create a fresh JN site
2. Go to WooCommerce > Home > Product task
3. Click `Import your products from a CSV file.`
4. Upload a CSV file containing all sample products 
[sample-products.csv](https://github.com/user-attachments/files/19246176/sample-products.csv)
5. Complete all import steps, ensure the products are imported at the end
6. Go back to homescreen
7. Observe the product task marked as incomplete

**Test importing csv containing partial sample products**

1. Create a fresh JN site / or delete all products and reset the product task as per the instructions above
2. Go to WooCommerce > Home > Product task
3. Click `Import your products from a CSV file.`
4. Upload a CSV file containing partial sample products 
[partial-sample-products.csv](https://github.com/user-attachments/files/19246181/partial-sample-products.csv)
5. Complete all import steps, ensure the products are imported at the end
6. Go back to homescreen
7. Observe the product task marked as completed
8. Reset the product task as per the instructions above
9. Go to WooCommerce Home
10. Observe the product task still marked as completed (To confirm that product query count is correct)

**Test importing products via CSV**

1. Create a fresh JN site / or delete all products and reset the product task as per the instructions above
2. Go to WooCommerce > Home > Product task
3. Click `Import your products from a CSV file.`
4. Upload a csv file with valid products [wc-products.csv](https://github.com/user-attachments/files/19246190/wc-products.csv)
5. Complete all import steps, ensure the products are imported at the end
6. Go back to homescreen
7. Observe the product task marked as completed
8. Reset the product task as per the instructions above
9. Go to WooCommerce Home
10. Observe the product task still marked as completed (To confirm that product query count is correct)



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
