### PR TITLE
DraftOrders Block: Use as_has_scheduled_action() if function exists.

### DIFF
--- a/plugins/woocommerce/changelog/56532-fix-53564-use-as_has_scheduled_action
+++ b/plugins/woocommerce/changelog/56532-fix-53564-use-as_has_scheduled_action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Use as_has_scheduled_action() if function exists when scheduling DraftOrders clean up.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -61,7 +61,8 @@ class DraftOrders {
 	 * Maybe create cron events.
 	 */
 	protected function maybe_create_cronjobs() {
-		if ( function_exists( 'as_next_scheduled_action' ) && false === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+		if ( false === call_user_func( $has_scheduled_action, 'woocommerce_cleanup_draft_orders' ) ) {
 			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates `Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders` to attempt to use `as_has_scheduled_action()` over `as_next_scheduled_action()` if it exists when attempting to schedule the action for improved query performance.

Applies to #53564.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  With a query monitoring plugin available, make a request to any page within the admin.
2. There should be a query similar to the below for the `woocommerce_cleanup_draft_orders` action:
  ```
SELECT a.action_id
FROM wp_actionscheduler_actions a
WHERE 1=1
AND a.hook='woocommerce_cleanup_draft_orders'
AND a.status IN ('in-progress', 'pending')
LIMIT 0, 1
  ```
4.  Verify that the query doesn't contain an order by clause which is a slower query used by `as_next_scheduled_action()`.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message  Use as_has_scheduled_action() if function exists when scheduling DraftOrders clean up.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
