### PR TITLE
[Payments NOX] Record suggestion attachment

### DIFF
--- a/packages/js/data/src/payment-settings/actions.ts
+++ b/packages/js/data/src/payment-settings/actions.ts
@@ -82,6 +82,20 @@ export function* togglePaymentGateway(
 	}
 }
 
+export function* attachPaymentExtensionSuggestion( url: string ) {
+	try {
+		// Use apiFetch for the AJAX request
+		const result: { success: boolean } = yield apiFetch( {
+			url,
+			method: 'POST',
+		} );
+
+		return result;
+	} catch ( error ) {
+		throw error;
+	}
+}
+
 export function* hidePaymentExtensionSuggestion( url: string ) {
 	try {
 		// Use apiFetch for the AJAX request
@@ -131,6 +145,7 @@ export type Actions =
 	| ReturnType< typeof getPaymentProvidersSuccess >
 	| ReturnType< typeof getPaymentProvidersError >
 	| ReturnType< typeof togglePaymentGateway >
+	| ReturnType< typeof attachPaymentExtensionSuggestion >
 	| ReturnType< typeof hidePaymentExtensionSuggestion >
 	| ReturnType< typeof updateProviderOrdering >
 	| ReturnType< typeof setIsWooPayEligible >;

--- a/packages/js/data/src/payment-settings/types.ts
+++ b/packages/js/data/src/payment-settings/types.ts
@@ -150,6 +150,7 @@ export type SuggestedPaymentExtension = {
 	tags: string[];
 	plugin: PluginData;
 	links: PaymentGatewayLink[];
+	_links?: Record< string, LinkData >;
 };
 
 export type SuggestedPaymentExtensionCategory = {

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/incentive-banner.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-banner/incentive-banner.tsx
@@ -53,7 +53,8 @@ interface IncentiveBannerProps {
 	setupPlugin: (
 		id: string,
 		slug: string,
-		onboardingUrl: string | null
+		onboardingUrl: string | null,
+		attachUrl: string | null
 	) => void;
 }
 
@@ -102,7 +103,14 @@ export const IncentiveBanner = ( {
 		onAccept( incentive.promo_id );
 		onDismiss( incentive._links.dismiss.href, context ); // We also dismiss the incentive when it is accepted.
 		setIsSubmitted( true );
-		setupPlugin( provider.id, provider.plugin.slug, onboardingUrl );
+		setupPlugin(
+			provider.id,
+			provider.plugin.slug,
+			onboardingUrl,
+			provider.plugin.status === 'not_installed'
+				? provider._links?.attach?.href ?? null
+				: null
+		);
 		setIsBusy( false );
 	};
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-modal/incentive-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/incentive-modal/incentive-modal.tsx
@@ -59,7 +59,8 @@ interface IncentiveModalProps {
 	setupPlugin: (
 		id: string,
 		slug: string,
-		onboardingUrl: string | null
+		onboardingUrl: string | null,
+		attachUrl: string | null
 	) => void;
 }
 
@@ -114,12 +115,19 @@ export const IncentiveModal = ( {
 			display_context: context,
 		} );
 
-		// Accept the incentive and setup the plugin.
+		// Accept the incentive and set up the plugin.
 		setIsBusy( true );
 		onAccept( incentive.promo_id );
 		onDismiss( incentive._links.dismiss.href, context ); // We also dismiss the incentive when it is accepted.
 		handleClose(); // Close the modal.
-		setupPlugin( provider.id, provider.plugin.slug, onboardingUrl );
+		setupPlugin(
+			provider.id,
+			provider.plugin.slug,
+			onboardingUrl,
+			provider.plugin.status === 'not_installed'
+				? provider._links?.attach?.href ?? null
+				: null
+		);
 		setIsBusy( false );
 	};
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -37,7 +37,8 @@ interface OtherPaymentGatewaysProps {
 	setupPlugin: (
 		id: string,
 		slug: string,
-		onboardingUrl: string | null
+		onboardingUrl: string | null,
+		attachUrl: string | null
 	) => void;
 	/**
 	 * Indicates whether the suggestions are still being fetched.
@@ -246,7 +247,17 @@ export const OtherPaymentGateways = ( {
 															extension.id,
 															extension.plugin
 																.slug,
-															null // Suggested gateways won't have an onboarding URL.
+															null, // Suggested gateways won't have an onboarding URL.
+															// Only provide the attach link if not already installed.
+															extension.plugin
+																.status ===
+																'not_installed'
+																? extension
+																		._links
+																		?.attach
+																		?.href ??
+																		null
+																: null
 														)
 													}
 													isBusy={

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-extension-suggestion-list-item/payment-extension-suggestion-list-item.tsx
@@ -40,7 +40,8 @@ type PaymentExtensionSuggestionListItemProps = {
 	setupPlugin: (
 		id: string,
 		slug: string,
-		onboardingUrl: string | null
+		onboardingUrl: string | null,
+		attachUrl: string | null
 	) => void;
 	/**
 	 * Indicates whether the plugin is already installed.
@@ -152,7 +153,10 @@ export const PaymentExtensionSuggestionListItem = ( {
 									extension.id,
 									extension.plugin.slug,
 									extension.onboarding?._links.onboard.href ??
-										null
+										null,
+									pluginInstalled
+										? null
+										: extension._links?.attach?.href ?? null
 								);
 							} }
 							isBusy={ installingPlugin === extension.id }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.tsx
@@ -41,7 +41,8 @@ interface PaymentGatewayListProps {
 	setupPlugin: (
 		id: string,
 		slug: string,
-		onboardingUrl: string | null
+		onboardingUrl: string | null,
+		attachUrl: string | null
 	) => void;
 	/**
 	 * Callback to handle accepting an incentive. Receives the incentive ID as a parameter.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
@@ -34,7 +34,8 @@ interface PaymentGatewaysProps {
 	setupPlugin: (
 		id: string,
 		slug: string,
-		onboardingUrl: string | null
+		onboardingUrl: string | null,
+		attachUrl: string | null
 	) => void;
 	acceptIncentive: ( id: string ) => void;
 	updateOrdering: ( providers: PaymentProvider[] ) => void;

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -50,7 +50,8 @@ export const SettingsPaymentsMain = () => {
 		PaymentProvider[] | null
 	>( null );
 	const { installAndActivatePlugins } = useDispatch( pluginsStore );
-	const { updateProviderOrdering } = useDispatch( paymentSettingsStore );
+	const { updateProviderOrdering, attachPaymentExtensionSuggestion } =
+		useDispatch( paymentSettingsStore );
 	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
 	const [
 		postSandboxAccountSetupModalVisible,
@@ -267,7 +268,12 @@ export const SettingsPaymentsMain = () => {
 	}, [ suggestions, providers, isFetching ] );
 
 	const setupPlugin = useCallback(
-		( id: string, slug: string, onboardingUrl: string | null ) => {
+		(
+			id: string,
+			slug: string,
+			onboardingUrl: string | null,
+			attachUrl: string | null
+		) => {
 			if ( installingPlugin ) {
 				return;
 			}
@@ -284,6 +290,10 @@ export const SettingsPaymentsMain = () => {
 			} );
 			installAndActivatePlugins( [ slug ] )
 				.then( async ( response ) => {
+					if ( attachUrl ) {
+						attachPaymentExtensionSuggestion( attachUrl );
+					}
+
 					createNoticesFromResponse( response );
 					invalidateResolutionForStoreSelector(
 						'getPaymentProviders'

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
@@ -398,6 +398,71 @@ class PaymentProviders {
 	}
 
 	/**
+	 * Attach a payment extension suggestion.
+	 *
+	 * @param string $id The ID of the payment extension suggestion to attach.
+	 *
+	 * @return bool True if the suggestion was successfully marked as attached, false otherwise.
+	 * @throws Exception If the suggestion ID is invalid.
+	 */
+	public function attach_extension_suggestion( string $id ): bool {
+		// We may receive a suggestion ID that is actually an order map ID used in the settings page providers list.
+		// Extract the suggestion ID from the order map ID.
+		if ( $this->is_suggestion_order_map_id( $id ) ) {
+			$id = $this->get_suggestion_id_from_order_map_id( $id );
+		}
+
+		$suggestion = $this->get_extension_suggestion_by_id( $id );
+		if ( is_null( $suggestion ) ) {
+			throw new Exception( esc_html__( 'Invalid suggestion ID.', 'woocommerce' ) );
+		}
+
+		$payments_nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY, array() );
+		if ( empty( $payments_nox_profile ) ) {
+			$payments_nox_profile = array();
+		} else {
+			$payments_nox_profile = maybe_unserialize( $payments_nox_profile );
+		}
+
+		// Mark the suggestion as attached.
+		if ( empty( $payments_nox_profile['suggestions'] ) ) {
+			$payments_nox_profile['suggestions'] = array();
+		}
+		if ( empty( $payments_nox_profile['suggestions'][ $id ] ) ) {
+			$payments_nox_profile['suggestions'][ $id ] = array();
+		}
+		if ( empty( $payments_nox_profile['suggestions'][ $id ]['attached'] ) ) {
+			$payments_nox_profile['suggestions'][ $id ]['attached'] = array();
+		}
+		// Check if it is already marked as attached.
+		if ( ! empty( $payments_nox_profile['suggestions'][ $id ]['attached']['timestamp'] ) ) {
+			return true;
+		}
+		$payments_nox_profile['suggestions'][ $id ]['attached']['timestamp'] = time();
+
+		$result = update_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY, $payments_nox_profile, false );
+		// Since we already check if the suggestion is already attached, we should not get a false result
+		// for trying to update with the same value.
+		// False means the update failed and the suggestion is not marked as attached.
+		if ( false === $result ) {
+			return false;
+		}
+
+		// Handle custom attachment logic per-provider.
+		switch ( $id ) {
+			case ExtensionSuggestions::PAYPAL_FULL_STACK:
+			case ExtensionSuggestions::PAYPAL_WALLET:
+				// Set an option to inform the extension.
+				update_option( 'woocommerce_paypal_branded', 'yes', false );
+				break;
+			default:
+				break;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Hide a payment extension suggestion.
 	 *
 	 * @param string $id The ID of the payment extension suggestion to hide.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
@@ -400,6 +400,10 @@ class PaymentProviders {
 	/**
 	 * Attach a payment extension suggestion.
 	 *
+	 * Attachment is a broad concept that can mean different things depending on the suggestion.
+	 * Currently, we use it to record the extension installation. This is why we expect to receive
+	 * instructions to record attachment when the extension is installed.
+	 *
 	 * @param string $id The ID of the payment extension suggestion to attach.
 	 *
 	 * @return bool True if the suggestion was successfully marked as attached, false otherwise.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
@@ -417,7 +417,7 @@ class PaymentProviders {
 			throw new Exception( esc_html__( 'Invalid suggestion ID.', 'woocommerce' ) );
 		}
 
-		$payments_nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY, array() );
+		$payments_nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_KEY, array() );
 		if ( empty( $payments_nox_profile ) ) {
 			$payments_nox_profile = array();
 		} else {
@@ -442,7 +442,7 @@ class PaymentProviders {
 		$payments_nox_profile['suggestions'][ $id ]['attached']['timestamp'] = time();
 
 		// Store the modified profile data.
-		$result = update_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY, $payments_nox_profile, false );
+		$result = update_option( Payments::PAYMENTS_NOX_PROFILE_KEY, $payments_nox_profile, false );
 		// Since we already check if the suggestion is already attached, we should not get a false result
 		// for trying to update with the same value.
 		// False means the update failed and the suggestion is not marked as attached.
@@ -484,7 +484,7 @@ class PaymentProviders {
 			throw new Exception( esc_html__( 'Invalid suggestion ID.', 'woocommerce' ) );
 		}
 
-		$user_payments_nox_profile = get_user_meta( get_current_user_id(), Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_payments_nox_profile = get_user_meta( get_current_user_id(), Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		if ( empty( $user_payments_nox_profile ) ) {
 			$user_payments_nox_profile = array();
 		} else {
@@ -504,7 +504,7 @@ class PaymentProviders {
 			'timestamp' => time(),
 		);
 
-		$result = update_user_meta( get_current_user_id(), Payments::USER_PAYMENTS_NOX_PROFILE_KEY, $user_payments_nox_profile );
+		$result = update_user_meta( get_current_user_id(), Payments::PAYMENTS_NOX_PROFILE_KEY, $user_payments_nox_profile );
 		// Since we already check if the suggestion is already hidden, we should not get a false result
 		// for trying to update with the same value. False means the update failed and the suggestion is not hidden.
 		if ( false === $result ) {
@@ -1045,7 +1045,7 @@ class PaymentProviders {
 	 * @return bool True if the extension suggestion is hidden, false otherwise.
 	 */
 	private function is_payment_extension_suggestion_hidden( array $extension ): bool {
-		$user_payments_nox_profile = get_user_meta( get_current_user_id(), Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_payments_nox_profile = get_user_meta( get_current_user_id(), Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		if ( empty( $user_payments_nox_profile ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
@@ -459,7 +459,7 @@ class PaymentProviders {
 			case ExtensionSuggestions::PAYPAL_FULL_STACK:
 			case ExtensionSuggestions::PAYPAL_WALLET:
 				// Set an option to inform the extension.
-				update_option( 'woocommerce_paypal_branded', 'yes', false );
+				update_option( 'woocommerce_paypal_branded', 'payments_settings', false );
 				break;
 			default:
 				break;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders.php
@@ -424,6 +424,11 @@ class PaymentProviders {
 			$payments_nox_profile = maybe_unserialize( $payments_nox_profile );
 		}
 
+		// Check if it is already marked as attached.
+		if ( ! empty( $payments_nox_profile['suggestions'][ $id ]['attached']['timestamp'] ) ) {
+			return true;
+		}
+
 		// Mark the suggestion as attached.
 		if ( empty( $payments_nox_profile['suggestions'] ) ) {
 			$payments_nox_profile['suggestions'] = array();
@@ -434,12 +439,9 @@ class PaymentProviders {
 		if ( empty( $payments_nox_profile['suggestions'][ $id ]['attached'] ) ) {
 			$payments_nox_profile['suggestions'][ $id ]['attached'] = array();
 		}
-		// Check if it is already marked as attached.
-		if ( ! empty( $payments_nox_profile['suggestions'][ $id ]['attached']['timestamp'] ) ) {
-			return true;
-		}
 		$payments_nox_profile['suggestions'][ $id ]['attached']['timestamp'] = time();
 
+		// Store the modified profile data.
 		$result = update_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY, $payments_nox_profile, false );
 		// Since we already check if the suggestion is already attached, we should not get a false result
 		// for trying to update with the same value.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -12,8 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Payments {
 
-	const PAYMENTS_NOX_PROFILE_OPTION_KEY = 'woocommerce_payments_nox_profile';
-	const USER_PAYMENTS_NOX_PROFILE_KEY   = 'woocommerce_payments_nox_profile';
+	const PAYMENTS_NOX_PROFILE_KEY = 'woocommerce_payments_nox_profile';
 
 	const SUGGESTIONS_CONTEXT = 'wc_settings_payments';
 
@@ -189,7 +188,7 @@ class Payments {
 	 *                If the user didn't set a location, the WC base location country code is used.
 	 */
 	public function get_country(): string {
-		$user_nox_meta = get_user_meta( get_current_user_id(), self::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_nox_meta = get_user_meta( get_current_user_id(), self::PAYMENTS_NOX_PROFILE_KEY, true );
 		if ( ! empty( $user_nox_meta['business_country_code'] ) ) {
 			return $user_nox_meta['business_country_code'];
 		}
@@ -203,7 +202,7 @@ class Payments {
 	 * @param string $location The country code. This should be a ISO 3166-1 alpha-2 country code.
 	 */
 	public function set_country( string $location ): bool {
-		$user_payments_nox_profile = get_user_meta( get_current_user_id(), self::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_payments_nox_profile = get_user_meta( get_current_user_id(), self::PAYMENTS_NOX_PROFILE_KEY, true );
 
 		if ( empty( $user_payments_nox_profile ) ) {
 			$user_payments_nox_profile = array();
@@ -212,7 +211,7 @@ class Payments {
 		}
 		$user_payments_nox_profile['business_country_code'] = $location;
 
-		return false !== update_user_meta( get_current_user_id(), self::USER_PAYMENTS_NOX_PROFILE_KEY, $user_payments_nox_profile );
+		return false !== update_user_meta( get_current_user_id(), self::PAYMENTS_NOX_PROFILE_KEY, $user_payments_nox_profile );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Payments.php
@@ -12,7 +12,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Payments {
 
-	const USER_PAYMENTS_NOX_PROFILE_KEY = 'woocommerce_payments_nox_profile';
+	const PAYMENTS_NOX_PROFILE_OPTION_KEY = 'woocommerce_payments_nox_profile';
+	const USER_PAYMENTS_NOX_PROFILE_KEY   = 'woocommerce_payments_nox_profile';
 
 	const SUGGESTIONS_CONTEXT = 'wc_settings_payments';
 
@@ -223,6 +224,20 @@ class Payments {
 	 */
 	public function update_payment_providers_order_map( array $order_map ): bool {
 		return $this->providers->update_payment_providers_order_map( $order_map );
+	}
+
+	/**
+	 * Attach a payment extension suggestion.
+	 *
+	 * This is only an internal recording of attachment. No actual extension installation or activation happens.
+	 *
+	 * @param string $id The ID of the payment extension suggestion to hide.
+	 *
+	 * @return bool True if the suggestion was successfully marked as attached, false otherwise.
+	 * @throws Exception If the suggestion ID is invalid.
+	 */
+	public function attach_payment_extension_suggestion( string $id ): bool {
+		return $this->providers->attach_extension_suggestion( $id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -176,10 +176,10 @@ class PaymentsController {
 		}
 
 		// Add the business location country to the settings.
-		if ( ! isset( $settings[ Payments::USER_PAYMENTS_NOX_PROFILE_KEY ] ) ) {
-			$settings[ Payments::USER_PAYMENTS_NOX_PROFILE_KEY ] = array();
+		if ( ! isset( $settings[ Payments::PAYMENTS_NOX_PROFILE_KEY ] ) ) {
+			$settings[ Payments::PAYMENTS_NOX_PROFILE_KEY ] = array();
 		}
-		$settings[ Payments::USER_PAYMENTS_NOX_PROFILE_KEY ]['business_country_code'] = $this->payments->get_country();
+		$settings[ Payments::PAYMENTS_NOX_PROFILE_KEY ]['business_country_code'] = $this->payments->get_country();
 
 		return $settings;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -131,6 +131,18 @@ class PaymentsRestController extends RestApiControllerBase {
 		);
 		register_rest_route(
 			$this->route_namespace,
+			'/' . $this->rest_base . '/suggestion/(?P<id>[\w\d\-]+)/attach',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'attach_payment_extension_suggestion' ),
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+				),
+			),
+			$override
+		);
+		register_rest_route(
+			$this->route_namespace,
 			'/' . $this->rest_base . '/suggestion/(?P<id>[\w\d\-]+)/hide',
 			array(
 				array(
@@ -249,6 +261,25 @@ class PaymentsRestController extends RestApiControllerBase {
 		$order_map = $request->get_param( 'order_map' );
 
 		$result = $this->payments->update_payment_providers_order_map( $order_map );
+
+		return rest_ensure_response( array( 'success' => $result ) );
+	}
+
+	/**
+	 * Attach a payment extension suggestion.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	protected function attach_payment_extension_suggestion( WP_REST_Request $request ) {
+		$suggestion_id = $request->get_param( 'id' );
+
+		try {
+			$result = $this->payments->attach_payment_extension_suggestion( $suggestion_id );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_payment_extension_suggestion_error', $e->getMessage(), array( 'status' => 400 ) );
+		}
 
 		return rest_ensure_response( array( 'success' => $result ) );
 	}
@@ -485,11 +516,14 @@ class PaymentsRestController extends RestApiControllerBase {
 				$providers[ $key ]['_links'] = array();
 			}
 
-			// If this is a suggestion, add a link to hide it.
+			// If this is a suggestion, add dedicated links.
 			if ( ! empty( $provider['_type'] ) &&
 				PaymentProviders::TYPE_SUGGESTION === $provider['_type'] &&
 				! empty( $provider['_suggestion_id'] )
 				) {
+				$providers[ $key ]['_links']['attach'] = array(
+					'href' => rest_url( sprintf( '/%s/%s/suggestion/%s/attach', $this->route_namespace, $this->rest_base, $provider['_suggestion_id'] ) ),
+				);
 				$providers[ $key ]['_links']['hide'] = array(
 					'href' => rest_url( sprintf( '/%s/%s/suggestion/%s/hide', $this->route_namespace, $this->rest_base, $provider['_suggestion_id'] ) ),
 				);
@@ -1004,6 +1038,20 @@ class PaymentsRestController extends RestApiControllerBase {
 					'context'    => array( 'view', 'edit' ),
 					'readonly'   => true,
 					'properties' => array(
+						'attach' => array(
+							'type'        => 'object',
+							'description' => esc_html__( 'The link to mark the suggestion as attached.', 'woocommerce' ),
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'properties'  => array(
+								'href' => array(
+									'type'        => 'string',
+									'description' => esc_html__( 'The URL to attach the suggestion.', 'woocommerce' ),
+									'context'     => array( 'view', 'edit' ),
+									'readonly'    => true,
+								),
+							),
+						),
 						'hide' => array(
 							'type'        => 'object',
 							'description' => esc_html__( 'The link to hide the suggestion.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -520,11 +520,11 @@ class PaymentsRestController extends RestApiControllerBase {
 			if ( ! empty( $provider['_type'] ) &&
 				PaymentProviders::TYPE_SUGGESTION === $provider['_type'] &&
 				! empty( $provider['_suggestion_id'] )
-				) {
+			) {
 				$providers[ $key ]['_links']['attach'] = array(
 					'href' => rest_url( sprintf( '/%s/%s/suggestion/%s/attach', $this->route_namespace, $this->rest_base, $provider['_suggestion_id'] ) ),
 				);
-				$providers[ $key ]['_links']['hide'] = array(
+				$providers[ $key ]['_links']['hide']   = array(
 					'href' => rest_url( sprintf( '/%s/%s/suggestion/%s/hide', $this->route_namespace, $this->rest_base, $provider['_suggestion_id'] ) ),
 				);
 			}
@@ -1052,7 +1052,7 @@ class PaymentsRestController extends RestApiControllerBase {
 								),
 							),
 						),
-						'hide' => array(
+						'hide'   => array(
 							'type'        => 'object',
 							'description' => esc_html__( 'The link to hide the suggestion.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -1040,7 +1040,7 @@ class PaymentsRestController extends RestApiControllerBase {
 					'properties' => array(
 						'attach' => array(
 							'type'        => 'object',
-							'description' => esc_html__( 'The link to mark the suggestion as attached.', 'woocommerce' ),
+							'description' => esc_html__( 'The link to mark the suggestion as attached. This should be called when an extension is installed.', 'woocommerce' ),
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
@@ -1294,7 +1294,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		// Assert.
 		$this->assertTrue( $result );
 		$branded_option = get_option( 'woocommerce_paypal_branded' );
-		$this->assertSame( 'yes', $branded_option );
+		$this->assertSame( 'payments_settings', $branded_option );
 		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_KEY );
 		$this->assertIsArray( $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
 		$this->assertArrayHasKey( 'timestamp', $nox_profile['suggestions'][ $suggestion_id ]['attached'] );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
@@ -1223,7 +1223,6 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 			->willReturn( $suggestion_details );
 
 		update_option(
-			$this->store_admin_id,
 			Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY,
 			array(
 				'something_other' => 'value',

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
@@ -1311,7 +1311,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 	 */
 	public function data_provider_test_attach_extension_suggestion_paypal() {
 		return array(
-			'PayPal full-stack' => array(
+			'PayPal full-stack'          => array(
 				ExtensionSuggestions::PAYPAL_FULL_STACK,
 				ExtensionSuggestions::PAYPAL_FULL_STACK,
 				ExtensionSuggestions::TYPE_PSP,
@@ -1321,12 +1321,12 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 				PaymentProviders::SUGGESTION_ORDERING_PREFIX . ExtensionSuggestions::PAYPAL_FULL_STACK,
 				ExtensionSuggestions::TYPE_PSP,
 			),
-			'PayPal wallet' => array(
+			'PayPal wallet'              => array(
 				ExtensionSuggestions::PAYPAL_WALLET,
 				ExtensionSuggestions::PAYPAL_WALLET,
 				ExtensionSuggestions::TYPE_EXPRESS_CHECKOUT,
 			),
-			'PayPal wallet prefixed' => array(
+			'PayPal wallet prefixed'     => array(
 				ExtensionSuggestions::PAYPAL_WALLET,
 				PaymentProviders::SUGGESTION_ORDERING_PREFIX . ExtensionSuggestions::PAYPAL_WALLET,
 				ExtensionSuggestions::TYPE_EXPRESS_CHECKOUT,

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings;
 
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
 use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
-use Automattic\WooCommerce\Internal\Admin\Suggestions\PaymentExtensionSuggestions;
 use Automattic\WooCommerce\Internal\Admin\Suggestions\PaymentExtensionSuggestions as ExtensionSuggestions;
 use Automattic\WooCommerce\Tests\Internal\Admin\Settings\Mocks\FakePaymentGateway;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,7 +27,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 	protected $sut;
 
 	/**
-	 * @var PaymentExtensionSuggestions|MockObject
+	 * @var ExtensionSuggestions|MockObject
 	 */
 	protected $mock_extension_suggestions;
 
@@ -48,7 +47,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->store_admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->store_admin_id );
 
-		$this->mock_extension_suggestions = $this->getMockBuilder( PaymentExtensionSuggestions::class )
+		$this->mock_extension_suggestions = $this->getMockBuilder( ExtensionSuggestions::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -1188,6 +1187,152 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		// Assert.
 		$this->assertIsArray( $categories );
 		$this->assertCount( 4, $categories );
+	}
+
+	/**
+	 * Test marking a payment extension suggestion as attached.
+	 */
+	public function test_attach_extension_suggestion() {
+		// Arrange.
+		$suggestion_id      = 'suggestion1';
+		$suggestion_details = array(
+			'id'                => $suggestion_id,
+			'_priority'         => 1,
+			'_type'             => ExtensionSuggestions::TYPE_PSP,
+			'title'             => 'Suggestion 1',
+			'description'       => 'Description 1',
+			'plugin'            => array(
+				'_type' => ExtensionSuggestions::PLUGIN_TYPE_WPORG,
+				'slug'  => 'slug1',
+			),
+			'image'             => 'http://example.com/image1.png',
+			'icon'              => 'http://example.com/icon1.png',
+			'short_description' => null,
+			'links'             => array(
+				array(
+					'_type' => ExtensionSuggestions::LINK_TYPE_ABOUT,
+					'url'   => 'url1',
+				),
+			),
+			'tags'              => array( 'tag1', ExtensionSuggestions::TAG_PREFERRED ),
+		);
+		$this->mock_extension_suggestions
+			->expects( $this->once() )
+			->method( 'get_by_id' )
+			->with( $suggestion_id )
+			->willReturn( $suggestion_details );
+
+		update_option(
+			$this->store_admin_id,
+			Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY,
+			array(
+				'something_other' => 'value',
+			)
+		);
+
+		// Act.
+		$result = $this->sut->attach_extension_suggestion( $suggestion_id );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+		$this->assertIsArray( $nox_profile );
+		$this->assertArrayHasKey( 'suggestions', $nox_profile );
+		$this->assertIsArray( $nox_profile['suggestions'] );
+		$this->assertArrayHasKey( $suggestion_id, $nox_profile['suggestions'] );
+		$this->assertIsArray( $nox_profile['suggestions'][ $suggestion_id ] );
+		$this->assertArrayHasKey( 'attached', $nox_profile['suggestions'][ $suggestion_id ] );
+		$this->assertIsArray( $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
+		$this->assertArrayHasKey( 'timestamp', $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
+		// The other profile entries should be kept.
+		$this->assertSame( 'value', $nox_profile['something_other'] );
+
+		// Clean up.
+		delete_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+	}
+
+	/**
+	 * Test marking the PayPal payment extension suggestion as attached.
+	 *
+	 * @dataProvider data_provider_test_attach_extension_suggestion_paypal
+	 *
+	 * @param string $suggestion_id The suggestion ID.
+	 * @param string $received_id   The received suggestion ID.
+	 * @param string $type          The suggestion type.
+	 */
+	public function test_attach_extension_suggestion_paypal( string $suggestion_id, string $received_id, string $type ) {
+		// Arrange.
+		$suggestion_details = array(
+			'id'                => $suggestion_id,
+			'_priority'         => 1,
+			'_type'             => $type,
+			'title'             => 'Suggestion 1',
+			'description'       => 'Description 1',
+			'plugin'            => array(
+				'_type' => ExtensionSuggestions::PLUGIN_TYPE_WPORG,
+				'slug'  => 'slug1',
+			),
+			'image'             => 'http://example.com/image1.png',
+			'icon'              => 'http://example.com/icon1.png',
+			'short_description' => null,
+			'links'             => array(
+				array(
+					'_type' => ExtensionSuggestions::LINK_TYPE_ABOUT,
+					'url'   => 'url1',
+				),
+			),
+			'tags'              => array( 'tag1', ExtensionSuggestions::TAG_PREFERRED ),
+		);
+		$this->mock_extension_suggestions
+			->expects( $this->once() )
+			->method( 'get_by_id' )
+			->with( $suggestion_id )
+			->willReturn( $suggestion_details );
+
+		// Act.
+		$result = $this->sut->attach_extension_suggestion( $received_id );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$branded_option = get_option( 'woocommerce_paypal_branded' );
+		$this->assertSame( 'yes', $branded_option );
+		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+		$this->assertIsArray( $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
+		$this->assertArrayHasKey( 'timestamp', $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
+
+		// Clean up.
+		delete_option( 'woocommerce_paypal_branded' );
+		delete_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+	}
+
+	/**
+	 * Data provider for test_attach_extension_suggestion_paypal.
+	 *
+	 * @return array[]
+	 */
+	public function data_provider_test_attach_extension_suggestion_paypal() {
+		return array(
+			'PayPal full-stack' => array(
+				ExtensionSuggestions::PAYPAL_FULL_STACK,
+				ExtensionSuggestions::PAYPAL_FULL_STACK,
+				ExtensionSuggestions::TYPE_PSP,
+			),
+			'PayPal full-stack prefixed' => array(
+				ExtensionSuggestions::PAYPAL_FULL_STACK,
+				PaymentProviders::SUGGESTION_ORDERING_PREFIX . ExtensionSuggestions::PAYPAL_FULL_STACK,
+				ExtensionSuggestions::TYPE_PSP,
+			),
+			'PayPal wallet' => array(
+				ExtensionSuggestions::PAYPAL_WALLET,
+				ExtensionSuggestions::PAYPAL_WALLET,
+				ExtensionSuggestions::TYPE_EXPRESS_CHECKOUT,
+			),
+			'PayPal wallet prefixed' => array(
+				ExtensionSuggestions::PAYPAL_WALLET,
+				PaymentProviders::SUGGESTION_ORDERING_PREFIX . ExtensionSuggestions::PAYPAL_WALLET,
+				ExtensionSuggestions::TYPE_EXPRESS_CHECKOUT,
+			),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProvidersTest.php
@@ -786,7 +786,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		// We have 5 suggestions, but two are hidden from the preferred places.
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'hidden_suggestions' => array(
 					array(
@@ -1223,7 +1223,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 			->willReturn( $suggestion_details );
 
 		update_option(
-			Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'something_other' => 'value',
 			)
@@ -1234,7 +1234,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertTrue( $result );
-		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_KEY );
 		$this->assertIsArray( $nox_profile );
 		$this->assertArrayHasKey( 'suggestions', $nox_profile );
 		$this->assertIsArray( $nox_profile['suggestions'] );
@@ -1247,7 +1247,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'value', $nox_profile['something_other'] );
 
 		// Clean up.
-		delete_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+		delete_option( Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -1295,13 +1295,13 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $result );
 		$branded_option = get_option( 'woocommerce_paypal_branded' );
 		$this->assertSame( 'yes', $branded_option );
-		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+		$nox_profile = get_option( Payments::PAYMENTS_NOX_PROFILE_KEY );
 		$this->assertIsArray( $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
 		$this->assertArrayHasKey( 'timestamp', $nox_profile['suggestions'][ $suggestion_id ]['attached'] );
 
 		// Clean up.
 		delete_option( 'woocommerce_paypal_branded' );
-		delete_option( Payments::PAYMENTS_NOX_PROFILE_OPTION_KEY );
+		delete_option( Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -1369,7 +1369,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'something_other' => 'value',
 			)
@@ -1380,7 +1380,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertTrue( $result );
-		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		$this->assertIsArray( $user_nox_profile );
 		$this->assertArrayHasKey( 'hidden_suggestions', $user_nox_profile );
 		$this->assertIsList( $user_nox_profile['hidden_suggestions'] );
@@ -1391,7 +1391,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'value', $user_nox_profile['something_other'] );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -1431,7 +1431,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'something_other' => 'value',
 			)
@@ -1442,7 +1442,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertTrue( $result );
-		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		$this->assertIsArray( $user_nox_profile );
 		$this->assertArrayHasKey( 'hidden_suggestions', $user_nox_profile );
 		$this->assertIsList( $user_nox_profile['hidden_suggestions'] );
@@ -1454,7 +1454,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'value', $user_nox_profile['something_other'] );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -1494,7 +1494,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'something_other'    => 'value',
 				'hidden_suggestions' => array(
@@ -1511,7 +1511,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertTrue( $result );
-		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		$this->assertIsArray( $user_nox_profile );
 		$this->assertArrayHasKey( 'hidden_suggestions', $user_nox_profile );
 		$this->assertIsList( $user_nox_profile['hidden_suggestions'] );
@@ -1523,7 +1523,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'value', $user_nox_profile['something_other'] );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -1564,7 +1564,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'something_other'    => 'value',
 				'hidden_suggestions' => array(
@@ -1581,7 +1581,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertTrue( $result );
-		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		$this->assertIsArray( $user_nox_profile );
 		$this->assertArrayHasKey( 'hidden_suggestions', $user_nox_profile );
 		$this->assertIsList( $user_nox_profile['hidden_suggestions'] );
@@ -1593,7 +1593,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 		$this->assertSame( 'value', $user_nox_profile['something_other'] );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -1631,7 +1631,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'something_other'    => 'value',
 				'hidden_suggestions' => array(
@@ -1650,7 +1650,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertFalse( $result );
-		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$user_nox_profile = get_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		$this->assertIsArray( $user_nox_profile );
 		$this->assertArrayHasKey( 'hidden_suggestions', $user_nox_profile );
 		$this->assertIsList( $user_nox_profile['hidden_suggestions'] );
@@ -1661,7 +1661,7 @@ class PaymentProvidersTest extends WC_Unit_Test_Case {
 
 		// Clean up.
 		remove_filter( 'update_user_metadata', '__return_false' );
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
@@ -941,7 +941,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertContains( PaymentExtensionSuggestions::WOOPAYMENTS, array_column( $other_suggestions, 'id' ) );
 
 		// Delete the user meta.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 
 		// Act.
 		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsTest.php
@@ -460,7 +460,7 @@ class PaymentsTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				'business_country_code' => $country,
 				'something_other'       => 'value',
@@ -474,7 +474,7 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		$this->assertSame( $country, $result );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**
@@ -486,7 +486,7 @@ class PaymentsTest extends WC_Unit_Test_Case {
 
 		update_user_meta(
 			$this->store_admin_id,
-			Payments::USER_PAYMENTS_NOX_PROFILE_KEY,
+			Payments::PAYMENTS_NOX_PROFILE_KEY,
 			array(
 				// business_country_code not set.
 				'something_other' => 'value',
@@ -503,7 +503,7 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		$this->assertSame( $country, $result );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 		update_option( 'woocommerce_default_country', $initial_country );
 	}
 
@@ -521,13 +521,13 @@ class PaymentsTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $result );
 
 		// Check the value was saved.
-		$meta = get_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY, true );
+		$meta = get_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY, true );
 		$this->assertIsArray( $meta );
 		$this->assertArrayHasKey( 'business_country_code', $meta );
 		$this->assertSame( $country, $meta['business_country_code'] );
 
 		// Clean up.
-		delete_user_meta( $this->store_admin_id, Payments::USER_PAYMENTS_NOX_PROFILE_KEY );
+		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We add extension suggestion attachment recording whenever the user installs a plugin from the new Payments settings page. We record the attachment timestamp in a general NOX profile WP option, but also handle custom recording for certain providers (PayPal).

This NOX profile will allow us to have a history of what happened and adjust the UX accordingly.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JurassicNinja site with WooCommerce on this PR's live branch and WooCommerce Beta Tester (here is [a direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=dev/payment-setttings-record-suggestion-attachment))
1. Go to the newly created site WP admin dashboard.
1. Go to Tools > WCA Test Helper > Features and enable the `reactify-classic-payments-settings` feature.
1. Go to Jetpack > Beta Tester and make sure WooCommerce is on this PR's branch:
![Screenshot 2025-03-13 at 18 04 59](https://github.com/user-attachments/assets/35e77af2-6c1a-49cf-8cb5-c781e79d98eb)
1. Go to Plugins > Add new and install and activate the [Options View ](https://wordpress.org/plugins/options-view/)WP plugin.
1. Go through the WooCommerce profiler (click on the "WooCommerce" menu item if it doesn't start automatically), click on "Skip guided setup", and choose **Antigua and Barbuda** as your store's location.
1. Go to the new Payments settings page and you should see Tilopay and PayPal in the providers list:
![Screenshot 2025-03-13 at 18 09 23](https://github.com/user-attachments/assets/3d03271d-a471-4f71-9c7c-e459355aadff)
1. Change the business location to "United States" from the top-right select and you should see WooPayments and PayPal in the providers list, and the WooPayments incentive banner:
![Screenshot 2025-03-21 at 17 40 50](https://github.com/user-attachments/assets/924643c5-bbc9-4b50-b5e4-2a242d60ca9d)
1. Install and active the PayPal extension by clicking the "Install" button. Once it is complete, the button label for PayPal should change to "Complete setup":
![Screenshot 2025-03-21 at 17 42 37](https://github.com/user-attachments/assets/55e4a1ea-e9ab-4b04-910d-eed07ca3b24d)
1. Go to Tools > Options View  and search for `woocommerce_payments_nox_profile `. You should have an option with a value like this:
![Screenshot 2025-03-21 at 17 44 52](https://github.com/user-attachments/assets/bac3ba9d-21d1-4527-8006-ff980d7344c5)
1. Search for `woocommerce_paypal_branded` and you should have an option with `payments_settings` as its value. DELETE this option.
1. Click on the "Payments" main menu item and click "Install" for WooPayments.
1. When presented with the "Choose your payment methods" step, click the back arrow:
![Screenshot 2025-03-21 at 17 47 19](https://github.com/user-attachments/assets/de81bb75-1d2e-49ca-af2c-b20f2809f87c)
1. The button label for WooPayments should be "Complete setup".
1. Go to Tools > Options View and search for `woocommerce_payments_nox_profile `. You should have an option with a value like this:
![Screenshot 2025-03-21 at 17 49 26](https://github.com/user-attachments/assets/ad43c916-3b54-4cc5-acf3-80ef67806423)
1. Search for `woocommerce_paypal_branded` and you should have no option.
1. Go to WooCommerce > Settings > Payments and deactivate PayPal via the context menu under the ellipsis:
![Screenshot 2025-03-21 at 17 51 19](https://github.com/user-attachments/assets/9ff716f7-427e-4743-9e59-e03df6b52c4b)
1. Go to Plugins and check that the WooCommerce PayPal Payments plugin is not active:
![Screenshot 2025-03-21 at 17 52 32](https://github.com/user-attachments/assets/27368301-cb3f-4f56-bcee-d8f373f98045)
1. Go to WooCommerce > Settings > Payments and click on "Enable" for PayPal.
1. Go to Plugins and check that the WooCommerce PayPal Payments plugin is active.
1. Go to Tools > Options View and search for `woocommerce_paypal_branded `. You should not have an option.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
