### PR TITLE
Hide blueprint feature from features UI

### DIFF
--- a/plugins/woocommerce/changelog/fix-9.8-disable-blueprint-feature-ui
+++ b/plugins/woocommerce/changelog/fix-9.8-disable-blueprint-feature-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Hide blueprint feature checkbox

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -380,7 +380,7 @@ class FeaturesController {
 						'woocommerce'
 					),
 					'enabled_by_default' => false,
-					'disable_ui'         => false,
+					'disable_ui'         => true,
 
 					/*
 					* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

p1742453613631689-slack-C01SFMVEYAK

Blueprint feature is deferred to WooCommerce 9.9 release, thus we're disabling the feature UI to prevent users from enabling it which may have unknown risks.

Note: Disabling the UI does not automatically disable the feature if it's enabled prior. This behaviour is desired.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="941" alt="image" src="https://github.com/user-attachments/assets/ffff797e-cb52-450d-8a3f-775786ee5f99" /> | <img width="789" alt="image" src="https://github.com/user-attachments/assets/2410784a-60fd-45e7-acfc-b5cfa6f3f1b8" />   |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Advanced > Features
2. In the list of features, ensure `Blueprint (beta)` is not listed

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

Tested in local environment with WordPress 6.7.2 and PHP 7.2, TT24 theme.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>