### PR TITLE
Fix loading email preview when email is registered with different than class name

### DIFF
--- a/plugins/woocommerce/changelog/55869-email-type-previews
+++ b/plugins/woocommerce/changelog/55869-email-type-previews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix loading email preview when email is registered with different than class name

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -627,10 +627,10 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$this->delete_transient_email_settings();
 		$emails      = WC()->mailer()->get_emails();
 		$email_types = array();
-		foreach ( $emails as $type => $email ) {
+		foreach ( $emails as $email ) {
 			$email_types[] = array(
 				'label' => $email->get_title(),
-				'value' => $type,
+				'value' => get_class( $email ),
 			);
 		}
 		?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This is a follow-up for https://github.com/woocommerce/woocommerce/pull/55870 which didn't fully fix the issue in all cases. 

Closes #55869 and closes #56623.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="648" alt="Screenshot 2025-03-23 at 22 14 45" src="https://github.com/user-attachments/assets/7659e895-435f-4417-a4f0-50a3ceb97eff" />    |  <img width="641" alt="Screenshot 2025-03-23 at 22 14 15" src="https://github.com/user-attachments/assets/98d495f5-239e-486e-ab4c-191c359f581f" />     |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Described in https://github.com/woocommerce/woocommerce/discussions/54779#discussioncomment-12540690

<!-- End testing instructions -->

### Testing that has already taken place:

1. I used an extension provided by a 3rd-party developer, which has the issue (https://woocommerce.com/products/print-invoices-packing-lists/)
2. I went to **WooCommerce > Settings > Emails** and selected emails from this extension to observe the issue. I also click to Manage these emails to see, that the issue is not present when managing a specific email.
3. I verified that with this PR, the emails can be previewed on both pages. 

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
