### PR TITLE
React 18 Update: Enable `AttributeTermInputField` Test

### DIFF
--- a/packages/js/product-editor/changelog/56398-update-prod-editor-attribute-input-field-test-react-18
+++ b/packages/js/product-editor/changelog/56398-update-prod-editor-attribute-input-field-test-react-18
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: React 18 update cleanup task - enable the `AttributeTermInputField` test and remove related comments.
+

--- a/packages/js/product-editor/src/components/attribute-term-input-field/test/attribute-term-input-field.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-term-input-field/test/attribute-term-input-field.spec.tsx
@@ -9,8 +9,7 @@ import { ProductAttributeTerm } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import { AttributeTermInputField } from '../attribute-term-input-field'; // see below explanation for the skip
-/* eslint-disable react/jsx-no-undef */
+import { AttributeTermInputField } from '../attribute-term-input-field';
 
 jest.mock( '@wordpress/core-data', () => ( {
 	registerStore: jest.fn(),
@@ -156,8 +155,7 @@ jest.mock( '@woocommerce/components', () => {
 // 	},
 // ];
 
-// TODO: react-18-upgrade - not sure why there's an error where it's calling require("@wordpress/core-data") and erroring with "Cannot unlock an undefined object."
-describe.skip( 'AttributeTermInputField', () => {
+describe( 'AttributeTermInputField', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );

--- a/packages/js/product-editor/src/components/attribute-term-input-field/test/attribute-term-input-field.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-term-input-field/test/attribute-term-input-field.spec.tsx
@@ -205,7 +205,6 @@ describe( 'AttributeTermInputField', () => {
 				/>
 			);
 		} );
-		// debug();
 		await waitFor( () => {
 			expect( screen.queryByText( 'spinner' ) ).toBeInTheDocument();
 		} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR removes the `AttributeTermInputField` test from being skipped. It also removes the comment explaining the skip reasoning. Confirmed this test is now passing.

Sub-task of #55399.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the `packages/js/product-editor/src/components/attribute-term-input-field/test/attribute-term-input-field.spec.tsx` file and confirm there are no TS errors introduced by this PR.
3. Run tests from product-editor dir (`cd packages/js/product-editor && pnpm test:js`) and confirm all tests pass.
4. Build the WooCommerce plugin via `pnpm --filter='@woocommerce/plugin-woocommerce' build` and confirm build succeeds without errors.

_Note: This PR only includes changes to types, there are no user-facing changes._

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

React 18 update cleanup task - enable the `AttributeTermInputField` test and remove related comments.

</details>
