### PR TITLE
Add NOX in-context APIs

### DIFF
--- a/packages/js/data/changelog/add-nox-in-context-apis
+++ b/packages/js/data/changelog/add-nox-in-context-apis
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Use the new WooPay eligibility endpoint.
+
+

--- a/packages/js/data/src/payment-settings/resolvers.ts
+++ b/packages/js/data/src/payment-settings/resolvers.ts
@@ -43,7 +43,7 @@ export function* getOfflinePaymentGateways( country?: string ) {
 
 export function* getWooPayEligibility() {
 	const response: WooPayEligibilityResponse = yield apiFetch( {
-		path: `${ WC_ADMIN_NAMESPACE }/settings/payments/woopay-eligibility`,
+		path: `${ WC_ADMIN_NAMESPACE }/settings/payments/woopayments/woopay-eligibility`,
 	} );
 
 	return response;

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -351,6 +351,7 @@ final class WooCommerce {
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderActionsRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Orders\OrderStatusRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController::class )->register();
+		$container->get( Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments\WooPaymentsRestController::class )->register();
 		$container->get( Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreviewRestController::class )->register();
 	}
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -222,7 +222,6 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 	 * @param WP_REST_Request $request WP_REST_Request object.
 	 *
 	 * @return array
-	 * @throws \Exception If there is an error registering the site.
 	 */
 	public function get_jetpack_authorization_url( WP_REST_Request $request ) {
 		$manager = new Manager( 'woocommerce' );

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -235,6 +235,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_show_lys_tour',
 			'woocommerce_remote_variant_assignment',
 			'woocommerce_gateway_order',
+			'woocommerce_woopayments_nox_profile', // This is temporary.
 			// WC Test helper options.
 			'wc-admin-test-helper-rest-api-filters',
 			'wc_admin_helper_feature_values',

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/PaymentGateway.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/PaymentGateway.php
@@ -361,7 +361,7 @@ class PaymentGateway {
 			return $payment_gateway->get_settings_url();
 		}
 
-		return Utils::wc_payments_settings_url(null, array( 'section', strtolower( $payment_gateway->id ) ) );
+		return Utils::wc_payments_settings_url( null, array( 'section', strtolower( $payment_gateway->id ) ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/PaymentGateway.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/PaymentGateway.php
@@ -19,6 +19,17 @@ defined( 'ABSPATH' ) || exit;
  */
 class PaymentGateway {
 
+	// This is the default onboarding type for all gateways.
+	// It means that the payment extension will handle the onboarding.
+	const ONBOARDING_TYPE_EXTERNAL = 'external';
+
+	// This is the onboarding type for gateways that have a WooCommerce-tailored onboarding flow.
+	// This might mean just having the payment methods select step in the WooCommerce settings.
+	const ONBOARDING_TYPE_NATIVE = 'native';
+
+	// This is the onboarding type for gateways that have a WooCommerce in-context onboarding flow.
+	const ONBOARDING_TYPE_NATIVE_IN_CONTEXT = 'native_in_context';
+
 	/**
 	 * Extract the payment gateway provider details from the object.
 	 *
@@ -56,6 +67,7 @@ class PaymentGateway {
 				),
 			),
 			'onboarding'  => array(
+				'type'                        => self::ONBOARDING_TYPE_EXTERNAL,
 				'state'                       => array(
 					'started'   => $this->is_onboarding_started( $gateway ),
 					'completed' => $this->is_onboarding_completed( $gateway ),
@@ -349,7 +361,7 @@ class PaymentGateway {
 			return $payment_gateway->get_settings_url();
 		}
 
-		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $payment_gateway->id ) );
+		return Utils::wc_payments_settings_url(null, array( 'section', strtolower( $payment_gateway->id ) ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Admin\WCAdminHelper;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
+use Automattic\WooCommerce\Internal\Admin\Settings\Utils;
 use WC_Abstract_Order;
 use WC_Payment_Gateway;
 use WooCommerce\Admin\Experimental_Abtest;
@@ -21,6 +22,32 @@ defined( 'ABSPATH' ) || exit;
 class WooPayments extends PaymentGateway {
 
 	const PREFIX = 'woocommerce_admin_settings_payments__woopayments__';
+
+	/**
+	 * Extract the payment gateway provider details from the object.
+	 *
+	 * @param WC_Payment_Gateway $gateway      The payment gateway object.
+	 * @param int                $order        Optional. The order to assign.
+	 *                                         Defaults to 0 if not provided.
+	 * @param string             $country_code Optional. The country code for which the details are being gathered.
+	 *                                         This should be a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array The payment gateway provider details.
+	 */
+	public function get_details( WC_Payment_Gateway $gateway, int $order = 0, string $country_code = '' ): array {
+		$details = parent::get_details( $gateway, $order, $country_code );
+
+		// Switch the onboarding type to native in-context.
+		$details['onboarding']['type'] = self::ONBOARDING_TYPE_NATIVE_IN_CONTEXT;
+
+		// Provide the native, in-context onboarding URL instead of the external one.
+		// This is a catch-all URL that should start or continue the onboarding process.
+		$details['onboarding']['_links']['onboard'] = array(
+			'href' => Utils::wc_payments_settings_url( '/woopayments/onboarding' ),
+		);
+
+		return $details;
+	}
 
 	/**
 	 * Check if the payment gateway needs setup.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments;
 
 use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
+use Automattic\WooCommerce\Internal\Admin\WCPayPromotion\Init as WCPayPromotion;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
 use Exception;
 use WP_Error;
@@ -276,6 +277,18 @@ class WooPaymentsRestController extends RestApiControllerBase {
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/woopay-eligibility',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'get_woopay_eligibility' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 				),
 			),
 			$override
@@ -564,6 +577,19 @@ class WooPaymentsRestController extends RestApiControllerBase {
 		}
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get WooPay eligibility status.
+	 *
+	 * @return WP_REST_Response The response.
+	 */
+	protected function get_woopay_eligibility() {
+		return rest_ensure_response(
+			array(
+				'is_eligible' => WCPayPromotion::is_woopay_eligible(),
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -185,7 +185,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_test_account_initialize' ),
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_test_account_init' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
@@ -360,7 +360,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 		$response = array(
 			'success'         => true,
 			'previous_status' => $previous_status,
-			'status'          => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
+			'current_status'  => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
 		);
 
 		return rest_ensure_response( $response );
@@ -468,14 +468,15 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @return WP_Error|WP_REST_Response The response.
 	 */
-	protected function handle_onboarding_test_account_initialize( WP_REST_Request $request ) {
+	protected function handle_onboarding_test_account_init( WP_REST_Request $request ) {
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
 			// Fall back to the providers country if no location is provided
 			$location = $this->payments->get_country();
 		}
 
-		// @todo Mark the step as started, if not already.
+		// Mark the step as started, if not already.
+		$this->woopayments->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
 		try {
 			$result = $this->woopayments->onboarding_test_account_init( $location );
@@ -777,19 +778,18 @@ class WooPaymentsRestController extends RestApiControllerBase {
 						),
 						'status' => array(
 							'type'        => 'enum',
-							'description' => esc_html__( 'The status of the step.', 'woocommerce' ),
+							'description' => esc_html__( 'The current status of the step.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'enum'        => array(
 								WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 								WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
 								WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
-								WooPaymentsService::ONBOARDING_STEP_STATUS_ERROR,
 							),
 						),
 						'errors' => array(
 							'type'        => 'array',
-							'description' => esc_html__( 'The errors for the step.', 'woocommerce' ),
+							'description' => esc_html__( 'Errors list for the step.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'items'       => array(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -89,6 +89,21 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_start' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+						'source'   => array(
+							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
 				),
 			),
 			$override
@@ -101,6 +116,15 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_save' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+					),
 				),
 			),
 			$override
@@ -113,18 +137,145 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_check' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+					),
 				),
 			),
 			$override
 		);
 		register_rest_route(
 			$this->route_namespace,
-			'/' . $this->rest_base . '/onboarding/step/(?P<step>[a-zA-Z0-9_-]+)/complete',
+			'/' . $this->rest_base . '/onboarding/step/(?P<step>[a-zA-Z0-9_-]+)/finish',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_complete' ),
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_finish' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+						'source'   => array(
+							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			),
+			$override
+		);
+		// Onboarding step specific routes.
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/' . WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT . '/init',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_test_account_initialize' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+					),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/' . WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/check/po_eligible',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_business_verification_check_po_eligible' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+					),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/' . WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/session/start',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_business_verification_session_start' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+						'progressive' => array(
+							'description'       => __( 'Whether the session is for progressive onboarding.', 'woocommerce' ),
+							'type'              => 'boolean',
+							'default'           => false,
+							'sanitize_callback' => 'wc_string_to_bool',
+						),
+						'source'   => array(
+							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/' . WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/session/finish',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_business_verification_session_finish' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+						'source'   => array(
+							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
 				),
 			),
 			$override
@@ -167,27 +318,11 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	}
 
 	/**
-	 * Get the controller's REST URL path.
-	 *
-	 * @param string $relative_path Optional. Relative path to append to the REST URL.
-	 *
-	 * @return string The REST URL path.
-	 */
-	protected function get_rest_url_path( string $relative_path = '' ): string {
-		$path = '/' . trim( $this->route_namespace, '/' ) . '/' . trim( $this->rest_base, '/' );
-		if ( ! empty( $relative_path ) ) {
-			$path .= '/' . ltrim( $relative_path, '/' );
-		}
-
-		return $path;
-	}
-
-	/**
 	 * Handle the onboarding step start action.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response The response.
 	 */
 	protected function handle_onboarding_step_start( WP_REST_Request $request ) {
 		$step_id = $request->get_param( 'step' );
@@ -209,9 +344,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}
 
-
-
 		$response = array(
+			'success'         => true,
 			'previous_status' => $previous_status,
 			'status'          => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
 		);
@@ -224,7 +358,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response The response.
 	 */
 	protected function handle_onboarding_step_save( WP_REST_Request $request ) {
 		$step_id = $request->get_param( 'step' );
@@ -244,17 +378,48 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}
 
-		return rest_ensure_response( array() );
+		return rest_ensure_response( array( 'success' => true ) );
 	}
 
 	/**
-	 * Handle the onboarding step complete action.
+	 * Handle the onboarding step check action.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response The response.
 	 */
-	protected function handle_onboarding_step_complete( WP_REST_Request $request ) {
+	protected function handle_onboarding_step_check( WP_REST_Request $request ) {
+		$step_id = $request->get_param( 'step' );
+		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		try {
+			$result = $this->woopayments->onboarding_step_check( $step_id, $location );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		// Merge the result with the success flag.
+		$response = array_merge( array( 'success' => true ), $result );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Handle the onboarding step finish action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response The response.
+	 */
+	protected function handle_onboarding_step_finish( WP_REST_Request $request ) {
 		$step_id = $request->get_param( 'step' );
 		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
@@ -275,6 +440,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 		}
 
 		$response = array(
+			'success'         => true,
 			'previous_status' => $previous_status,
 			'status'          => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
 		);
@@ -283,9 +449,128 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	}
 
 	/**
+	 * Handle the onboarding test account initialize action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response The response.
+	 */
+	protected function handle_onboarding_test_account_initialize( WP_REST_Request $request ) {
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided
+			$location = $this->payments->get_country();
+		}
+
+		// @todo Mark the step as started, if not already.
+
+		try {
+			$result = $this->woopayments->onboarding_test_account_init( $location );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return rest_ensure_response( array_merge( array(
+			'success' => true,
+		), $result ) );
+	}
+
+	/**
+	 * Handle the onboarding business verification step check PO eligible action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response The response.
+	 */
+	protected function handle_onboarding_business_verification_check_po_eligible( WP_REST_Request $request ) {
+		// If we receive self assessment data with the request, we will use it.
+		$self_assessment = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
+
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided
+			$location = $this->payments->get_country();
+		}
+
+		try {
+			$result = $this->woopayments->get_onboarding_kyc_po_eligible( $location, $self_assessment );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response( array_merge( array(
+			'success' => true,
+		), $result ) );
+	}
+
+	/**
+	 * Handle the onboarding business verification step session start action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response The response.
+	 */
+	protected function handle_onboarding_business_verification_session_start( WP_REST_Request $request ) {
+		$progressive = (bool) $request->get_param( 'progressive' );
+
+		// If we receive self assessment data with the request, we will use it.
+		$self_assessment = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
+
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		try {
+			$account_session = $this->woopayments->get_onboarding_kyc_session( $location, $self_assessment, $progressive );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response( array(
+			'success' => true,
+			'session' => $account_session,
+		) );
+	}
+
+	/**
+	 * Handle the onboarding business verification step session finish action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response The response.
+	 */
+	protected function handle_onboarding_business_verification_session_finish( WP_REST_Request $request ) {
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		try {
+			$response = $this->woopayments->finish_onboarding_kyc_session( $location, $request->get_param( 'source' ) ?? '' );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		// If there is no success key in the response, we assume the operation was successful.
+		if ( ! isset( $response['success'] ) ) {
+			$response['success'] = true;
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
 	 * General permissions check for Payments settings REST API endpoint.
 	 *
 	 * @param WP_REST_Request $request The request for which the permission is checked.
+	 *
 	 * @return bool|WP_Error True if the current user has the capability, otherwise an "Unauthorized" error or False if no error is available for the request method.
 	 */
 	private function check_permissions( WP_REST_Request $request ) {
@@ -526,6 +811,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
+								'init'    => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to initialize a test account.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
 								'kyc_session' => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to start a KYC session.', 'woocommerce' ),
@@ -535,9 +827,9 @@ class WooPaymentsRestController extends RestApiControllerBase {
 								),
 							),
 						),
-						'data'   => array(
+						'context'   => array(
 							'type'        => 'object',
-							'description' => esc_html__( 'Various data for the step.', 'woocommerce' ),
+							'description' => esc_html__( 'Various contextual data for the step to use.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
@@ -570,5 +862,21 @@ class WooPaymentsRestController extends RestApiControllerBase {
 				'readonly'    => true,
 			),
 		);
+	}
+
+	/**
+	 * Get the controller's REST URL path.
+	 *
+	 * @param string $relative_path Optional. Relative path to append to the REST URL.
+	 *
+	 * @return string The REST URL path.
+	 */
+	private function get_rest_url_path( string $relative_path = '' ): string {
+		$path = '/' . trim( $this->route_namespace, '/' ) . '/' . trim( $this->rest_base, '/' );
+		if ( ! empty( $relative_path ) ) {
+			$path .= '/' . ltrim( $relative_path, '/' );
+		}
+
+		return $path;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -50,7 +50,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 * @return string
 	 */
 	protected function get_rest_api_namespace(): string {
-		return 'wc-admin';
+		return 'wc-admin-settings-payments-woopayments';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -1,0 +1,574 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments;
+
+use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
+use Automattic\WooCommerce\Internal\RestApiControllerBase;
+use Exception;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Controller for the WooPayments-specific REST endpoints to service the Payments settings page.
+ */
+class WooPaymentsRestController extends RestApiControllerBase {
+
+	/**
+	 * The root namespace for the JSON REST API endpoints.
+	 *
+	 * @var string
+	 */
+	protected string $route_namespace = 'wc-admin';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected string $rest_base = 'settings/payments/woopayments';
+
+	/**
+	 * The payments settings page service.
+	 *
+	 * @var Payments
+	 */
+	private Payments $payments;
+
+	/**
+	 * The WooPayments-specific Payments settings page service.
+	 *
+	 * @var WooPaymentsService
+	 */
+	private WooPaymentsService $woopayments;
+
+	/**
+	 * Get the WooCommerce REST API namespace for the class.
+	 *
+	 * @return string
+	 */
+	protected function get_rest_api_namespace(): string {
+		return 'wc-admin';
+	}
+
+	/**
+	 * Register the REST API endpoints handled by this controller.
+	 *
+	 * @param bool $override Whether to override the existing routes. Useful for testing.
+	 */
+	public function register_routes( bool $override = false ) {
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'get_onboarding_details' ),
+					'validation_callback' => 'rest_validate_request_arg',
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'location' => array(
+							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
+							'type'              => 'string',
+							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
+							'required'          => false,
+							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
+						),
+					),
+				),
+				'schema' => fn() => $this->get_schema_for_get_onboarding_details(),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/(?P<step>[a-zA-Z0-9_-]+)/start',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_start' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/(?P<step>[a-zA-Z0-9_-]+)/save',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_save' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/(?P<step>[a-zA-Z0-9_-]+)/check',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_check' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/step/(?P<step>[a-zA-Z0-9_-]+)/complete',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_step_complete' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+				),
+			),
+			$override
+		);
+	}
+
+	/**
+	 * Initialize the class instance.
+	 *
+	 * @param Payments $payments The general payments settings page service.
+	 * @param WooPaymentsService $woopayments The WooPayments-specific Payments settings page service.
+	 *
+	 * @internal
+	 */
+	final public function init( Payments $payments, WooPaymentsService $woopayments ): void {
+		$this->payments    = $payments;
+		$this->woopayments = $woopayments;
+	}
+
+	/**
+	 * Get the onboarding details for the given location.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	protected function get_onboarding_details( WP_REST_Request $request ) {
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		try {
+			$onboarding_details = $this->woopayments->get_onboarding_details( $location, $this->get_rest_url_path( 'onboarding' ) );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response( $this->prepare_onboarding_details_response( $onboarding_details ) );
+	}
+
+	/**
+	 * Get the controller's REST URL path.
+	 *
+	 * @param string $relative_path Optional. Relative path to append to the REST URL.
+	 *
+	 * @return string The REST URL path.
+	 */
+	protected function get_rest_url_path( string $relative_path = '' ): string {
+		$path = '/' . trim( $this->route_namespace, '/' ) . '/' . trim( $this->rest_base, '/' );
+		if ( ! empty( $relative_path ) ) {
+			$path .= '/' . ltrim( $relative_path, '/' );
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Handle the onboarding step start action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	protected function handle_onboarding_step_start( WP_REST_Request $request ) {
+		$step_id = $request->get_param( 'step' );
+		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		$previous_status = $this->woopayments->get_onboarding_step_status( $step_id, $location );
+
+		try {
+			$this->woopayments->set_onboarding_step_started( $step_id, $location );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+
+
+		$response = array(
+			'previous_status' => $previous_status,
+			'status'          => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Handle the onboarding step save action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	protected function handle_onboarding_step_save( WP_REST_Request $request ) {
+		$step_id = $request->get_param( 'step' );
+		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		try {
+			$this->woopayments->onboarding_step_save( $step_id, $location, $request->get_params() );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response( array() );
+	}
+
+	/**
+	 * Handle the onboarding step complete action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	protected function handle_onboarding_step_complete( WP_REST_Request $request ) {
+		$step_id = $request->get_param( 'step' );
+		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$location = $request->get_param( 'location' );
+		if ( empty( $location ) ) {
+			// Fall back to the providers country if no location is provided.
+			$location = $this->payments->get_country();
+		}
+
+		$previous_status = $this->woopayments->get_onboarding_step_status( $step_id, $location );
+
+		try {
+			$this->woopayments->set_onboarding_step_completed( $step_id, $location );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		$response = array(
+			'previous_status' => $previous_status,
+			'status'          => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * General permissions check for Payments settings REST API endpoint.
+	 *
+	 * @param WP_REST_Request $request The request for which the permission is checked.
+	 * @return bool|WP_Error True if the current user has the capability, otherwise an "Unauthorized" error or False if no error is available for the request method.
+	 */
+	private function check_permissions( WP_REST_Request $request ) {
+		$context = 'read';
+		if ( 'POST' === $request->get_method() ) {
+			$context = 'edit';
+		} elseif ( 'DELETE' === $request->get_method() ) {
+			$context = 'delete';
+		}
+
+		if ( wc_rest_check_manager_permissions( 'payment_gateways', $context ) ) {
+			return true;
+		}
+
+		$error_information = $this->get_authentication_error_by_method( $request->get_method() );
+		if ( is_null( $error_information ) ) {
+			return false;
+		}
+
+		return new WP_Error(
+			$error_information['code'],
+			$error_information['message'],
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Validate the location argument.
+	 *
+	 * @param mixed           $value   Value of the argument.
+	 * @param WP_REST_Request $request The current request object.
+	 *
+	 * @return WP_Error|true True if the location argument is valid, otherwise a WP_Error object.
+	 */
+	private function check_location_arg( $value, WP_REST_Request $request ) {
+		// If the 'location' argument is not a string return an error.
+		if ( ! is_string( $value ) ) {
+			return new WP_Error( 'rest_invalid_param', esc_html__( 'The location argument must be a string.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		// Get the registered attributes for this endpoint request.
+		$attributes = $request->get_attributes();
+
+		// Grab the location param schema.
+		$args = $attributes['args']['location'];
+
+		// If the location param doesn't match the regex pattern then we should return an error as well.
+		if ( ! preg_match( '/^' . $args['pattern'] . '$/', $value ) ) {
+			return new WP_Error( 'rest_invalid_param', esc_html__( 'The location argument must be a valid ISO3166 alpha-2 country code.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Prepare the response for the GET onboarding details request.
+	 *
+	 * @param array $response The response to prepare.
+	 *
+	 * @return array The prepared response.
+	 */
+	private function prepare_onboarding_details_response( array $response ): array {
+		return $this->prepare_onboarding_details_response_recursive( $response, $this->get_schema_for_get_onboarding_details() );
+	}
+
+	/**
+	 * Recursively prepare the response items for the GET onboarding details request.
+	 *
+	 * @param mixed $response_item The response item to prepare.
+	 * @param array $schema        The schema to use for preparing the response.
+	 *
+	 * @return mixed The prepared response item.
+	 */
+	private function prepare_onboarding_details_response_recursive( $response_item, array $schema ) {
+		if ( is_null( $response_item ) ||
+			 ! array_key_exists( 'properties', $schema ) ||
+			 ! is_array( $schema['properties'] ) ) {
+			return $response_item;
+		}
+
+		$prepared_response = array();
+		foreach ( $schema['properties'] as $key => $property_schema ) {
+			if ( is_array( $response_item ) && array_key_exists( $key, $response_item ) ) {
+				if ( is_array( $property_schema ) && array_key_exists( 'properties', $property_schema ) ) {
+					$prepared_response[ $key ] = $this->prepare_onboarding_details_response_recursive( $response_item[ $key ], $property_schema );
+				} elseif ( is_array( $property_schema ) && array_key_exists( 'items', $property_schema ) ) {
+					$prepared_response[ $key ] = array_map(
+						fn( $item ) => $this->prepare_onboarding_details_response_recursive( $item, $property_schema['items'] ),
+						$response_item[ $key ]
+					);
+				} else {
+					$prepared_response[ $key ] = $response_item[ $key ];
+				}
+			}
+		}
+
+		// Ensure the order is the same as in the schema.
+		$prepared_response = array_merge( array_fill_keys( array_keys( $schema['properties'] ), null ), $prepared_response );
+
+		// Remove any null values from the response.
+		$prepared_response = array_filter( $prepared_response, fn( $value ) => ! is_null( $value ) );
+
+		return $prepared_response;
+	}
+
+	/**
+	 * Get the schema for the GET onboarding details request.
+	 *
+	 * @return array[]
+	 */
+	private function get_schema_for_get_onboarding_details(): array {
+		$schema               = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'WooCommerce Settings Payments WooPayments onboarding details for the given location.',
+			'type'    => 'object',
+		);
+		$schema['properties'] = array(
+			'state' 				 => array(
+				'type'        => 'object',
+				'description' => esc_html__( 'The general state of the onboarding process.', 'woocommerce' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'properties'  => array(
+					'started'  => array(
+						'type'        => 'boolean',
+						'description' => esc_html__( 'Whether the onboarding process is started.', 'woocommerce' ),
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'completed' => array(
+						'type'        => 'boolean',
+						'description' => esc_html__( 'Whether the onboarding process is completed.', 'woocommerce' ),
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'test_mode' => array(
+						'type'        => 'boolean',
+						'description' => esc_html__( 'Whether the onboarding process is in test mode.', 'woocommerce' ),
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'dev_mode' => array(
+						'type'        => 'boolean',
+						'description' => esc_html__( 'Whether WooPayments is in dev mode.', 'woocommerce' ),
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+				),
+			),
+			'steps' => array(
+				'type'        => 'array',
+				'description' => esc_html__( 'The onboarding steps.', 'woocommerce' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'     => array(
+							'type'        => 'string',
+							'description' => esc_html__( 'The unique identifier for the step.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'path'  => array(
+							'type'        => 'string',
+							'description' => esc_html__( 'The relative path of the step to use for frontend navigation.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'required_steps' => array(
+							'type'        => 'array',
+							'description' => esc_html__( 'The steps that are required to be completed before this step.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'status' => array(
+							'type'        => 'enum',
+							'description' => esc_html__( 'The status of the step.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'enum'        => array(
+								WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+								WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+								WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+								WooPaymentsService::ONBOARDING_STEP_STATUS_ERROR,
+							),
+						),
+						'errors' => array(
+							'type'        => 'array',
+							'description' => esc_html__( 'The errors for the step.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'actions' => array(
+							'type'        => 'object',
+							'description' => esc_html__( 'The available actions for the step.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'properties'  => array(
+								'start'    => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to signal the step start.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+								'save'    => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to save step information in the database.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+								'check'    => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to check the step status.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+								'complete' => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to signal the step completion.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+								'auth'    => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to authorize the WPCOM connection.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+								'kyc_session' => array(
+									'type'        => 'object',
+									'description' => esc_html__( 'Action to start a KYC session.', 'woocommerce' ),
+									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+							),
+						),
+						'data'   => array(
+							'type'        => 'object',
+							'description' => esc_html__( 'Various data for the step.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Get the schema properties for an onboarding step action.
+	 *
+	 * @return array[] The schema properties for an onboarding step action.
+	 */
+	private function get_schema_properties_for_onboarding_step_action(): array {
+		return array(
+			'type' => array(
+				'type'        => 'enum',
+				'description' => esc_html__( 'The action type to determine how to use the URL.', 'woocommerce' ),
+				'enum'        => array( WooPaymentsService::ACTION_TYPE_REST, WooPaymentsService::ACTION_TYPE_REDIRECT ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'href' => array(
+				'type'        => 'string',
+				'description' => esc_html__( 'The URL to use for the action.', 'woocommerce' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -230,7 +230,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'callback'            => fn( $request ) => $this->run( $request, 'handle_onboarding_business_verification_session_start' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
-						'location' => array(
+						'location'    => array(
 							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to WooCommerce\'s base location country.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
@@ -243,7 +243,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 							'default'           => false,
 							'sanitize_callback' => 'wc_string_to_bool',
 						),
-						'source'   => array(
+						'source'      => array(
 							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
@@ -298,7 +298,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	/**
 	 * Initialize the class instance.
 	 *
-	 * @param Payments $payments The general payments settings page service.
+	 * @param Payments           $payments The general payments settings page service.
 	 * @param WooPaymentsService $woopayments The WooPayments-specific Payments settings page service.
 	 *
 	 * @internal
@@ -471,7 +471,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	protected function handle_onboarding_test_account_init( WP_REST_Request $request ) {
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
-			// Fall back to the providers country if no location is provided
+			// Fall back to the providers country if no location is provided.
 			$location = $this->payments->get_country();
 		}
 
@@ -488,9 +488,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			return $result;
 		}
 
-		return rest_ensure_response( array_merge( array(
-			'success' => true,
-		), $result ) );
+		return rest_ensure_response(
+			array_merge(
+				array(
+					'success' => true,
+				),
+				$result
+			)
+		);
 	}
 
 	/**
@@ -502,11 +507,11 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 */
 	protected function handle_onboarding_business_verification_check_po_eligible( WP_REST_Request $request ) {
 		// If we receive self assessment data with the request, we will use it.
-		$self_assessment = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
+		$self_assessment = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : array();
 
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
-			// Fall back to the providers country if no location is provided
+			// Fall back to the providers country if no location is provided.
 			$location = $this->payments->get_country();
 		}
 
@@ -516,9 +521,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}
 
-		return rest_ensure_response( array_merge( array(
-			'success' => true,
-		), $result ) );
+		return rest_ensure_response(
+			array_merge(
+				array(
+					'success' => true,
+				),
+				$result
+			)
+		);
 	}
 
 	/**
@@ -532,7 +542,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 		$progressive = (bool) $request->get_param( 'progressive' );
 
 		// If we receive self assessment data with the request, we will use it.
-		$self_assessment = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
+		$self_assessment = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : array();
 
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
@@ -546,10 +556,12 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}
 
-		return rest_ensure_response( array(
-			'success' => true,
-			'session' => $account_session,
-		) );
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'session' => $account_session,
+			)
+		);
 	}
 
 	/**
@@ -673,8 +685,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 */
 	private function prepare_onboarding_details_response_recursive( $response_item, array $schema ) {
 		if ( is_null( $response_item ) ||
-			 ! array_key_exists( 'properties', $schema ) ||
-			 ! is_array( $schema['properties'] ) ) {
+			! array_key_exists( 'properties', $schema ) ||
+			! is_array( $schema['properties'] ) ) {
 			return $response_item;
 		}
 
@@ -715,13 +727,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			'type'    => 'object',
 		);
 		$schema['properties'] = array(
-			'state' 				 => array(
+			'state' => array(
 				'type'        => 'object',
 				'description' => esc_html__( 'The general state of the onboarding process.', 'woocommerce' ),
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'properties'  => array(
-					'started'  => array(
+					'started'   => array(
 						'type'        => 'boolean',
 						'description' => esc_html__( 'Whether the onboarding process is started.', 'woocommerce' ),
 						'context'     => array( 'view', 'edit' ),
@@ -739,7 +751,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 						'context'     => array( 'view', 'edit' ),
 						'readonly'    => true,
 					),
-					'dev_mode' => array(
+					'dev_mode'  => array(
 						'type'        => 'boolean',
 						'description' => esc_html__( 'Whether WooPayments is in dev mode.', 'woocommerce' ),
 						'context'     => array( 'view', 'edit' ),
@@ -755,13 +767,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'id'     => array(
+						'id'             => array(
 							'type'        => 'string',
 							'description' => esc_html__( 'The unique identifier for the step.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
-						'path'  => array(
+						'path'           => array(
 							'type'        => 'string',
 							'description' => esc_html__( 'The relative path of the step to use for frontend navigation.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
@@ -776,7 +788,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 								'type' => 'string',
 							),
 						),
-						'status' => array(
+						'status'         => array(
 							'type'        => 'enum',
 							'description' => esc_html__( 'The current status of the step.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
@@ -787,7 +799,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 								WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 							),
 						),
-						'errors' => array(
+						'errors'         => array(
 							'type'        => 'array',
 							'description' => esc_html__( 'Errors list for the step.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
@@ -796,48 +808,48 @@ class WooPaymentsRestController extends RestApiControllerBase {
 								'type' => 'string',
 							),
 						),
-						'actions' => array(
+						'actions'        => array(
 							'type'        => 'object',
 							'description' => esc_html__( 'The available actions for the step.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
-								'start'    => array(
+								'start'       => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to signal the step start.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'save'    => array(
+								'save'        => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to save step information in the database.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'check'    => array(
+								'check'       => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to check the step status.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'complete' => array(
+								'complete'    => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to signal the step completion.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'auth'    => array(
+								'auth'        => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to authorize the WPCOM connection.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'init'    => array(
+								'init'        => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to initialize a test account.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),
@@ -853,7 +865,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 								),
 							),
 						),
-						'context'   => array(
+						'context'        => array(
 							'type'        => 'object',
 							'description' => esc_html__( 'Various contextual data for the step to use.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -455,7 +455,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 		$response = array(
 			'success'         => true,
 			'previous_status' => $previous_status,
-			'status'          => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
+			'current_status'  => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
 		);
 
 		return rest_ensure_response( $response );
@@ -835,7 +835,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'complete'    => array(
+								'finish'    => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to signal the step completion.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -835,7 +835,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 									'context'     => array( 'view', 'edit' ),
 									'readonly'    => true,
 								),
-								'finish'    => array(
+								'finish'      => array(
 									'type'        => 'object',
 									'description' => esc_html__( 'Action to signal the step completion.', 'woocommerce' ),
 									'properties'  => $this->get_schema_properties_for_onboarding_step_action(),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1,0 +1,502 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments;
+
+use Automattic\WooCommerce\Admin\API\OnboardingPlugins;
+use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
+use Automattic\WooCommerce\Internal\Admin\Settings\Utils;
+use Automattic\WooCommerce\Utilities\RestApiUtil;
+use Exception;
+use WC_Payments;
+use WP_REST_Request;
+
+defined( 'ABSPATH' ) || exit;
+/**
+ * WooPayments-specific Payments settings page service class.
+ */
+class WooPaymentsService {
+
+	const ONBOARDING_PATH_BASE = '/woopayments/onboarding';
+
+	const ONBOARDING_STEP_PAYMENT_METHODS = 'payment_methods';
+	const ONBOARDING_STEP_WPCOM_CONNECTION = 'wpcom_connection';
+	const ONBOARDING_STEP_TEST_ACCOUNT = 'test_account';
+	const ONBOARDING_STEP_BUSINESS_VERIFICATION = 'business_verification';
+
+	const ONBOARDING_STEP_STATUS_NOT_STARTED = 'not_started';
+	const ONBOARDING_STEP_STATUS_STARTED = 'started';
+	const ONBOARDING_STEP_STATUS_COMPLETED = 'completed';
+	const ONBOARDING_STEP_STATUS_ERROR = 'error';
+
+	const ACTION_TYPE_REST = 'REST';
+	const ACTION_TYPE_REDIRECT = 'REDIRECT';
+
+	const NOX_PROFILE_OPTION_KEY = 'woocommerce_woopayments_nox_profile';
+
+	/**
+	 * The payments settings page service.
+	 *
+	 * @var RestApiUtil
+	 */
+	private RestApiUtil $rest_api_util;
+
+	/**
+	 * The WooPayments provider instance.
+	 *
+	 * @var PaymentProviders\WooPayments
+	 */
+	private PaymentProviders\WooPayments $provider;
+
+	/**
+	 * Initialize the class instance.
+	 *
+	 * @internal
+	 */
+	final public function init( RestApiUtil $rest_api_util ): void {
+		$this->rest_api_util = $rest_api_util;
+		$this->provider      = new PaymentProviders\WooPayments();
+	}
+
+	/**
+	 * Get the onboarding details for the settings page.
+	 *
+	 * @param string $location  The location for which we are onboarding.
+	 *                          This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
+	 *
+	 * @return array The onboarding details.
+	 * @throws Exception If the WooPayments plugin is not active.
+	 */
+	public function get_onboarding_details( string $location, string $rest_path ): array {
+		// If the WooPayments plugin is not active, we don't do onboarding.
+		if ( ! $this->is_woopayments_active() ) {
+			throw new Exception( 'WooPayments is not active.' );
+		}
+
+		return array(
+			'state' => array(
+				'started'   => $this->provider->is_onboarding_started( $this->get_payment_gateway() ),
+				'completed' => $this->provider->is_onboarding_completed( $this->get_payment_gateway() ),
+				'test_mode' => $this->provider->is_in_test_mode_onboarding( $this->get_payment_gateway() ),
+				'dev_mode'  => $this->provider->is_in_dev_mode( $this->get_payment_gateway() ),
+			),
+			'steps' => $this->get_onboarding_steps_details( $location, trailingslashit( $rest_path ) . 'step' ),
+		);
+	}
+
+	/**
+	 * Check if the given onboarding step ID is valid.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 *
+	 * @return bool Whether the given onboarding step ID is valid.
+	 */
+	public function is_valid_onboarding_step_id( string $step_id ): bool {
+		return in_array( $step_id, array(
+			self::ONBOARDING_STEP_PAYMENT_METHODS,
+			self::ONBOARDING_STEP_WPCOM_CONNECTION,
+			self::ONBOARDING_STEP_TEST_ACCOUNT,
+			self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+		), true );
+	}
+
+	/**
+	 * Get the onboarding steps details.
+	 *
+	 * @param string $location  The location for which we are onboarding.
+	 *                          This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
+	 *
+	 * @return array[] The onboarding steps details.
+	 */
+	private function get_onboarding_steps_details( string $location, string $rest_path ): array {
+		$details = array();
+
+		// Add the payment methods onboarding step details.
+		$details[] = array(
+			'id'                          => self::ONBOARDING_STEP_PAYMENT_METHODS,
+			'path'                        => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_PAYMENT_METHODS,
+			'required_steps'              => array(),
+			'status'                      => $this->get_onboarding_step_status( self::ONBOARDING_STEP_PAYMENT_METHODS, $location ),
+			'errors'                      => array(),
+			'actions'                     => array(
+				'start'    => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/start' ),
+				),
+				'save'    => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/save' ),
+				),
+				'complete' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/complete' ),
+				),
+			),
+			'data'                        => array(
+				'recommended_payment_methods' => $this->provider->get_recommended_payment_methods( $this->get_payment_gateway(), $location ),
+			),
+		);
+
+		// Add the WPCOM connection onboarding step details.
+		$wpcom_step_details = array(
+			'id'              => self::ONBOARDING_STEP_WPCOM_CONNECTION,
+			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_WPCOM_CONNECTION,
+			'required_steps'  => array(),
+			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_WPCOM_CONNECTION, $location ),
+			'errors'          => array(),
+		);
+
+		// If the WPCOM connection is already set up, we don't need to add anything more.
+		if ( $wpcom_step_details['status'] !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+			// Try to generate the authorization URL.
+			$wpcom_connection = $this->get_wpcom_connection_authorization( Utils::wc_payments_settings_url( self::ONBOARDING_PATH_BASE ), 'woocommerce' );
+			if ( ! $wpcom_connection['success'] ) {
+				$wpcom_step_details['status'] = self::ONBOARDING_STEP_STATUS_ERROR;
+				$wpcom_step_details['errors'] = $wpcom_connection['errors'];
+			}
+			$wpcom_step_details['actions'] = array(
+				'start' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/start' ),
+				),
+				'auth'  => array(
+					'type' => self::ACTION_TYPE_REDIRECT,
+					'href' => $wpcom_connection['url'],
+				),
+			);
+		}
+
+		$details[] = $wpcom_step_details;
+
+		// Add the test account onboarding step details.
+		$test_account_step_details = array(
+			'id'              => self::ONBOARDING_STEP_TEST_ACCOUNT,
+			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_TEST_ACCOUNT,
+			'required_steps'  => array( self::ONBOARDING_STEP_PAYMENT_METHODS, self::ONBOARDING_STEP_WPCOM_CONNECTION ),
+			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ),
+			'errors'          => array(),
+		);
+
+		// If the step is not completed, we need to add the actions.
+		if ( $test_account_step_details['status'] !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+			$test_account_step_details['actions'] = array(
+				'start' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/start' ),
+				),
+				'check' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/check' ),
+				),
+			);
+		}
+
+		$details[] = $test_account_step_details;
+
+		// Add the live account business verification onboarding step details.
+		$business_verification_step_details = array(
+			'id'              => self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+			'required_steps'  => array( self::ONBOARDING_STEP_PAYMENT_METHODS, self::ONBOARDING_STEP_WPCOM_CONNECTION ),
+			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ),
+			'errors'          => array(),
+		);
+
+		// If the step is not completed, we need to add the actions.
+		if ( $business_verification_step_details['status'] !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+			$business_verification_step_details['actions'] = array(
+				'start' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/start' ),
+				),
+				'save' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/save' ),
+				),
+				'kyc_session' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/kyc_session' ),
+				),
+				'complete' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/complete' ),
+				),
+			);
+		}
+
+		$details[] = $business_verification_step_details;
+
+		return $details;
+	}
+
+	/**
+	 * Get the status of an onboarding step.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return string The status of the onboarding step.
+	 */
+	public function get_onboarding_step_status( string $step_id, string $location ): string {
+		switch ( $step_id ) {
+			case self::ONBOARDING_STEP_PAYMENT_METHODS:
+				// @todo Implement the logic to check the status of the payment methods onboarding step.
+				return self::ONBOARDING_STEP_STATUS_NOT_STARTED;
+			case self::ONBOARDING_STEP_WPCOM_CONNECTION:
+				if ( Utils::store_has_wpcom_connection() ) {
+					return self::ONBOARDING_STEP_STATUS_COMPLETED;
+				}
+				break;
+			case self::ONBOARDING_STEP_TEST_ACCOUNT:
+				if ( ! $this->has_account() ) {
+					return self::ONBOARDING_STEP_STATUS_NOT_STARTED;
+				}
+
+				// A valid, fully onboarded account that is a test account marks this step as complete.
+				if ( $this->has_valid_account() && $this->has_test_account() ) {
+					return self::ONBOARDING_STEP_STATUS_COMPLETED;
+				}
+				break;
+			case self::ONBOARDING_STEP_BUSINESS_VERIFICATION:
+				// If no account or the current account is a test account,
+				// then we didn't start the live account business verification.
+				if ( ! $this->has_account() || $this->has_test_account() ) {
+					return self::ONBOARDING_STEP_STATUS_NOT_STARTED;
+				}
+
+				// If the current account is fully onboarded and is not a test account,
+				// we consider the business verification step as completed.
+				if ( $this->has_valid_account() ) {
+					return self::ONBOARDING_STEP_STATUS_COMPLETED;
+				}
+				break;
+		}
+
+		// We default to not started.
+		return self::ONBOARDING_STEP_STATUS_NOT_STARTED;
+	}
+
+	/**
+	 * Mark an onboarding step as started.
+	 *
+	 * @param string $step_id  The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return bool Whether the onboarding step was marked as started.
+	 * @throws Exception If the given onboarding step ID is invalid.
+	 */
+	public function set_onboarding_step_started( string $step_id, string $location ): bool {
+		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
+			throw new Exception( 'Invalid onboarding step ID.' );
+		}
+
+		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
+
+		if ( empty( $nox_profile ) ) {
+			$nox_profile = array();
+		} else {
+			$nox_profile = maybe_unserialize( $nox_profile );
+		}
+
+		if ( empty( $nox_profile['onboarding'] ) ) {
+			$nox_profile['onboarding'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
+			$nox_profile['onboarding'][ $location ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] = array();
+		}
+
+		// Mark the step as started and record the timestamp.
+		$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'][ self::ONBOARDING_STEP_STATUS_STARTED ] = time() ;
+
+		return update_option( self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+	}
+
+	/**
+	 * Mark an onboarding step as completed.
+	 *
+	 * @param string $step_id  The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return bool Whether the onboarding step was marked as completed.
+	 * @throws Exception If the given onboarding step ID is invalid.
+	 */
+	public function set_onboarding_step_completed( string $step_id, string $location ): bool {
+		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
+			throw new Exception( 'Invalid onboarding step ID.' );
+		}
+
+		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
+
+		if ( empty( $nox_profile ) ) {
+			$nox_profile = array();
+		} else {
+			$nox_profile = maybe_unserialize( $nox_profile );
+		}
+
+		if ( empty( $nox_profile['onboarding'] ) ) {
+			$nox_profile['onboarding'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
+			$nox_profile['onboarding'][ $location ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] = array();
+		}
+
+		// Mark the step as completed and record the timestamp.
+		$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'][ self::ONBOARDING_STEP_STATUS_COMPLETED ] = time() ;
+
+		return update_option( self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+	}
+
+	/**
+	 * Save the data for an onboarding step.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $request_data The entire data received in the request.
+	 *
+	 * @return bool Whether the onboarding step data was saved.
+	 * @throws Exception If the given onboarding step ID or data are invalid.
+	 */
+	public function onboarding_step_save( string $step_id, string $location, array $request_data ) {
+		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
+			throw new Exception( 'Invalid onboarding step ID.' );
+		}
+
+		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
+
+		if ( empty( $nox_profile ) ) {
+			$nox_profile = array();
+		} else {
+			$nox_profile = maybe_unserialize( $nox_profile );
+		}
+
+		if ( empty( $nox_profile['onboarding'] ) ) {
+			$nox_profile['onboarding'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
+			$nox_profile['onboarding'][ $location ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['data'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['data'] = array();
+		}
+
+		// We support save for only certain steps.
+		switch ( $step_id ) {
+			case self::ONBOARDING_STEP_PAYMENT_METHODS:
+				if ( ! isset( $request_data['payment_methods'] ) || ! is_array( $request_data['payment_methods'] ) ) {
+					throw new Exception( 'Invalid onboarding step data.' );
+				}
+
+				$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['data']['payment_methods'] = $request_data['payment_methods'];
+				break;
+			default:
+				return false;
+		}
+
+		return update_option( self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+	}
+
+	/**
+	 * Get the WPCOM (Jetpack) connection authorization details.
+	 *
+	 * @param string $redirect_url The URL to redirect to after the connection is set up.
+	 * @param string $from
+	 *
+	 * @return array The WPCOM connection authorization details.
+	 */
+	private function get_wpcom_connection_authorization( string $redirect_url, string $from ): array {
+		$plugin_onboarding = new OnboardingPlugins();
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'redirect_url', $redirect_url );
+		$request->set_param( 'from', $from );
+
+		return $plugin_onboarding->get_jetpack_authorization_url( $request );
+	}
+
+
+
+	/**
+	 * Check if the WooPayments plugin is active.
+	 *
+	 * @return boolean
+	 */
+	private function is_woopayments_active(): bool {
+		return class_exists( '\WC_Payments' );
+	}
+
+	/**
+	 * Get the main payment gateway instance.
+	 *
+	 * @return \WC_Payment_Gateway_WCPay
+	 */
+	private function get_payment_gateway(): \WC_Payment_Gateway_WCPay {
+		return \WC_Payments::get_gateway();
+	}
+
+	/**
+	 * Determine if WooPayments has an account set up.
+	 *
+	 * @return bool
+	 */
+	private function has_account(): bool {
+		return $this->provider->is_account_connected( $this->get_payment_gateway() );
+	}
+
+	/**
+	 * Determine if WooPayments has a valid, fully onboarded account set up.
+	 *
+	 * @return bool
+	 */
+	private function has_valid_account(): bool {
+		if ( ! $this->has_account() ) {
+			return false;
+		}
+
+		return WC_Payments::get_account_service()->is_stripe_account_valid();
+	}
+
+	/**
+	 * Determine if WooPayments has a test account set up.
+	 *
+	 * @return bool
+	 */
+	private function has_test_account(): bool {
+		if ( ! $this->has_account() ) {
+			return false;
+		}
+
+		$account_status = WC_Payments::get_account_service()->get_account_status_data();
+
+		return ! empty( $account_status['testDrive'] );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -178,21 +178,21 @@ class WooPaymentsService {
 		// If the step is not completed, we need to add the actions.
 		if ( self::ONBOARDING_STEP_STATUS_COMPLETED !== $test_account_step_details['status'] ) {
 			$test_account_step_details['actions'] = array(
-				'start'    => array(
+				'start'  => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/start' ),
 				),
-				'init'     => array(
+				'init'   => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/init' ),
 				),
-				'check'    => array(
+				'check'  => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/check' ),
 				),
-				'complete' => array(
+				'finish' => array(
 					'type' => self::ACTION_TYPE_REST,
-					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/complete' ),
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/finish' ),
 				),
 			);
 		}
@@ -226,9 +226,9 @@ class WooPaymentsService {
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/session/start' ),
 				),
-				'complete'      => array(
+				'finish'        => array(
 					'type' => self::ACTION_TYPE_REST,
-					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/complete' ),
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/finish' ),
 				),
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -26,7 +26,6 @@ class WooPaymentsService {
 	const ONBOARDING_STEP_STATUS_NOT_STARTED = 'not_started';
 	const ONBOARDING_STEP_STATUS_STARTED = 'started';
 	const ONBOARDING_STEP_STATUS_COMPLETED = 'completed';
-	const ONBOARDING_STEP_STATUS_ERROR = 'error';
 
 	const ACTION_TYPE_REST = 'REST';
 	const ACTION_TYPE_REDIRECT = 'REDIRECT';
@@ -63,7 +62,7 @@ class WooPaymentsService {
 	 */
 	public function get_onboarding_details( string $location, string $rest_path ): array {
 		// If the WooPayments plugin is not active, we don't do onboarding.
-		if ( ! $this->is_woopayments_active() ) {
+		if ( ! $this->is_extension_active() ) {
 			throw new Exception( 'WooPayments is not active.' );
 		}
 
@@ -147,7 +146,6 @@ class WooPaymentsService {
 			// Try to generate the authorization URL.
 			$wpcom_connection = $this->get_wpcom_connection_authorization( Utils::wc_payments_settings_url( self::ONBOARDING_PATH_BASE ), 'woocommerce' );
 			if ( ! $wpcom_connection['success'] ) {
-				$wpcom_step_details['status'] = self::ONBOARDING_STEP_STATUS_ERROR;
 				$wpcom_step_details['errors'] = $wpcom_connection['errors'];
 			}
 			$wpcom_step_details['actions'] = array(
@@ -301,26 +299,31 @@ class WooPaymentsService {
 	/**
 	 * Mark an onboarding step as started.
 	 *
-	 * @param string $step_id  The ID of the onboarding step.
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $step_id   The ID of the onboarding step.
+	 * @param string $location  The location for which we are onboarding.
+	 *                          This is a ISO 3166-1 alpha-2 country code.
+	 * @param bool   $overwrite Whether to overwrite the step status if it is already started and update the timestamp.
 	 *
 	 * @return bool Whether the onboarding step was marked as started.
 	 * @throws Exception If the given onboarding step ID is invalid.
 	 */
-	public function set_onboarding_step_started( string $step_id, string $location ): bool {
+	public function set_onboarding_step_started( string $step_id, string $location, bool $overwrite = false ): bool {
 		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
 			throw new Exception( 'Invalid onboarding step ID.' );
 		}
 
 		// Check step requirements.
 		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
-			throw new Exception( 'Onboarding step requirements are not met.' );
+			throw new Exception( 'Onboarding step can no be started because requirements are not met.' );
 		}
 
 		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
 		if ( empty( $step_details['statuses'] ) ) {
 			$step_details['statuses'] = array();
+		}
+
+		if ( ! $overwrite && ! empty( $step_details['statuses'][ self::ONBOARDING_STEP_STATUS_STARTED ] ) ) {
+			return true;
 		}
 
 		// Mark the step as started and record the timestamp.
@@ -333,14 +336,15 @@ class WooPaymentsService {
 	/**
 	 * Mark an onboarding step as completed.
 	 *
-	 * @param string $step_id  The ID of the onboarding step.
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $step_id   The ID of the onboarding step.
+	 * @param string $location  The location for which we are onboarding.
+	 *                          This is a ISO 3166-1 alpha-2 country code.
+	 * @param bool   $overwrite Whether to overwrite the step status if it is already completed and update the timestamp.
 	 *
 	 * @return bool Whether the onboarding step was marked as completed.
 	 * @throws Exception If the given onboarding step ID is invalid.
 	 */
-	public function set_onboarding_step_completed( string $step_id, string $location ): bool {
+	public function set_onboarding_step_completed( string $step_id, string $location, bool $overwrite = false ): bool {
 		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
 			throw new Exception( 'Invalid onboarding step ID.' );
 		}
@@ -355,6 +359,10 @@ class WooPaymentsService {
 			$step_details['statuses'] = array();
 		}
 
+		if ( ! $overwrite && ! empty( $step_details['statuses'][ self::ONBOARDING_STEP_STATUS_COMPLETED ] ) ) {
+			return true;
+		}
+
 		// Mark the step as completed and record the timestamp.
 		$step_details['statuses'][ self::ONBOARDING_STEP_STATUS_COMPLETED ] = time();
 
@@ -365,9 +373,9 @@ class WooPaymentsService {
 	/**
 	 * Save the data for an onboarding step.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $step_id      The ID of the onboarding step.
+	 * @param string $location     The location for which we are onboarding.
+	 *                             This is a ISO 3166-1 alpha-2 country code.
 	 * @param array  $request_data The entire data received in the request.
 	 *
 	 * @return bool Whether the onboarding step data was saved.
@@ -383,7 +391,7 @@ class WooPaymentsService {
 			$step_details['data'] = array();
 		}
 
-		// We support save for only certain steps.
+		// We support save for only certain steps, each with its own data structure.
 		switch ( $step_id ) {
 			case self::ONBOARDING_STEP_PAYMENT_METHODS:
 				if ( ! isset( $request_data['payment_methods'] ) || ! is_array( $request_data['payment_methods'] ) ) {
@@ -400,7 +408,7 @@ class WooPaymentsService {
 				$step_details['data']['self_assessment'] = $request_data['self_assessment'];
 				break;
 			default:
-				return false;
+				throw new Exception( 'Invalid onboarding step ID.' );
 		}
 
 		// Store the updated step data.
@@ -444,7 +452,7 @@ class WooPaymentsService {
 		$payment_methods = $this->provider->get_recommended_payment_methods( $this->get_payment_gateway(), $location );
 
 		// Grab the stored payment methods state
-		// (a key-value array of payment method IDs and if they should be enabled or not).
+		// (a key-value array of payment method IDs and if they should be automatically enabled or not).
 		$step_data = $this->get_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_PAYMENT_METHODS, $location, 'data' );
 		if ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) {
 			foreach ( $payment_methods as $key => $payment_method ) {
@@ -489,6 +497,13 @@ class WooPaymentsService {
 			);
 		}
 
+		// Nothing to do if there is an account, but it is not a test account.
+		if ( $this->has_account() ) {
+			return array(
+				'message' => __( 'An account is already set up. Reset the onboarding first.', 'woocommerce' ),
+			);
+		}
+
 		// Check step requirements.
 		if( ! $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
 			throw new Exception( 'Onboarding step requirements are not met.' );
@@ -517,8 +532,8 @@ class WooPaymentsService {
 			throw new Exception( 'Failed to initialize the test account.' );
 		}
 
-		// Mark the business verification step as completed.
-		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
+		// Mark the test account step as completed.
+		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
 		return $response;
 	}
@@ -526,9 +541,10 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding KYC progressive onboarding (PO) eligibility.
 	 *
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
-	 * @param array  $self_assessment The self-assessment data.
+	 * @param string $location        The location for which we are onboarding.
+	 *                                This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $self_assessment Optional. The self-assessment data.
+	 *                                If not provided, the stored data will be used.
 	 *
 	 * @return array The KYC PO eligibility data.
 	 * @throws Exception If the eligibility could not be determined or there was an error.
@@ -542,8 +558,8 @@ class WooPaymentsService {
 			}
 		}
 
-		// Gather the needed details.
-		$payload = array(
+		// Prepare the needed details.
+		$request_payload = array(
 			'business' => array(
 				'country' => $self_assessment['country'] ?? $location,
 				'type'    => $self_assessment['business_type'] ?? '',
@@ -556,7 +572,7 @@ class WooPaymentsService {
 		);
 
 		// Call the WooPayments API to determine PO eligibility.
-		$response_data = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/router/po_eligible', $payload );
+		$response_data = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/router/po_eligible', $request_payload );
 
 		if ( is_wp_error( $response_data ) ) {
 			throw new Exception( $response_data->get_error_message(), $response_data->get_error_code() );
@@ -575,10 +591,12 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding KYC account session.
 	 *
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
-	 * @param array  $self_assessment The self-assessment data.
-	 * @param bool   $progressive Whether the KYC session is for progressive onboarding.
+	 * @param string $location        The location for which we are onboarding.
+	 *                                This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $self_assessment Optional. The self-assessment data.
+	 *                                If not provided, the stored data will be used.
+	 * @param bool   $progressive     Optional. Whether the KYC session is for progressive onboarding.
+	 *                                Default is to get the KYC session for regular onboarding.
 	 *
 	 * @return array The KYC account session data.
 	 * @throws Exception If the KYC session data could not be retrieved or there was an error.
@@ -615,8 +633,8 @@ class WooPaymentsService {
 	/**
 	 * Finish the onboarding KYC account session.
 	 *
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $location        The location for which we are onboarding.
+	 *                                This is a ISO 3166-1 alpha-2 country code.
 	 * @param string $tracking_source Optional. The tracking source for the KYC session.
 	 *                                If not provided, it will identify the source as the WC Admin Payments settings.
 	 *
@@ -645,7 +663,7 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Get the stored NOX profile.
+	 * Get the entire stored NOX profile data
 	 *
 	 * @return array The stored NOX profile.
 	 */
@@ -664,11 +682,12 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding step data from the NOX profile.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $step_id  The ID of the onboarding step.
 	 * @param string $location The location for which we are onboarding.
 	 *                         This is a ISO 3166-1 alpha-2 country code.
 	 *
-	 * @return array The onboarding step data from the NOX profile.
+	 * @return array The onboarding step stored data from the NOX profile.
+	 *               If the step data is not found, an empty array is returned.
 	 */
 	private function get_nox_profile_onboarding_step( string $step_id, string $location ): array {
 		$nox_profile = $this->get_nox_profile();
@@ -692,12 +711,12 @@ class WooPaymentsService {
 	/**
 	 * Save the onboarding step data in the NOX profile.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $step_id  The ID of the onboarding step.
 	 * @param string $location The location for which we are onboarding.
 	 *                         This is a ISO 3166-1 alpha-2 country code.
-	 * @param array  $data The onboarding step data to save in the profile.
+	 * @param array  $data     The onboarding step data to save in the profile.
 	 *
-	 * @return bool
+	 * @return bool Whether the onboarding step data was saved.
 	 */
 	private function save_nox_profile_onboarding_step( string $step_id, string $location, array $data ): bool {
 		$nox_profile = $this->get_nox_profile();
@@ -721,11 +740,11 @@ class WooPaymentsService {
 	/**
 	 * Get an entry from the NOX profile onboarding step details.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $step_id  The ID of the onboarding step.
 	 * @param string $location The location for which we are onboarding.
 	 *                         This is a ISO 3166-1 alpha-2 country code.
-	 * @param string $entry The entry to get from the step data.
-	 * @param mixed  $default The default value to return if the entry is not found.
+	 * @param string $entry    The entry to get from the step data.
+	 * @param mixed  $default  The default value to return if the entry is not found.
 	 *
 	 * @return mixed The entry from the NOX profile step details. If the entry is not found, the default value is returned.
 	 */
@@ -742,11 +761,11 @@ class WooPaymentsService {
 	/**
 	 * Save an entry in the NOX profile onboarding step details.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $step_id  The ID of the onboarding step.
 	 * @param string $location The location for which we are onboarding.
 	 *                         This is a ISO 3166-1 alpha-2 country code.
-	 * @param string $entry The entry key under which to save in the step data.
-	 * @param array  $data The data to save in the step data.
+	 * @param string $entry    The entry key under which to save in the step data.
+	 * @param array  $data     The data to save in the step data.
 	 *
 	 * @return bool Whether the onboarding step data was saved.
 	 */
@@ -768,10 +787,10 @@ class WooPaymentsService {
 	 */
 	private function get_onboarding_step_required_steps( string $step_id ): array {
 		switch ( $step_id ) {
+			// Both the test account and business verification (live account) steps require a working WPCOM connection.
 			case self::ONBOARDING_STEP_TEST_ACCOUNT:
 			case self::ONBOARDING_STEP_BUSINESS_VERIFICATION:
 				return array(
-					self::ONBOARDING_STEP_PAYMENT_METHODS,
 					self::ONBOARDING_STEP_WPCOM_CONNECTION,
 				);
 			default:
@@ -804,7 +823,7 @@ class WooPaymentsService {
 	 * Get the WPCOM (Jetpack) connection authorization details.
 	 *
 	 * @param string $redirect_url The URL to redirect to after the connection is set up.
-	 * @param string $from
+	 * @param string $from         The source of the connection setup.
 	 *
 	 * @return array The WPCOM connection authorization details.
 	 */
@@ -823,14 +842,14 @@ class WooPaymentsService {
 	 *
 	 * @return boolean
 	 */
-	private function is_woopayments_active(): bool {
+	private function is_extension_active(): bool {
 		return class_exists( '\WC_Payments' );
 	}
 
 	/**
 	 * Get the main payment gateway instance.
 	 *
-	 * @return \WC_Payment_Gateway_WCPay
+	 * @return \WC_Payment_Gateway_WCPay The main payment gateway instance.
 	 */
 	private function get_payment_gateway(): \WC_Payment_Gateway_WCPay {
 		return \WC_Payments::get_gateway();
@@ -839,7 +858,7 @@ class WooPaymentsService {
 	/**
 	 * Determine if WooPayments has an account set up.
 	 *
-	 * @return bool
+	 * @return bool Whether WooPayments has an account set up.
 	 */
 	private function has_account(): bool {
 		return $this->provider->is_account_connected( $this->get_payment_gateway() );
@@ -848,7 +867,7 @@ class WooPaymentsService {
 	/**
 	 * Determine if WooPayments has a valid, fully onboarded account set up.
 	 *
-	 * @return bool
+	 * @return bool Whether WooPayments has a valid, fully onboarded account set up.
 	 */
 	private function has_valid_account(): bool {
 		if ( ! $this->has_account() ) {
@@ -861,7 +880,7 @@ class WooPaymentsService {
 	/**
 	 * Determine if WooPayments has a test account set up.
 	 *
-	 * @return bool
+	 * @return bool Whether WooPayments has a test account set up.
 	 */
 	private function has_test_account(): bool {
 		if ( ! $this->has_account() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -207,7 +207,7 @@ class WooPaymentsService {
 			'status'         => $this->get_onboarding_step_status( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ),
 			'errors'         => array(),
 			'context'        => array(
-				'business_types' => $this->get_onboarding_kyc_business_types(),
+				'fields' => $this->get_onboarding_kyc_fields(),
 			),
 		);
 
@@ -906,21 +906,21 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Get the business types data for the KYC business verification.
+	 * Get the onboarding fields data for the KYC business verification.
 	 *
-	 * @return array The business types data.
-	 * @throws Exception If the business types data could not be retrieved or there was an error.
+	 * @return array The onboarding fields data.
+	 * @throws Exception If the onboarding fields data could not be retrieved or there was an error.
 	 */
-	private function get_onboarding_kyc_business_types(): array {
-		// Call the WooPayments API to get the business types.
-		$response = Utils::rest_endpoint_get_request( '/wc/v3/payments/onboarding/business_types' );
+	private function get_onboarding_kyc_fields(): array {
+		// Call the WooPayments API to get the onboarding fields.
+		$response = Utils::rest_endpoint_get_request( '/wc/v3/payments/onboarding/fields' );
 
 		if ( is_wp_error( $response ) ) {
 			throw new Exception( esc_html( $response->get_error_message() ), esc_attr( $response->get_error_code() ) );
 		}
 
 		if ( ! is_array( $response ) || ! isset( $response['data'] ) ) {
-			throw new Exception( esc_html__( 'Failed to get business types data.', 'woocommerce' ) );
+			throw new Exception( esc_html__( 'Failed to get onboarding fields data.', 'woocommerce' ) );
 		}
 
 		return $response['data'];

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPay
 use Automattic\WooCommerce\Admin\API\OnboardingPlugins;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
 use Automattic\WooCommerce\Internal\Admin\Settings\Utils;
-use Automattic\WooCommerce\Utilities\RestApiUtil;
 use Exception;
 use WC_Payments;
 use WP_REST_Request;
@@ -34,12 +33,7 @@ class WooPaymentsService {
 
 	const NOX_PROFILE_OPTION_KEY = 'woocommerce_woopayments_nox_profile';
 
-	/**
-	 * The payments settings page service.
-	 *
-	 * @var RestApiUtil
-	 */
-	private RestApiUtil $rest_api_util;
+	const TRACKING_FROM = 'WCADMIN_PAYMENT_SETTINGS';
 
 	/**
 	 * The WooPayments provider instance.
@@ -53,9 +47,8 @@ class WooPaymentsService {
 	 *
 	 * @internal
 	 */
-	final public function init( RestApiUtil $rest_api_util ): void {
-		$this->rest_api_util = $rest_api_util;
-		$this->provider      = new PaymentProviders\WooPayments();
+	final public function init(): void {
+		$this->provider = new PaymentProviders\WooPayments();
 	}
 
 	/**
@@ -66,7 +59,7 @@ class WooPaymentsService {
 	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
 	 *
 	 * @return array The onboarding details.
-	 * @throws Exception If the WooPayments plugin is not active.
+	 * @throws Exception If the WooPayments plugin is not active or there was an error.
 	 */
 	public function get_onboarding_details( string $location, string $rest_path ): array {
 		// If the WooPayments plugin is not active, we don't do onboarding.
@@ -109,6 +102,7 @@ class WooPaymentsService {
 	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
 	 *
 	 * @return array[] The onboarding steps details.
+	 * @throws Exception If there was an error generating the onboarding steps details.
 	 */
 	private function get_onboarding_steps_details( string $location, string $rest_path ): array {
 		$details = array();
@@ -117,7 +111,7 @@ class WooPaymentsService {
 		$details[] = array(
 			'id'                          => self::ONBOARDING_STEP_PAYMENT_METHODS,
 			'path'                        => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_PAYMENT_METHODS,
-			'required_steps'              => array(),
+			'required_steps'              => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_PAYMENT_METHODS ),
 			'status'                      => $this->get_onboarding_step_status( self::ONBOARDING_STEP_PAYMENT_METHODS, $location ),
 			'errors'                      => array(),
 			'actions'                     => array(
@@ -134,8 +128,8 @@ class WooPaymentsService {
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/complete' ),
 				),
 			),
-			'data'                        => array(
-				'recommended_payment_methods' => $this->provider->get_recommended_payment_methods( $this->get_payment_gateway(), $location ),
+			'context'                    => array(
+				'payment_methods' => $this->get_onboarding_payment_methods( $location ),
 			),
 		);
 
@@ -143,7 +137,7 @@ class WooPaymentsService {
 		$wpcom_step_details = array(
 			'id'              => self::ONBOARDING_STEP_WPCOM_CONNECTION,
 			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_WPCOM_CONNECTION,
-			'required_steps'  => array(),
+			'required_steps'  => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_WPCOM_CONNECTION ),
 			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_WPCOM_CONNECTION, $location ),
 			'errors'          => array(),
 		);
@@ -174,7 +168,7 @@ class WooPaymentsService {
 		$test_account_step_details = array(
 			'id'              => self::ONBOARDING_STEP_TEST_ACCOUNT,
 			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_TEST_ACCOUNT,
-			'required_steps'  => array( self::ONBOARDING_STEP_PAYMENT_METHODS, self::ONBOARDING_STEP_WPCOM_CONNECTION ),
+			'required_steps'  => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_TEST_ACCOUNT ),
 			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ),
 			'errors'          => array(),
 		);
@@ -186,9 +180,17 @@ class WooPaymentsService {
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/start' ),
 				),
+				'init' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/init' ),
+				),
 				'check' => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/check' ),
+				),
+				'complete' => array(
+					'type' => self::ACTION_TYPE_REST,
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/complete' ),
 				),
 			);
 		}
@@ -199,9 +201,12 @@ class WooPaymentsService {
 		$business_verification_step_details = array(
 			'id'              => self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-			'required_steps'  => array( self::ONBOARDING_STEP_PAYMENT_METHODS, self::ONBOARDING_STEP_WPCOM_CONNECTION ),
+			'required_steps'  => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_BUSINESS_VERIFICATION ),
 			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ),
 			'errors'          => array(),
+			'context' 		  => array(
+				'business_types' => $this->get_onboarding_kyc_business_types(),
+			),
 		);
 
 		// If the step is not completed, we need to add the actions.
@@ -215,9 +220,9 @@ class WooPaymentsService {
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/save' ),
 				),
-				'kyc_session' => array(
+				'session_start' => array(
 					'type' => self::ACTION_TYPE_REST,
-					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/kyc_session' ),
+					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/session/start' ),
 				),
 				'complete' => array(
 					'type' => self::ACTION_TYPE_REST,
@@ -241,10 +246,11 @@ class WooPaymentsService {
 	 * @return string The status of the onboarding step.
 	 */
 	public function get_onboarding_step_status( string $step_id, string $location ): string {
+		// First, we check the status of the onboarding step based on the current state of the store.
 		switch ( $step_id ) {
 			case self::ONBOARDING_STEP_PAYMENT_METHODS:
-				// @todo Implement the logic to check the status of the payment methods onboarding step.
-				return self::ONBOARDING_STEP_STATUS_NOT_STARTED;
+				// No custom checks, for now.
+				break;
 			case self::ONBOARDING_STEP_WPCOM_CONNECTION:
 				if ( Utils::store_has_wpcom_connection() ) {
 					return self::ONBOARDING_STEP_STATUS_COMPLETED;
@@ -275,7 +281,20 @@ class WooPaymentsService {
 				break;
 		}
 
-		// We default to not started.
+		// Second, try to determine the status of the onboarding step based on the saved data.
+		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
+		if ( ! empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['statuses'] ) ) {
+			// We take a waterfall approach, where completed supersedes started.
+			$step_statuses = $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['statuses'];
+			if ( ! empty( $step_statuses[ self::ONBOARDING_STEP_STATUS_COMPLETED ] ) ) {
+				return self::ONBOARDING_STEP_STATUS_COMPLETED;
+			}
+			if ( ! empty( $step_statuses[ self::ONBOARDING_STEP_STATUS_STARTED ] ) ) {
+				return self::ONBOARDING_STEP_STATUS_STARTED;
+			}
+		}
+
+		// Finally, we default to not started.
 		return self::ONBOARDING_STEP_STATUS_NOT_STARTED;
 	}
 
@@ -294,34 +313,21 @@ class WooPaymentsService {
 			throw new Exception( 'Invalid onboarding step ID.' );
 		}
 
-		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
-
-		if ( empty( $nox_profile ) ) {
-			$nox_profile = array();
-		} else {
-			$nox_profile = maybe_unserialize( $nox_profile );
+		// Check step requirements.
+		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+			throw new Exception( 'Onboarding step requirements are not met.' );
 		}
 
-		if ( empty( $nox_profile['onboarding'] ) ) {
-			$nox_profile['onboarding'] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
-			$nox_profile['onboarding'][ $location ] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] = array();
+		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
+		if ( empty( $step_details['statuses'] ) ) {
+			$step_details['statuses'] = array();
 		}
 
 		// Mark the step as started and record the timestamp.
-		$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'][ self::ONBOARDING_STEP_STATUS_STARTED ] = time() ;
+		$step_details['statuses'][ self::ONBOARDING_STEP_STATUS_STARTED ] = time() ;
 
-		return update_option( self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+		// Store the updated step data.
+		return $this->save_nox_profile_onboarding_step( $step_id, $location, $step_details );
 	}
 
 	/**
@@ -339,34 +345,21 @@ class WooPaymentsService {
 			throw new Exception( 'Invalid onboarding step ID.' );
 		}
 
-		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
-
-		if ( empty( $nox_profile ) ) {
-			$nox_profile = array();
-		} else {
-			$nox_profile = maybe_unserialize( $nox_profile );
+		// Check step requirements.
+		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+			throw new Exception( 'Onboarding step requirements are not met.' );
 		}
 
-		if ( empty( $nox_profile['onboarding'] ) ) {
-			$nox_profile['onboarding'] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
-			$nox_profile['onboarding'][ $location ] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'] = array();
+		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
+		if ( empty( $step_details['statuses'] ) ) {
+			$step_details['statuses'] = array();
 		}
 
 		// Mark the step as completed and record the timestamp.
-		$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['status'][ self::ONBOARDING_STEP_STATUS_COMPLETED ] = time() ;
+		$step_details['statuses'][ self::ONBOARDING_STEP_STATUS_COMPLETED ] = time();
 
-		return update_option( self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+		// Store the updated step data.
+		return $this->save_nox_profile_onboarding_step( $step_id, $location, $step_details );
 	}
 
 	/**
@@ -380,11 +373,283 @@ class WooPaymentsService {
 	 * @return bool Whether the onboarding step data was saved.
 	 * @throws Exception If the given onboarding step ID or data are invalid.
 	 */
-	public function onboarding_step_save( string $step_id, string $location, array $request_data ) {
+	public function onboarding_step_save( string $step_id, string $location, array $request_data ): bool {
 		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
 			throw new Exception( 'Invalid onboarding step ID.' );
 		}
 
+		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
+		if ( empty( $step_details['data'] ) ) {
+			$step_details['data'] = array();
+		}
+
+		// We support save for only certain steps.
+		switch ( $step_id ) {
+			case self::ONBOARDING_STEP_PAYMENT_METHODS:
+				if ( ! isset( $request_data['payment_methods'] ) || ! is_array( $request_data['payment_methods'] ) ) {
+					throw new Exception( 'Invalid onboarding step data.' );
+				}
+
+				$step_details['data']['payment_methods'] = $request_data['payment_methods'];
+				break;
+			case self::ONBOARDING_STEP_BUSINESS_VERIFICATION:
+				if ( ! isset( $request_data['self_assessment'] ) || ! is_array( $request_data['self_assessment'] ) ) {
+					throw new Exception( 'Invalid onboarding step data.' );
+				}
+
+				$step_details['data']['self_assessment'] = $request_data['self_assessment'];
+				break;
+			default:
+				return false;
+		}
+
+		// Store the updated step data.
+		return $this->save_nox_profile_onboarding_step( $step_id, $location, $step_details );
+	}
+
+	/**
+	 * Check an onboarding step's status/progress.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array The check result.
+	 * @throws Exception If the given onboarding step ID is invalid.
+	 */
+	public function onboarding_step_check( string $step_id, string $location ): array {
+		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
+			throw new Exception( 'Invalid onboarding step ID.' );
+		}
+
+		// Check step requirements.
+		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+			throw new Exception( 'Onboarding step requirements are not met.' );
+		}
+
+		// Just return the step status, for now.
+		return array( 'status' => $this->get_onboarding_step_status( $step_id, $location ) );
+	}
+
+	/**
+	 * Get the payment methods details for onboarding.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array The onboarding payment methods details.
+	 */
+	public function get_onboarding_payment_methods( string $location ): array {
+		// First, get the recommended payment methods details from the provider.
+		$payment_methods = $this->provider->get_recommended_payment_methods( $this->get_payment_gateway(), $location );
+
+		// Grab the stored payment methods state
+		// (a key-value array of payment method IDs and if they should be enabled or not).
+		$step_data = $this->get_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_PAYMENT_METHODS, $location, 'data' );
+		if ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) {
+			foreach ( $payment_methods as $key => $payment_method ) {
+				// Force enable and skip required payment methods since these should always be enabled.
+				if ( ! empty( $payment_method['required'] ) ) {
+					$payment_methods[ $key ]['enabled'] = true;
+					continue;
+				}
+
+				// Go through the recommended payment methods and overwrite their enabled status with the stored one.
+				if ( isset( $step_data['payment_methods'][ $payment_method['id'] ] ) ) {
+					$payment_methods[ $key ]['enabled'] = wc_string_to_bool( $step_data['payment_methods'][ $payment_method['id'] ] );
+				}
+			}
+		}
+
+		return $payment_methods;
+	}
+
+	/**
+	 * Initialize the test account for onboarding.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array|\WP_Error The result of the test account initialization.
+	 * @throws Exception If there was an error initializing the test account.
+	 */
+	public function onboarding_test_account_init( string $location ) {
+		// Nothing to do if we already have a valid test account.
+		if ( $this->has_account() && $this->has_test_account() ) {
+			return array(
+				'message' => __( 'Test account is already set up.', 'woocommerce' ),
+			);
+		}
+
+		// Check if the test account is already in progress.
+		$step_data = $this->get_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'data' );
+		if ( ! empty( $step_data['in_progress'] ) ) {
+			return array(
+				'message' => __( 'Test account creation is already in progress.', 'woocommerce' ),
+			);
+		}
+
+		// Check step requirements.
+		if( ! $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
+			throw new Exception( 'Onboarding step requirements are not met.' );
+		}
+
+		// Mark the test account step as in progress.
+		$step_data['in_progress'] = true;
+		$this->save_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'data', $step_data );
+
+		// Call the WooPayments API to initialize the test account.
+		$response = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/test_account/init', array(
+			'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
+			'source' => ! empty( $tracking_source ) ? $tracking_source : self::TRACKING_FROM,
+			'from'   => self::TRACKING_FROM,
+		) );
+
+		// Remove the in progress flag.
+		unset( $step_data['in_progress'] );
+		$this->save_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'data', $step_data );
+
+		if ( is_wp_error( $response ) ) {
+			throw new Exception( $response->get_error_message(), $response->get_error_code() );
+		}
+
+		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
+			throw new Exception( 'Failed to initialize the test account.' );
+		}
+
+		// Mark the business verification step as completed.
+		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
+
+		return $response;
+	}
+
+	/**
+	 * Get the onboarding KYC progressive onboarding (PO) eligibility.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $self_assessment The self-assessment data.
+	 *
+	 * @return array The KYC PO eligibility data.
+	 * @throws Exception If the eligibility could not be determined or there was an error.
+	 */
+	public function get_onboarding_kyc_po_eligible( string $location, array $self_assessment = array() ): array {
+		if ( empty( $self_assessment ) ) {
+			// Get the stored self-assessment data.
+			$step_data = $this->get_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'data' );
+			if ( ! empty( $step_data['self_assessment'] ) && is_array( $step_data['self_assessment'] ) ) {
+				$self_assessment = $step_data['self_assessment'];
+			}
+		}
+
+		// Gather the needed details.
+		$payload = array(
+			'business' => array(
+				'country' => $self_assessment['country'] ?? $location,
+				'type'    => $self_assessment['business_type'] ?? '',
+				'mcc'     => $self_assessment['mcc'] ?? '',
+			),
+			'store'   => array(
+				'annual_revenue'    => $self_assessment['annual_revenue'] ?? '',
+				'go_live_timeframe' => $self_assessment['go_live_timeframe'] ?? ''
+			),
+		);
+
+		// Call the WooPayments API to determine PO eligibility.
+		$response_data = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/router/po_eligible', $payload );
+
+		if ( is_wp_error( $response_data ) ) {
+			throw new Exception( $response_data->get_error_message(), $response_data->get_error_code() );
+		}
+
+		if ( ! is_array( $response_data ) || ! isset( $response_data['result'] ) ) {
+			throw new Exception( 'Failed to determine KYC progressive onboarding eligibility.' );
+		}
+
+		return array(
+			'eligible' => ( 'eligible' === $response_data['result'] ),
+			'context'  => $response_data['context'] ?? array(),
+		);
+	}
+
+	/**
+	 * Get the onboarding KYC account session.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $self_assessment The self-assessment data.
+	 * @param bool   $progressive Whether the KYC session is for progressive onboarding.
+	 *
+	 * @return array The KYC account session data.
+	 * @throws Exception If the KYC session data could not be retrieved or there was an error.
+	 */
+	public function get_onboarding_kyc_session( string $location, array $self_assessment = array(), bool $progressive = false ): array {
+		if ( empty( $self_assessment ) ) {
+			// Get the stored self-assessment data.
+			$step_data = $this->get_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'data' );
+			if ( ! empty( $step_data['self_assessment'] ) && is_array( $step_data['self_assessment'] ) ) {
+				$self_assessment = $step_data['self_assessment'];
+			}
+		}
+
+		// Call the WooPayments API to get the KYC session.
+		$account_session = Utils::rest_endpoint_get_request( '/wc/v3/payments/onboarding/kyc/session', array(
+			'progressive'     => $progressive,
+			'self_assessment' => $self_assessment,
+		) );
+
+		if ( is_wp_error( $account_session ) ) {
+			throw new Exception( $account_session->get_error_message(), $account_session->get_error_code() );
+		}
+
+		if ( ! is_array( $account_session ) ) {
+			throw new Exception( 'Failed to get KYC session data.' );
+		}
+
+		// Add the user locale to the account session data to allow for localized KYC sessions.
+		$account_session['locale'] = get_user_locale();
+
+		return $account_session;
+	}
+
+	/**
+	 * Finish the onboarding KYC account session.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $tracking_source Optional. The tracking source for the KYC session.
+	 *                                If not provided, it will identify the source as the WC Admin Payments settings.
+	 *
+	 * @return array The response from the WooPayments API.
+	 * @throws Exception If the KYC session could not be finished or there was an error.
+	 */
+	public function finish_onboarding_kyc_session( string $location, string $tracking_source = '' ): array {
+		// Call the WooPayments API to finalize the KYC session.
+		$response = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/kyc/finalize', array(
+			'source' => ! empty( $tracking_source ) ? $tracking_source : self::TRACKING_FROM,
+			'from'   => self::TRACKING_FROM,
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			throw new Exception( $response->get_error_message(), $response->get_error_code() );
+		}
+
+		if ( ! is_array( $response ) ) {
+			throw new Exception( 'Failed to finish the KYC session.' );
+		}
+
+		// Mark the business verification step as completed.
+		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
+
+		return $response;
+	}
+
+	/**
+	 * Get the stored NOX profile.
+	 *
+	 * @return array The stored NOX profile.
+	 */
+	private function get_nox_profile(): array {
 		$nox_profile = get_option( self::NOX_PROFILE_OPTION_KEY, array() );
 
 		if ( empty( $nox_profile ) ) {
@@ -392,6 +657,21 @@ class WooPaymentsService {
 		} else {
 			$nox_profile = maybe_unserialize( $nox_profile );
 		}
+
+		return $nox_profile;
+	}
+
+	/**
+	 * Get the onboarding step data from the NOX profile.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array The onboarding step data from the NOX profile.
+	 */
+	private function get_nox_profile_onboarding_step( string $step_id, string $location ): array {
+		$nox_profile = $this->get_nox_profile();
 
 		if ( empty( $nox_profile['onboarding'] ) ) {
 			$nox_profile['onboarding'] = array();
@@ -405,24 +685,119 @@ class WooPaymentsService {
 		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
 			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
 		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['data'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['data'] = array();
+
+		return $nox_profile['onboarding'][ $location ]['steps'][ $step_id ];
+	}
+
+	/**
+	 * Save the onboarding step data in the NOX profile.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $data The onboarding step data to save in the profile.
+	 *
+	 * @return bool
+	 */
+	private function save_nox_profile_onboarding_step( string $step_id, string $location, array $data ): bool {
+		$nox_profile = $this->get_nox_profile();
+
+		if ( empty( $nox_profile['onboarding'] ) ) {
+			$nox_profile['onboarding'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
+			$nox_profile['onboarding'][ $location ] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
+			$nox_profile['onboarding'][ $location ]['steps'] = array();
 		}
 
-		// We support save for only certain steps.
-		switch ( $step_id ) {
-			case self::ONBOARDING_STEP_PAYMENT_METHODS:
-				if ( ! isset( $request_data['payment_methods'] ) || ! is_array( $request_data['payment_methods'] ) ) {
-					throw new Exception( 'Invalid onboarding step data.' );
-				}
-
-				$nox_profile['onboarding'][ $location ]['steps'][ $step_id ]['data']['payment_methods'] = $request_data['payment_methods'];
-				break;
-			default:
-				return false;
-		}
+		// Update the stored step data.
+		$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = $data;
 
 		return update_option( self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+	}
+
+	/**
+	 * Get an entry from the NOX profile onboarding step details.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $entry The entry to get from the step data.
+	 * @param mixed  $default The default value to return if the entry is not found.
+	 *
+	 * @return mixed The entry from the NOX profile step details. If the entry is not found, the default value is returned.
+	 */
+	private function get_nox_profile_onboarding_step_entry( string $step_id, string $location, string $entry, $default = array() ): array {
+		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
+
+		if ( ! isset( $step_details[ $entry ] ) ) {
+			return $default;
+		}
+
+		return $step_details[ $entry ];
+	}
+
+	/**
+	 * Save an entry in the NOX profile onboarding step details.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $entry The entry key under which to save in the step data.
+	 * @param array  $data The data to save in the step data.
+	 *
+	 * @return bool Whether the onboarding step data was saved.
+	 */
+	private function save_nox_profile_onboarding_step_entry( string $step_id, string $location, string $entry, array $data ): bool {
+		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
+
+		// Update the stored step data.
+		$step_details[ $entry ] = $data;
+
+		return $this->save_nox_profile_onboarding_step( $step_id, $location, $step_details );
+	}
+
+	/**
+	 * Get the IDs of the onboarding steps that are required for the given step.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 *
+	 * @return array|string[] The IDs of the onboarding steps that are required for the given step.
+	 */
+	private function get_onboarding_step_required_steps( string $step_id ): array {
+		switch ( $step_id ) {
+			case self::ONBOARDING_STEP_TEST_ACCOUNT:
+			case self::ONBOARDING_STEP_BUSINESS_VERIFICATION:
+				return array(
+					self::ONBOARDING_STEP_PAYMENT_METHODS,
+					self::ONBOARDING_STEP_WPCOM_CONNECTION,
+				);
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Check if the requirements for an onboarding step are met.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return bool Whether the onboarding step requirements are met.
+	 */
+	private function check_onboarding_step_requirements( string $step_id, string $location ): bool {
+		$requirements = $this->get_onboarding_step_required_steps( $step_id );
+
+		foreach ( $requirements as $required_step_id ) {
+			if ( $this->get_onboarding_step_status( $required_step_id, $location ) !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -442,8 +817,6 @@ class WooPaymentsService {
 
 		return $plugin_onboarding->get_jetpack_authorization_url( $request );
 	}
-
-
 
 	/**
 	 * Check if the WooPayments plugin is active.
@@ -498,5 +871,26 @@ class WooPaymentsService {
 		$account_status = WC_Payments::get_account_service()->get_account_status_data();
 
 		return ! empty( $account_status['testDrive'] );
+	}
+
+	/**
+	 * Get the business types data for the KYC business verification.
+	 *
+	 * @return array The business types data.
+	 * @throws Exception If the business types data could not be retrieved or there was an error.
+	 */
+	private function get_onboarding_kyc_business_types(): array {
+		// Call the WooPayments API to get the business types.
+		$response = Utils::rest_endpoint_get_request( '/wc/v3/payments/onboarding/business_types' );
+
+		if ( is_wp_error( $response ) ) {
+			throw new Exception( $response->get_error_message(), $response->get_error_code() );
+		}
+
+		if ( ! is_array( $response ) || ! isset( $response['data'] ) ) {
+			throw new Exception( 'Failed to get business types data.' );
+		}
+
+		return $response['data'];
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -18,16 +18,16 @@ class WooPaymentsService {
 
 	const ONBOARDING_PATH_BASE = '/woopayments/onboarding';
 
-	const ONBOARDING_STEP_PAYMENT_METHODS = 'payment_methods';
-	const ONBOARDING_STEP_WPCOM_CONNECTION = 'wpcom_connection';
-	const ONBOARDING_STEP_TEST_ACCOUNT = 'test_account';
+	const ONBOARDING_STEP_PAYMENT_METHODS       = 'payment_methods';
+	const ONBOARDING_STEP_WPCOM_CONNECTION      = 'wpcom_connection';
+	const ONBOARDING_STEP_TEST_ACCOUNT          = 'test_account';
 	const ONBOARDING_STEP_BUSINESS_VERIFICATION = 'business_verification';
 
 	const ONBOARDING_STEP_STATUS_NOT_STARTED = 'not_started';
-	const ONBOARDING_STEP_STATUS_STARTED = 'started';
-	const ONBOARDING_STEP_STATUS_COMPLETED = 'completed';
+	const ONBOARDING_STEP_STATUS_STARTED     = 'started';
+	const ONBOARDING_STEP_STATUS_COMPLETED   = 'completed';
 
-	const ACTION_TYPE_REST = 'REST';
+	const ACTION_TYPE_REST     = 'REST';
 	const ACTION_TYPE_REDIRECT = 'REDIRECT';
 
 	const NOX_PROFILE_OPTION_KEY = 'woocommerce_woopayments_nox_profile';
@@ -85,12 +85,16 @@ class WooPaymentsService {
 	 * @return bool Whether the given onboarding step ID is valid.
 	 */
 	public function is_valid_onboarding_step_id( string $step_id ): bool {
-		return in_array( $step_id, array(
-			self::ONBOARDING_STEP_PAYMENT_METHODS,
-			self::ONBOARDING_STEP_WPCOM_CONNECTION,
-			self::ONBOARDING_STEP_TEST_ACCOUNT,
-			self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-		), true );
+		return in_array(
+			$step_id,
+			array(
+				self::ONBOARDING_STEP_PAYMENT_METHODS,
+				self::ONBOARDING_STEP_WPCOM_CONNECTION,
+				self::ONBOARDING_STEP_TEST_ACCOUNT,
+				self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+			),
+			true
+		);
 	}
 
 	/**
@@ -108,17 +112,17 @@ class WooPaymentsService {
 
 		// Add the payment methods onboarding step details.
 		$details[] = array(
-			'id'                          => self::ONBOARDING_STEP_PAYMENT_METHODS,
-			'path'                        => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_PAYMENT_METHODS,
-			'required_steps'              => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_PAYMENT_METHODS ),
-			'status'                      => $this->get_onboarding_step_status( self::ONBOARDING_STEP_PAYMENT_METHODS, $location ),
-			'errors'                      => array(),
-			'actions'                     => array(
+			'id'             => self::ONBOARDING_STEP_PAYMENT_METHODS,
+			'path'           => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_PAYMENT_METHODS,
+			'required_steps' => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_PAYMENT_METHODS ),
+			'status'         => $this->get_onboarding_step_status( self::ONBOARDING_STEP_PAYMENT_METHODS, $location ),
+			'errors'         => array(),
+			'actions'        => array(
 				'start'    => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/start' ),
 				),
-				'save'    => array(
+				'save'     => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/save' ),
 				),
@@ -127,22 +131,22 @@ class WooPaymentsService {
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_PAYMENT_METHODS . '/complete' ),
 				),
 			),
-			'context'                    => array(
+			'context'        => array(
 				'payment_methods' => $this->get_onboarding_payment_methods( $location ),
 			),
 		);
 
 		// Add the WPCOM connection onboarding step details.
 		$wpcom_step_details = array(
-			'id'              => self::ONBOARDING_STEP_WPCOM_CONNECTION,
-			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_WPCOM_CONNECTION,
-			'required_steps'  => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_WPCOM_CONNECTION ),
-			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_WPCOM_CONNECTION, $location ),
-			'errors'          => array(),
+			'id'             => self::ONBOARDING_STEP_WPCOM_CONNECTION,
+			'path'           => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_WPCOM_CONNECTION,
+			'required_steps' => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_WPCOM_CONNECTION ),
+			'status'         => $this->get_onboarding_step_status( self::ONBOARDING_STEP_WPCOM_CONNECTION, $location ),
+			'errors'         => array(),
 		);
 
 		// If the WPCOM connection is already set up, we don't need to add anything more.
-		if ( $wpcom_step_details['status'] !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+		if ( self::ONBOARDING_STEP_STATUS_COMPLETED !== $wpcom_step_details['status'] ) {
 			// Try to generate the authorization URL.
 			$wpcom_connection = $this->get_wpcom_connection_authorization( Utils::wc_payments_settings_url( self::ONBOARDING_PATH_BASE ), 'woocommerce' );
 			if ( ! $wpcom_connection['success'] ) {
@@ -164,25 +168,25 @@ class WooPaymentsService {
 
 		// Add the test account onboarding step details.
 		$test_account_step_details = array(
-			'id'              => self::ONBOARDING_STEP_TEST_ACCOUNT,
-			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_TEST_ACCOUNT,
-			'required_steps'  => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_TEST_ACCOUNT ),
-			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ),
-			'errors'          => array(),
+			'id'             => self::ONBOARDING_STEP_TEST_ACCOUNT,
+			'path'           => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_TEST_ACCOUNT,
+			'required_steps' => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_TEST_ACCOUNT ),
+			'status'         => $this->get_onboarding_step_status( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ),
+			'errors'         => array(),
 		);
 
 		// If the step is not completed, we need to add the actions.
-		if ( $test_account_step_details['status'] !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+		if ( self::ONBOARDING_STEP_STATUS_COMPLETED !== $test_account_step_details['status'] ) {
 			$test_account_step_details['actions'] = array(
-				'start' => array(
+				'start'    => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/start' ),
 				),
-				'init' => array(
+				'init'     => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/init' ),
 				),
-				'check' => array(
+				'check'    => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_TEST_ACCOUNT . '/check' ),
 				),
@@ -197,24 +201,24 @@ class WooPaymentsService {
 
 		// Add the live account business verification onboarding step details.
 		$business_verification_step_details = array(
-			'id'              => self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-			'path'            => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-			'required_steps'  => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_BUSINESS_VERIFICATION ),
-			'status'          => $this->get_onboarding_step_status( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ),
-			'errors'          => array(),
-			'context' 		  => array(
+			'id'             => self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+			'path'           => trailingslashit( self::ONBOARDING_PATH_BASE ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+			'required_steps' => $this->get_onboarding_step_required_steps( self::ONBOARDING_STEP_BUSINESS_VERIFICATION ),
+			'status'         => $this->get_onboarding_step_status( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ),
+			'errors'         => array(),
+			'context'        => array(
 				'business_types' => $this->get_onboarding_kyc_business_types(),
 			),
 		);
 
 		// If the step is not completed, we need to add the actions.
-		if ( $business_verification_step_details['status'] !== self::ONBOARDING_STEP_STATUS_COMPLETED ) {
+		if ( self::ONBOARDING_STEP_STATUS_COMPLETED !== $business_verification_step_details['status'] ) {
 			$business_verification_step_details['actions'] = array(
-				'start' => array(
+				'start'         => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/start' ),
 				),
-				'save' => array(
+				'save'          => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/save' ),
 				),
@@ -222,7 +226,7 @@ class WooPaymentsService {
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/session/start' ),
 				),
-				'complete' => array(
+				'complete'      => array(
 					'type' => self::ACTION_TYPE_REST,
 					'href' => rest_url( trailingslashit( $rest_path ) . self::ONBOARDING_STEP_BUSINESS_VERIFICATION . '/complete' ),
 				),
@@ -313,7 +317,7 @@ class WooPaymentsService {
 		}
 
 		// Check step requirements.
-		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
 			throw new Exception( 'Onboarding step can no be started because requirements are not met.' );
 		}
 
@@ -327,7 +331,7 @@ class WooPaymentsService {
 		}
 
 		// Mark the step as started and record the timestamp.
-		$step_details['statuses'][ self::ONBOARDING_STEP_STATUS_STARTED ] = time() ;
+		$step_details['statuses'][ self::ONBOARDING_STEP_STATUS_STARTED ] = time();
 
 		// Store the updated step data.
 		return $this->save_nox_profile_onboarding_step( $step_id, $location, $step_details );
@@ -350,7 +354,7 @@ class WooPaymentsService {
 		}
 
 		// Check step requirements.
-		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
 			throw new Exception( 'Onboarding step requirements are not met.' );
 		}
 
@@ -431,7 +435,7 @@ class WooPaymentsService {
 		}
 
 		// Check step requirements.
-		if( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
 			throw new Exception( 'Onboarding step requirements are not met.' );
 		}
 
@@ -505,7 +509,7 @@ class WooPaymentsService {
 		}
 
 		// Check step requirements.
-		if( ! $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
+		if ( ! $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
 			throw new Exception( 'Onboarding step requirements are not met.' );
 		}
 
@@ -514,22 +518,25 @@ class WooPaymentsService {
 		$this->save_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'data', $step_data );
 
 		// Call the WooPayments API to initialize the test account.
-		$response = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/test_account/init', array(
-			'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
-			'source' => ! empty( $tracking_source ) ? $tracking_source : self::TRACKING_FROM,
-			'from'   => self::TRACKING_FROM,
-		) );
+		$response = Utils::rest_endpoint_post_request(
+			'/wc/v3/payments/onboarding/test_account/init',
+			array(
+				'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
+				'source'       => ! empty( $tracking_source ) ? $tracking_source : self::TRACKING_FROM,
+				'from'         => self::TRACKING_FROM,
+			)
+		);
 
 		// Remove the in progress flag.
 		unset( $step_data['in_progress'] );
 		$this->save_nox_profile_onboarding_step_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'data', $step_data );
 
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( $response->get_error_message(), $response->get_error_code() );
+			throw new Exception( esc_html( $response->get_error_message() ), esc_attr( $response->get_error_code() ) );
 		}
 
 		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
-			throw new Exception( 'Failed to initialize the test account.' );
+			throw new Exception( esc_html__( 'Failed to initialize the test account.', 'woocommerce' ) );
 		}
 
 		// Mark the test account step as completed.
@@ -565,9 +572,9 @@ class WooPaymentsService {
 				'type'    => $self_assessment['business_type'] ?? '',
 				'mcc'     => $self_assessment['mcc'] ?? '',
 			),
-			'store'   => array(
+			'store'    => array(
 				'annual_revenue'    => $self_assessment['annual_revenue'] ?? '',
-				'go_live_timeframe' => $self_assessment['go_live_timeframe'] ?? ''
+				'go_live_timeframe' => $self_assessment['go_live_timeframe'] ?? '',
 			),
 		);
 
@@ -575,11 +582,11 @@ class WooPaymentsService {
 		$response_data = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/router/po_eligible', $request_payload );
 
 		if ( is_wp_error( $response_data ) ) {
-			throw new Exception( $response_data->get_error_message(), $response_data->get_error_code() );
+			throw new Exception( esc_html( $response_data->get_error_message() ), esc_attr( $response_data->get_error_code() ) );
 		}
 
 		if ( ! is_array( $response_data ) || ! isset( $response_data['result'] ) ) {
-			throw new Exception( 'Failed to determine KYC progressive onboarding eligibility.' );
+			throw new Exception( esc_html__( 'Failed to determine KYC progressive onboarding eligibility.', 'woocommerce' ) );
 		}
 
 		return array(
@@ -611,17 +618,20 @@ class WooPaymentsService {
 		}
 
 		// Call the WooPayments API to get the KYC session.
-		$account_session = Utils::rest_endpoint_get_request( '/wc/v3/payments/onboarding/kyc/session', array(
-			'progressive'     => $progressive,
-			'self_assessment' => $self_assessment,
-		) );
+		$account_session = Utils::rest_endpoint_get_request(
+			'/wc/v3/payments/onboarding/kyc/session',
+			array(
+				'progressive'     => $progressive,
+				'self_assessment' => $self_assessment,
+			)
+		);
 
 		if ( is_wp_error( $account_session ) ) {
-			throw new Exception( $account_session->get_error_message(), $account_session->get_error_code() );
+			throw new Exception( esc_html( $account_session->get_error_message() ), esc_attr( $account_session->get_error_code() ) );
 		}
 
 		if ( ! is_array( $account_session ) ) {
-			throw new Exception( 'Failed to get KYC session data.' );
+			throw new Exception( esc_html__( 'Failed to get KYC session data.', 'woocommerce' ) );
 		}
 
 		// Add the user locale to the account session data to allow for localized KYC sessions.
@@ -643,17 +653,20 @@ class WooPaymentsService {
 	 */
 	public function finish_onboarding_kyc_session( string $location, string $tracking_source = '' ): array {
 		// Call the WooPayments API to finalize the KYC session.
-		$response = Utils::rest_endpoint_post_request( '/wc/v3/payments/onboarding/kyc/finalize', array(
-			'source' => ! empty( $tracking_source ) ? $tracking_source : self::TRACKING_FROM,
-			'from'   => self::TRACKING_FROM,
-		) );
+		$response = Utils::rest_endpoint_post_request(
+			'/wc/v3/payments/onboarding/kyc/finalize',
+			array(
+				'source' => ! empty( $tracking_source ) ? $tracking_source : self::TRACKING_FROM,
+				'from'   => self::TRACKING_FROM,
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( $response->get_error_message(), $response->get_error_code() );
+			throw new Exception( esc_html( $response->get_error_message() ), esc_attr( $response->get_error_code() ) );
 		}
 
 		if ( ! is_array( $response ) ) {
-			throw new Exception( 'Failed to finish the KYC session.' );
+			throw new Exception( esc_html__( 'Failed to finish the KYC session.', 'woocommerce' ) );
 		}
 
 		// Mark the business verification step as completed.
@@ -740,19 +753,19 @@ class WooPaymentsService {
 	/**
 	 * Get an entry from the NOX profile onboarding step details.
 	 *
-	 * @param string $step_id  The ID of the onboarding step.
-	 * @param string $location The location for which we are onboarding.
-	 *                         This is a ISO 3166-1 alpha-2 country code.
-	 * @param string $entry    The entry to get from the step data.
-	 * @param mixed  $default  The default value to return if the entry is not found.
+	 * @param string $step_id       The ID of the onboarding step.
+	 * @param string $location      The location for which we are onboarding.
+	 *                              This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $entry         The entry to get from the step data.
+	 * @param mixed  $default_value The default value to return if the entry is not found.
 	 *
 	 * @return mixed The entry from the NOX profile step details. If the entry is not found, the default value is returned.
 	 */
-	private function get_nox_profile_onboarding_step_entry( string $step_id, string $location, string $entry, $default = array() ): array {
+	private function get_nox_profile_onboarding_step_entry( string $step_id, string $location, string $entry, $default_value = array() ): array {
 		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
 
 		if ( ! isset( $step_details[ $entry ] ) ) {
-			return $default;
+			return $default_value;
 		}
 
 		return $step_details[ $entry ];
@@ -903,11 +916,11 @@ class WooPaymentsService {
 		$response = Utils::rest_endpoint_get_request( '/wc/v3/payments/onboarding/business_types' );
 
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( $response->get_error_message(), $response->get_error_code() );
+			throw new Exception( esc_html( $response->get_error_message() ), esc_attr( $response->get_error_code() ) );
 		}
 
 		if ( ! is_array( $response ) || ! isset( $response['data'] ) ) {
-			throw new Exception( 'Failed to get business types data.' );
+			throw new Exception( esc_html__( 'Failed to get business types data.', 'woocommerce' ) );
 		}
 
 		return $response['data'];

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Admin\Settings;
 
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Internal\Admin\Suggestions\PaymentExtensionSuggestions;
 use Exception;
 use WooCommerce\Admin\Experimental_Abtest;
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -53,18 +53,6 @@ class PaymentsRestController extends RestApiControllerBase {
 	public function register_routes( bool $override = false ) {
 		register_rest_route(
 			$this->route_namespace,
-			'/' . $this->rest_base . '/woopay-eligibility',
-			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => fn( $request ) => $this->run( $request, 'get_woopay_eligibility' ),
-					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
-				),
-			),
-			$override
-		);
-		register_rest_route(
-			$this->route_namespace,
 			'/' . $this->rest_base . '/country',
 			array(
 				array(
@@ -1197,19 +1185,6 @@ class PaymentsRestController extends RestApiControllerBase {
 					'readonly'    => true,
 				),
 			),
-		);
-	}
-
-	/**
-	 * Get WooPay eligibility status.
-	 *
-	 * @return array The WooPay eligibility status.
-	 */
-	protected function get_woopay_eligibility() {
-		return rest_ensure_response(
-			array(
-				'is_eligible' => WCPayPromotion::is_woopay_eligible(),
-			)
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -42,7 +42,7 @@ class PaymentsRestController extends RestApiControllerBase {
 	 * @return string
 	 */
 	protected function get_rest_api_namespace(): string {
-		return 'wc-admin';
+		return 'wc-admin-settings-payments';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -119,18 +119,6 @@ class PaymentsRestController extends RestApiControllerBase {
 		);
 		register_rest_route(
 			$this->route_namespace,
-			'/' . $this->rest_base . '/onboarding-steps',
-			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => fn( $request ) => $this->run( $request, 'get_onboarding_steps' ),
-					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
-				),
-			),
-			$override
-		);
-		register_rest_route(
-			$this->route_namespace,
 			'/' . $this->rest_base . '/suggestion/(?P<id>[\w\d\-]+)/hide',
 			array(
 				array(
@@ -1021,43 +1009,6 @@ class PaymentsRestController extends RestApiControllerBase {
 					),
 				),
 			),
-		);
-	}
-
-	/**
-	 * Get the onboarding steps.
-	 *
-	 * @return array The onboarding steps.
-	 */
-	protected function get_onboarding_steps() {
-		return rest_ensure_response(
-			array(
-				'steps' => array(
-					array(
-						'id' => 'welcome',
-						'label' => 'Welcome to WooPayments',
-						'path' => '/woopayments/onboarding/welcome',
-						'status' => 'completed',
-						'dependencies' => array(),
-					),
-					array(
-						'id' => 'jetpack',
-						'label' => 'Connect with Jetpack',
-						'path' => '/woopayments/onboarding/jetpack',
-						'status' => 'incomplete',
-						'dependencies' => array(
-							'welcome',
-						),
-					),
-					array(
-						'id' => 'final',
-						'label' => 'Payment methods',
-						'path' => '/woopayments/onboarding/payment-methods',
-						'status' => 'incomplete',
-						'dependencies' => array( "jetpack"),
-					),
-				),
-			)
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Settings;
 
+use Automattic\Jetpack\Connection\Manager;
+
 defined( 'ABSPATH' ) || exit;
 /**
  * Payments settings utilities class.
@@ -306,5 +308,36 @@ class Utils {
 		}
 
 		return $truncated;
+	}
+
+	/**
+	 * Retrieves a URL to relative path inside WooCommerce admin Payments settings with
+	 * the provided query parameters.
+	 *
+	 * @param string|null $path  Relative path of the desired page.
+	 * @param array       $query Query parameters to append to the path.
+	 *
+	 * @return string       Fully qualified URL pointing to the desired path.
+	 */
+	public static function wc_payments_settings_url( string $path = null, array $query = array() ): string {
+		$path = $path ? '&path=' . $path : '';
+
+		$query_string = '';
+		if ( ! empty( $query ) ) {
+			$query_string = http_build_query( $query );
+		}
+
+		return admin_url( 'admin.php?page=wc-settings&tab=checkout' . $path . $query_string, dirname( __FILE__ ) );
+	}
+
+	/**
+	 * Check if the store is properly connected to WPCOM (aka has a Jetpack connection).
+	 *
+	 * @return bool
+	 */
+	public static function store_has_wpcom_connection(): bool {
+		$jetpack_connection_manager = new Manager( 'woocommerce' );
+
+		return $jetpack_connection_manager->is_connected() && $jetpack_connection_manager->has_connected_owner();
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -362,7 +362,7 @@ class Utils {
 	}
 
 	/**
-	 * Post data to a WooCommerce API endpoint.
+	 * Post data to a WooCommerce API endpoint and return the response data.
 	 *
 	 * @param string $endpoint Endpoint.
 	 * @param array  $params   Params to pass with request body.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -340,4 +340,44 @@ class Utils {
 
 		return $jetpack_connection_manager->is_connected() && $jetpack_connection_manager->has_connected_owner();
 	}
+
+	/**
+	 * Get data from a WooCommerce API endpoint.
+	 *
+	 * @param string $endpoint Endpoint.
+	 * @param array  $params   Params to pass with request query.
+	 *
+	 * @return array|\WP_Error The response data or a WP_Error object.
+	 */
+	public static function rest_endpoint_get_request( $endpoint, $params = array() ) {
+		$request = new \WP_REST_Request( 'GET', $endpoint );
+		if ( $params ) {
+			$request->set_query_params( $params );
+		}
+		$response = rest_do_request( $request );
+		$server   = rest_get_server();
+		$json     = wp_json_encode( $server->response_to_data( $response, false ) );
+
+		return json_decode( $json, true );
+	}
+
+	/**
+	 * Post data to a WooCommerce API endpoint.
+	 *
+	 * @param string $endpoint Endpoint.
+	 * @param array  $params   Params to pass with request body.
+	 *
+	 * @return array|\WP_Error The response data or a WP_Error object.
+	 */
+	public static function rest_endpoint_post_request( $endpoint, $params = array() ) {
+		$request = new \WP_REST_Request( 'POST', $endpoint );
+		if ( $params ) {
+			$request->set_body_params( $params );
+		}
+		$response = rest_do_request( $request );
+		$server   = rest_get_server();
+		$json     = wp_json_encode( $server->response_to_data( $response, false ) );
+
+		return json_decode( $json, true );
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Utils.php
@@ -327,7 +327,7 @@ class Utils {
 			$query_string = http_build_query( $query );
 		}
 
-		return admin_url( 'admin.php?page=wc-settings&tab=checkout' . $path . $query_string, dirname( __FILE__ ) );
+		return admin_url( 'admin.php?page=wc-settings&tab=checkout' . $path . $query_string );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AdminSettingsServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AdminSettingsServiceProvider.php
@@ -10,7 +10,6 @@ use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsController;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController;
 use Automattic\WooCommerce\Internal\Admin\Suggestions\PaymentExtensionSuggestions;
-use Automattic\WooCommerce\Utilities\RestApiUtil;
 
 /**
  * Service provider for the admin settings controller classes in the Automattic\WooCommerce\Internal\Admin\Settings namespace.
@@ -45,8 +44,7 @@ class AdminSettingsServiceProvider extends AbstractInterfaceServiceProvider {
 			->addArgument( Payments::class );
 
 		// Provider-specific.
-		$this->share( WooPaymentsService::class )
-			->addArgument( RestApiUtil::class );
+		$this->share( WooPaymentsService::class );
 		$this->share_with_implements_tags( WooPaymentsRestController::class )
 			 ->addArguments( array( Payments::class, WooPaymentsService::class ) );
 	}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AdminSettingsServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AdminSettingsServiceProvider.php
@@ -4,10 +4,13 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
+use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments\WooPaymentsRestController;
+use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments\WooPaymentsService;
 use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsController;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsRestController;
 use Automattic\WooCommerce\Internal\Admin\Suggestions\PaymentExtensionSuggestions;
+use Automattic\WooCommerce\Utilities\RestApiUtil;
 
 /**
  * Service provider for the admin settings controller classes in the Automattic\WooCommerce\Internal\Admin\Settings namespace.
@@ -23,6 +26,9 @@ class AdminSettingsServiceProvider extends AbstractInterfaceServiceProvider {
 		Payments::class,
 		PaymentsController::class,
 		PaymentProviders::class,
+		// Provider-specific.
+		WooPaymentsRestController::class,
+		WooPaymentsService::class,
 	);
 
 	/**
@@ -37,5 +43,11 @@ class AdminSettingsServiceProvider extends AbstractInterfaceServiceProvider {
 			->addArgument( Payments::class );
 		$this->share_with_implements_tags( PaymentsRestController::class )
 			->addArgument( Payments::class );
+
+		// Provider-specific.
+		$this->share( WooPaymentsService::class )
+			->addArgument( RestApiUtil::class );
+		$this->share_with_implements_tags( WooPaymentsRestController::class )
+			 ->addArguments( array( Payments::class, WooPaymentsService::class ) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AdminSettingsServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/AdminSettingsServiceProvider.php
@@ -46,6 +46,6 @@ class AdminSettingsServiceProvider extends AbstractInterfaceServiceProvider {
 		// Provider-specific.
 		$this->share( WooPaymentsService::class );
 		$this->share_with_implements_tags( WooPaymentsRestController::class )
-			 ->addArguments( array( Payments::class, WooPaymentsService::class ) );
+			->addArguments( array( Payments::class, WooPaymentsService::class ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/PaymentGatewayTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/PaymentGatewayTest.php
@@ -183,6 +183,7 @@ class PaymentGatewayTest extends WC_Unit_Test_Case {
 							'icon'        => '',
 						),
 					),
+					'type'				  => PaymentGateway::ONBOARDING_TYPE_EXTERNAL,
 				),
 			),
 			$gateway_details

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/PaymentGatewayTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/PaymentGatewayTest.php
@@ -183,7 +183,7 @@ class PaymentGatewayTest extends WC_Unit_Test_Case {
 							'icon'        => '',
 						),
 					),
-					'type'				  => PaymentGateway::ONBOARDING_TYPE_EXTERNAL,
+					'type'                        => PaymentGateway::ONBOARDING_TYPE_EXTERNAL,
 				),
 			),
 			$gateway_details


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We introduce dedicated Payments Settings REST APIs for powering WooPayments' native, in-context onboarding flow (via a modal).

The main API endpoint is `GET /wp-json/wc-admin/settings/payments/woopayments/onboarding` to retrieve all the onboarding details:
- `state`: a mirror of the onboarding state details retrieved in the providers payload
- `steps`: a list of functional steps that the backend handles with the needed details and API actions to support the frontend UX. There are 4 steps supported, with the following IDs:
   - `payment_methods`
   - `wpcom_connection`
   - `test_account`
   - `business_verification`

Each step has a series of actions, most of which are other REST API endpoints introduced in this PR.
There are some general step endpoints:
- `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/{step_id}/start` to let the backend know that the step was started (and store this)
- `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/{step_id}/finish` to let the backend know that the step was finished (and store this)
- `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/{step_id}/save` to have the backend store certain data about a step (what data can be saved/accepted is defined in the backend)
- `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/{step_id}/check` to query the backend about the status of a step

And some step-specific ones:
- the test account setup step:
    - `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/test_account/init` to trigger the creation of a new test account. No data needs to be provided because it will use already stored data from previous steps (mainly the payment_methods one). You can use the `check` endpoint to do polling.
    - `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/business_verification/check/po_eligible` to query for progression onboarding eligibility
    - `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/business_verification/session/start` to start and get the details for a Stripe embedded KYC session
    - `POST /wp-json/wc-admin/settings/payments/woopayments/onboarding/step/business_verification/session/finish` to trigger the finalize of the KYC process

On the DB storing side, we introduce a new WP option called `woocommerce_woopayments_nox_profile`. This will be used for all WooPayments' NOX storage. The onboarding has an `onboarding` entry, and each step details get stored under the current business location and its id.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/Automattic/woocommerce-payments/issues/10535


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. The code architecture makes sense
2. The REST APIs match the needs of the frontend
3. Smoke-test the mentioned endpoints and confirm they work accordingly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
