### PR TITLE
Fix order notes not persisting

### DIFF
--- a/plugins/woocommerce/changelog/56557-fix-order-notes-not-persisting
+++ b/plugins/woocommerce/changelog/56557-fix-order-notes-not-persisting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Persist order notes in checkout block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/order-notes/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/order-notes/index.tsx
@@ -19,10 +19,6 @@ const CheckoutOrderNotes = ( {
 	value,
 }: CheckoutOrderNotesProps ): JSX.Element => {
 	const [ withOrderNotes, setWithOrderNotes ] = useState( value !== '' );
-	// Store order notes when the textarea is hidden. This allows us to recover
-	// text entered previously by the user when the checkbox is re-enabled
-	// while keeping the context clean if the checkbox is disabled.
-	const [ hiddenOrderNotesText, setHiddenOrderNotesText ] = useState( '' );
 
 	return (
 		<div className="wc-block-checkout__add-note">
@@ -32,19 +28,9 @@ const CheckoutOrderNotes = ( {
 				checked={ withOrderNotes }
 				onChange={ ( isChecked ) => {
 					setWithOrderNotes( isChecked );
-					if ( isChecked ) {
-						// When re-enabling the checkbox, store in context the
-						// order notes value previously stored in the component
-						// state.
-						if ( value !== hiddenOrderNotesText ) {
-							onChange( hiddenOrderNotesText );
-						}
-					} else {
-						// When un-checking the checkbox, clear the order notes
-						// value in the context but store it in the component
-						// state.
+					if ( ! isChecked ) {
+						// Clear the notes when the checkbox is unchecked.
 						onChange( '' );
-						setHiddenOrderNotesText( value );
 					}
 				} }
 			/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/order-notes/test/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/order-notes/test/index.js
@@ -64,7 +64,7 @@ describe( 'Checkout order notes', () => {
 		expect( textarea ).toBeNull();
 	} );
 
-	it( 'Retains the order note when toggling the textarea on and off', async () => {
+	it( 'Clears the order note when toggling the textarea on and off', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();
 		const { container, rerender } = render(
@@ -129,6 +129,6 @@ describe( 'Checkout order notes', () => {
 		await act( async () => {
 			await user.click( checkbox );
 		} );
-		expect( onChange ).toHaveBeenLastCalledWith( 'Test message' );
+		expect( onChange ).toHaveBeenLastCalledWith( '' );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
@@ -111,7 +111,7 @@ const updateCheckoutData = (): void => {
 	}
 
 	if ( newCheckoutData.orderNotes !== localState.checkoutData.orderNotes ) {
-		requestData.order_notes = newCheckoutData.orderNotes;
+		requestData.customer_note = newCheckoutData.orderNotes;
 	}
 
 	if (

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/types.ts
@@ -47,6 +47,6 @@ export type emitValidateEventType = ( {
 
 export type CheckoutPutData = {
 	additional_fields?: AdditionalValues;
-	order_notes?: string;
+	customer_note?: string;
 	payment_method?: string;
 };

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -147,7 +147,7 @@ trait CheckoutTrait {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		if ( isset( $request['customer_note'] ) ) {
-			$this->order->set_customer_note( wc_sanitize_textarea( $request['customer_note'] ) ?? '' );
+			$this->order->set_customer_note( wc_sanitize_textarea( $request['customer_note'] ) );
 		}
 		$payment_method = $this->get_request_payment_method( $request );
 		if ( null !== $payment_method ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -146,7 +146,9 @@ trait CheckoutTrait {
 	 * @param \WP_REST_Request $request Full details about the request.
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
-		$this->order->set_customer_note( wc_sanitize_textarea( $request['customer_note'] ) ?? '' );
+		if ( isset( $request['customer_note'] ) ) {
+			$this->order->set_customer_note( wc_sanitize_textarea( $request['customer_note'] ) ?? '' );
+		}
 		$payment_method = $this->get_request_payment_method( $request );
 		if ( null !== $payment_method ) {
 			WC()->session->set( 'chosen_payment_method', $payment_method->id );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -1311,7 +1311,7 @@ class Checkout extends MockeryTestCase {
 					'plugin-namespace/leave-on-porch' => true,
 				),
 				'payment_method'    => 'bacs',
-				'order_notes'       => 'Please leave my package on the porch',
+				'customer_note'     => 'Please leave my package on the porch',
 			)
 		);
 
@@ -1329,6 +1329,7 @@ class Checkout extends MockeryTestCase {
 		$this->assertArrayNotHasKey( 'plugin-namespace/student-id', $additional_fields_address );
 		$this->assertEquals( 'engineering', $additional_fields_contact['plugin-namespace/job-function']['value'] );
 		$this->assertEquals( true, $additional_fields_order['plugin-namespace/leave-on-porch']['value'] );
+		$this->assertEquals( 'Please leave my package on the porch', $order->get_customer_note() );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes a bug where the order notes don't persist, following some changes to how checkout fields persist. The problem was a mismatch between the keys used on the client and server to reder to the order notes. The client was sending `order_notes` and the server was expecting `customer_note`. We are now using `customer_note` for both, and only updating the customer note if it is being appended to the request.

Also updated a test to catch this which was missing.

Update by @<!-- linear:userMention:a11300a5-c516-4ff0-a705-73279ff7c669 -->thomas.roberts  - Also added code to remove the order notes when unchecking the Order Notes checkbox. This brings it more in line with the rest of the AdditionalCheckout Fields API conditional fields.

Closes woocommerce/woocommerce#56555.

(For Bug Fixes) Bug introduced in PR [#55989](<https://github.com/woocommerce/woocommerce/issues/55989>).

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](<https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions>), include your detailed testing instructions:

1. Install and activate the [Additional Fields Tester](<https://github.com/woocommerce/additional-checkout-fields-tester>) plugin.
2. Add an item to your cart and go to the Checkout block
3. Tick the order notes box and add some text.
4. Wait 1.5s or more (or wit for a PUT request to /checkout then refresh the page.
5. Check that what you entered in the order notes is still there
6. Update one of the additional fields, wait as in step 4 and refresh
7. Check that the order notes are still there
8. Update all the additional fields, order notes and payment method, refresh, and check they are persisted.

### Testing that has already taken place:

### Changelog entry

- [X] Automatically create a changelog entry from the details below.
- [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details><summary>Changelog Entry Details</summary>

#### Significance

- [X] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [X] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Persist order notes in checkout block

</details>

<details><summary>Changelog Entry Comment</summary>

#### Comment

</details>