### PR TITLE
Store API - Ensure shipping hashes change when choosing shipping methods so orders get updated

### DIFF
--- a/plugins/woocommerce/changelog/fix-56523-order-total-update
+++ b/plugins/woocommerce/changelog/fix-56523-order-total-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Regression in 56367
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -160,7 +160,7 @@ test.describe( 'Shopper → Local pickup', () => {
 		}
 	);
 
-	test( 'Switching between local pickup and shipping does not affect the address', async ( {
+	test( 'Switching between local pickup and shipping does not affect the address and is used for the order', async ( {
 		page,
 		frontendUtils,
 		checkoutPageObject,
@@ -197,6 +197,16 @@ test.describe( 'Shopper → Local pickup', () => {
 		await expect( page.getByLabel( 'Email address' ) ).toHaveValue(
 			'john.doe@test.com'
 		);
+
+		await page
+			.getByRole( 'radio', { name: 'Pickup', exact: true } )
+			.click();
+		await checkoutPageObject.placeOrder();
+
+		await expect(
+			page.getByText( 'Collection from Testing' )
+		).toBeVisible();
+		await checkoutPageObject.verifyBillingDetails();
 	} );
 
 	test( 'Delivery/pickup toggle is not shown when other shipping methods are disabled and hide rates until address is entered is off', async ( {

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -823,7 +823,7 @@ class CartController {
 		$cart = $this->get_cart_instance();
 		return [
 			'line_items' => $cart->get_cart_hash(),
-			'shipping'   => md5( wp_json_encode( $cart->shipping_methods ) ),
+			'shipping'   => md5( wp_json_encode( [ $cart->shipping_methods, wc()->session->get( 'chosen_shipping_methods' ) ] ) ),
 			'fees'       => md5( wp_json_encode( $cart->get_fees() ) ),
 			'coupons'    => md5( wp_json_encode( $cart->get_applied_coupons() ) ),
 			'taxes'      => md5( wp_json_encode( $cart->get_taxes() ) ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/56367 we fixed some logic so that cart hashes were correctly used to detect if the order needed to be updated or not. The logic in this function was broken previously.

Uncaught in tests, because of a separate bug in the `get_cart_hashes) method, the hash would not change after changing shipping method selection on checkout. This caused the order to contain stale data.

The fix is to include chosen methods as part of the hash.

Closes #56523

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/56367

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a store, enable a shipping method, and local pickup
2. Add something to cart and go to block checkout
3. Fill out the checkout form, then toggle shipping -> local pickup.
4. Place order
5. Confirm Local Pickup was used and you can see a collection address in the confirmation

I've updated one of the e2e tests to check that the toggle works.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
