### PR TITLE
Avoid initializing block pattern PHP classes unnecessarily in the frontend

### DIFF
--- a/plugins/woocommerce/changelog/fix-56634-admin-classes
+++ b/plugins/woocommerce/changelog/fix-56634-admin-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Avoid initializing block pattern PHP classes unnecessarily in the frontend

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -163,13 +163,16 @@ class Bootstrap {
 		if ( ! $is_store_api_request ) {
 			// Template related functionality. These won't be loaded for store API requests, but may be loaded for
 			// regular rest requests to maintain compatibility with the store editor.
-			$this->container->get( AIPatterns::class );
-			$this->container->get( BlockPatterns::class );
 			$this->container->get( BlockTypesController::class );
 			$this->container->get( ClassicTemplatesCompatibility::class );
 			$this->container->get( Notices::class )->init();
-			$this->container->get( PTKPatternsStore::class );
-			$this->container->get( TemplateOptions::class )->init();
+
+			if ( is_admin() ) {
+				$this->container->get( AIPatterns::class );
+				$this->container->get( BlockPatterns::class );
+				$this->container->get( PTKPatternsStore::class );
+				$this->container->get( TemplateOptions::class )->init();
+			}
 		}
 
 		$this->container->get( QueryFilters::class )->init();

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -167,10 +167,13 @@ class Bootstrap {
 			$this->container->get( ClassicTemplatesCompatibility::class );
 			$this->container->get( Notices::class )->init();
 
-			if ( is_admin() ) {
+			if ( is_admin() || $is_rest ) {
 				$this->container->get( AIPatterns::class );
 				$this->container->get( BlockPatterns::class );
 				$this->container->get( PTKPatternsStore::class );
+			}
+
+			if ( is_admin() ) {
 				$this->container->get( TemplateOptions::class )->init();
 			}
 		}

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -163,13 +163,13 @@ class Bootstrap {
 		if ( ! $is_store_api_request ) {
 			// Template related functionality. These won't be loaded for store API requests, but may be loaded for
 			// regular rest requests to maintain compatibility with the store editor.
+			$this->container->get( BlockPatterns::class );
 			$this->container->get( BlockTypesController::class );
 			$this->container->get( ClassicTemplatesCompatibility::class );
 			$this->container->get( Notices::class )->init();
 
 			if ( is_admin() || $is_rest ) {
 				$this->container->get( AIPatterns::class );
-				$this->container->get( BlockPatterns::class );
 				$this->container->get( PTKPatternsStore::class );
 			}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Blocks\Options;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\BlockTemplatesRegistry;
+use Automattic\WooCommerce\Blocks\TemplateOptions;
 use WP_UnitTestCase;
 
 /**
@@ -30,6 +31,10 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 		// Switch to a block theme and initialize template logic.
 		switch_theme( 'twentytwentytwo' );
 		$this->container = Package::container();
+
+		// We need to manually register the BlockTemplatesRegistry and
+		// TemplateOptions classes because they are conditionally registered
+		// in Bootstrap.php so they wouldn't run in the test environment.
 		$this->container->register(
 			BlockTemplatesRegistry::class,
 			function () {
@@ -37,6 +42,13 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			}
 		);
 		$this->container->get( BlockTemplatesRegistry::class )->init();
+		$this->container->register(
+			TemplateOptions::class,
+			function () {
+				return new TemplateOptions();
+			}
+		);
+		$this->container->get( TemplateOptions::class )->init();
 
 		// Reset options.
 		delete_option( Options::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR started with the goal of making the `BlockPatterns` PHP class editor-only. However, I noticed that would be a [breaking change](https://github.com/woocommerce/woocommerce/issues/56634#issuecomment-2748636067) and, in fact, it would break the [_Coming soon_ feature](https://github.com/woocommerce/woocommerce/blob/3fe53a3a362431aa50ecc6aa70b85902cfcac6e6/plugins/woocommerce/templates/templates/coming-soon.html#L1). So unfortunately, I had to leave it where it is. In the process, however, I noticed there were a few more classes that weren't needed in the frontend, so I moved those ones.

~Closes https://github.com/woocommerce/woocommerce/issues/56634.~
Helps with https://github.com/woocommerce/woocommerce/issues/50714.

This PR makes it so we only initialize certain PHP classes in the admin or Rest API calls. Those are:

* `AIPatterns`
* ~`BlockPatterns`~
* `PTKPatternsStore`
* `TemplateOptions`

My understanding is that PHP patterns only need to be initialized in the editor, CYS, etc. But they are not needed in the frontend.

`TemplateOptions` only contains one filter on `after_switch_theme`, so it should also be safe to make it frontend-only.

### How to test the changes in this Pull Request:

Testing this PR means making sure there are no regressions.

**Patterns**

1. Create a post or page.
2. Open the inserter, go to the _Patterns_ tab and verify there is a _WooCommerce_ pattern category.
3. Open it and verify you can insert patterns.

![imatge](https://github.com/user-attachments/assets/aaabcdb6-ef6a-4784-8ab3-bc0f0cb04352)

4. Now repeat the process while editing a template in the Site Editor (ie: `/wp-admin/site-editor.php?p=%2Fwp_template%2Ftwentytwentyfive%2F%2Findex&canvas=edit`).

![imatge](https://github.com/user-attachments/assets/12cd66d1-a557-41cc-afdd-cd6a33ad6a01)

5. If needed, restart the Customize Your Store flow by installing the WooCommerce Beta Tester plugin and going to `wp-admin/tools.php?page=woocommerce-admin-test-helper` > Tools > "Reset Customize Your Store".
6. Go to WooCommerce > Customize Your Store > Design your own theme > Design your homepage.
7. Verify the block patterns appear in the inserter and you can add them to your homepage:

![imatge](https://github.com/user-attachments/assets/a5ad08d6-dfdf-4336-9f0a-8e31a906c24d)

**Theme switch option**

1. Switch to a classic theme.
2. Switch to a block theme.
3. Go to Appearance > Editor > Templates > Product Catalog.
4. Verify it contains the _Product Collection_ block (instead of the _Classic Template_ block).
5. Optionally, search in the `wp_options` table of your store's database the option `wc_blocks_use_blockified_product_grid_block_as_template` and verify it's value is `1`.

![imatge](https://github.com/user-attachments/assets/f0d5b8f3-dbf4-4eae-b8b6-6f018d1d4b89)
