### PR TITLE
Fix get_permalink method logic in WC_Product_Variation

### DIFF
--- a/plugins/woocommerce/changelog/56607-55081-variable-product-with-attribute-named-variation-crashes-abstractorderconfirmationblock
+++ b/plugins/woocommerce/changelog/56607-55081-variable-product-with-attribute-named-variation-crashes-abstractorderconfirmationblock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix get_permalink method logic in WC_Product_Variation.

--- a/plugins/woocommerce/includes/class-wc-product-variation.php
+++ b/plugins/woocommerce/includes/class-wc-product-variation.php
@@ -166,12 +166,12 @@ class WC_Product_Variation extends WC_Product_Simple {
 	public function get_permalink( $item_object = null ) {
 		$url = get_permalink( $this->get_parent_id() );
 
-		if ( ! empty( $item_object['variation'] ) ) {
-			$data = $item_object['variation'];
-		} elseif ( ! empty( $item_object['item_meta_array'] ) ) {
+		if ( ! empty( $item_object['item_meta_array'] ) ) {
 			$data_keys   = array_map( 'wc_variation_attribute_name', wp_list_pluck( $item_object['item_meta_array'], 'key' ) );
 			$data_values = wp_list_pluck( $item_object['item_meta_array'], 'value' );
 			$data        = array_intersect_key( array_combine( $data_keys, $data_values ), $this->get_variation_attributes() );
+		} elseif ( ! empty( $item_object['variation'] ) ) {
+			$data = $item_object['variation'];
 		} else {
 			$data = $this->get_variation_attributes();
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

## Problem
In the original code, when checking `$item_object['variation']`, there was no distinction between:
- A variation data structure (intended use)
- A product attribute coincidentally named "variation"

The issue stems from how `WC_Order_Item` implements the `ArrayAccess` interface:

https://github.com/woocommerce/woocommerce/blob/122abcf053e2d03d97a5e7da98164d11ce07c230/plugins/woocommerce/includes/class-wc-order-item.php#L417-L450

1. When accessing `$item_object['variation']`, PHP uses the `offsetGet` method through `ArrayAccess`.
2. `offsetGet` checks for meta values with the key 'variation' in the item's metadata.
3. If a product has an attribute named "variation", it gets stored as meta data.
4. When accessing `$item_object['variation']`, instead of getting the expected variation data structure, we get the attribute value,
5. This leads to a crash when the code tries to process an attribute value as if it were a variation data structure (an array).


I reordered the condition checks in `get_permalink()` to:
1. First check for `item_meta_array` which has a more predictable structure.
2. Then fall back to checking for variation data.
3. Finally default to `get_variation_attributes()`.



<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #55081.



(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a variable product with an attribute named "Variation" and add variations
2. Add product to cart and attempt to checkout
3. Ensure that Order is placed and no error is thrown.

![Image](https://github.com/user-attachments/assets/a8d495eb-d19e-4b83-81a3-23e6ab8b6800)

It seems _something_ is adding that `variation` to the order item meta (which does _not_ appear to happen for other variable product types?)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix get_permalink method logic in WC_Product_Variation.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
