### PR TITLE
Adding filter to customise report email labels.

### DIFF
--- a/plugins/woocommerce/changelog/56391-add-report-email-labels-filter
+++ b/plugins/woocommerce/changelog/56391-add-report-email-labels-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds a filter to customise Core report email labels.

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -54,7 +54,7 @@ class ReportCSVEmail extends \WC_Email {
 		/**
 		 * Used to customise report email labels.
 		 *
-		 * @since <x.x.x>
+		 * @since 9.9.0
 		 *
 		 * @param string[] $labels An array of labels.
 		 *

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -61,7 +61,7 @@ class ReportCSVEmail extends \WC_Email {
 		 * @return string[] An Array of labels.
 		 */
 		$this->report_labels  = apply_filters(
-			'woocommerce_report_email_labels',
+			'woocommerce_report_export_email_labels',
 			array(
 				'categories' => __( 'Categories', 'woocommerce' ),
 				'coupons'    => __( 'Coupons', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -54,7 +54,7 @@ class ReportCSVEmail extends \WC_Email {
 		/**
 		 * Used to customise report email labels.
 		 *
-		 * @since x.x.x
+		 * @since <x.x.x>
 		 *
 		 * @param string[] $labels An array of labels.
 		 *

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -50,17 +50,30 @@ class ReportCSVEmail extends \WC_Email {
 		$this->template_base  = WC()->plugin_path() . '/includes/react-admin/emails/';
 		$this->template_html  = 'html-admin-report-export-download.php';
 		$this->template_plain = 'plain-admin-report-export-download.php';
-		$this->report_labels  = array(
-			'categories' => __( 'Categories', 'woocommerce' ),
-			'coupons'    => __( 'Coupons', 'woocommerce' ),
-			'customers'  => __( 'Customers', 'woocommerce' ),
-			'downloads'  => __( 'Downloads', 'woocommerce' ),
-			'orders'     => __( 'Orders', 'woocommerce' ),
-			'products'   => __( 'Products', 'woocommerce' ),
-			'revenue'    => __( 'Revenue', 'woocommerce' ),
-			'stock'      => __( 'Stock', 'woocommerce' ),
-			'taxes'      => __( 'Taxes', 'woocommerce' ),
-			'variations' => __( 'Variations', 'woocommerce' ),
+
+		/**
+		 * Used to customise report email labels.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string[] $labels An array of labels.
+		 *
+		 * @return string[] An Array of labels.
+		 */
+		$this->report_labels  = apply_filters(
+			'woocommerce_report_email_labels',
+			array(
+				'categories' => __( 'Categories', 'woocommerce' ),
+				'coupons'    => __( 'Coupons', 'woocommerce' ),
+				'customers'  => __( 'Customers', 'woocommerce' ),
+				'downloads'  => __( 'Downloads', 'woocommerce' ),
+				'orders'     => __( 'Orders', 'woocommerce' ),
+				'products'   => __( 'Products', 'woocommerce' ),
+				'revenue'    => __( 'Revenue', 'woocommerce' ),
+				'stock'      => __( 'Stock', 'woocommerce' ),
+				'taxes'      => __( 'Taxes', 'woocommerce' ),
+				'variations' => __( 'Variations', 'woocommerce' ),
+			)
 		);
 
 		// Call parent constructor.

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -60,7 +60,7 @@ class ReportCSVEmail extends \WC_Email {
 		 *
 		 * @return string[] An Array of labels.
 		 */
-		$this->report_labels  = apply_filters(
+		$this->report_labels = apply_filters(
 			'woocommerce_report_export_email_labels',
 			array(
 				'categories' => __( 'Categories', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding filters to make export report email labels extendable. Required to successfully extend Core Analytics CSV reports. A followup PR to the #55812 

### How to test

1. Add a filter e.g.

```php
add_filter(
	'woocommerce_report_export_email_labels',
	function ( $labels ) {
		$labels['orders'] = 'The PR Test Label';
		return $labels;
	}
);
```
2. Go to Analytics > Orders (`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Forders`)
3. Click `Download`

<img width="1326" alt="Orders_‹_Analytics_‹_WooCommerce_‹_Visiting_Crocodile_Toucan_—_WooCommerce" src="https://github.com/user-attachments/assets/18163045-11a2-403d-906d-9a128906db3e" />

4. Observe the email at your Inbox with the `The PR Test Label` text in the Subject and Download Link.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Adds a filter to customise Core report email labels.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
