### PR TITLE
[Product Editor] Remove the use of wp-edit-blocks and depend on wp-editor instead

### DIFF
--- a/plugins/woocommerce/changelog/fix-56494_product_editor_toolbar_styling
+++ b/plugins/woocommerce/changelog/fix-56494_product_editor_toolbar_styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing styling conflict with WordPress 6.8 for the experimental product editor.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -161,7 +161,7 @@ class Init {
 			return;
 		}
 		wp_enqueue_style( 'wc-product-editor' );
-		wp_enqueue_style( 'wp-edit-blocks' );
+		wp_enqueue_style( 'wp-editor' );
 		wp_enqueue_style( 'wp-format-library' );
 		wp_enqueue_editor();
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As part of [this commit](https://github.com/WordPress/wordpress-develop/commit/67bc44b3118bbb7cd06273233bbbe18a74383a06) in the upcoming WP 6.8 release `wp-editor` style dependency was removed from the `wp-edit-blocks` package.
In the product editor we were relying on `wp-edit-blocks`, but turns out we only need to rely on `wp-editor`. 

Closes #56494 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|      <img width="925" alt="Screenshot 2025-03-18 at 15 28 40" src="https://github.com/user-attachments/assets/f091d26d-c60c-4d6f-9018-0e00ab7a10b4" />  |   <img width="820" alt="Screenshot 2025-03-18 at 16 15 29" src="https://github.com/user-attachments/assets/ad8ee5dd-76de-4769-a751-2fcae00ed012" />    |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add new**
3. Make sure to add a summary and also a description within the full editor, the block toolbar styling should be correct
4. Install the **WordPress Beta Tester** and change the settings to **Bleeding edge** and **Beta/RC Only**
5. Go to **Dashboard > Updates** and update WP to the latest 6.8 beta
6. Go to **Products > Add new**
7. And add the summary and description again ( also going to the block editor in the description field )
8. The styling of the toolbar should look correctly

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
