### PR TITLE
Add product details alignment options and limit block to product context

### DIFF
--- a/plugins/woocommerce/changelog/add-product-details-alignment-options
+++ b/plugins/woocommerce/changelog/add-product-details-alignment-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update experimental blockified product details block to support alignment, and to limit the context in which it can be used.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -7,10 +7,14 @@
 	"description": "Display a product's description, attributes, and reviews",
 	"category": "woocommerce",
 	"textdomain": "woocommerce",
-	
+	"ancestor": [
+		"woocommerce/single-product",
+		"woocommerce/product-template",
+		"core/post-template"
+	],
 	"supports": {
 		"align": [ "wide", "full" ]
 	},
 	"attributes": {},
-	"usesContext": [ "query", "queryId", "postId" ]
+	"usesContext": [ "query", "queryId", "postId", "postType" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -7,6 +7,10 @@
 	"description": "Display a product's description, attributes, and reviews",
 	"category": "woocommerce",
 	"textdomain": "woocommerce",
+	
+	"supports": {
+		"align": [ "wide", "full" ]
+	},
 	"attributes": {},
 	"usesContext": [ "query", "queryId", "postId" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -1,8 +1,20 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 import { InnerBlockTemplate } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
+	Warning,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ProductDetailsEditProps } from './types';
 
 const createAccordionItem = (
 	title: string,
@@ -51,8 +63,49 @@ const TEMPLATE: InnerBlockTemplate[] = [
 	],
 ];
 
-const Edit = () => {
-	return <InnerBlocks template={ TEMPLATE } />;
+/**
+ * Check if block is inside a Query Loop with non-product post type
+ *
+ * @param {string} clientId The block's client ID
+ * @param {string} postType The current post type
+ * @return {boolean} Whether the block is in an invalid Query Loop context
+ */
+const useIsInvalidQueryLoopContext = ( clientId: string, postType: string ) => {
+	return useSelect(
+		( select ) => {
+			const blockParents = select(
+				blockEditorStore
+			).getBlockParentsByBlockName( clientId, 'core/post-template' );
+			return blockParents.length > 0 && postType !== 'product';
+		},
+		[ clientId, postType ]
+	);
+};
+
+const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
+	const blockProps = useBlockProps();
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+	} );
+
+	const isInvalidQueryLoopContext = useIsInvalidQueryLoopContext(
+		clientId,
+		context.postType
+	);
+	if ( isInvalidQueryLoopContext ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __(
+						'The Product Details block requires a product context. When used in a Query Loop, the Query Loop must be configured to display products.',
+						'woocommerce'
+					) }
+				</Warning>
+			</div>
+		);
+	}
+	return <div { ...innerBlocksProps } />;
 };
 
 export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
 import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
+import { registerProductBlockType } from '@woocommerce/atomic-utils';
 
 /**
  * Internal dependencies
@@ -13,10 +13,14 @@ import edit from './edit';
 import icon from './icon';
 
 if ( isExperimentalBlocksEnabled() ) {
-	// @ts-expect-error metadata is not typed.
-	registerBlockType( metadata, {
+	const blockConfig = {
+		...metadata,
 		icon,
 		edit,
 		save,
+	};
+	// @ts-expect-error blockConfig is not typed.
+	registerProductBlockType( blockConfig, {
+		isAvailableOnPostEditor: true,
 	} );
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { BlockEditProps } from '@wordpress/blocks';
+
+type Context = {
+	context: { postId: string; postType: string };
+};
+
+export type ProductDetailsEditProps = BlockEditProps<
+	Record< string, never >
+> &
+	Context;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/constants.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/single-product/constants.tsx
@@ -81,5 +81,6 @@ export const ALLOWED_INNER_BLOCKS = [
 	'woocommerce/product-meta',
 	'woocommerce/product-gallery',
 	'woocommerce/blockified-product-reviews',
+	'woocommerce/blockified-product-details',
 	...Object.keys( getBlockMap( metadata.name ) ),
 ];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes two changes:
- Adds the `"align": [ "wide", "full" ]` to the supports, so the block can be properly aligned. In order to do this, I removed the use of the `InnerBlocks` component and made use the inner block props instead.
- Add the ancestors and make use of the `registerProductBlockType` function to limit where the block can be inserted ( only places where a product context exists ).

Alignment option:
<img width="864" alt="Screenshot 2025-03-18 at 13 30 18" src="https://github.com/user-attachments/assets/8bdc2376-c555-457d-8674-398d960d3a2f" />

Warning if not in product context ( within query loop )
<img width="449" alt="Screenshot 2025-03-18 at 13 30 34" src="https://github.com/user-attachments/assets/7bda8572-eada-41fa-a54e-1963829ec3fe" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and have the **WooCommerce Beta Tester** plugin activated
2. Go to **Tools > WCA Test Helper > Features** and enable the **experimental blocks** feature flag
3. Go to **Appearance > Editor > Templates** and edit the **Single Product** template
4. Add the **Blockified Product Details** block ( an accordion )
5. You should now be able to select the **Blockified Product Details** block and change the alignment in the block tools to **Wide width**, **Full width**, and **None**

**Test the context limitation**

1. Edit or create a new page or post.
2. Try inserting the **Blockified Product Details**, it should not be possible, or visible in the list.
3. Now either add a single product block ( and select a product ) or add a **Product collection** block
4. Select a block within the **Product template** or the **Single product** block, you should now be able to add the **Blockified Product Details** block
5. Add a query loop block and select a template
6. Add the **Blockified Product Details** block inside of the **Post Template** block
7. A warning should show that the block requires a product context.
8. Now select the Query loop and change the post type to **Product**
9. The warning should disappear and it will render the product details accordions.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
