### PR TITLE
Add order attribution support for `pos` order source type

### DIFF
--- a/plugins/woocommerce/changelog/56625-add-order-attribution-support-for-pos-source-type
+++ b/plugins/woocommerce/changelog/56625-add-order-attribution-support-for-pos-source-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds order attribution support for pos order source type.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/OrderAttribution.php
@@ -72,7 +72,7 @@ class OrderAttribution {
 		$has_more_details = array( 'origin' ) !== array_keys( $meta );
 
 		// For direct, web admin, or mobile app orders, also don't show more details.
-		$simple_sources = array( 'typein', 'admin', 'mobile_app' );
+		$simple_sources = array( 'typein', 'admin', 'mobile_app', 'pos' );
 		if ( isset( $meta['source_type'] ) && in_array( $meta['source_type'], $simple_sources, true ) ) {
 			$has_more_details = false;
 		}

--- a/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
+++ b/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php
@@ -312,6 +312,12 @@ trait OrderAttributionMeta {
 					__( 'Web admin', 'woocommerce' )
 					: 'Web admin';
 				break;
+			case 'pos':
+				$label  = '';
+				$source = $translated ?
+					__( 'Point of Sale', 'woocommerce' )
+					: 'Point of Sale';
+				break;
 
 			default:
 				$label  = '';

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
@@ -139,4 +139,52 @@ class OrderAttributionTest extends WP_UnitTestCase {
 		ob_get_contents();
 		ob_end_clean();
 	}
+
+	/**
+	 * Test that mobile app source type sets origin label without more details.
+	 *
+	 * @return void
+	 */
+	public function test_mobile_app_source_type_sets_origin_label_without_more_details() {
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( '_wc_order_attribution_source_type', 'mobile_app' );
+		
+		add_action(
+			'woocommerce_before_template_part',
+			function( $template_name, $template_path, $located, $args ) {
+				$this->assertEquals( 'Mobile app', $args['meta']['origin'] ?? '' );
+				$this->assertFalse( $args['has_more_details'] );
+			},
+			10,
+			4
+		);
+
+		ob_start();
+		$this->sut->output( $order );
+		ob_end_clean();
+	}
+
+	/**
+	 * Test that POS source type sets origin label without more details.
+	 *
+	 * @return void
+	 */
+	public function test_pos_source_type_sets_origin_label_without_more_details() {
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( '_wc_order_attribution_source_type', 'pos' );
+		
+		add_action(
+			'woocommerce_before_template_part',
+			function( $template_name, $template_path, $located, $args ) {
+				$this->assertEquals( 'Point of Sale', $args['meta']['origin'] ?? '' );
+				$this->assertFalse( $args['has_more_details'] );
+			},
+			10,
+			4
+		);
+
+		ob_start();
+		$this->sut->output( $order );
+		ob_end_clean();
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/MetaBoxes/OrderAttributionTest.php
@@ -148,10 +148,10 @@ class OrderAttributionTest extends WP_UnitTestCase {
 	public function test_mobile_app_source_type_sets_origin_label_without_more_details() {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_wc_order_attribution_source_type', 'mobile_app' );
-		
+
 		add_action(
 			'woocommerce_before_template_part',
-			function( $template_name, $template_path, $located, $args ) {
+			function ( $template_name, $template_path, $located, $args ) {
 				$this->assertEquals( 'Mobile app', $args['meta']['origin'] ?? '' );
 				$this->assertFalse( $args['has_more_details'] );
 			},
@@ -172,10 +172,10 @@ class OrderAttributionTest extends WP_UnitTestCase {
 	public function test_pos_source_type_sets_origin_label_without_more_details() {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_wc_order_attribution_source_type', 'pos' );
-		
+
 		add_action(
 			'woocommerce_before_template_part',
-			function( $template_name, $template_path, $located, $args ) {
+			function ( $template_name, $template_path, $located, $args ) {
 				$this->assertEquals( 'Point of Sale', $args['meta']['origin'] ?? '' );
 				$this->assertFalse( $args['has_more_details'] );
 			},

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/OrderAttributionControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/OrderAttributionControllerTest.php
@@ -98,6 +98,11 @@ class OrderAttributionControllerTest extends WP_UnitTestCase {
 				'expected_output' => 'Mobile app',
 			),
 			array(
+				'source_type'     => 'pos',
+				'source'          => '',
+				'expected_output' => 'Point of Sale',
+			),
+			array(
 				'source_type'     => '',
 				'source'          => '',
 				'expected_output' => 'Unknown',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Ref: pdfdoF-6Gf-p2

This PR supports the new order source type `pos` that Woo mobile apps will set on the client side in the order metadata. It shows the origin label as `Point of Sale` without more details.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

\ | Before | After
-- | ------ | -----
order list | <img width="1062" alt="Screenshot 2025-03-24 at 12 31 25 PM" src="https://github.com/user-attachments/assets/d24dd7e1-e857-4aab-bdd0-740c060d2c7d" /> | <img width="1062" alt="Screenshot 2025-03-24 at 12 31 08 PM" src="https://github.com/user-attachments/assets/dd624457-ff08-4910-a57e-9f2d31289610" />
order details | <img width="302" alt="Screenshot 2025-03-24 at 11 55 46 AM" src="https://github.com/user-attachments/assets/7c4c7c1c-8e7b-4e4c-afee-fa768f2abb5c" /> | <img width="301" alt="Screenshot 2025-03-24 at 1 38 28 PM" src="https://github.com/user-attachments/assets/f1ad5549-9cf8-46de-92a0-dbbbd56ed67d" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an order in the API with an entry in the `meta_data` field:
```
{
    "key": "_wc_order_attribution_source_type",
    "value": "pos"
}
```
2. Refresh WooCommerce > Orders --> the order created above should have origin `Point of Sale`
4. Click on the order created above --> the order attribution card should have origin `Point of Sale` without more details like before

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>