### PR TITLE
Move email sender options to the email template editor

### DIFF
--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -239,7 +239,7 @@ export function Header() {
 				<SaveEmailButton />
 				<PreviewDropdown />
 				{ hasNonEmailEdits ? (
-					<SaveAllButton />
+					<SaveAllButton validateContent={ validateContent } />
 				) : (
 					<SendButton
 						validateContent={ validateContent }

--- a/packages/js/email-editor/src/components/header/save-all-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-all-button.tsx
@@ -44,7 +44,7 @@ const SaveAllContent = ( { onToggle } ) => {
 	return <EntitiesSavedStates close={ onToggle } />;
 };
 
-export function SaveAllButton() {
+export function SaveAllButton( { validateContent } ) {
 	const { isSaving } = useSelect(
 		( select ) => ( {
 			isSaving: select( storeName ).isSaving(),
@@ -73,7 +73,9 @@ export function SaveAllButton() {
 							recordEvent(
 								'header_save_all_button_save_button_clicked'
 							);
-							onToggle();
+							if ( validateContent() ) {
+								onToggle();
+							}
 						} }
 						variant="primary"
 						disabled={ isSaving }

--- a/packages/js/email-editor/src/components/sidebar/template-settings-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/template-settings-panel.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+interface TemplatePanelSection {
+	id: string;
+	render: () => JSX.Element | null;
+}
+
+export function TemplateSettingsPanel() {
+	// Allow plugins to add custom template sections
+	const templateSections = applyFilters(
+		'woocommerce_email_editor_template_sections',
+		[]
+	) as TemplatePanelSection[];
+
+	if ( templateSections.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ templateSections.map( ( section ) => (
+				<div key={ section.id }>{ section.render() }</div>
+			) ) }
+		</>
+	);
+}

--- a/packages/js/email-editor/src/components/sidebar/template-settings.tsx
+++ b/packages/js/email-editor/src/components/sidebar/template-settings.tsx
@@ -7,11 +7,13 @@ import { Panel } from '@wordpress/components';
  * Internal dependencies
  */
 import { TemplateInfo } from './template-info';
+import { TemplateSettingsPanel } from './template-settings-panel';
 
 export function TemplateSettings() {
 	return (
 		<Panel>
 			<TemplateInfo />
+			<TemplateSettingsPanel />
 		</Panel>
 	);
 }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
@@ -8,5 +8,9 @@ interface Window {
 			id: string;
 		}[];
 		block_preview_url: string;
+		sender_settings: {
+			from_name: string;
+			from_address: string;
+		};
 	};
 }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -6,7 +6,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { isEmail } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -36,12 +35,13 @@ addFilter(
 		const emailValidationRule: EmailContentValidationRule = {
 			id: 'sender-email-validation',
 			testContent: () => {
-				const email = document.querySelector< HTMLInputElement >(
+				const input = document.querySelector< HTMLInputElement >(
 					'input[name="from_email"]'
-				)?.value;
+				);
+				const email = input?.value;
 				if ( ! email ) return false;
 
-				return ! email || ! isEmail( email );
+				return ! email || ! input?.checkValidity();
 			},
 			message: __(
 				'The "from" email address is invalid. Please enter a valid email address that will appear as the sender in outgoing WooCommerce emails.',

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { wooContentPlaceholderBlock } from './blocks/woo-email-content';
 import { NAME_SPACE } from './constants';
+import { modifyTemplateSidebar } from './templates';
 
 addFilter( 'woocommerce_email_editor_send_button_label', NAME_SPACE, () =>
 	__( 'Save email', 'woocommerce' )
@@ -24,3 +25,4 @@ addFilter(
 );
 
 registerBlockType( 'woo/email-content', wooContentPlaceholderBlock );
+modifyTemplateSidebar();

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts
@@ -6,6 +6,7 @@
 import { addFilter } from '@wordpress/hooks';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { isEmail } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -14,8 +15,42 @@ import { wooContentPlaceholderBlock } from './blocks/woo-email-content';
 import { NAME_SPACE } from './constants';
 import { modifyTemplateSidebar } from './templates';
 
+// The type is copied from the email-editor package.
+// When the type was imported from the email-editor package, the build failed due to more than 50 type errors.
+type EmailContentValidationRule = {
+	id: string;
+	testContent: ( emailContent: string ) => boolean;
+	message: string;
+	actions: [];
+};
+
 addFilter( 'woocommerce_email_editor_send_button_label', NAME_SPACE, () =>
 	__( 'Save email', 'woocommerce' )
+);
+
+// Add email validation rule
+addFilter(
+	'woocommerce_email_editor_content_validation_rules',
+	NAME_SPACE,
+	( rules: EmailContentValidationRule[] ) => {
+		const emailValidationRule: EmailContentValidationRule = {
+			id: 'sender-email-validation',
+			testContent: () => {
+				const email = document.querySelector< HTMLInputElement >(
+					'input[name="from_email"]'
+				)?.value;
+				if ( ! email ) return false;
+
+				return ! email || ! isEmail( email );
+			},
+			message: __(
+				'The "from" email address is invalid. Please enter a valid email address that will appear as the sender in outgoing WooCommerce emails.',
+				'woocommerce'
+			),
+			actions: [],
+		};
+		return [ ...( rules || [] ), emailValidationRule ];
+	}
 );
 
 addFilter(

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { TemplateSenderPanel } from './template_sender_panel';
+import './style.scss';
+
+function modifyTemplateSidebar() {
+	addFilter(
+		'woocommerce_email_editor_template_sections',
+		'my-plugin/template-settings',
+		( sections ) => [
+			...sections,
+			{
+				id: 'my-custom-section',
+				render: () => {
+					return <TemplateSenderPanel />;
+				},
+			},
+		]
+	);
+}
+
+export { modifyTemplateSidebar };

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/style.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/style.scss
@@ -3,7 +3,7 @@
 		margin-top: 0;
 	}
 	p {
-		color: #757575;
+		color: $gray-700;
 	}
 }
 .woocommerce-email-sidebar-template-settings-sender-options-input {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/style.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/style.scss
@@ -1,0 +1,12 @@
+.woocommerce-email-sidebar-template-settings-sender-options {
+	h2 {
+		margin-top: 0;
+	}
+	p {
+		color: #757575;
+	}
+}
+.woocommerce-email-sidebar-template-settings-sender-options-input {
+	margin-bottom: 10px;
+	width: 100%;
+}

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
@@ -4,38 +4,43 @@
 import { __ } from '@wordpress/i18n';
 import { Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 
 function TemplateSenderPanel() {
 	const [ woocommerce_template_data, setWoocommerceTemplateData ] =
 		useEntityProp( 'postType', 'wp_template', 'woocommerce_data' );
 	const emailInputRef = useRef< HTMLInputElement >( null );
 
-	const handleFromNameChange = ( value: string ) => {
-		setWoocommerceTemplateData( {
-			...woocommerce_template_data,
-			sender_settings: {
-				...woocommerce_template_data?.sender_settings,
-				from_name: value,
-			},
-		} );
-	};
+	const handleFromNameChange = useCallback(
+		( value: string ) => {
+			setWoocommerceTemplateData( {
+				...woocommerce_template_data,
+				sender_settings: {
+					...woocommerce_template_data?.sender_settings,
+					from_name: value,
+				},
+			} );
+		},
+		[ woocommerce_template_data, setWoocommerceTemplateData ]
+	);
+	const handleFromAddressChange = useCallback(
+		( value: string ) => {
+			setWoocommerceTemplateData( {
+				...woocommerce_template_data,
+				sender_settings: {
+					...woocommerce_template_data?.sender_settings,
+					from_address: value,
+				},
+			} );
 
-	const handleFromAddressChange = ( value: string ) => {
-		setWoocommerceTemplateData( {
-			...woocommerce_template_data,
-			sender_settings: {
-				...woocommerce_template_data?.sender_settings,
-				from_address: value,
-			},
-		} );
-
-		// Use HTML5 validation
-		if ( emailInputRef.current ) {
-			emailInputRef.current.checkValidity();
-			emailInputRef.current.reportValidity();
-		}
-	};
+			// Use HTML5 validation
+			if ( emailInputRef.current ) {
+				emailInputRef.current.checkValidity();
+				emailInputRef.current.reportValidity();
+			}
+		},
+		[ woocommerce_template_data, setWoocommerceTemplateData ]
+	);
 
 	return (
 		<Panel className="woocommerce-email-sidebar-template-settings-sender-options">

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
@@ -54,7 +54,8 @@ function TemplateSenderPanel() {
 				<PanelRow>
 					<TextControl
 						className="woocommerce-email-sidebar-template-settings-sender-options-input"
-						label={ __( '"from" name', 'woocommerce' ) }
+						/* translators: Label for the sender's `“from” name` in email settings. */
+						label={ __( '“from” name', 'woocommerce' ) }
 						name="from_name"
 						type="text"
 						value={
@@ -68,7 +69,8 @@ function TemplateSenderPanel() {
 					<TextControl
 						ref={ emailInputRef }
 						className="woocommerce-email-sidebar-template-settings-sender-options-input"
-						label={ __( '"from" email', 'woocommerce' ) }
+						/* translators: Label for the sender's `“from” email` in email settings. */
+						label={ __( '“from” email', 'woocommerce' ) }
 						name="from_email"
 						type="email"
 						value={

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
@@ -3,8 +3,32 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 
 function TemplateSenderPanel() {
+	const [ woocommerce_template_data, setWoocommerceTemplateData ] =
+		useEntityProp( 'postType', 'wp_template', 'woocommerce_data' );
+
+	const handleFromNameChange = ( value: string ) => {
+		setWoocommerceTemplateData( {
+			...woocommerce_template_data,
+			sender_settings: {
+				...woocommerce_template_data?.sender_settings,
+				from_name: value,
+			},
+		} );
+	};
+
+	const handleFromAddressChange = ( value: string ) => {
+		setWoocommerceTemplateData( {
+			...woocommerce_template_data,
+			sender_settings: {
+				...woocommerce_template_data?.sender_settings,
+				from_address: value,
+			},
+		} );
+	};
+
 	return (
 		<Panel className="woocommerce-email-sidebar-template-settings-sender-options">
 			<PanelBody>
@@ -22,23 +46,27 @@ function TemplateSenderPanel() {
 				<PanelRow>
 					<TextControl
 						className="woocommerce-email-sidebar-template-settings-sender-options-input"
-						label={ __( '“from” name', 'woocommerce' ) }
+						label={ __( '"from" name', 'woocommerce' ) }
 						name="from_name"
-						value={ 'Store name' }
-						onChange={ ( value: string ) =>
-							console.log( 'value', value )
+						type="text"
+						value={
+							woocommerce_template_data?.sender_settings
+								?.from_name || ''
 						}
+						onChange={ handleFromNameChange }
 					/>
 				</PanelRow>
 				<PanelRow>
 					<TextControl
 						className="woocommerce-email-sidebar-template-settings-sender-options-input"
-						label={ __( '“from” email', 'woocommerce' ) }
+						label={ __( '"from" email', 'woocommerce' ) }
 						name="from_email"
-						value={ 'sender@example.com' }
-						onChange={ ( value: string ) =>
-							console.log( 'value', value )
+						type="email"
+						value={
+							woocommerce_template_data?.sender_settings
+								?.from_address || ''
 						}
+						onChange={ handleFromAddressChange }
 					/>
 				</PanelRow>
 			</PanelBody>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
+
+function TemplateSenderPanel() {
+	return (
+		<Panel className="woocommerce-email-sidebar-template-settings-sender-options">
+			<PanelBody>
+				<PanelRow>
+					<div>
+						<h2>{ __( 'Sender Options', 'woocommerce' ) }</h2>
+						<p>
+							{ __(
+								'This is how your sender name and email address would appear in outgoing WooCommerce emails.',
+								'woocommerce'
+							) }
+						</p>
+					</div>
+				</PanelRow>
+				<PanelRow>
+					<TextControl
+						className="woocommerce-email-sidebar-template-settings-sender-options-input"
+						label={ __( '“from” name', 'woocommerce' ) }
+						name="from_name"
+						value={ 'Store name' }
+						onChange={ ( value: string ) =>
+							console.log( 'value', value )
+						}
+					/>
+				</PanelRow>
+				<PanelRow>
+					<TextControl
+						className="woocommerce-email-sidebar-template-settings-sender-options-input"
+						label={ __( '“from” email', 'woocommerce' ) }
+						name="from_email"
+						value={ 'sender@example.com' }
+						onChange={ ( value: string ) =>
+							console.log( 'value', value )
+						}
+					/>
+				</PanelRow>
+			</PanelBody>
+		</Panel>
+	);
+}
+
+export { TemplateSenderPanel };

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/templates/template_sender_panel.tsx
@@ -4,10 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
+import { useRef } from '@wordpress/element';
 
 function TemplateSenderPanel() {
 	const [ woocommerce_template_data, setWoocommerceTemplateData ] =
 		useEntityProp( 'postType', 'wp_template', 'woocommerce_data' );
+	const emailInputRef = useRef< HTMLInputElement >( null );
 
 	const handleFromNameChange = ( value: string ) => {
 		setWoocommerceTemplateData( {
@@ -27,6 +29,12 @@ function TemplateSenderPanel() {
 				from_address: value,
 			},
 		} );
+
+		// Use HTML5 validation
+		if ( emailInputRef.current ) {
+			emailInputRef.current.checkValidity();
+			emailInputRef.current.reportValidity();
+		}
 	};
 
 	return (
@@ -58,6 +66,7 @@ function TemplateSenderPanel() {
 				</PanelRow>
 				<PanelRow>
 					<TextControl
+						ref={ emailInputRef }
 						className="woocommerce-email-sidebar-template-settings-sender-options-input"
 						label={ __( '"from" email', 'woocommerce' ) }
 						name="from_email"
@@ -67,6 +76,7 @@ function TemplateSenderPanel() {
 								?.from_address || ''
 						}
 						onChange={ handleFromAddressChange }
+						required
 					/>
 				</PanelRow>
 			</PanelBody>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -673,7 +673,7 @@ class WC_Admin_Notices {
 			 */
 			$notice_dismissed = apply_filters(
 				'woocommerce_hide_email_sender_options_notice',
-				get_user_meta( get_current_user_id(), 'dismissed_email_sender_options_notice', true )
+				get_user_meta( get_current_user_id(), 'dismissed_woocommerce_email_sender_options_notice', true )
 			);
 
 			if ( ! $notice_dismissed ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -673,7 +673,7 @@ class WC_Admin_Notices {
 			 */
 			$notice_dismissed = apply_filters(
 				'woocommerce_hide_email_sender_options_notice',
-				get_user_meta( get_current_user_id(), 'dismissed_block_email_editor_notice', true )
+				get_user_meta( get_current_user_id(), 'dismissed_email_sender_options_notice', true )
 			);
 
 			if ( ! $notice_dismissed ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -9,7 +9,7 @@
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Utilities\Users;
 use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +46,7 @@ class WC_Admin_Notices {
 		'uploads_directory_is_unprotected'   => 'uploads_directory_is_unprotected_notice',
 		'base_tables_missing'                => 'base_tables_missing_notice',
 		'download_directories_sync_complete' => 'download_directories_sync_complete',
+		'email_sender_options'               => 'email_sender_options_notice',
 	);
 
 	/**
@@ -654,6 +655,33 @@ class WC_Admin_Notices {
 		}
 
 		include __DIR__ . '/views/html-notice-base-table-missing.php';
+	}
+
+	/**
+	 * Display notice about moving the sender options to the email template editor.
+	 */
+	public static function email_sender_options_notice() {
+		$is_block_editor_enabled = FeaturesUtil::feature_is_enabled( 'block_email_editor' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $is_block_editor_enabled && ! empty( $_GET['page'] ) && ! empty( $_GET['tab'] ) && 'wc-settings' === $_GET['page'] && 'email' === $_GET['tab'] ) {
+			/**
+			 * Filter whether to hide the email sender options notice.
+			 *
+			 * @since 9.8.0
+			 *
+			 * @param bool $is_dismissed Whether the notice has been dismissed by the current user.
+			 */
+			$notice_dismissed = apply_filters(
+				'woocommerce_hide_email_sender_options_notice',
+				get_user_meta( get_current_user_id(), 'dismissed_block_email_editor_notice', true )
+			);
+
+			if ( ! $notice_dismissed ) {
+				include __DIR__ . '/views/html-notice-email-sender-options.php';
+			} else {
+				self::remove_notice( 'email_sender_options' );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -31,6 +31,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$this->id    = 'email';
 		$this->label = __( 'Emails', 'woocommerce' );
 
+		add_action( 'admin_notices', array( $this, 'display_email_sender_options_notice' ) );
 		add_action( 'woocommerce_admin_field_email_notification', array( $this, 'email_notification_setting' ) );
 		add_action( 'woocommerce_admin_field_email_preview', array( $this, 'email_preview' ) );
 		add_action( 'woocommerce_admin_field_email_image_url', array( $this, 'email_image_url' ) );
@@ -861,6 +862,17 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				update_option( 'woocommerce_email_improvements_last_disabled_at', $current_date );
 			}
 		}
+	}
+
+	/**
+	 * Display the email sender options notice about moving the sender options to the email template editor.
+	 */
+	public function display_email_sender_options_notice() {
+		if ( FeaturesUtil::feature_is_enabled( 'block_email_editor' ) ) {
+			WC_Admin_Notices::add_notice( 'email_sender_options' );
+			return;
+		}
+		WC_Admin_Notices::remove_notice( 'email_sender_options' );
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -277,6 +277,8 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$body_text_color_setting_in_palette   = $reorder_colors ? $body_text_color_setting : null;
 		$footer_text_color_setting_in_palette = $reorder_colors ? $footer_text_color_setting : null;
 
+		$block_email_editor_enabled = get_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
+
 		$settings =
 			array(
 				array(
@@ -298,39 +300,51 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'type' => 'sectionend',
 					'id'   => 'email_recipient_options',
 				),
-
+			);
+		// Email sender options is available in the new email editor.
+		// If the feature flag is disabled, we show the email sender options.
+		if ( 'no' === $block_email_editor_enabled ) {
+			$settings = array_merge(
+				$settings,
 				array(
-					'title' => __( 'Email sender options', 'woocommerce' ),
-					'type'  => 'title',
-					'desc'  => __( "Set the name and email address you'd like your outgoing emails to use.", 'woocommerce' ),
-					'id'    => 'email_options',
-				),
-
-				array(
-					'title'    => __( '"From" name', 'woocommerce' ),
-					'desc'     => '',
-					'id'       => 'woocommerce_email_from_name',
-					'type'     => 'text',
-					'css'      => 'min-width:400px;',
-					'default'  => esc_attr( get_bloginfo( 'name', 'display' ) ),
-					'autoload' => false,
-					'desc_tip' => true,
-				),
-
-				array(
-					'title'             => __( '"From" address', 'woocommerce' ),
-					'desc'              => '',
-					'id'                => 'woocommerce_email_from_address',
-					'type'              => 'email',
-					'custom_attributes' => array(
-						'multiple' => 'multiple',
+					array(
+						'title' => __( 'Email sender options', 'woocommerce' ),
+						'type'  => 'title',
+						'desc'  => __( "Set the name and email address you'd like your outgoing emails to use.", 'woocommerce' ),
+						'id'    => 'email_options',
 					),
-					'css'               => 'min-width:400px;',
-					'default'           => get_option( 'admin_email' ),
-					'autoload'          => false,
-					'desc_tip'          => true,
-				),
 
+					array(
+						'title'    => __( '"From" name', 'woocommerce' ),
+						'desc'     => '',
+						'id'       => 'woocommerce_email_from_name',
+						'type'     => 'text',
+						'css'      => 'min-width:400px;',
+						'default'  => esc_attr( get_bloginfo( 'name', 'display' ) ),
+						'autoload' => false,
+						'desc_tip' => true,
+					),
+
+					array(
+						'title'             => __( '"From" address', 'woocommerce' ),
+						'desc'              => '',
+						'id'                => 'woocommerce_email_from_address',
+						'type'              => 'email',
+						'custom_attributes' => array(
+							'multiple' => 'multiple',
+						),
+						'css'               => 'min-width:400px;',
+						'default'           => get_option( 'admin_email' ),
+						'autoload'          => false,
+						'desc_tip'          => true,
+					),
+				)
+			);
+		}
+
+		$settings = array_merge(
+			$settings,
+			array(
 				array(
 					'type' => 'sectionend',
 					'id'   => 'email_options',
@@ -402,7 +416,8 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				$color_palette_section_end,
 
 				array( 'type' => 'email_preview' ),
-			);
+			)
+		);
 
 		// Remove empty elements that depend on the email_improvements feature flag.
 		$settings = array_filter( $settings );

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -278,7 +278,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$body_text_color_setting_in_palette   = $reorder_colors ? $body_text_color_setting : null;
 		$footer_text_color_setting_in_palette = $reorder_colors ? $footer_text_color_setting : null;
 
-		$block_email_editor_enabled = get_option( 'woocommerce_feature_block_email_editor_enabled', 'no' );
+		$block_email_editor_enabled = FeaturesUtil::feature_is_enabled( 'block_email_editor' );
 
 		$settings =
 			array(
@@ -304,7 +304,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			);
 		// Email sender options is available in the new email editor.
 		// If the feature flag is disabled, we show the email sender options.
-		if ( 'no' === $block_email_editor_enabled ) {
+		if ( ! $block_email_editor_enabled ) {
 			$settings = array_merge(
 				$settings,
 				array(

--- a/plugins/woocommerce/includes/admin/views/html-notice-email-sender-options.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-email-sender-options.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Admin View: Notice - Email sender options.
+ * Admin View: Notice - WooCommerce Email sender options.
  *
  * @package WooCommerce\Admin\Notices
  */
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 ?>
 <div id="message" class="updated woocommerce-message">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'email_sender_options' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'woocommerce_email_sender_options' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
 	<p>
 	<?php

--- a/plugins/woocommerce/includes/admin/views/html-notice-email-sender-options.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-email-sender-options.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Admin View: Notice - Email sender options.
+ *
+ * @package WooCommerce\Admin\Notices
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\Integration;
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div id="message" class="updated woocommerce-message">
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'email_sender_options' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+	<p>
+	<?php
+		echo wp_kses_post(
+			sprintf(
+			/* translators: %s: documentation URL */
+				__( 'Email sender options have been moved. You can access these settings via <a href="%s">Email Template</a>.', 'woocommerce' ),
+				admin_url( 'edit.php?post_type=' . Integration::EMAIL_POST_TYPE )
+			)
+		);
+		?>
+	</p>
+</div>

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailEditorServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/EmailEditorServiceProvider.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplateApiController;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
 use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 use Automattic\WooCommerce\Internal\EmailEditor\PageRenderer;
 use Automattic\WooCommerce\Internal\EmailEditor\PersonalizationTagManager;
-use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController;
-use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
-use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 use Automattic\WooCommerce\Internal\EmailEditor\WooContentProcessor;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 
@@ -31,6 +32,7 @@ class EmailEditorServiceProvider extends AbstractInterfaceServiceProvider {
 		TemplatesController::class,
 		WooContentProcessor::class,
 		BlockEmailRenderer::class,
+		TemplateApiController::class,
 		WCTransactionalEmails::class,
 	);
 
@@ -46,5 +48,6 @@ class EmailEditorServiceProvider extends AbstractInterfaceServiceProvider {
 		$this->share( WooContentProcessor::class );
 		$this->share( BlockEmailRenderer::class )->addArgument( WooContentProcessor::class );
 		$this->share( WCTransactionalEmails::class );
+		$this->share( TemplateApiController::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
@@ -43,14 +43,25 @@ class TemplateApiController {
 	 */
 	public function save_template_data( array $data, \WP_Block_Template $template_post ): void {
 		if ( WooEmailTemplate::TEMPLATE_SLUG === $template_post->slug && isset( $data['sender_settings'] ) ) {
-			update_option( 'woocommerce_email_from_name', $data['sender_settings']['from_name'] );
+			$new_from_name     = $data['sender_settings']['from_name'] ?? null;
+			$current_from_name = get_option( 'woocommerce_email_from_name' );
 
+			if ( null !== $new_from_name && $new_from_name !== $current_from_name ) {
+				update_option( 'woocommerce_email_from_name', $new_from_name );
+			}
+
+			$new_from_address = $data['sender_settings']['from_address'] ?? null;
 			// This validation matches HTML input type email validation.
 			// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#validation.
-			if ( ! preg_match( '/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/', $data['sender_settings']['from_address'] ) ) {
+			$email_validation_pattern = '/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/';
+			if ( null === $new_from_address || ! preg_match( $email_validation_pattern, $new_from_address ) ) {
 				throw new \InvalidArgumentException( esc_html( __( 'Invalid email address provided for sender settings', 'woocommerce' ) ) );
 			}
-			update_option( 'woocommerce_email_from_address', $data['sender_settings']['from_address'] );
+
+			$current_from_address = get_option( 'woocommerce_email_from_address' );
+			if ( $new_from_address !== $current_from_address ) {
+				update_option( 'woocommerce_email_from_address', $new_from_address );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates;
+
+use Automattic\WooCommerce\EmailEditor\Validator\Builder;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * API Controller for managing WooCommerce email templates via extending the post type API.
+ *
+ * @internal
+ */
+class TemplateApiController {
+	/**
+	 * Returns the sender settings for the given template.
+	 *
+	 * @param array $template_data - WP_Block_Template data.
+	 * @return array
+	 */
+	public function get_template_data( $template_data ): array {
+		$template_slug = $template_data['slug'] ?? null;
+		if ( WooEmailTemplate::TEMPLATE_SLUG !== $template_slug ) {
+			return array();
+		}
+
+		return array(
+			'sender_settings' => array(
+				'from_name'    => get_option( 'woocommerce_email_from_name' ),
+				'from_address' => get_option( 'woocommerce_email_from_address' ),
+			),
+		);
+	}
+
+	/**
+	 * Update WooCommerce specific data we store with Template.
+	 *
+	 * @param array              $data - WP_Block_Template data.
+	 * @param \WP_Block_Template $template_post - WP_Block_Template object.
+	 */
+	public function save_template_data( array $data, \WP_Block_Template $template_post ): void {
+		if ( WooEmailTemplate::TEMPLATE_SLUG === $template_post->slug && isset( $data['sender_settings'] ) ) {
+			update_option( 'woocommerce_email_from_name', $data['sender_settings']['from_name'] );
+			update_option( 'woocommerce_email_from_address', $data['sender_settings']['from_address'] );
+		}
+	}
+
+	/**
+	 * Get the schema for the template data.
+	 *
+	 * @return array
+	 */
+	public function get_template_data_schema(): array {
+		return Builder::object(
+			array(
+				'sender_settings' => Builder::object(
+					array(
+						'preheader'   => Builder::string(),
+						'preview_url' => Builder::string(),
+					)
+				),
+			)
+		)->to_array();
+	}
+}

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
@@ -39,10 +39,15 @@ class TemplateApiController {
 	 *
 	 * @param array              $data - WP_Block_Template data.
 	 * @param \WP_Block_Template $template_post - WP_Block_Template object.
+	 * @throws \InvalidArgumentException If the email address is invalid.
 	 */
 	public function save_template_data( array $data, \WP_Block_Template $template_post ): void {
 		if ( WooEmailTemplate::TEMPLATE_SLUG === $template_post->slug && isset( $data['sender_settings'] ) ) {
 			update_option( 'woocommerce_email_from_name', $data['sender_settings']['from_name'] );
+
+			if ( ! is_email( $data['sender_settings']['from_address'] ) ) {
+				throw new \InvalidArgumentException( esc_html( __( 'Invalid email address provided for sender settings', 'woocommerce' ) ) );
+			}
 			update_option( 'woocommerce_email_from_address', $data['sender_settings']['from_address'] );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/TemplateApiController.php
@@ -45,7 +45,9 @@ class TemplateApiController {
 		if ( WooEmailTemplate::TEMPLATE_SLUG === $template_post->slug && isset( $data['sender_settings'] ) ) {
 			update_option( 'woocommerce_email_from_name', $data['sender_settings']['from_name'] );
 
-			if ( ! is_email( $data['sender_settings']['from_address'] ) ) {
+			// This validation matches HTML input type email validation.
+			// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#validation.
+			if ( ! preg_match( '/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/', $data['sender_settings']['from_address'] ) ) {
 				throw new \InvalidArgumentException( esc_html( __( 'Invalid email address provided for sender settings', 'woocommerce' ) ) );
 			}
 			update_option( 'woocommerce_email_from_address', $data['sender_settings']['from_address'] );

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -6,6 +6,10 @@ namespace Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates;
  * Basic template for WooCommerce transactional emails used in the email editor.
  */
 class WooEmailTemplate {
+	/**
+	 * The template slug.
+	 */
+	public const TEMPLATE_SLUG = 'wooemailtemplate';
 
 	/**
 	 * Get the template slug.
@@ -13,7 +17,7 @@ class WooEmailTemplate {
 	 * @return string Template identifier.
 	 */
 	public function get_slug(): string {
-		return 'wooemailtemplate';
+		return self::TEMPLATE_SLUG;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -85,7 +85,7 @@ class Integration {
 		$container->get( PersonalizationTagManager::class );
 		$container->get( BlockEmailRenderer::class );
 		$container->get( WCTransactionalEmails::class );
-		$this->editor_page_renderer = $container->get( PageRenderer::class );
+		$this->editor_page_renderer    = $container->get( PageRenderer::class );
 		$this->template_api_controller = $container->get( TemplateApiController::class );
 	}
 
@@ -185,10 +185,14 @@ class Integration {
 	 * Extend the post API for the wp_template post type to add and save the woocommerce_data field.
 	 */
 	public function extend_template_post_api(): void {
-		register_rest_field( 'wp_template', 'woocommerce_data', [
-			'get_callback' => [ $this->template_api_controller, 'get_template_data'],
-			'update_callback' => [$this->template_api_controller, 'save_template_data'],
-			'schema' => $this->template_api_controller->get_template_data_schema(),
-		]);
+		register_rest_field(
+			'wp_template',
+			'woocommerce_data',
+			array(
+				'get_callback'    => array( $this->template_api_controller, 'get_template_data' ),
+				'update_callback' => array( $this->template_api_controller, 'save_template_data' ),
+				'schema'          => $this->template_api_controller->get_template_data_schema(),
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns\PatternsController
 use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplatesController;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplateApiController;
+use WP_Post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,6 +36,13 @@ class Integration {
 	 * @var Dependency_Check
 	 */
 	private Dependency_Check $dependency_check;
+
+	/**
+	 * The template API controller instance.
+	 *
+	 * @var TemplateApiController
+	 */
+	private TemplateApiController $template_api_controller;
 
 	/**
 	 * Constructor.
@@ -62,6 +71,7 @@ class Integration {
 	 */
 	public function initialize() {
 		$this->init_hooks();
+		$this->extend_template_post_api();
 		$this->register_hooks();
 	}
 
@@ -76,6 +86,7 @@ class Integration {
 		$container->get( BlockEmailRenderer::class );
 		$container->get( WCTransactionalEmails::class );
 		$this->editor_page_renderer = $container->get( PageRenderer::class );
+		$this->template_api_controller = $container->get( TemplateApiController::class );
 	}
 
 	/**
@@ -168,5 +179,16 @@ class Integration {
 		}
 
 		WCTransactionalEmailPostsManager::get_instance()->delete_email_template( $email_type );
+	}
+
+	/**
+	 * Extend the post API for the wp_template post type to add and save the woocommerce_data field.
+	 */
+	public function extend_template_post_api(): void {
+		register_rest_field( 'wp_template', 'woocommerce_data', [
+			'get_callback' => [ $this->template_api_controller, 'get_template_data'],
+			'update_callback' => [$this->template_api_controller, 'save_template_data'],
+			'schema' => $this->template_api_controller->get_template_data_schema(),
+		]);
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -84,6 +84,7 @@ class PageRenderer {
 		// Load the email editor integration script.
 		// The JS file is located in plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/index.ts.
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'email-editor-integration', true );
+		WCAdminAssets::register_style( 'email-editor-integration', 'style', true );
 
 		$email_editor_assets_path = WC_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'email-editor/';
 		$email_editor_assets_url  = WC()->plugin_url() . '/' . WC_ADMIN_DIST_JS_FOLDER . 'email-editor/';

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailTemplates/TemplateApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailTemplates/TemplateApiControllerTest.php
@@ -105,4 +105,24 @@ class TemplateApiControllerTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( $original_from_name, get_option( 'woocommerce_email_from_name' ) );
 		$this->assertEquals( $original_from_address, get_option( 'woocommerce_email_from_address' ) );
 	}
+
+	/**
+	 * Test that saveTemplateData throws an exception for invalid email addresses.
+	 */
+	public function testItThrowsExceptionForInvalidEmailAddress(): void {
+		$template       = new \WP_Block_Template();
+		$template->slug = WooEmailTemplate::TEMPLATE_SLUG;
+
+		$data = array(
+			'sender_settings' => array(
+				'from_name'    => 'Test Store',
+				'from_address' => 'invalid-email',
+			),
+		);
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Invalid email address provided for sender settings' );
+
+		$this->template_api_controller->save_template_data( $data, $template );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailTemplates/TemplateApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailTemplates/TemplateApiControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Automattic\WooCommerce\Tests\Internal\EmailEditor\EmailTemplates;
+
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\TemplateApiController;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\WooEmailTemplate;
+
+/**
+ * Tests for the TemplateApiController class.
+ */
+class TemplateApiControllerTest extends \WC_Unit_Test_Case {
+	/**
+	 * @var TemplateApiController $template_api_controller
+	 */
+	private TemplateApiController $template_api_controller;
+
+	/**
+	 * Setup test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->template_api_controller = new TemplateApiController();
+	}
+
+	/**
+	 * Test that getTemplateData returns empty array for non-WooCommerce templates.
+	 */
+	public function testItDoesNotGetTemplateDataForNonWooTemplate(): void {
+		$template_data = array(
+			'slug' => 'non-woo-template',
+		);
+
+		$result = $this->template_api_controller->get_template_data( $template_data );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that getTemplateData returns sender settings for WooCommerce templates.
+	 */
+	public function testItGetsTemplateDataForWooTemplate(): void {
+		$from_name    = 'Test Store';
+		$from_address = 'test@example.com';
+
+		update_option( 'woocommerce_email_from_name', $from_name );
+		update_option( 'woocommerce_email_from_address', $from_address );
+
+		$template_data = array(
+			'slug' => WooEmailTemplate::TEMPLATE_SLUG,
+		);
+
+		$result = $this->template_api_controller->get_template_data( $template_data );
+
+		$this->assertArrayHasKey( 'sender_settings', $result );
+		$this->assertEquals( $from_name, $result['sender_settings']['from_name'] );
+		$this->assertEquals( $from_address, $result['sender_settings']['from_address'] );
+	}
+
+	/**
+	 * Test that saveData updates WooCommerce email settings.
+	 */
+	public function testItSavesTemplateDataForWooTemplate(): void {
+		$new_from_name    = 'New Store Name';
+		$new_from_address = 'new@example.com';
+
+		$template       = new \WP_Block_Template();
+		$template->slug = WooEmailTemplate::TEMPLATE_SLUG;
+
+		$data = array(
+			'sender_settings' => array(
+				'from_name'    => $new_from_name,
+				'from_address' => $new_from_address,
+			),
+		);
+
+		$this->template_api_controller->save_template_data( $data, $template );
+
+		$this->assertEquals( $new_from_name, get_option( 'woocommerce_email_from_name' ) );
+		$this->assertEquals( $new_from_address, get_option( 'woocommerce_email_from_address' ) );
+	}
+
+	/**
+	 * Test that saveTemplateData does not update settings for non-WooCommerce templates.
+	 */
+	public function testItDoesNotSaveTemplateDataForNonWooTemplate(): void {
+		$original_from_name    = 'Original Store';
+		$original_from_address = 'original@example.com';
+
+		update_option( 'woocommerce_email_from_name', $original_from_name );
+		update_option( 'woocommerce_email_from_address', $original_from_address );
+
+		$template       = new \WP_Block_Template();
+		$template->slug = 'non-woo-template';
+
+		$data = array(
+			'sender_settings' => array(
+				'from_name'    => 'New Store',
+				'from_address' => 'new@example.com',
+			),
+		);
+
+		$this->template_api_controller->save_template_data( $data, $template );
+
+		$this->assertEquals( $original_from_name, get_option( 'woocommerce_email_from_name' ) );
+		$this->assertEquals( $original_from_address, get_option( 'woocommerce_email_from_address' ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56123.

- This PR moves the email sender options from `WooCommerce -> Settings -> Emails` to the new email template editor, which is behind a feature flag `block_email_editor`.
- When the feature flag `block_email_editor` is active, a user can see a notice in the `WooCommerce -> Settings -> Emails`.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1278" alt="Screenshot 2025-03-17 at 20 24 30" src="https://github.com/user-attachments/assets/6be369ac-160e-405d-be38-105f044a9ff0" /> | <img width="1279" alt="Screenshot 2025-03-17 at 20 30 34" src="https://github.com/user-attachments/assets/8f06a729-7a03-4261-9cfa-a558607cf1e2" />|  
|<img width="1280" alt="Screenshot 2025-03-17 at 20 31 33" src="https://github.com/user-attachments/assets/58863da5-eca4-421c-916c-1f7268411631" /> | <img width="1279" alt="Screenshot 2025-03-17 at 20 31 00" src="https://github.com/user-attachments/assets/15a9228e-6596-4178-a81f-dc167b07ca29" /> |
|<img width="1277" alt="Screenshot 2025-03-17 at 20 31 50" src="https://github.com/user-attachments/assets/18c44453-2ce1-47ed-b633-30368b997f61" />|<img width="1282" alt="Screenshot 2025-03-17 at 20 38 38" src="https://github.com/user-attachments/assets/77dbdc6d-9902-4292-bd1b-cbb0f674f524" />|
||<img width="492" alt="Screenshot 2025-03-19 at 10 28 17" src="https://github.com/user-attachments/assets/ff298022-2ba0-411e-a3cd-29a5f5a0e961" />|
||<img width="1582" alt="Screenshot 2025-03-19 at 10 28 36" src="https://github.com/user-attachments/assets/b45733bb-a8d1-43f0-b9f3-a7629f612d23" />|



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check that saving the sender name and email address still works in `WooCommerce -> Settings -> Emails` when the feature `block_email_editor` is disabled.
2. Enable the feature flag `block_email_editor`
  a. A notice about moving the sender options is visible only in `Settings` and only for the `Emails` tab
  b. The notice is closable
  c. The notice is not visible anymore when the feature flag `block_email_editor` is deactivated
3. The sender options can be set in the email template editor after opening the sidebar related to the template
  a. When an invalid email address is typed, the input should display an HTML validation warning.
  b. Saving an invalid email address is not allowed, and a notice about an invalid email is displayed after clicking on save.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

Because this feature is still behind the feature flag I think we don't need changelog here.
<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
