### PR TITLE
Improvements and fixes when recounting product category and tag terms

### DIFF
--- a/plugins/woocommerce/changelog/fix-54680-recount-terms
+++ b/plugins/woocommerce/changelog/fix-54680-recount-terms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure term counts are calculated correctly when the term count method is not given a list of term taxonomy IDs. Also improve performance by avoiding unnecessary queries while counting terms.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -490,7 +490,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 		 * Product->Inventory has a setting `Out of stock visibility`.
 		 * Because of this, we need to recount the terms to keep them in-sync.
 		 */
-		WC()->call_function( 'wc_recount_all_terms' );
+		WC()->call_function( 'wc_recount_all_terms', false );
 
 		$this->do_update_options_action();
 	}

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -658,7 +658,8 @@ function wc_get_product_visibility_term_ids() {
 
 	static $term_ids = array();
 
-	if ( count( $term_ids ) > 0 ) {
+	// The static variable doesn't work well with unit tests.
+	if ( count( $term_ids ) > 0 && ! class_exists( 'WC_Unit_Tests_Bootstrap' ) ) {
 		return $term_ids;
 	}
 

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -526,7 +526,17 @@ function wc_change_term_counts( $terms, $taxonomies ) {
 		return $terms;
 	}
 
-	if ( ! isset( $taxonomies[0] ) || ! in_array( $taxonomies[0], apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag' ) ), true ) ) {
+	/**
+	 * Filter which product taxonomies should have their term counts overridden to take catalog visibility into account.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array $valid_taxonomies List of taxonomy slugs.
+	 */
+	$valid_taxonomies   = apply_filters( 'woocommerce_change_term_counts', array( 'product_cat', 'product_tag' ) );
+	$current_taxonomies = array_intersect( (array) $taxonomies, $valid_taxonomies );
+
+	if ( empty( $current_taxonomies ) ) {
 		return $terms;
 	}
 
@@ -534,21 +544,24 @@ function wc_change_term_counts( $terms, $taxonomies ) {
 	$term_counts   = false === $o_term_counts ? array() : $o_term_counts;
 
 	foreach ( $terms as &$term ) {
-		if ( is_object( $term ) ) {
-			$term_counts[ $term->term_id ] =
-				isset( $term_counts[ $term->term_id ] ) ?
-					$term_counts[ $term->term_id ] :
-					get_term_meta( $term->term_id, 'product_count_' . $taxonomies[0], true );
+		if ( $term instanceof WP_Term && in_array( $term->taxonomy, $current_taxonomies, true ) ) {
+			$key = $term->term_id . '_' . $term->taxonomy;
+			if ( isset( $term_counts[ $key ] ) ) {
+				continue;
+			}
 
-			if ( '' !== $term_counts[ $term->term_id ] ) {
-				$term->count = absint( $term_counts[ $term->term_id ] );
+			$count = get_term_meta( $term->term_id, 'product_count_' . $term->taxonomy, true );
+			if ( '' !== $count ) {
+				$count               = absint( $count );
+				$term->count         = $count;
+				$term_counts[ $key ] = $count;
 			}
 		}
 	}
 
 	// Update transient.
 	if ( $term_counts !== $o_term_counts ) {
-		set_transient( 'wc_term_counts', $term_counts, DAY_IN_SECONDS * 30 );
+		set_transient( 'wc_term_counts', $term_counts, MONTH_IN_SECONDS );
 	}
 
 	return $terms;

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -661,28 +661,33 @@ function wc_get_product_visibility_term_ids() {
 }
 
 /**
- * Recounts all terms.
+ * Recounts all terms for product categories and product tags.
  *
  * @since 5.2
+ *
+ * @param bool $include_callback True to update the standard term counts in addition to the product-specific counts,
+ *                               which will cause a lot more queries to run.
+ *
  * @return void
  */
-function wc_recount_all_terms() {
+function wc_recount_all_terms( bool $include_callback = true ) {
 	$product_cats = get_terms(
-		'product_cat',
 		array(
+			'taxonomy'   => 'product_cat',
 			'hide_empty' => false,
 			'fields'     => 'id=>parent',
 		)
 	);
-	_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), true, false );
+	_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), $include_callback, false );
+
 	$product_tags = get_terms(
-		'product_tag',
 		array(
+			'taxonomy'   => 'product_tag',
 			'hide_empty' => false,
 			'fields'     => 'id=>parent',
 		)
 	);
-	_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), true, false );
+	_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), $include_callback, false );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -386,10 +386,10 @@ function wc_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 /**
  * Function for recounting product terms, ignoring hidden products.
  *
- * @param array  $terms                       List of terms.
- * @param object $taxonomy                    Taxonomy.
- * @param bool   $callback                    Callback.
- * @param bool   $terms_are_term_taxonomy_ids If terms are from term_taxonomy_id column.
+ * @param array       $terms                       List of terms.
+ * @param WP_Taxonomy $taxonomy                    Taxonomy.
+ * @param bool        $callback                    Callback.
+ * @param bool        $terms_are_term_taxonomy_ids If terms are from term_taxonomy_id column.
  */
 function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_taxonomy_ids = true ) {
 	global $wpdb;
@@ -407,9 +407,22 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 		return;
 	}
 
-	// Standard callback.
+	// Standard callback for calculating post term counts.
 	if ( $callback ) {
-		_update_post_term_count( $terms, $taxonomy );
+		$callback_terms = $terms;
+		if ( true !== $terms_are_term_taxonomy_ids ) {
+			// The _update_post_term_count function expects term_taxonomy_id instead of term_id.
+			// We currently have terms in format of term_id=>parent.
+			$callback_terms = array_map(
+				function ( $term_id ) use ( $taxonomy ) {
+					$term = get_term_by( 'term_id', $term_id, $taxonomy->name );
+					return $term->term_taxonomy_id;
+				},
+				array_keys( $terms )
+			);
+		}
+
+		_update_post_term_count( $callback_terms, $taxonomy );
 	}
 
 	$exclude_term_ids            = array();

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -632,7 +632,14 @@ function wc_get_product_visibility_term_ids() {
 		wc_doing_it_wrong( __FUNCTION__, 'wc_get_product_visibility_term_ids should not be called before taxonomies are registered (woocommerce_after_register_post_type action).', '3.1' );
 		return array();
 	}
-	return array_map(
+
+	static $term_ids = array();
+
+	if ( count( $term_ids ) > 0 ) {
+		return $term_ids;
+	}
+
+	$term_ids = array_map(
 		'absint',
 		wp_parse_args(
 			wp_list_pluck(
@@ -658,6 +665,8 @@ function wc_get_product_visibility_term_ids() {
 			)
 		)
 	);
+
+	return $term_ids;
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -386,10 +386,32 @@ function wc_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 /**
  * Function for recounting product terms, ignoring hidden products.
  *
- * @param array       $terms                       List of terms.
- * @param WP_Taxonomy $taxonomy                    Taxonomy.
- * @param bool        $callback                    Callback.
- * @param bool        $terms_are_term_taxonomy_ids If terms are from term_taxonomy_id column.
+ * This is used as the update_count_callback for the Product Category and Product Tag
+ * taxonomies. By default, it actually calculates two (possibly different) counts for each
+ * term, which it stores in two different places. The first count is the one done by WordPress
+ * itself, and is based on the status of the objects that are assigned the terms. In this case,
+ * only products with the publish status are counted. This count is stored in the
+ * `wp_term_taxonomy` table in the `count` field.
+ *
+ * The second count is based on WooCommerce-specific characteristics. In addition to the
+ * publish status requirement, products are only counted if they are considered visible in the
+ * catalog. This count is stored in the `wp_termmeta` table. The wc_change_term_counts function
+ * is used to override the first count with the second count in some circumstances.
+ *
+ * Since the first count only needs to be recalculated when a product status is changed in some
+ * way, it can sometimes be skipped (thus avoiding some potentially expensive queries). Setting
+ * the $callback parameter to false skips the first count.
+ *
+ * @param array       $terms                       List of terms. For legacy reasons, this can
+ *                                                 either be a list of taxonomy term IDs or an
+ *                                                 associative array in the format of
+ *                                                 term ID > parent term ID.
+ * @param WP_Taxonomy $taxonomy                    The relevant taxonomy.
+ * @param bool        $callback                    Whether to also recalculate the term counts
+ *                                                 using the WP Core callback. Default true.
+ * @param bool        $terms_are_term_taxonomy_ids Flag to indicate which format the list of
+ *                                                 terms is in. Default true, which indicates
+ *                                                 that it is a list of taxonomy term IDs.
  */
 function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_taxonomy_ids = true ) {
 	global $wpdb;
@@ -407,22 +429,41 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 		return;
 	}
 
-	// Standard callback for calculating post term counts.
+	if ( true === $terms_are_term_taxonomy_ids ) {
+		$taxonomy_term_ids = $terms;
+		$term_ids          = array_map(
+			function ( $term_taxonomy_id ) use ( $taxonomy ) {
+				$term = get_term_by( 'term_taxonomy_id', $term_taxonomy_id, $taxonomy->name );
+				return $term instanceof WP_Term ? $term->term_id : null;
+			},
+			$terms
+		);
+	} else {
+		$taxonomy_term_ids = array(); // Defer querying these until the callback check.
+		$term_ids          = array_keys( $terms );
+	}
+
+	$term_ids          = array_unique( array_filter( $term_ids ) );
+	$taxonomy_term_ids = array_unique( array_filter( $taxonomy_term_ids ) );
+
+	// Exit if we have no terms to count.
+	if ( empty( $term_ids ) ) {
+		return;
+	}
+
+	// Standard WP callback for calculating post term counts.
 	if ( $callback ) {
-		$callback_terms = $terms;
-		if ( true !== $terms_are_term_taxonomy_ids ) {
-			// The _update_post_term_count function expects term_taxonomy_id instead of term_id.
-			// We currently have terms in format of term_id=>parent.
-			$callback_terms = array_map(
+		if ( count( $taxonomy_term_ids ) < 1 ) {
+			$taxonomy_term_ids = array_map(
 				function ( $term_id ) use ( $taxonomy ) {
 					$term = get_term_by( 'term_id', $term_id, $taxonomy->name );
-					return $term->term_taxonomy_id;
+					return $term instanceof WP_Term ? $term->term_taxonomy_id : null;
 				},
-				array_keys( $terms )
+				$term_ids
 			);
 		}
 
-		_update_post_term_count( $callback_terms, $taxonomy );
+		_update_post_term_count( $taxonomy_term_ids, $taxonomy );
 	}
 
 	$exclude_term_ids            = array();
@@ -432,7 +473,10 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 		$exclude_term_ids[] = $product_visibility_term_ids['exclude-from-catalog'];
 	}
 
-	if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && $product_visibility_term_ids[ ProductStockStatus::OUT_OF_STOCK ] ) {
+	if (
+		'yes' === get_option( 'woocommerce_hide_out_of_stock_items' )
+		&& $product_visibility_term_ids[ ProductStockStatus::OUT_OF_STOCK ]
+	) {
 		$exclude_term_ids[] = $product_visibility_term_ids[ ProductStockStatus::OUT_OF_STOCK ];
 	}
 
@@ -445,7 +489,6 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 			WHERE 1=1
 			AND p.post_status = 'publish'
 			AND p.post_type = 'product'
-
 		",
 	);
 
@@ -454,37 +497,17 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 		$query['where'] .= ' AND exclude_join.object_id IS NULL';
 	}
 
-	// Pre-process term taxonomy ids.
-	if ( ! $terms_are_term_taxonomy_ids ) {
-		// We passed in an array of TERMS in format id=>parent.
-		$terms = array_filter( (array) array_keys( $terms ) );
-	} else {
-		// If we have term taxonomy IDs we need to get the term ID.
-		$term_taxonomy_ids = $terms;
-		$terms             = array();
-		foreach ( $term_taxonomy_ids as $term_taxonomy_id ) {
-			$term    = get_term_by( 'term_taxonomy_id', $term_taxonomy_id, $taxonomy->name );
-			$terms[] = $term->term_id;
-		}
-	}
-
-	// Exit if we have no terms to count.
-	if ( empty( $terms ) ) {
-		return;
-	}
-
 	// Ancestors need counting.
 	if ( is_taxonomy_hierarchical( $taxonomy->name ) ) {
-		foreach ( $terms as $term_id ) {
-			$terms = array_merge( $terms, get_ancestors( $term_id, $taxonomy->name ) );
+		foreach ( $term_ids as $term_id ) {
+			$term_ids = array_merge( $term_ids, get_ancestors( $term_id, $taxonomy->name ) );
 		}
+
+		$term_ids = array_unique( $term_ids );
 	}
 
-	// Unique terms only.
-	$terms = array_unique( $terms );
-
 	// Count the terms.
-	foreach ( $terms as $term_id ) {
+	foreach ( $term_ids as $term_id ) {
 		$terms_to_count = array( absint( $term_id ) );
 
 		if ( is_taxonomy_hierarchical( $taxonomy->name ) ) {

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 
@@ -24,12 +25,12 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->terms['parent']        = wp_insert_term( 'Parent term', 'product_cat' );
-		$this->terms['child1']        = wp_insert_term( 'Child term 1', 'product_cat', array( 'parent' => $this->terms['parent']['term_id'] ) );
-		$this->terms['child2']        = wp_insert_term( 'Child term 2', 'product_cat', array( 'parent' => $this->terms['parent']['term_id'] ) );
+		$this->terms['parent'] = wp_insert_term( 'Parent term', 'product_cat' );
+		$this->terms['child1'] = wp_insert_term( 'Child term 1', 'product_cat', array( 'parent' => $this->terms['parent']['term_id'] ) );
+		$this->terms['child2'] = wp_insert_term( 'Child term 2', 'product_cat', array( 'parent' => $this->terms['parent']['term_id'] ) );
 
-		$this->terms['tag1']          = wp_insert_term( 'Tag 1', 'product_tag' );
-		$this->terms['tag2']          = wp_insert_term( 'Tag 2', 'product_tag' );
+		$this->terms['tag1'] = wp_insert_term( 'Tag 1', 'product_tag' );
+		$this->terms['tag2'] = wp_insert_term( 'Tag 2', 'product_tag' );
 
 		$this->products['product1'] = WC_Helper_Product::create_simple_product(
 			true,
@@ -78,10 +79,12 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	 * @testdox Term product counts with default settings.
 	 */
 	public function test_term_count_baseline(): void {
-		$terms = get_terms( array(
-			'taxonomy'   => array( 'product_cat', 'product_tag' ),
-			'hide_empty' => false,
-		) );
+		$terms       = get_terms(
+			array(
+				'taxonomy'   => array( 'product_cat', 'product_tag' ),
+				'hide_empty' => false,
+			)
+		);
 		$term_counts = wp_list_pluck( $terms, 'count', 'term_id' );
 
 		$this->assertEquals( 3, $term_counts[ $this->terms['parent']['term_id'] ] );
@@ -101,10 +104,12 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		wc_recount_all_terms();
 		delete_transient( 'wc_term_counts' );
 
-		$terms = get_terms( array(
-			'taxonomy'   => array( 'product_cat', 'product_tag' ),
-			'hide_empty' => false,
-		) );
+		$terms       = get_terms(
+			array(
+				'taxonomy'   => array( 'product_cat', 'product_tag' ),
+				'hide_empty' => false,
+			)
+		);
 		$term_counts = wp_list_pluck( $terms, 'count', 'term_id' );
 
 		$this->assertEquals( 2, $term_counts[ $this->terms['parent']['term_id'] ] );
@@ -123,10 +128,12 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 		wc_recount_all_terms();
 		delete_transient( 'wc_term_counts' );
 
-		$terms = get_terms( array(
-			'taxonomy'   => array( 'product_cat', 'product_tag' ),
-			'hide_empty' => false,
-		) );
+		$terms       = get_terms(
+			array(
+				'taxonomy'   => array( 'product_cat', 'product_tag' ),
+				'hide_empty' => false,
+			)
+		);
 		$term_counts = wp_list_pluck( $terms, 'count', 'term_id' );
 
 		$this->assertEquals( 2, $term_counts[ $this->terms['parent']['term_id'] ] );

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -1,0 +1,140 @@
+<?php
+
+use Automattic\WooCommerce\Enums\ProductStockStatus;
+
+/**
+ * Class WC_Stock_Functions_Tests.
+ */
+class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
+	/**
+	 * @var WP_Term[] Test terms.
+	 */
+	private $terms = array();
+
+	/**
+	 * @var WC_Product_Simple[] Test products.
+	 */
+	private $products = array();
+
+	/**
+	 * Setup before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->terms['parent']        = wp_insert_term( 'Parent term', 'product_cat' );
+		$this->terms['child1']        = wp_insert_term( 'Child term 1', 'product_cat', array( 'parent' => $this->terms['parent']['term_id'] ) );
+		$this->terms['child2']        = wp_insert_term( 'Child term 2', 'product_cat', array( 'parent' => $this->terms['parent']['term_id'] ) );
+
+		$this->terms['tag1']          = wp_insert_term( 'Tag 1', 'product_tag' );
+		$this->terms['tag2']          = wp_insert_term( 'Tag 2', 'product_tag' );
+
+		$this->products['product1'] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'category_ids' => array( $this->terms['child1']['term_id'] ),
+				'tag_ids'      => array( $this->terms['tag1']['term_id'] ),
+			)
+		);
+		$this->products['product2'] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'category_ids' => array( $this->terms['child2']['term_id'] ),
+				'tag_ids'      => array( $this->terms['tag2']['term_id'] ),
+				'stock_status' => ProductStockStatus::OUT_OF_STOCK,
+			)
+		);
+		$this->products['product3'] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'category_ids' => array( $this->terms['parent']['term_id'] ),
+				'tag_ids'      => array( $this->terms['tag1']['term_id'], $this->terms['tag2']['term_id'] ),
+			)
+		);
+	}
+
+	/**
+	 * Teardown after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		foreach ( $this->terms as $term ) {
+			wp_delete_term( $term['term_id'], $term['term_taxonomy_id'] );
+		}
+		$this->terms = array();
+
+		foreach ( $this->products as $product ) {
+			$product->delete();
+		}
+		$this->products = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Term product counts with default settings.
+	 */
+	public function test_term_count_baseline(): void {
+		$terms = get_terms( array(
+			'taxonomy'   => array( 'product_cat', 'product_tag' ),
+			'hide_empty' => false,
+		) );
+		$term_counts = wp_list_pluck( $terms, 'count', 'term_id' );
+
+		$this->assertEquals( 3, $term_counts[ $this->terms['parent']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['child1']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['child2']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['tag1']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['tag2']['term_id'] ] );
+	}
+
+	/**
+	 * @testdox Term product counts when a product is hidden from the catalog.
+	 */
+	public function test_product_visibility(): void {
+		$this->products['product1']->set_catalog_visibility( 'hidden' );
+		$this->products['product1']->save();
+
+		wc_recount_all_terms();
+		delete_transient( 'wc_term_counts' );
+
+		$terms = get_terms( array(
+			'taxonomy'   => array( 'product_cat', 'product_tag' ),
+			'hide_empty' => false,
+		) );
+		$term_counts = wp_list_pluck( $terms, 'count', 'term_id' );
+
+		$this->assertEquals( 2, $term_counts[ $this->terms['parent']['term_id'] ] );
+		$this->assertEquals( 0, $term_counts[ $this->terms['child1']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['child2']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['tag1']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['tag2']['term_id'] ] );
+	}
+
+	/**
+	 * @testdox Term product counts when a product is out of stock and OOS products are hidden from the catalog.
+	 */
+	public function test_hide_out_of_stock_products(): void {
+		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
+
+		wc_recount_all_terms();
+		delete_transient( 'wc_term_counts' );
+
+		$terms = get_terms( array(
+			'taxonomy'   => array( 'product_cat', 'product_tag' ),
+			'hide_empty' => false,
+		) );
+		$term_counts = wp_list_pluck( $terms, 'count', 'term_id' );
+
+		$this->assertEquals( 2, $term_counts[ $this->terms['parent']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['child1']['term_id'] ] );
+		$this->assertEquals( 0, $term_counts[ $this->terms['child2']['term_id'] ] );
+		$this->assertEquals( 2, $term_counts[ $this->terms['tag1']['term_id'] ] );
+		$this->assertEquals( 1, $term_counts[ $this->terms['tag2']['term_id'] ] );
+
+		delete_option( 'woocommerce_hide_out_of_stock_items' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -125,7 +125,7 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 	public function test_hide_out_of_stock_products(): void {
 		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
 
-		wc_recount_all_terms();
+		wc_recount_all_terms( false );
 		delete_transient( 'wc_term_counts' );
 
 		$terms       = get_terms(

--- a/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-term-functions-tests.php
@@ -144,4 +144,36 @@ class WC_Term_Functions_Tests extends \WC_Unit_Test_Case {
 
 		delete_option( 'woocommerce_hide_out_of_stock_items' );
 	}
+
+	/**
+	 * @testdox The call to WP Core's _update_post_term_count function in _wc_term_recount should receive
+	 *          term_taxonomy_id values rather than term_id values for its first parameter.
+	 */
+	public function test_standard_callback_gets_correct_params(): void {
+		$target_tt_id = $this->terms['parent']['term_taxonomy_id'];
+		$success      = false;
+
+		$action_callback = function ( $tt_id ) use ( $target_tt_id, &$success ) {
+			if ( $tt_id === $target_tt_id ) {
+				$success = true;
+			}
+		};
+
+		add_action( 'edited_term_taxonomy', $action_callback );
+
+		$target_term = get_terms(
+			array(
+				'taxonomy'   => 'product_cat',
+				'include'    => $this->terms['parent']['term_id'],
+				'hide_empty' => false,
+				'fields'     => 'id=>parent',
+			)
+		);
+
+		_wc_term_recount( $target_term, get_taxonomy( 'product_cat' ), true, false );
+
+		$this->assertTrue( $success );
+
+		remove_action( 'edited_term_taxonomy', $action_callback );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This makes a few changes to the system that calculates how many products are assigned to each Product Category and Product Tag taxonomy term. The main changes are:

* Fixing a subtle bug that made it so that the counts could be incorrect for some terms retrieved with the `get_terms` function when multiple taxonomies were specified.
* Fixing a bug where the built-in WP callback for counting terms, `_update_post_term_count`, was being given the wrong IDs (term IDs instead of term taxonomy IDs in some cases, parent term IDs in other cases), which caused queries to be run, and counts updated for _the wrong terms_.
* Reworking the flow of the code to avoid unnecessary queries running during certain times when terms are being recounted.

Fixes #44462
Fixes #54680

### How to test the changes in this Pull Request:

Some parts of this changeset are difficult to test manually. In those cases I've added unit tests to try and ensure that no regressions are caused.

* ~Follow the "Steps to reproduce" in #44462 and make sure only the correct count field gets reset.~ Smoke test to ensure that updating posts and categories, products and product categories/tags results in accurate counts for those terms.
* Follow the "Steps to reproduce" in #54680 and note that Query Monitor no longer shows any duplicate queries relating to term counts after saving the settings in WooCommerce -> Settings -> Products -> Inventory.
* Create a few product categories. Have at least one be a child of another category. Create a few products. Assign various categories to these products. Make sure you're working with a small enough number that you can easily figure out what the product count should be for each category. Visit the front end of your shop and spot check the category archive pages (e.g. `http://localhost/product-category/category-1`) for a few categories and make sure the "Showing all X results" header is correct for these categories.
* Now mark one of your products as "Out of stock" and then go to WooCommerce -> Settings -> Products -> Inventory and check the "Hide out of stock items from the catalog" box and save your settings. Go back and visit the category archive page for one of the categories assigned to the out of stock product. It should be changed to not take that product into account anymore.

### Testing that has already taken place:

* During development, these changes were tested using wp-env with WP 6.7.2, in both PHP 7.4 and PHP 8.1.
* This PR adds several unit tests that verify the functionality in the relevant changes.
