### PR TITLE
Always load preview data in the editor for Checkout

### DIFF
--- a/plugins/woocommerce/changelog/56562-fix-cart-request-in-cart
+++ b/plugins/woocommerce/changelog/56562-fix-cart-request-in-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug in which real address was being shown on the editor page for Checkout.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -6,8 +6,7 @@ import {
 	RadioControlOptionType,
 } from '@woocommerce/blocks-components';
 import { CartShippingPackageShippingRate } from '@woocommerce/types';
-import { cartStore } from '@woocommerce/block-data';
-import { useSelect } from '@wordpress/data';
+import { useShippingData } from '@woocommerce/base-context';
 
 interface LocalPickupSelectProps {
 	title?: string | undefined;
@@ -33,9 +32,8 @@ export const LocalPickupSelect = ( {
 	renderPickupLocation,
 	packageCount,
 }: LocalPickupSelectProps ) => {
-	const internalPackageCount = useSelect(
-		( select ) => select( cartStore )?.getCartData()?.shippingRates?.length
-	);
+	const { shippingRates } = useShippingData();
+	const internalPackageCount = shippingRates?.length || 1;
 	// Hacky way to check if there are multiple packages, this way is borrowed from  `assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx`
 	// We have no built-in way of checking if other extensions have added packages.
 	const multiplePackages =

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -29,11 +29,10 @@ export const ShippingRatesControlPackage = ( {
 	showItems,
 	highlightChecked = false,
 }: PackageProps ): ReactElement => {
-	const { selectShippingRate, isSelectingRate } = useShippingData();
+	const { selectShippingRate, isSelectingRate, shippingRates } =
+		useShippingData();
 
-	const internalPackageCount = useSelect(
-		( select ) => select( cartStore )?.getCartData()?.shippingRates?.length
-	);
+	const internalPackageCount = shippingRates?.length || 1;
 
 	const packageClass = 'wc-block-components-shipping-rates-control__package';
 	const [ instanceCount, setInstanceCount ] = useState( 0 );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -8,8 +8,6 @@ import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { sanitizeHTML } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
-import { useSelect } from '@wordpress/data';
-import { cartStore } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/test/use-store-cart.jsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/test/use-store-cart.jsx
@@ -3,7 +3,6 @@
  */
 import TestRenderer, { act } from 'react-test-renderer';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
-import { previewCart } from '@woocommerce/resource-previews';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 /**
@@ -23,68 +22,6 @@ jest.mock( '@woocommerce/block-data', () => ( {
 
 describe( 'useStoreCart', () => {
 	let registry, renderer;
-
-	const receiveCartMock = () => {};
-	const receiveCartContentsMock = () => {};
-
-	const previewCartData = {
-		cartCoupons: previewCart.coupons,
-		cartItems: previewCart.items,
-		crossSellsProducts: previewCart.cross_sells,
-		cartFees: previewCart.fees,
-		cartItemsCount: previewCart.items_count,
-		cartItemsWeight: previewCart.items_weight,
-		cartNeedsPayment: previewCart.needs_payment,
-		cartNeedsShipping: previewCart.needs_shipping,
-		cartTotals: previewCart.totals,
-		cartIsLoading: false,
-		cartItemErrors: [],
-		cartErrors: [],
-		billingData: {
-			first_name: '',
-			last_name: '',
-			company: '',
-			address_1: '',
-			address_2: '',
-			city: '',
-			state: '',
-			postcode: '',
-			country: '',
-			email: '',
-			phone: '',
-		},
-		billingAddress: {
-			first_name: '',
-			last_name: '',
-			company: '',
-			address_1: '',
-			address_2: '',
-			city: '',
-			state: '',
-			postcode: '',
-			country: '',
-			email: '',
-			phone: '',
-		},
-		shippingAddress: {
-			first_name: '',
-			last_name: '',
-			company: '',
-			address_1: '',
-			address_2: '',
-			city: '',
-			state: '',
-			postcode: '',
-			country: '',
-			phone: '',
-		},
-		shippingRates: previewCart.shipping_rates,
-		extensions: {},
-		isLoadingRates: false,
-		cartHasCalculatedShipping: true,
-		paymentMethods: previewCart.payment_methods,
-		paymentRequirements: previewCart.payment_requirements,
-	};
 
 	const mockCartItems = [ { key: '1', id: 1, name: 'Lorem Ipsum' } ];
 	const mockShippingAddress = {
@@ -235,40 +172,6 @@ describe( 'useStoreCart', () => {
 			expect( results ).toEqual( mockStoreCartData );
 			expect( receiveCart ).toBeUndefined();
 			expect( receiveCartContents ).toBeUndefined();
-		} );
-	} );
-
-	describe( 'in editor', () => {
-		beforeEach( () => {
-			useEditorContext.mockReturnValue( {
-				isEditor: true,
-				previewData: {
-					previewCart: {
-						...previewCart,
-						receiveCart: receiveCartMock,
-						receiveCartContents: receiveCartContentsMock,
-					},
-				},
-			} );
-		} );
-
-		it( 'return preview data in editor', () => {
-			const TestComponent = getTestComponent();
-
-			act( () => {
-				renderer = TestRenderer.create(
-					getWrappedComponents( TestComponent )
-				);
-			} );
-
-			const props = renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
-			const results = props[ 'data-results' ];
-			const receiveCart = props[ 'data-receiveCart' ];
-			const receiveCartContents = props[ 'data-receiveCartContents' ];
-
-			expect( results ).toEqual( previewCartData );
-			expect( receiveCart ).toEqual( receiveCartMock );
-			expect( receiveCartContents ).toEqual( receiveCartContentsMock );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -23,7 +23,6 @@ import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import type {
 	StoreCart,
-	CartResponse,
 	CartResponseTotals,
 	CartResponseFeeItem,
 	CartResponseBillingAddress,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -36,7 +36,6 @@ import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
 /**
  * Internal dependencies
  */
-import { useEditorContext } from '../../providers/editor-context';
 import { useStoreCartEventListeners } from './use-store-cart-event-listeners';
 
 declare module '@wordpress/html-entities' {
@@ -140,11 +139,6 @@ export const useStoreCart = (
 	options: { shouldSelect: boolean } = { shouldSelect: true }
 ): StoreCart => {
 	const { shouldSelect } = options;
-	const { isEditor, previewData } = useEditorContext();
-	const previewCart = previewData?.previewCart as unknown as CartResponse & {
-		receiveCart?: ( cart: CartResponse ) => void;
-		receiveCartContents?: ( cart: CartResponse ) => void;
-	};
 	const currentResults = useRef();
 	const billingAddressRef = useRef( defaultBillingAddress );
 	const shippingAddressRef = useRef( defaultShippingAddress );
@@ -156,35 +150,6 @@ export const useStoreCart = (
 		( select, { dispatch } ) => {
 			if ( ! shouldSelect ) {
 				return defaultCartData;
-			}
-
-			if ( isEditor ) {
-				return {
-					...defaultCartData,
-					cartCoupons: previewCart.coupons,
-					cartItems: previewCart.items,
-					crossSellsProducts: previewCart.cross_sells,
-					cartFees: previewCart.fees,
-					cartItemsCount: previewCart.items_count,
-					cartItemsWeight: previewCart.items_weight,
-					cartNeedsPayment: previewCart.needs_payment,
-					cartNeedsShipping: previewCart.needs_shipping,
-					cartTotals: previewCart.totals,
-					shippingRates: previewCart.shipping_rates,
-					cartHasCalculatedShipping:
-						previewCart.has_calculated_shipping,
-					paymentMethods: previewCart.payment_methods,
-					paymentRequirements: previewCart.payment_requirements,
-					cartIsLoading: false,
-					receiveCart:
-						typeof previewCart?.receiveCart === 'function'
-							? previewCart.receiveCart
-							: () => undefined,
-					receiveCartContents:
-						typeof previewCart?.receiveCartContents === 'function'
-							? previewCart.receiveCartContents
-							: () => undefined,
-				};
 			}
 
 			const store = select( cartStore );
@@ -265,7 +230,7 @@ export const useStoreCart = (
 				receiveCartContents,
 			};
 		},
-		[ shouldSelect, isEditor ]
+		[ shouldSelect ]
 	);
 
 	if (

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -10,18 +10,14 @@ import {
 	deriveSelectedShippingRates,
 } from '@woocommerce/base-utils';
 import isShallowEqual from '@wordpress/is-shallow-equal';
-import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
  */
 import { useStoreEvents } from '../use-store-events';
 import type { ShippingData } from './types';
-import { useEditorContext } from '../../providers';
 
 export const useShippingData = (): ShippingData => {
-	const { isEditor } = useEditorContext();
-
 	const {
 		shippingRates,
 		needsShipping,
@@ -29,37 +25,23 @@ export const useShippingData = (): ShippingData => {
 		isLoadingRates,
 		isCollectable,
 		isSelectingRate,
-	} = useSelect(
-		( select ) => {
-			const store = select( cartStore );
-			const rates = isEditor
-				? previewCart.shipping_rates
-				: store.getShippingRates();
-			return {
-				shippingRates: rates,
-				needsShipping: isEditor
-					? previewCart.needs_shipping
-					: store.getNeedsShipping(),
-				hasCalculatedShipping: isEditor
-					? previewCart.has_calculated_shipping
-					: store.getHasCalculatedShipping(),
-				isLoadingRates: isEditor
-					? false
-					: store.isCustomerDataUpdating(),
-				isCollectable: rates.every(
-					( { shipping_rates: packageShippingRates } ) =>
-						packageShippingRates.find(
-							( { method_id: methodId } ) =>
-								hasCollectableRate( methodId )
-						)
-				),
-				isSelectingRate: isEditor
-					? false
-					: store.isShippingRateBeingSelected(),
-			};
-		},
-		[ isEditor ]
-	);
+	} = useSelect( ( select ) => {
+		const store = select( cartStore );
+		const rates = store.getShippingRates();
+		return {
+			shippingRates: rates,
+			needsShipping: store.getNeedsShipping(),
+			hasCalculatedShipping: store.getHasCalculatedShipping(),
+			isLoadingRates: store.isCustomerDataUpdating(),
+			isCollectable: rates.every(
+				( { shipping_rates: packageShippingRates } ) =>
+					packageShippingRates.find( ( { method_id: methodId } ) =>
+						hasCollectableRate( methodId )
+					)
+			),
+			isSelectingRate: store.isShippingRateBeingSelected(),
+		};
+	}, [] );
 
 	// set selected rates on ref so it's always current.
 	const selectedRates = useRef< Record< string, string > >( {} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -53,7 +53,16 @@ const Block = (): JSX.Element => {
 			delete syncValues.company;
 		}
 
-		setBillingAddress( syncValues );
+		// Only sync if any values are different
+		const needsSync = ! Object.keys( syncValues ).every(
+			( key ) =>
+				syncValues[ key as keyof BillingAddress ] ===
+				billingAddress[ key as keyof BillingAddress ]
+		);
+
+		if ( needsSync ) {
+			setBillingAddress( syncValues );
+		}
 	};
 
 	const clearBillingAddress = ( address: BillingAddress ) => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -54,11 +54,13 @@ const Block = (): JSX.Element => {
 		}
 
 		// Only sync if any values are different
-		const needsSync = ! Object.keys( syncValues ).every(
-			( key ) =>
-				syncValues[ key as keyof BillingAddress ] ===
-				billingAddress[ key as keyof BillingAddress ]
-		);
+		const needsSync =
+			Object.keys( syncValues ).length !== Object.keys( billingAddress ).length ||
+			!Object.keys( syncValues ).every(
+				( key ) =>
+					syncValues[ key as keyof BillingAddress ] ===
+					billingAddress[ key as keyof BillingAddress ]
+			);
 
 		if ( needsSync ) {
 			setBillingAddress( syncValues );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -55,8 +55,9 @@ const Block = (): JSX.Element => {
 
 		// Only sync if any values are different
 		const needsSync =
-			Object.keys( syncValues ).length !== Object.keys( billingAddress ).length ||
-			!Object.keys( syncValues ).every(
+			Object.keys( syncValues ).length !==
+				Object.keys( billingAddress ).length ||
+			! Object.keys( syncValues ).every(
 				( key ) =>
 					syncValues[ key as keyof BillingAddress ] ===
 					billingAddress[ key as keyof BillingAddress ]

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/resolvers.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/resolvers.ts
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { CartResponse } from '@woocommerce/types';
+import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import { CartResponse } from '@woocommerce/types';
 import { CART_API_ERROR } from './constants';
 import type { CartDispatchFromMap, CartResolveSelectFromMap } from './index';
 import { setTriggerStoreSyncEvent } from './utils';
+import { isEditor } from '../utils';
 
 /**
  * Resolver for retrieving all cart data.
@@ -17,6 +19,11 @@ import { setTriggerStoreSyncEvent } from './utils';
 export const getCartData =
 	() =>
 	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
+		if ( isEditor() ) {
+			dispatch.receiveCart( previewCart );
+			return;
+		}
+
 		const response = await apiFetch< Response >( {
 			path: '/wc/store/v1/cart',
 			method: 'GET',

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -37,7 +37,7 @@ import {
 	setIsCustomerDataDirty,
 	setTriggerStoreSyncEvent,
 } from './utils';
-
+import { isEditor } from '../utils';
 interface CartThunkArgs {
 	select: CurriedSelectorsOf< typeof cartStore >;
 	dispatch: ActionCreatorsOf< ConfigOf< typeof cartStore > >;
@@ -426,6 +426,7 @@ let abortController: AbortController | null = null;
 export const selectShippingRate =
 	( rateId: string, packageId: number | null = null ) =>
 	async ( { dispatch, select }: CartThunkArgs ) => {
+
 		const selectedShippingRate = select
 			.getShippingRates()
 			.find(
@@ -438,6 +439,10 @@ export const selectShippingRate =
 			);
 
 		if ( selectedShippingRate?.rate_id === rateId ) {
+			return;
+		}
+
+		if ( isEditor() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -426,7 +426,6 @@ let abortController: AbortController | null = null;
 export const selectShippingRate =
 	( rateId: string, packageId: number | null = null ) =>
 	async ( { dispatch, select }: CartThunkArgs ) => {
-
 		const selectedShippingRate = select
 			.getShippingRates()
 			.find(

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/default-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/default-state.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import type { EmptyObjectType, PaymentResult } from '@woocommerce/types';
+import type {
+	EmptyObjectType,
+	PaymentResult,
+	GlobalPaymentMethod,
+} from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
 import {
 	PlainPaymentMethods,
@@ -12,13 +16,21 @@ import {
  * Internal dependencies
  */
 import { SavedPaymentMethod } from './types';
+import { isEditor } from '../utils';
 import { STATUS as PAYMENT_STATUS } from './constants';
 import { checkoutData } from '../checkout/constants';
 
-const defaultPaymentMethod = checkoutData?.payment_method;
+const globalPaymentMethods = getSetting< GlobalPaymentMethod[] >(
+	'globalPaymentMethods'
+);
+
 const savedPaymentMethods = getSetting<
 	Record< string, SavedPaymentMethod[] > | EmptyObjectType
 >( 'customerPaymentMethods', {} );
+
+const defaultPaymentMethod = isEditor()
+	? globalPaymentMethods[ 0 ].id
+	: checkoutData?.payment_method;
 
 function getDefaultPaymentMethod() {
 	if ( ! defaultPaymentMethod ) {

--- a/plugins/woocommerce/client/blocks/assets/js/data/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/data/utils/index.js
@@ -2,3 +2,4 @@ export { default as hasInState } from './has-in-state';
 export { default as updateState } from './update-state';
 export * from './process-error-response';
 export * from './clear-put-requests';
+export * from './is-editor';

--- a/plugins/woocommerce/client/blocks/assets/js/data/utils/is-editor.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/utils/is-editor.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { getPath } from '@wordpress/url';
+
+/**
+ * Returns true if the current page is in the editor.
+ */
+export const isEditor = (): boolean => {
+	return (
+		getPath( window.location.href )?.includes( 'site-editor.php' ) ||
+		getPath( window.location.href )?.includes( 'post.php' ) ||
+		false
+	);
+};


### PR DESCRIPTION
This PR fixes an issue in which real cart ended up being loaded in the editor, something causing mixed results, or showing the address in the editor, which is not what should happen.

This also fixes a side issue in which a request is made to PUT checkout in the editor because no PHP default payment is set, this would cause a draft order to be created.

Around the codebase, we had places where we would patch in `isEditor` and return preview data instead of actual data, but in the data store, we would always fetch data.

This however, caused anyone who reaches to `getCartData` to trigger a request to Store API, and plenty of components did (ones that couldn't subscribe to `useStoreCart`). So in this PR, I fixed it at the root of it, which will be future proof.

For the extra PUT request, an easy solution would have been to bail early in `pushChanges` but a better solution would be to correct the default state there.

Closes WOOPLUG-3236

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Checkout, fill out your address, place order, all should be good. This just ensures you have an address in your account. Skip if you placed orders before logged in.
2. Once an order is placed, add an item to your cart
3. Go to Checkout editor page, ensure all fields are empty.
4. Open network tab, ensure there is no request being made to cart or checkout endpoints.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a bug in which real address was being shown on the editor page for Checkout.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
