### PR TITLE
Fix payment method stored as wrong type

### DIFF
--- a/plugins/woocommerce/changelog/56520-fix-default-payment-method-returns-array
+++ b/plugins/woocommerce/changelog/56520-fix-default-payment-method-returns-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a Array to string conversion PHP Warning where saved payment methods are sometimes saved as the wrong type.

--- a/plugins/woocommerce/src/StoreApi/Utilities/PaymentUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/PaymentUtils.php
@@ -93,7 +93,7 @@ class PaymentUtils {
 		$saved_payment_methods = self::get_saved_payment_methods();
 		// A saved payment method exists, set as default.
 		if ( $saved_payment_methods && ! empty( $saved_payment_methods['default'] ) ) {
-			return $saved_payment_methods['default'];
+			return $saved_payment_methods['default']['method']['gateway'] ?? '';
 		}
 
 		$chosen_payment_method = WC()->session->get( 'chosen_payment_method' );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The `get_default_payment_method` currently returns an array which is passed to [$order->set_payment_method](https://github.com/woocommerce/woocommerce/blob/master/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php#L116). 

`set_payment_method` should be either a Payment object or a string. Passing an array causes a an `array to string conversion` PHP warning. This only happens if HPOS is active. 

Since the `payment_method` passed to the client cannot be an array anymore, there's no need to handle that use case. Instead, if a saved payment method is set as the default, we look up the id of the payment method in `customerPaymentMethods` which is already hydrated to the client.

Fixes https://github.com/Automattic/woocommerce-payments/issues/10539.

Slack discussion: p1742289731530579-slack-C8X6Q7XQU

Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/53553.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Quickly replicate the PHP warning without installing additional plugins
In order to quickly replicate the issue, you can do the following:

1. Add the following snippet to `woocommerce.php`, `functions.php` or using the Code Snippets plugin:

```php
add_action( 'woocommerce_store_api_checkout_update_order_meta', 'update_payment_method', 10, 1 );

function update_payment_method( $order ) {
	$order->set_payment_method( array( 'gateway' => 'stripe' ) );
	$order->save();
}
```

2. Either install Query Monitor plugin or make sure logging is enabled.
3. Enable HPOS (WooCommerce -> Settings -> Advanced -> Features -> Order Data Storage -> High Performance Order Storage)
4. Add a product to the cart and visit the checkout page
5. `Array to string conversion` PHP Warning should be logged.

#### Testing this PR

To test this PR fully, you will need to install WooPayments and Woo Subscriptions.

1. Install WooPayments and Woo Subscriptions
2. Activate WooPayments and complete KYC flow if not done so already
3. Enable 'Accept Early Renewal Payments' from WooCommerce Subscriptions settings.
4. Create Simple subscription product.
5. Go to My account > Subscriptions page.
6. Note the newly created subscription and click the 'View' button
7. Note the 'Renew now' button and click it.
8. You are expected to land on the checkout page.
9. Observe that, no PHP errors should be logged
10. No PHP warning should be logged.
11. Smoke test payment methods (enable a few of them, select them, make sure they are persisted, reload the page, make sure the right one is still selected. If there are saved payment methods available, the default one should always be selected.
12. Place an order with a saved payment method. The order should go through successfully.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixes a Array to string conversion PHP Warning where saved payment methods are sometimes saved as the wrong type.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>