### PR TITLE
Update core-profiler to eliminate the use of option store and eliminate the outdated fields from the onboarding API

### DIFF
--- a/plugins/woocommerce/changelog/update-migrate-core-profiler-options
+++ b/plugins/woocommerce/changelog/update-migrate-core-profiler-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update core-profiler to eliminate the use of option store and eliminate the outdated fields from the onboarding API

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -409,11 +409,10 @@ const updateTrackingOption = fromPromise(
 		} );
 
 		const trackingValue = input.optInDataSharing ? 'yes' : 'no';
-		dispatch( settingOptionsStore ).updateSetting(
+		dispatch( settingOptionsStore ).saveSetting(
 			'advanced',
 			'woocommerce_allow_tracking',
-			trackingValue,
-			{ save: true }
+			trackingValue
 		);
 	}
 );
@@ -433,11 +432,10 @@ const updateOnboardingProfileOption = fromPromise(
 );
 
 const updateBusinessLocation = ( countryAndState: string ) => {
-	return dispatch( settingOptionsStore ).updateSetting(
+	return dispatch( settingOptionsStore ).saveSetting(
 		'general',
 		'woocommerce_default_country',
-		countryAndState,
-		{ save: true }
+		countryAndState
 	);
 };
 
@@ -499,11 +497,10 @@ const updateBusinessInfo = fromPromise(
 			dispatch( coreStore ).saveEntityRecord( 'root', 'site', {
 				title: input.payload.storeName,
 			} ),
-			dispatch( settingOptionsStore ).updateSetting(
+			dispatch( settingOptionsStore ).saveSetting(
 				'general',
 				'woocommerce_default_country',
-				input.payload.storeLocation,
-				{ save: true }
+				input.payload.storeLocation
 			),
 		] );
 	}

--- a/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce/client/admin/client/core-profiler/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useMachine, useSelector } from '@xstate5/react';
 import { useMemo } from '@wordpress/element';
 import { resolveSelect, dispatch } from '@wordpress/data';
+import { store as coreStore, Settings } from '@wordpress/core-data';
 import {
 	updateQueryString,
 	getQuery,
@@ -23,7 +24,6 @@ import {
 } from '@woocommerce/navigation';
 import {
 	ExtensionList,
-	optionsStore,
 	COUNTRIES_STORE_NAME,
 	Country,
 	onboardingStore,
@@ -35,6 +35,7 @@ import {
 	ProfileItems,
 	CoreProfilerStep,
 	CoreProfilerCompletedSteps,
+	experimentalSettingOptionsStore as settingOptionsStore,
 } from '@woocommerce/data';
 import { initializeExPlat } from '@woocommerce/explat';
 import { CountryStateOption } from '@woocommerce/onboarding';
@@ -133,7 +134,10 @@ export type CoreProfilerStateMachineContext = {
 };
 
 const getAllowTrackingOption = fromPromise( async () =>
-	resolveSelect( optionsStore ).getOption( 'woocommerce_allow_tracking' )
+	resolveSelect( settingOptionsStore ).getSettingValue(
+		'advanced',
+		'woocommerce_allow_tracking'
+	)
 );
 
 const handleTrackingOption = assign( {
@@ -145,7 +149,10 @@ const handleTrackingOption = assign( {
 } );
 
 const getStoreNameOption = fromPromise( async () =>
-	resolveSelect( optionsStore ).getOption( 'blogname' )
+	resolveSelect( coreStore )
+		// @ts-expect-error getEntityRecord is not typed correctly in coreStore
+		.getEntityRecord( 'root', 'site' )
+		.then( ( site ) => ( site as Settings ).title )
 );
 
 const handleStoreNameOption = assign( {
@@ -166,7 +173,10 @@ const handleStoreNameOption = assign( {
 } );
 
 const getStoreCountryOption = fromPromise( async () =>
-	resolveSelect( optionsStore ).getOption( 'woocommerce_default_country' )
+	resolveSelect( settingOptionsStore ).getSettingValue(
+		'general',
+		'woocommerce_default_country'
+	)
 );
 
 const handleStoreCountryOption = assign( {
@@ -184,14 +194,6 @@ const handleStoreCountryOption = assign( {
 	},
 } );
 
-const preFetchOptions = fromPromise( async ( { input }: { input: string[] } ) =>
-	Promise.all( [
-		input.map( ( optionName: string ) =>
-			resolveSelect( optionsStore ).getOption( optionName )
-		),
-	] )
-);
-
 const getCountries = fromPromise( async () =>
 	resolveSelect( COUNTRIES_STORE_NAME ).getCountries()
 );
@@ -202,11 +204,11 @@ const handleCountries = assign( {
 	},
 } );
 
-const getOnboardingProfileOption = fromPromise( async () =>
-	resolveSelect( optionsStore ).getOption( 'woocommerce_onboarding_profile' )
+const getOnboardingProfileItems = fromPromise( async () =>
+	resolveSelect( onboardingStore ).getProfileItems()
 );
 
-const handleOnboardingProfileOption = assign( {
+const handleOnboardingProfileItems = assign( {
 	userProfile: ( {
 		event,
 	}: {
@@ -222,6 +224,7 @@ const handleOnboardingProfileOption = assign( {
 			selling_platforms: sellingPlatforms,
 			...rest
 		} = event.output;
+
 		return {
 			...rest,
 			businessChoice,
@@ -377,7 +380,8 @@ const recordUpdateTrackingOption = (
 const updateTrackingOption = fromPromise(
 	async ( { input }: { input: CoreProfilerStateMachineContext } ) => {
 		const prevValue =
-			( await resolveSelect( optionsStore ).getOption(
+			( await resolveSelect( settingOptionsStore ).getSettingValue(
+				'advanced',
 				'woocommerce_allow_tracking'
 			) ) === 'yes'
 				? 'yes'
@@ -405,9 +409,12 @@ const updateTrackingOption = fromPromise(
 		} );
 
 		const trackingValue = input.optInDataSharing ? 'yes' : 'no';
-		dispatch( optionsStore ).updateOptions( {
-			woocommerce_allow_tracking: trackingValue,
-		} );
+		dispatch( settingOptionsStore ).updateSetting(
+			'advanced',
+			'woocommerce_allow_tracking',
+			trackingValue,
+			{ save: true }
+		);
 	}
 );
 
@@ -426,9 +433,12 @@ const updateOnboardingProfileOption = fromPromise(
 );
 
 const updateBusinessLocation = ( countryAndState: string ) => {
-	return dispatch( optionsStore ).updateOptions( {
-		woocommerce_default_country: countryAndState,
-	} );
+	return dispatch( settingOptionsStore ).updateSetting(
+		'general',
+		'woocommerce_default_country',
+		countryAndState,
+		{ save: true }
+	);
 };
 
 const assignStoreLocation = assign( {
@@ -470,6 +480,7 @@ const updateBusinessInfo = fromPromise(
 	} ) => {
 		const { updateProfileItems, updateStoreCurrencyAndMeasurementUnits } =
 			dispatch( onboardingStore );
+
 		return Promise.all( [
 			updateStoreCurrencyAndMeasurementUnits(
 				getCountryCode( input.payload.storeLocation ) as string
@@ -485,10 +496,15 @@ const updateBusinessInfo = fromPromise(
 					store_email: input.payload.storeEmailAddress,
 				} ),
 			} ),
-			dispatch( optionsStore ).updateOptions( {
-				blogname: input.payload.storeName,
-				woocommerce_default_country: input.payload.storeLocation,
+			dispatch( coreStore ).saveEntityRecord( 'root', 'site', {
+				title: input.payload.storeName,
 			} ),
+			dispatch( settingOptionsStore ).updateSetting(
+				'general',
+				'woocommerce_default_country',
+				input.payload.storeLocation,
+				{ save: true }
+			),
 		] );
 	}
 );
@@ -659,7 +675,7 @@ const coreProfilerMachineActions = {
 	assignPluginsSelected,
 	assignUserProfile,
 	handleCountries,
-	handleOnboardingProfileOption,
+	handleOnboardingProfileItems,
 	assignOnboardingProfile,
 	assignCurrentUserEmail,
 	assignCurrentUser,
@@ -671,13 +687,12 @@ const coreProfilerMachineActions = {
 
 const coreProfilerMachineActors = {
 	preFetchGetPlugins,
-	preFetchOptions,
 	getAllowTrackingOption,
 	getStoreNameOption,
 	getStoreCountryOption,
 	getCountries,
 	getGeolocation,
-	getOnboardingProfileOption,
+	getOnboardingProfileItems,
 	getCurrentUserEmail,
 	getCurrentUser,
 	getPlugins,
@@ -801,14 +816,8 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						spawnChild( 'preFetchGetPlugins' ),
 						spawnChild( 'getCountries' ),
 						spawnChild( 'getCoreProfilerCompletedSteps' ),
-						spawnChild( 'preFetchOptions', {
-							id: 'prefetch-options',
-							input: [
-								'blogname',
-								'woocommerce_onboarding_profile',
-								'woocommerce_default_country',
-							],
-						} ),
+						spawnChild( 'getStoreCountryOption' ),
+						spawnChild( 'getStoreNameOption' ),
 					],
 					type: 'parallel',
 					states: {
@@ -844,12 +853,12 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							states: {
 								fetching: {
 									invoke: {
-										systemId: 'getOnboardingProfileOption',
-										src: 'getOnboardingProfileOption',
+										systemId: 'getOnboardingProfileItems',
+										src: 'getOnboardingProfileItems',
 										onDone: [
 											{
 												actions: [
-													'handleOnboardingProfileOption',
+													'handleOnboardingProfileItems',
 												],
 												target: 'done',
 											},
@@ -953,11 +962,11 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 			states: {
 				preUserProfile: {
 					invoke: {
-						src: 'getOnboardingProfileOption',
+						src: 'getOnboardingProfileItems',
 						onDone: [
 							{
 								actions: [
-									'handleOnboardingProfileOption',
+									'handleOnboardingProfileItems',
 									'assignOnboardingProfile',
 								],
 								target: 'userProfile',
@@ -1107,7 +1116,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							states: {
 								fetching: {
 									invoke: {
-										src: 'getOnboardingProfileOption',
+										src: 'getOnboardingProfileItems',
 										onDone: [
 											{
 												actions: [

--- a/plugins/woocommerce/client/admin/docs/features/core-profiler.md
+++ b/plugins/woocommerce/client/admin/docs/features/core-profiler.md
@@ -157,11 +157,11 @@ This is used to update `woocommerce_onboarding_profile`.
 
 This is used to update the store's currency and measurement units, which can be found under WooCommerce → Settings → General → Currency Options and WooCommerce → Settings → Products → Measurements.
 
-- `dispatch( settingOptionsStore ).updateSetting( 'general', 'woocommerce_default_country', countryCode, { save: true } )`
+- `dispatch( settingOptionsStore ).saveSetting( 'general', 'woocommerce_default_country', countryCode )`
 
 This is used to update the store's country.
 
-- `dispatch( settingOptionsStore ).updateSetting( 'advanced', 'woocommerce_allow_tracking', optInDataSharing, { save: true } )`
+- `dispatch( settingOptionsStore ).saveSetting( 'advanced', 'woocommerce_allow_tracking', optInDataSharing )`
 
 This is used to update the user's preference for usage tracking.
 

--- a/plugins/woocommerce/client/admin/docs/features/core-profiler.md
+++ b/plugins/woocommerce/client/admin/docs/features/core-profiler.md
@@ -109,6 +109,18 @@ As this information is not automatically updated, it would be best to refer dire
 
 The following WP Data API calls are used in the Core Profiler:
 
+- `resolveSelect( coreStore ).getEntityRecord( 'root', 'site' )`
+
+This is used to retrieve the store's name.
+
+- `resolveSelect( settingsOptionsStore ).getSettingValue( 'general', 'woocommerce_default_country' )`
+
+This is used to retrieve the store's country.
+
+- `resolveSelect( settingsOptionsStore ).getSettingValue( 'advanced', 'woocommerce_allow_tracking' )`
+
+This is used to retrieve whether the user has opted in to usage tracking.
+
 - `resolveSelect( onboardingStore ).getFreeExtensions()`
 
 This is used to retrieve the list of extensions that will be shown on the Extensions page. It makes an API call to the WooCommerce REST API, which will make a call to WooCommerce.com if permitted. Otherwise it retrieves the locally stored list of free extensions.
@@ -133,6 +145,10 @@ This is used to retrieve the URL that the browser should be redirected to in ord
 
 This is used to indicate to WooCommerce Admin that the Core Profiler has been completed, and this sets the Store's coming-soon mode to true. This hides the store pages from the public until the store is ready.
 
+- `resolveSelect( onboardingStore ).getProfileItems()`
+
+This is used to retrieve the profile items that have been completed by the user.
+
 - `dispatch( onboardingStore ).updateProfileItems( profileItems )`
 
 This is used to update `woocommerce_onboarding_profile`.
@@ -140,6 +156,14 @@ This is used to update `woocommerce_onboarding_profile`.
 - `dispatch( onboardingStore ).updateStoreCurrencyAndMeasurementUnits( countryCode )`
 
 This is used to update the store's currency and measurement units, which can be found under WooCommerce → Settings → General → Currency Options and WooCommerce → Settings → Products → Measurements.
+
+- `dispatch( settingOptionsStore ).updateSetting( 'general', 'woocommerce_default_country', countryCode, { save: true } )`
+
+This is used to update the store's country.
+
+- `dispatch( settingOptionsStore ).updateSetting( 'advanced', 'woocommerce_allow_tracking', optInDataSharing, { save: true } )`
+
+This is used to update the user's preference for usage tracking.
 
 ### Extensions Installation
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -433,21 +433,21 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
-			'completed'                     => array(
+			'completed'               => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'skipped'                       => array(
+			'skipped'                 => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'industry'                      => array(
+			'industry'                => array(
 				'type'              => 'array',
 				'description'       => __( 'Industry.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -458,103 +458,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'string',
 				),
 			),
-			'product_types'                 => array(
-				'type'              => 'array',
-				'description'       => __( 'Types of products sold.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'sanitize_callback' => 'wp_parse_slug_list',
-				'validate_callback' => 'rest_validate_request_arg',
-				'items'             => array(
-					'enum' => array_keys( OnboardingProducts::get_allowed_product_types() ),
-					'type' => 'string',
-				),
-			),
-			'product_count'                 => array(
-				'type'              => 'string',
-				'description'       => __( 'Number of products to be added.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'enum'              => array(
-					'0',
-					'1-10',
-					'11-100',
-					'101-1000',
-					'1000+',
-				),
-			),
-			'selling_venues'                => array(
-				'type'              => 'string',
-				'description'       => __( 'Other places the store is selling products.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'enum'              => array(
-					'no',
-					'other',
-					'brick-mortar',
-					'brick-mortar-other',
-					'other-woocommerce',
-				),
-			),
-			'number_employees'              => array(
-				'type'              => 'string',
-				'description'       => __( 'Number of employees of the store.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'enum'              => array(
-					'1',
-					'<10',
-					'10-50',
-					'50-250',
-					'+250',
-					'not specified',
-				),
-			),
-			'revenue'                       => array(
-				'type'              => 'string',
-				'description'       => __( 'Current annual revenue of the store.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'enum'              => array(
-					'none',
-					'up-to-2500',
-					'2500-10000',
-					'10000-50000',
-					'50000-250000',
-					'more-than-250000',
-					'rather-not-say',
-				),
-			),
-			'other_platform'                => array(
-				'type'              => 'string',
-				'description'       => __( 'Name of other platform used to sell.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'enum'              => array(
-					'shopify',
-					'bigcommerce',
-					'magento',
-					'wix',
-					'amazon',
-					'ebay',
-					'etsy',
-					'squarespace',
-					'other',
-				),
-			),
-			'other_platform_name'           => array(
-				'type'              => 'string',
-				'description'       => __( 'Name of other platform used to sell (not listed).', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'business_extensions'           => array(
+			'business_extensions'     => array(
 				'type'              => 'array',
 				'description'       => __( 'Extra business extensions to install.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -565,36 +469,14 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'string',
 				),
 			),
-			'theme'                         => array(
-				'type'              => 'string',
-				'description'       => __( 'Selected store theme.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'sanitize_callback' => 'sanitize_title_with_dashes',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'setup_client'                  => array(
-				'type'              => 'boolean',
-				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'wccom_connected'               => array(
-				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'is_agree_marketing'            => array(
+			'is_agree_marketing'      => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store agreed to receiving marketing contents from WooCommerce.com.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'store_email'                   => array(
+			'store_email'             => array(
 				'type'              => 'string',
 				'description'       => __( 'Store email address.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -602,45 +484,35 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'nullable'          => true,
 				'validate_callback' => array( __CLASS__, 'rest_validate_marketing_email' ),
 			),
-			'is_store_country_set'          => array(
+			'is_store_country_set'    => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store country is set via onboarding profiler.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'is_plugins_page_skipped'       => array(
+			'is_plugins_page_skipped' => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not plugins step in core profiler was skipped.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'core_profiler_completed_steps' => array(
-				'type'              => 'array',
-				'description'       => __( 'Completed steps in core profiler.', 'woocommerce' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'items'             => array(
-					'type' => 'object',
-				),
-			),
-			'business_choice'               => array(
+			'business_choice'         => array(
 				'type'        => 'string',
 				'description' => __( 'Business choice.', 'woocommerce' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
 				'nullable'    => true,
 			),
-			'selling_online_answer'         => array(
+			'selling_online_answer'   => array(
 				'type'        => 'string',
 				'description' => __( 'Selling online answer.', 'woocommerce' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
 				'nullable'    => true,
 			),
-			'selling_platforms'             => array(
+			'selling_platforms'       => array(
 				'type'        => array( 'array', 'null' ),
 				'description' => __( 'Selling platforms.', 'woocommerce' ),
 				'context'     => array( 'view' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/46817

The option API is deprecated and it doesn't provide the ability to validate the data before saving.

This PR transitions the core profiler away from using the options store, instead utilizing the new settings options store and other existing stores.

Additional changes:

- Removes legacy fields related to product types, product count, selling venues, etc as requested in issue acceptance criteria.
- Update core profiler documentation to reflect the changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fresh site
2. Open your browser's developer console > network tab
3. Go to the core profiler
4. Confirm that the required options are pre-loaded in intro step by verifying the following api requests are made and return 200.

- `/wc-analytics/settings/advanced/woocommerce_allow_tracking`
- `/wc-analytics/settings/general/woocommerce_default_country`
- `/wp-json/wc-admin/onboarding/profile`
- `/wp-json/wp/v2/settings`

5. Complete the core profiler steps and confirm the store name, country, onboarding profile and tracking settings are persisted in the database

- `wp option get blogname`
- `wp option get woocommerce_default_country`
- `wp option get woocommerce_allow_tracking`
- `wp option get woocommerce_onboarding_profile`

6. Go back to the core profiler and confirm the store name, country and tracking settings are pre-filled with the previously selected values.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Refactor core-profiler to remove the need for option store and update the onboarding  API

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
