### PR TITLE
[Product Collection]: Refactor InheritQueryControl and FilterableControl to use 'default' and 'custom' values for state management

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/use-page-context-control.tsx
+++ b/plugins/woocommerce-blocks/assets/js/blocks/product-collection/edit/inspector-controls/use-page-context-control.tsx
@@ -80,28 +80,31 @@ const InheritQueryControl = ( {
 				isBlock
 				label={ label }
 				help={ inherit ? defaultInheritHelpText : customHelpText }
-				value={ !! inherit }
-				onChange={ ( value: boolean ) => {
-					if ( value ) {
+				value={ !! inherit ? 'default' : 'custom' }
+				onChange={ ( value: 'default' | 'custom' ) => {
+					if ( value === 'default' ) {
 						// If the inherit is enabled, we want to reset the query to the default.
 						setQueryAttribute( {
 							...DEFAULT_QUERY,
-							inherit: value,
+							inherit: true,
 						} );
 					} else {
 						// If the inherit is disabled, we want to reset the query to the previous query before the inherit was enabled.
 						setQueryAttribute( {
 							...DEFAULT_QUERY,
 							...queryObjectBeforeInheritEnabled,
-							inherit: value,
+							inherit: false,
 						} );
 					}
 					trackInteraction( CoreFilterNames.INHERIT );
 				} }
 			>
-				<ToggleGroupControlOption value label={ defaultOptionLabel } />
 				<ToggleGroupControlOption
-					value={ false }
+					value="default"
+					label={ defaultOptionLabel }
+				/>
+				<ToggleGroupControlOption
+					value="custom"
 					label={ customOptionLabel }
 				/>
 			</ToggleGroupControl>
@@ -135,17 +138,20 @@ const FilterableControl = ( {
 				isBlock
 				label={ label }
 				help={ filterable ? defaultFilterableHelpText : customHelpText }
-				value={ !! filterable }
-				onChange={ ( value: boolean ) => {
+				value={ !! filterable ? 'default' : 'custom' }
+				onChange={ ( value: 'default' | 'custom' ) => {
 					setQueryAttribute( {
-						filterable: value,
+						filterable: value === 'default',
 					} );
 					trackInteraction( CoreFilterNames.FILTERABLE );
 				} }
 			>
-				<ToggleGroupControlOption value label={ defaultOptionLabel } />
 				<ToggleGroupControlOption
-					value={ false }
+					value="default"
+					label={ defaultOptionLabel }
+				/>
+				<ToggleGroupControlOption
+					value="custom"
 					label={ customOptionLabel }
 				/>
 			</ToggleGroupControl>

--- a/plugins/woocommerce/changelog/56582-56568-wordpress-68-product-collection---query-type-setting-ui-issue
+++ b/plugins/woocommerce/changelog/56582-56568-wordpress-68-product-collection---query-type-setting-ui-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix: Product Collection -  ensures that the query type indicator is displayed correctly in the Query Loop block.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Based on https://github.com/WordPress/gutenberg/pull/65877#pullrequestreview-2348292886 ToggleGroupControl component doesn't support boolean. So, inspired by https://github.com/WordPress/gutenberg/pull/65877, I used `default` and `custom` for the state management for the `inherit booelan value.

Closes #56568.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/3076ab84-e644-4922-b4b7-922d0cf0ae22" /> | <video src="https://github.com/user-attachments/assets/895cf05e-9269-4f1b-9da1-5fa3a31a8671" /> |






<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Ensure that you're running WordPress 6.8.

1. Open the Product Catalog Template.
2. Get focus on the Product Collection.
3. Open the block settings.
4. Switch from default and custom option for the Query Type setting.
5. Save.
6. Ensure that the frontend works as expected.
7. Create a new post
8. Add the Filters block
9. Add the Product Collection
10. Repeat 3-6.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix: Product Collection -  ensures that the query type indicator is displayed correctly in the Query Loop block.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
