### PR TITLE
[Experimental] Add support for extensions that hook into woocommerce_<product_type>_add_to_cart in the new Add to Cart with Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-56372-add-to-cart-hooks
+++ b/plugins/woocommerce/changelog/fix-56372-add-to-cart-hooks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add support for extensions that hook into woocommerce_<product_type>_add_to_cart in the new Add to Cart with Options block
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -222,6 +222,19 @@ class AddToCartWithOptions extends AbstractBlock {
 				$template_part_blocks,
 				$hooks_after,
 			);
+
+			ob_start();
+
+			remove_action( 'woocommerce_' . $product_type . '_add_to_cart', 'woocommerce_' . $product_type . '_add_to_cart', 30 );
+			/**
+			 * Trigger the single product add to cart action that prints the markup.
+			 *
+			 * @since 9.7.0
+			 */
+			do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
+			add_action( 'woocommerce_' . $product_type . '_add_to_cart', 'woocommerce_' . $product_type . '_add_to_cart', 30 );
+
+			$form_html = $form_html . ob_get_clean();
 		} else {
 			ob_start();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -229,7 +229,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			/**
 			 * Trigger the single product add to cart action that prints the markup.
 			 *
-			 * @since 9.7.0
+			 * @since 9.9.0
 			 */
 			do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
 			add_action( 'woocommerce_' . $product_type . '_add_to_cart', 'woocommerce_' . $product_type . '_add_to_cart', 30 );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -98,9 +98,9 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the correct content is rendered for each product type.
+	 * Tests that the  woocommerce_<product_type>_add_to_cart hooks are rendered when rendering the block.
 	 */
-	public function test_add_to_cart_hooks_render() {
+	public function test_product_type_add_to_cart_hooks_are_rendered() {
 		add_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
 
 		global $product;
@@ -109,7 +109,6 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		// Single Products contain the Add to Cart button and the quantity selector blocks.
 		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the hook.' );
 
 		remove_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -52,6 +52,16 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Hook into the add to cart action.
+	 *
+	 * Outputs a test message when the add to cart action is triggered.
+	 * Used for testing that hooks are properly called during add to cart.
+	 */
+	public function hook_into_add_to_cart_action() {
+		echo 'Hook into add to cart action';
+	}
+
+	/**
 	 * Tests that the correct content is rendered for each product type.
 	 */
 	public function test_product_type_add_to_cart_render() {
@@ -85,6 +95,24 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'Custom Product Type Add to Cart Form', $markup, 'The Custom Product Type Add to Cart with Options contains the custom product type add to cart form.' );
 
 		remove_action( 'woocommerce_custom_add_to_cart', array( $this, 'print_custom_product_type_add_to_cart_markup' ) );
+	}
+
+	/**
+	 * Tests that the correct content is rendered for each product type.
+	 */
+	public function test_add_to_cart_hooks_render() {
+		add_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
+
+		global $product;
+		$product = new \WC_Product_Simple();
+		$product->set_regular_price( 10 );
+		$product_id = $product->save();
+		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		// Single Products contain the Add to Cart button and the quantity selector blocks.
+		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the hook.' );
+
+		remove_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #56372.

This PR triggers the `woocommerce_<product_type>_add_to_cart` hooks also in WC core product types. This doesn't guarantee 100% compatibility with extensions using those hooks: the form markup is different from the PHP template, and the hook is triggered _after_ the form, so it's no longer possible to add contents before it. However, I hope this PR will offer compatibility with most plugins.

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_ and update the _Add to Cart with Options_ block to the blockified version.
2. Save the template.

#### Test with custom code

1. Install the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
2. Add this code to a new snippet:

```PHP
add_action(
	'woocommerce_simple_add_to_cart',
	function () {
		echo 'Hook inside the Simple Product Add to Cart form.';
	}
);
add_action(
	'woocommerce_external_add_to_cart',
	function () {
		echo 'Hook inside the External Product Add to Cart form.';
	}
);
add_action(
	'woocommerce_grouped_add_to_cart',
	function () {
		echo 'Hook inside the Grouped Product Add to Cart form.';
	}
);
add_action(
	'woocommerce_variable_add_to_cart',
	function () {
		echo 'Hook inside the Variable Product Add to Cart form.';
	}
);
```

3. In the frontend, visit the product template of a simple, variable, external and grouped products.
4. Verify in all of them the correct hook is displayed.

![imatge](https://github.com/user-attachments/assets/36460010-0ab1-41bc-aba2-c1c60de661e6)

#### Test with Back In Stock Notifications extension

1. Install the [Back In Stock Notifications](https://woocommerce.com/products/back-in-stock-notifications/) extension and activate it.
5. Set a simple product as out of stock.
6. Verify the BIS form is displayed under the product form (note, the product form will be removed from out of stock products in https://github.com/woocommerce/woocommerce/pull/56390):

![imatge](https://github.com/user-attachments/assets/547e7782-5eb9-45e5-ac58-7c28acea4fe2)
