### PR TITLE
[e2e-tests] Introduce `wpCoreVersion` worker fixture for Blocks tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-add-wp-core-version-fixture
+++ b/plugins/woocommerce/changelog/e2e-add-wp-core-version-fixture
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Introduce `wpCoreVersion` worker fixture for handling backwards compatibilty in Blocks E2E tests.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -230,6 +230,7 @@ test.describe( `${ blockData.name } Block `, () => {
 	test( `is still available after resetting a modified WC template`, async ( {
 		admin,
 		editor,
+		wpCoreVersion,
 	} ) => {
 		await admin.visitSiteEditor( {
 			postId: `woocommerce/woocommerce//single-product`,
@@ -271,9 +272,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		const editButton = editor.page.getByRole( 'menuitem', {
 			name: 'Edit',
 		} );
-
-		// Keep WP v6.7 compatibility.
-		if ( await editButton.isHidden() ) {
+		if ( wpCoreVersion >= 6.8 ) {
 			await actionsButton.click();
 		}
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -543,7 +543,10 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 			pageObject,
 			editor,
 			page,
+			wpCoreVersion,
 		} ) => {
+			test.skip( wpCoreVersion <= 6.6, 'Skipping on WP 6.6 and below' );
+
 			await pageObject.createNewPostAndInsertBlock();
 
 			await expect( pageObject.products ).toHaveCount( 9 );
@@ -599,7 +602,10 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 			pageObject,
 			editor,
 			page,
+			wpCoreVersion,
 		} ) => {
+			test.skip( wpCoreVersion <= 6.6, 'Skipping on WP 6.6 and below' );
+
 			await pageObject.createNewPostAndInsertBlock();
 
 			await expect( pageObject.products ).toHaveCount( 9 );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -431,14 +431,19 @@ test.describe( 'Product Collection', () => {
 			page,
 			pageObject,
 			editor,
+			wpCoreVersion,
 		} ) => {
 			await admin.visitSiteEditor( { path: '/wp_template' } );
 
 			await page
-				.getByRole( 'button', { name: 'Add Template' } )
-				// Keep WP v6.7 compatibility.
-				.or( page.getByRole( 'button', { name: 'Add New Template' } ) )
+				.getByRole( 'button', {
+					name:
+						wpCoreVersion >= 6.8
+							? 'Add Template'
+							: 'Add New Template',
+				} )
 				.click();
+
 			await page
 				.getByRole( 'button', { name: 'Single Item: Product' } )
 				.click();
@@ -859,6 +864,7 @@ test.describe( 'Product Collection', () => {
 			admin,
 			page,
 			editor,
+			wpCoreVersion,
 		} ) => {
 			await wpCLI(
 				'option update woocommerce_default_catalog_orderby price'
@@ -873,10 +879,14 @@ test.describe( 'Product Collection', () => {
 			await admin.visitSiteEditor( { path: '/wp_template' } );
 
 			await page
-				.getByRole( 'button', { name: 'Add Template' } )
-				// Keep WP v6.7 compatibility.
-				.or( page.getByRole( 'button', { name: 'Add New Template' } ) )
+				.getByRole( 'button', {
+					name:
+						wpCoreVersion >= 6.8
+							? 'Add Template'
+							: 'Add New Template',
+				} )
 				.click();
+
 			await page
 				.getByRole( 'button', { name: 'Products by Category' } )
 				.click();
@@ -901,6 +911,7 @@ test.describe( 'Product Collection', () => {
 			admin,
 			page,
 			editor,
+			wpCoreVersion,
 		} ) => {
 			await wpCLI(
 				'option update woocommerce_default_catalog_orderby price'
@@ -911,10 +922,14 @@ test.describe( 'Product Collection', () => {
 			await admin.visitSiteEditor( { path: '/wp_template' } );
 
 			await page
-				.getByRole( 'button', { name: 'Add Template' } )
-				// Keep WP v6.7 compatibility.
-				.or( page.getByRole( 'button', { name: 'Add New Template' } ) )
+				.getByRole( 'button', {
+					name:
+						wpCoreVersion >= 6.8
+							? 'Add Template'
+							: 'Add New Template',
+				} )
 				.click();
+
 			await page
 				.getByRole( 'button', { name: 'Products by Tag' } )
 				.click();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
@@ -76,7 +76,10 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 
 		test( 'filters the list of products by selecting an attribute', async ( {
 			page,
+			wpCoreVersion,
 		} ) => {
+			test.skip( wpCoreVersion <= 6.6, 'Skipping on WP 6.6 and below' );
+
 			await page.goto( '/shop' );
 
 			const grayCheckbox = page.getByText( 'Gray' );
@@ -92,7 +95,10 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 
 		test( 'clear button appears after a filter is applied', async ( {
 			page,
+			wpCoreVersion,
 		} ) => {
+			test.skip( wpCoreVersion <= 6.6, 'Skipping on WP 6.6 and below' );
+
 			await page.goto( '/shop' );
 
 			const grayCheckbox = page.getByText( 'Gray' );
@@ -110,7 +116,10 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 
 		test( 'clear button hides after deselecting all filters', async ( {
 			page,
+			wpCoreVersion,
 		} ) => {
+			test.skip( wpCoreVersion <= 6.6, 'Skipping on WP 6.6 and below' );
+
 			await page.goto( '/shop' );
 
 			const grayCheckbox = page.getByText( 'Gray' );
@@ -130,7 +139,10 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 
 		test( 'filters are cleared after clear button is clicked', async ( {
 			page,
+			wpCoreVersion,
 		} ) => {
+			test.skip( wpCoreVersion <= 6.6, 'Skipping on WP 6.6 and below' );
+
 			await page.goto( '/shop' );
 
 			const grayCheckbox = page.getByText( 'Gray' );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -8,6 +8,7 @@ test.describe( 'Single Product template', () => {
 		admin,
 		editor,
 		page,
+		wpCoreVersion,
 	} ) => {
 		const testData = {
 			productName: 'Belt',
@@ -20,11 +21,14 @@ test.describe( 'Single Product template', () => {
 
 		// Create the specific product template.
 		await admin.visitSiteEditor( { path: `/${ testData.templateType }` } );
+
 		await page
-			.getByRole( 'button', { name: 'Add Template' } )
-			// Keep WP v6.7 compatibility.
-			.or( page.getByRole( 'button', { name: 'Add New Template' } ) )
+			.getByRole( 'button', {
+				name:
+					wpCoreVersion >= 6.8 ? 'Add Template' : 'Add New Template',
+			} )
 			.click();
+
 		await page
 			.getByRole( 'button', { name: 'Single item: Product' } )
 			.click();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -13,6 +13,11 @@ import {
 import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
 
 test.describe( 'Template customization', () => {
+	test.skip(
+		( { wpCoreVersion } ) => wpCoreVersion <= 6.6,
+		'Skipping on WP 6.6 and below'
+	);
+
 	CUSTOMIZABLE_WC_TEMPLATES.forEach( ( testData ) => {
 		const userText = `Hello World in the ${ testData.templateName } template`;
 		const fallbackTemplateUserText = `Hello World in the fallback ${ testData.templateName } template`;

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme_with_templates.spec.ts
@@ -13,6 +13,11 @@ import {
 import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
 
 test.describe( 'Template customization', () => {
+	test.skip(
+		( { wpCoreVersion } ) => wpCoreVersion <= 6.6,
+		'Skipping on WP 6.6 and below'
+	);
+
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( BLOCK_THEME_WITH_TEMPLATES_SLUG );
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
@@ -42,6 +42,11 @@ const test = base.extend< { testUtils: TestUtils } >( {
 } );
 
 test.describe( 'Template part customization', () => {
+	test.skip(
+		( { wpCoreVersion } ) => wpCoreVersion <= 6.6,
+		'Skipping on WP 6.6 and below'
+	);
+
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme(
 			CLASSIC_CHILD_THEME_WITH_BLOCK_TEMPLATE_PARTS_SLUG

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
@@ -43,6 +43,11 @@ const test = base.extend< { testUtils: TestUtils } >( {
 } );
 
 test.describe( 'Template part customization', () => {
+	test.skip(
+		( { wpCoreVersion } ) => wpCoreVersion <= 6.6,
+		'Skipping on WP 6.6 and below'
+	);
+
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme(
 			CLASSIC_CHILD_THEME_WITH_BLOCK_TEMPLATE_PARTS_SUPPORT_SLUG

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
@@ -1,9 +1,33 @@
 /**
  * External dependencies
  */
-import { Admin as CoreAdmin } from '@wordpress/e2e-test-utils-playwright';
+import { Page } from '@playwright/test';
+import {
+	Admin as CoreAdmin,
+	PageUtils,
+	Editor,
+} from '@wordpress/e2e-test-utils-playwright';
+
+type AdminConstructorProps = {
+	page: Page;
+	pageUtils: PageUtils;
+	editor: Editor;
+	wpCoreVersion: number;
+};
 
 export class Admin extends CoreAdmin {
+	wpCoreVersion: number;
+
+	constructor( {
+		page,
+		pageUtils,
+		editor,
+		wpCoreVersion,
+	}: AdminConstructorProps ) {
+		super( { page, pageUtils, editor } );
+		this.wpCoreVersion = wpCoreVersion;
+	}
+
 	async visitWidgetEditor() {
 		await this.page.goto( '/wp-admin/widgets.php' );
 		await this.page
@@ -16,17 +40,11 @@ export class Admin extends CoreAdmin {
 		await this.page.goto( '/wp-admin/site-editor.php?postType=wp_block' );
 		await this.page.getByRole( 'button', { name: 'Patterns' } ).click();
 		await this.page
-			.getByLabel( 'Add Pattern' )
-			// Keep WP v6.7 compatibility.
-			.or( this.page.getByLabel( 'Add New Pattern' ) )
-			.click();
-		await this.page
-			.getByRole( 'menuitem', { name: 'Add Pattern' } )
-			// Keep WP v6.7 compatibility.
-			.or(
-				this.page.getByRole( 'menuitem', { name: 'Add New Pattern' } )
+			.getByLabel(
+				this.wpCoreVersion >= 6.8 ? 'Add Pattern' : 'Add New Pattern'
 			)
 			.click();
+
 		await this.page.getByLabel( 'Name' ).fill( name );
 
 		if ( ! synced ) {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
@@ -39,10 +39,20 @@ export class Admin extends CoreAdmin {
 	async createNewPattern( name: string, synced = true ) {
 		await this.page.goto( '/wp-admin/site-editor.php?postType=wp_block' );
 		await this.page.getByRole( 'button', { name: 'Patterns' } ).click();
+
 		await this.page
 			.getByLabel(
 				this.wpCoreVersion >= 6.8 ? 'Add Pattern' : 'Add New Pattern'
 			)
+			.click();
+
+		await this.page
+			.getByRole( 'menuitem', {
+				name:
+					this.wpCoreVersion >= 6.8
+						? 'Add Pattern'
+						: 'Add New Pattern',
+			} )
 			.click();
 
 		await this.page.getByLabel( 'Name' ).fill( name );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -1,12 +1,25 @@
 /**
  * External dependencies
  */
+import { Page } from '@playwright/test';
 import {
 	Editor as CoreEditor,
 	expect,
 } from '@wordpress/e2e-test-utils-playwright';
 
+type EditorConstructorProps = {
+	page: Page;
+	wpCoreVersion: number;
+};
+
 export class Editor extends CoreEditor {
+	wpCoreVersion: number;
+
+	constructor( { page, wpCoreVersion }: EditorConstructorProps ) {
+		super( { page } );
+		this.wpCoreVersion = wpCoreVersion;
+	}
+
 	async getBlockByName( name: string ) {
 		const blockSelector = `[data-type="${ name }"]`;
 		const canvasLocator = this.page
@@ -36,17 +49,13 @@ export class Editor extends CoreEditor {
 	 * Opens the global inserter.
 	 */
 	async openGlobalBlockInserter() {
-		const toggleButton = this.page
-			.getByRole( 'button', {
-				name: 'Block Inserter',
-				exact: true,
-			} )
-			// Keep WP v6.7 compatibility.
-			.or(
-				this.page.getByRole( 'button', {
-					name: 'Toggle block inserter',
-				} )
-			);
+		const toggleButton = this.page.getByRole( 'button', {
+			name:
+				this.wpCoreVersion >= 6.8
+					? 'Block Inserter'
+					: 'Toggle block inserter',
+			exact: true,
+		} );
 
 		const isOpen =
 			( await toggleButton.getAttribute( 'aria-pressed' ) ) === 'true';

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
@@ -115,13 +115,14 @@ const test = base.extend<
 	},
 	{
 		requestUtils: RequestUtils;
+		wpCoreVersion: number;
 	}
 >( {
-	admin: async ( { page, pageUtils, editor }, use ) => {
-		await use( new Admin( { page, pageUtils, editor } ) );
+	admin: async ( { page, pageUtils, editor, wpCoreVersion }, use ) => {
+		await use( new Admin( { page, pageUtils, editor, wpCoreVersion } ) );
 	},
-	editor: async ( { page }, use ) => {
-		await use( new Editor( { page } ) );
+	editor: async ( { page, wpCoreVersion }, use ) => {
+		await use( new Editor( { page, wpCoreVersion } ) );
 	},
 	page: async ( { page }, use ) => {
 		page.on( 'console', observeConsoleLogging );
@@ -167,6 +168,22 @@ const test = base.extend<
 			await use( requestUtils );
 		},
 		{ scope: 'worker', auto: true },
+	],
+	wpCoreVersion: [
+		async ( {}, use ) => {
+			const output = await wpCLI( 'core version' );
+			const version = output.stdout.trim().split( '\n' ).at( -1 ) ?? '';
+			const parsedVersion = Number.parseFloat( version );
+
+			if ( Number.isNaN( parsedVersion ) ) {
+				throw new Error(
+					`Failed to parse WordPress version: ${ version }`
+				);
+			}
+
+			await use( parsedVersion );
+		},
+		{ scope: 'worker' },
 	],
 } );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/test.ts
@@ -173,6 +173,9 @@ const test = base.extend<
 		async ( {}, use ) => {
 			const output = await wpCLI( 'core version' );
 			const version = output.stdout.trim().split( '\n' ).at( -1 ) ?? '';
+
+			// We can parse this as a float because WP never updates the minor
+			// version over x.9.x. E.g., after 6.9.x, it will be 7.0.x.
 			const parsedVersion = Number.parseFloat( version );
 
 			if ( Number.isNaN( parsedVersion ) ) {


### PR DESCRIPTION
## What?

This PR introduces a new worker-scoped fixture wpCoreVersion that detects the WordPress version being tested against and allows tests to adapt their behavior for backwards compatibility when functionality differs across WordPress versions.

> [!NOTE]
> This PR also skips some tests as agreed in p1742489145338069/1742483773.434129-slack-C02FL3X7KR6

### Key features:

- Integrated with the existing test environment (can be shared with any test and fixture).
- The version check/request happens only once per worker process (no extra delays in execution).
- Version is parsed to a number (e.g., "6.4.1" → 6.4) for simpler numeric comparisons.

### Example usage:

**Conditional actions**
```js
test('some feature', async ({ wpCoreVersion, page }) => {
    if (wpCoreVersion < 6.8) {
        // Handle pre-6.8 behavior
    } else {
        // Handle current behavior
    }
});
```

**Skipping tests**
```js
test('some feature', async ({ wpCoreVersion, page }) => {
    test.skip(wpCoreVersion < 6.8, 'This test requires WordPress 6.8 or higher');
    
    // Test code that only works in WP 6.8+
    await page.click('.new-feature-button');
});

// You can also skip at the describe level
test.describe('some block', () => {
    test.skip(({ wpCoreVersion }) => wpCoreVersion < 6.8, 'These tests require WordPress 6.8 or higher');
    
    test('feature A', async ({ page }) => {
        // Test code
    });

    test('feature B', async ({ page }) => {
        // Test code
    });
});
```

## How to test

All Blocks E2E tests should be passing for WP 6.6, 6.7 and 6.8.