### PR TITLE
Add unit tests for wc_add_aria_label_to_pagination_numbers function

### DIFF
--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -159,7 +159,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		// Include a payment gateway that supports "pay button".
 		add_filter(
 			'woocommerce_payment_gateways',
-			function( $gateways ) {
+			function ( $gateways ) {
 				$gateways[] = 'WC_Mock_Payment_Gateway';
 
 				return $gateways;
@@ -182,18 +182,20 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	}
 
 	public function test_hidden_field() {
-		$actual_html = woocommerce_form_field('test',
-		array(
-			'type' => 'hidden',
-			'id' => 'test_field',
-			'input_class' => array( 'test-field' ),
-			'custom_attributes' => array( 'data-total' => '10' ),
-			'return' => true
-		), 'test value');
+		$actual_html   = woocommerce_form_field(
+			'test',
+			array(
+				'type'              => 'hidden',
+				'id'                => 'test_field',
+				'input_class'       => array( 'test-field' ),
+				'custom_attributes' => array( 'data-total' => '10' ),
+				'return'            => true,
+			),
+			'test value'
+		);
 		$expected_html = '<p class="form-row " id="test_field_field" data-priority=""><span class="woocommerce-input-wrapper"><input type="hidden" class="input-hidden test-field" name="test" id="test_field" value="test value" data-total="10" /></span></p>';
 
 		$this->assertEquals( $expected_html, $actual_html );
-
 	}
 
 	/**
@@ -276,5 +278,65 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$expected_html = '<p class="form-row validate-required" id="test_field" data-priority=""><span class="woocommerce-input-wrapper"><label class="checkbox " ><input type="checkbox" name="test" id="test" value="1" class="input-checkbox "  checked=\'checked\' aria-required="true" /> Checkbox&nbsp;<span class="required" aria-hidden="true">*</span></label></span></p>';
 
 		$this->assertEquals( $expected_html, $actual_html );
+	}
+
+	/**
+	 * Test wc_add_aria_label_to_pagination_numbers with basic pagination links
+	 */
+	public function test_wc_add_aria_label_to_pagination_numbers_basic() {
+		$input_html = '<span class="page-numbers current">1</span> <a class="page-numbers" href="#">2</a>';
+		$args       = array( 'current' => 1 );
+
+		$output = wc_add_aria_label_to_pagination_numbers( $input_html, $args );
+
+		$this->assertStringContainsString( 'aria-label="Page 1"', $output );
+		$this->assertStringContainsString( 'aria-label="Page 2"', $output );
+	}
+
+	/**
+	 * Test wc_add_aria_label_to_pagination_numbers with prev/next navigation
+	 */
+	public function test_wc_add_aria_label_to_pagination_numbers_with_navigation() {
+		$input_html = '<a class="prev page-numbers" href="#">Previous</a> ' .
+					'<span class="page-numbers current">2</span> ' .
+					'<a class="next page-numbers" href="#">Next</a>';
+		$args       = array( 'current' => 2 );
+
+		$output = wc_add_aria_label_to_pagination_numbers( $input_html, $args );
+
+		$this->assertStringNotContainsString( 'aria-label="Page Previous"', $output );
+		$this->assertStringNotContainsString( 'aria-label="Page Next"', $output );
+		$this->assertStringContainsString( 'aria-label="Page 2"', $output );
+	}
+
+	/**
+	 * Test wc_add_aria_label_to_pagination_numbers with non-standard elements
+	 */
+	public function test_wc_add_aria_label_to_pagination_numbers_with_non_standard_elements() {
+		$input_html = '<div class="page-numbers">1</div> ' .
+					'<span class="page-numbers current">2</span> ' .
+					'<p class="page-numbers">3</p>';
+		$args       = array( 'current' => 2 );
+
+		$output = wc_add_aria_label_to_pagination_numbers( $input_html, $args );
+
+		$this->assertStringNotContainsString( '<div class="page-numbers" aria-label="Page 1">', $output );
+		$this->assertStringContainsString( 'aria-label="Page 2"', $output );
+		$this->assertStringNotContainsString( '<p class="page-numbers" aria-label="Page 3">', $output );
+	}
+
+	/**
+	 * Test wc_add_aria_label_to_pagination_numbers with malformed arguments
+	 */
+	public function test_wc_add_aria_label_to_pagination_numbers_malformed_args() {
+		$input_html     = '<span class="page-numbers current">1</span> <a class="page-numbers" href="#">2</a>';
+		$malformed_args = array( 'current' => 'a' );
+
+		$output = wc_add_aria_label_to_pagination_numbers( $input_html, $malformed_args );
+
+		// When args['current'] is not a valid number, the function should gracefully handle it
+		// by defaulting to page 0 and still add appropriate aria-labels to maintain accessibility.
+		$this->assertStringContainsString( 'aria-label="Page 0"', $output );
+		$this->assertStringContainsString( 'aria-label="Page 0"', $output );
 	}
 }


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR implement tests for various scenarios including basic pagination, navigation, and malformed arguments.

This is a follow-up on this https://github.com/woocommerce/woocommerce/pull/56049.

Closes https://github.com/woocommerce/woocommerce/issues/56078.




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Run `pnpm --filter="@woocommerce/plugin-woocommerce" env:start`
3. Run ` pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env --filter=WC_Tests_Template_Functions`
4. Ensure that unit tests pass
5. Remove the change made in https://github.com/woocommerce/woocommerce/pull/56049
6. Run ` pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env --filter=WC_Tests_Template_Functions`
7. Ensure that the test fails (this means that unit test covers a real potential regression).


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Add unit tests for wc_add_aria_label_to_pagination_numbers function

</details>
