### PR TITLE
[Experimental] Don't display the Add to Cart with Options form for out of stock products and not-purchasable simple products

### DIFF
--- a/plugins/woocommerce/changelog/fix-56371-out-of-stock-products
+++ b/plugins/woocommerce/changelog/fix-56371-out-of-stock-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Don't display the Add to Cart with Options form for out of stock products and not purchasable simple products
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-template/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-template/constants.ts
@@ -3,6 +3,9 @@
  */
 import type { TemplateArray } from '@wordpress/blocks';
 
+/**
+ * Template definition for Grouped Product Item Template in the Add to Cart form.
+ */
 export const GROUPED_PRODUCT_ITEM_TEMPLATE: TemplateArray = [
 	[
 		'woocommerce/add-to-cart-with-options-grouped-product-selector-item',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-template/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-template/constants.ts
@@ -52,17 +52,34 @@ export const GROUPED_PRODUCT_ITEM_TEMPLATE: TemplateArray = [
 						},
 					],
 					[
-						'woocommerce/product-price',
+						'core/group',
 						{
-							isDescendentOfSingleProductBlock: true,
-							fontSize: 'medium',
-							textAlign: 'right',
+							layout: {
+								type: 'flex',
+								orientation: 'vertical',
+							},
 							style: {
-								typography: {
-									fontWeight: 400,
+								spacing: {
+									blockGap: '0',
 								},
 							},
 						},
+						[
+							[
+								'woocommerce/product-price',
+								{
+									isDescendentOfSingleProductBlock: true,
+									fontSize: 'medium',
+									textAlign: 'right',
+									style: {
+										typography: {
+											fontWeight: 400,
+										},
+									},
+								},
+							],
+							[ 'woocommerce/product-stock-indicator' ],
+						],
 					],
 				],
 			],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -75,6 +75,8 @@ class AddToCartWithOptions extends AbstractBlock {
 		}
 
 		if ( ! $product->is_in_stock() ) {
+			$product = $previous_product;
+
 			return wc_get_stock_html( $product );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -74,7 +74,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			return '';
 		}
 
-		if ( ! $product->is_in_stock() ) {
+		if ( ProductType::SIMPLE === $product->get_type() && ! $product->is_in_stock() ) {
 			$product = $previous_product;
 
 			return wc_get_stock_html( $product );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -68,7 +68,7 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$previous_product = $product;
 		$product          = wc_get_product( $post_id );
-		if ( ! $product instanceof \WC_Product ) {
+		if ( ! $product instanceof \WC_Product || ( ProductType::SIMPLE === $product->get_type() && ! $product->is_purchasable() ) ) {
 			$product = $previous_product;
 
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -68,16 +68,10 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$previous_product = $product;
 		$product          = wc_get_product( $post_id );
-		if ( ! $product instanceof \WC_Product || ( ProductType::SIMPLE === $product->get_type() && ! $product->is_purchasable() ) ) {
+		if ( ! $product instanceof \WC_Product ) {
 			$product = $previous_product;
 
 			return '';
-		}
-
-		if ( ProductType::SIMPLE === $product->get_type() && ! $product->is_in_stock() ) {
-			$product = $previous_product;
-
-			return wc_get_stock_html( $product );
 		}
 
 		wp_enqueue_script_module( $this->get_full_block_name() );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -74,6 +74,10 @@ class AddToCartWithOptions extends AbstractBlock {
 			return '';
 		}
 
+		if ( ! $product->is_in_stock() ) {
+			return wc_get_stock_html( $product );
+		}
+
 		wp_enqueue_script_module( $this->get_full_block_name() );
 
 		$product_type = $product->get_type();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
@@ -97,6 +97,12 @@ class AddToCartWithOptionsQuantitySelector extends AbstractBlock {
 	/**
 	 * Render the block.
 	 *
+	 * The selector is hidden for:
+	 * - Simple products that are out of stock.
+	 * - Not purchasable simple products.
+	 * - External products with URLs
+	 * - Products sold individually
+	 *
 	 * @param array    $attributes Block attributes.
 	 * @param string   $content Block content.
 	 * @param WP_Block $block Block instance.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptionsQuantitySelector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * AddToCartWithOptionsQuantitySelector class.
@@ -116,14 +117,22 @@ class AddToCartWithOptionsQuantitySelector extends AbstractBlock {
 			return '';
 		}
 
-		wp_enqueue_script_module( $this->get_full_block_name() );
+		if ( ProductType::SIMPLE === $product->get_type() && ( ! $product->is_in_stock() || ! $product->is_purchasable() ) ) {
+			$product = $previous_product;
+
+			return '';
+		}
 
 		$is_external_product_with_url        = $product instanceof \WC_Product_External && $product->get_product_url();
 		$can_only_be_purchased_one_at_a_time = $product->is_sold_individually();
 
 		if ( $is_external_product_with_url || $can_only_be_purchased_one_at_a_time ) {
+			$product = $previous_product;
+
 			return '';
 		}
+
+		wp_enqueue_script_module( $this->get_full_block_name() );
 
 		$is_stepper_style = isset( $attributes['quantitySelectorStyle'] ) && 'stepper' === $attributes['quantitySelectorStyle'] && ! $product->is_sold_individually();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Blocks\Interactivity\Store;
+use Automattic\WooCommerce\Enums\ProductType;
 
 /**
  * ProductButton class.
@@ -95,6 +96,14 @@ class ProductButton extends AbstractBlock {
 			return '';
 		}
 
+		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
+
+		if ( $is_descendent_of_add_to_cart_form && ProductType::SIMPLE === $product->get_type() && ( ! $product->is_in_stock() || ! $product->is_purchasable() ) ) {
+			$product = $previous_product;
+
+			return '';
+		}
+
 		wp_enqueue_script_module( 'woocommerce/product-button' );
 
 		$this->initialize_cart_state();
@@ -155,8 +164,7 @@ class ProductButton extends AbstractBlock {
 		*/
 		$quantity_to_add = apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() );
 
-		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
-		$add_to_cart_text                  = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
+		$add_to_cart_text = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
 		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
 			$add_to_cart_text = $product->single_add_to_cart_text();
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -63,7 +63,10 @@ class ProductStockIndicator extends AbstractBlock {
 	}
 
 	/**
-	 * Include and render the block.
+	 * Renders the stock indicator block.
+	 *
+	 * This method handles both direct product context and global product context,
+	 * ensuring the stock indicator displays correctly in various template scenarios.
 	 *
 	 * @param array    $attributes Block attributes. Default empty array.
 	 * @param string   $content    Block content. Default empty string.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -71,31 +71,38 @@ class ProductStockIndicator extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		global $product;
+
 		if ( ! empty( $content ) ) {
 			parent::register_block_type_assets();
 			$this->register_chunk_translations( [ $this->block_name ] );
 			return $content;
 		}
-		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : '';
-		$product = wc_get_product( $post_id );
+		$post_id           = isset( $block->context['postId'] ) ? $block->context['postId'] : '';
+		$product_to_render = wc_get_product( $post_id );
 
-		if ( ! $product || in_array( $product->get_type(), $this->get_product_types_without_stock_indicator(), true ) ) {
+		// Use the global product if the product to render can't be retrieved from the context.
+		if ( ! $product_to_render instanceof WC_Product ) {
+			$product_to_render = $product;
+		}
+
+		if ( ! $product_to_render || in_array( $product_to_render->get_type(), $this->get_product_types_without_stock_indicator(), true ) ) {
 			return '';
 		}
 
-		$availability = ProductAvailabilityUtils::get_product_availability( $product );
+		$availability = ProductAvailabilityUtils::get_product_availability( $product_to_render );
 
 		if ( empty( $availability['availability'] ) ) {
 			return '';
 		}
 
-		$total_stock        = $product->get_stock_quantity();
+		$total_stock        = $product_to_render->get_stock_quantity();
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		$classnames  = isset( $classes_and_styles['classes'] ) ? ' ' . $classes_and_styles['classes'] . ' ' : '';
 		$classnames .= sprintf( ' wc-block-components-product-stock-indicator--%s', $availability['class'] );
 
-		$is_backorder_notification_visible = $product->is_in_stock() && $product->backorders_require_notification();
+		$is_backorder_notification_visible = $product_to_render->is_in_stock() && $product_to_render->backorders_require_notification();
 
 		if ( empty( $content ) && $is_backorder_notification_visible && $total_stock > 0 ) {
 			$low_stock_text = sprintf(

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -17,7 +17,11 @@
 
 			<!-- wp:post-title {"isLink":true,"style":{"layout":{"selfStretch":"fill"},"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":400}},"fontSize":"medium"} /-->
 
-			<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"fontSize":"medium","style":{"typography":{"fontWeight":400}}} /-->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group"><!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"fontSize":"medium","style":{"typography":{"fontWeight":400}}} /-->
+			
+			<!-- wp:woocommerce/product-stock-indicator /--></div>
+			<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -19,7 +19,7 @@
 
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group"><!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"fontSize":"medium","style":{"typography":{"fontWeight":400}}} /-->
-			
+
 			<!-- wp:woocommerce/product-stock-indicator /--></div>
 			<!-- /wp:group -->
 		</div>

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -1,3 +1,4 @@
+<!-- wp:woocommerce/product-stock-indicator /-->
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 <!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"small"} /--></div>

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -98,18 +98,28 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * * Tests that no Add to Cart button is displayed for out of stock products.
+	 * Tests that no Add to Cart button is displayed for out of stock products and not purchasable products.
 	 */
 	public function test_out_of_stock_product() {
-		// Single Products in stock contain the Add to Cart button.
-		$this->assertStringContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is visible for in stock products.' );
+		global $product;
+		$product    = new \WC_Product_Simple();
+		$product_id = $product->save();
+		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringNotContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is not visible for not purchasable simple products.' );
+
+		$product->set_regular_price( 10 );
+		$product_id = $product->save();
+		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is visible for purchasable in stock products.' );
 
 		$product->set_stock_status( 'outofstock' );
 		$product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		// Single Products out of stock contain the Read more button.
 		$this->assertStringNotContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is not visible for out of stock products.' );
+		$this->assertStringContainsString( 'Out of stock', $markup, 'The stock indicator is visible for out of stock products.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -99,6 +99,13 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 	/**
 	 * Tests that no Add to Cart button is displayed for out of stock products and not purchasable products.
+	 *
+	 * Verifies that:
+	 * 1. Add to Cart button is hidden for not purchasable simple products
+	 * 2. Add to Cart button is visible for in-stock purchasable products
+	 * 3. Add to Cart button is hidden and stock indicator shows for out of stock products
+	 *
+	 * @covers AddToCartWithOptions::render
 	 */
 	public function test_out_of_stock_product() {
 		global $product;

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -98,6 +98,21 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * * Tests that no Add to Cart button is displayed for out of stock products.
+	 */
+	public function test_out_of_stock_product() {
+		// Single Products in stock contain the Add to Cart button.
+		$this->assertStringContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is visible for in stock products.' );
+
+		$product->set_stock_status( 'outofstock' );
+		$product->save();
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		// Single Products out of stock contain the Read more button.
+		$this->assertStringNotContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is not visible for out of stock products.' );
+	}
+
+	/**
 	 * Tests that the  woocommerce_<product_type>_add_to_cart hooks are rendered when rendering the block.
 	 */
 	public function test_product_type_add_to_cart_hooks_are_rendered() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes it so we don't display the Add to Cart with Options template part when products are out of stock, or are not-purchasable simple products, matching the behavior of the PHP templates.

Closes https://github.com/woocommerce/woocommerce/issues/56371.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin.
0. Go to _Tools_ > _WCA Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Create a post or page, add the Single Product block and choose a simple product. (Alternatively, edit the Single Product template)
2. Update the _Add to Cart with Options_ block to the blockified version.
3. In the frontend, verify the Add to Cart form is displayed.

![imatge](https://github.com/user-attachments/assets/a885e380-b0bb-4413-b27b-1077e8df8044)

4. Now, edit the product and set it out of stock.
5. In the frontend, verify the Add to Cart form is not visible and instead an _Out of stock_ text is shown.

![imatge](https://github.com/user-attachments/assets/3e9003ca-35ca-40c9-9b41-4d180ab6187e)

6. Edit the product again and remove its price, making it not-purchasable.
7. In the frontend, verify the Add to Cart form is not visible and the _Out of stock_ text is not visible either.

![imatge](https://github.com/user-attachments/assets/cf108733-0e94-490e-a427-9848d9b52605)

8. Edit the product again, add the price again and set is as on backorder.
9. In the frontend, verify the Add to Cart form displays an _On backorder_ text before the form.

![imatge](https://github.com/user-attachments/assets/4241acb4-b9b7-4a9e-ae12-0f694679a4cf)

10. Now create or edit a Grouped Product block. Set one of its child products as out of stock or on backorder. Verify the stock status is displayed below the price.

![imatge](https://github.com/user-attachments/assets/bf353980-53c7-413a-a952-c708517b22d9)
