### PR TITLE
Adjusting the default quantity of the ProductButton block

### DIFF
--- a/plugins/woocommerce/changelog/improve-product-button-default-qty
+++ b/plugins/woocommerce/changelog/improve-product-button-default-qty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Default quantity for ProductButton block now fetched via `woocommerce_loop_add_to_cart_args` instead of `woocommerce_add_to_cart_quantity` hook.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -145,16 +145,27 @@ class ProductButton extends AbstractBlock {
 			)
 		);
 
-		$default_quantity = 1;
 		/**
-		* Filters the change the quantity to add to cart.
-		*
-		* @since 10.9.0
-		* @param number $default_quantity The default quantity.
-		* @param number $product_id The product id.
-		*/
-		$quantity_to_add = apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() );
+		 * Allow filtering of the add to cart button arguments.
+		 *
+		 * @since 9.7.0
+		 */
+		$args = apply_filters(
+			'woocommerce_loop_add_to_cart_args',
+			array(
+				'quantity'   => 1,
+				'class'      => $html_classes,
+				'attributes' => array(
+					'data-product_id'  => $product->get_id(),
+					'data-product_sku' => $product->get_sku(),
+					'aria-label'       => $product->add_to_cart_description(),
+					'rel'              => 'nofollow',
+				),
+			),
+			$product
+		);
 
+		$quantity_to_add                   = absint( $args['quantity'] );
 		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
 		$add_to_cart_text                  = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
 		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
@@ -167,25 +178,6 @@ class ProductButton extends AbstractBlock {
 			'addToCartText'   => $add_to_cart_text,
 			'tempQuantity'    => $number_of_items_in_cart,
 			'animationStatus' => 'IDLE',
-		);
-
-		/**
-		 * Allow filtering of the add to cart button arguments.
-		 *
-		 * @since 9.7.0
-		 */
-		$args = apply_filters(
-			'woocommerce_loop_add_to_cart_args',
-			array(
-				'class'      => $html_classes,
-				'attributes' => array(
-					'data-product_id'  => $product->get_id(),
-					'data-product_sku' => $product->get_sku(),
-					'aria-label'       => $product->add_to_cart_description(),
-					'rel'              => 'nofollow',
-				),
-			),
-			$product
 		);
 
 		if ( isset( $args['attributes']['aria-label'] ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR ensures that the default quantity used when rendering the ProductButton block is fetched in the same way as it is in the "[woocommerce_template_loop_add_to_cart](https://github.com/woocommerce/woocommerce/blob/6f05893904a1e535fb359a25cf86830ab3bde438/plugins/woocommerce/includes/wc-template-functions.php#L1430)" function used in classic themes. This is by utilizing the `woocommerce_loop_add_to_cart_args` hook.

The main takeaway here is that the `woocommerce_add_to_cart_quantity` hook has been removed from that block's rendering function and will instead be addressed as part of the future enhancements to the Store API (see #56454), if that decision is made. For now, a workaround for this hook can be achieved using the `woocommerce_add_cart_item ` alternative that functions in both the classic and the StoreAPI contexts.

### Risks of using `woocommerce_add_to_cart_quantity` during rendering addressed by this PR:
- **Validation issues**: Classic WooCommerce sections may carry out validation operations (like throwing exceptions). If these happen during rendering, they could unexpectedly disrupt the page.
- **Superglobal dependencies**: This hook may rely on $_REQUEST or $_POST, creating potential problems during rendering and resulting in erratic behavior.

Closes #56454 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

### Prerequisites

Install the following PHP code for easier debugging:
```php
add_filter( 'woocommerce_add_to_cart_quantity',
	function( $quantity, $product_id ) {
		error_log( 'woocommerce_add_to_cart_quantity: ' . $product_id );
		return $quantity;
	},
	10,
	2
);
add_filter( 'woocommerce_add_cart_item',
	function( $data, $cart_id ) {
		error_log( 'woocommerce_add_cart_item: ' . $data['product_id'] );
		return $data;
	},
	10,
	2
);
add_filter( 'woocommerce_loop_add_to_cart_args',
	function( $args, $product ) {
		error_log( 'woocommerce_loop_add_to_cart_args: ' . $product->get_id() );
		return $args;
	},
	10,
	2
);
```

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a classic theme (e.g., Storefront). 
2. Navigate to the Shop page. 
3. Check the logs to ensure that only `woocommerce_loop_add_to_cart_args` runs during the initial rendering. 
4. Click on a simple product's add-to-cart button and observe the `woocommerce_add_to_cart_quantity` and `woocommerce_add_cart_item` run. 
5. Now switch to a block theme (e.g., TT5). 
6. Navigate to the Shop page again.
7. Ensure that only `woocommerce_loop_add_to_cart_args` runs during the initial rendering (not `woocommerce_add_to_cart_quantity`).
8. Click on the same product's add-to-cart button and notice that only the `woocommerce_add_cart_item` hook runs.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
