### PR TITLE
Prevent count cache errors when order hooks are run in different orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-56650
+++ b/plugins/woocommerce/changelog/fix-56650
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent count cache errors when order hooks are run in different orders

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * A service class to help with updates to the aggregate orders cache.
+ *
+ * @internal
  */
 class OrderCountCacheService {
 
@@ -19,6 +21,20 @@ class OrderCountCacheService {
 	 * @var OrderCountCache
 	 */
 	private $order_count_cache;
+
+	/**
+	 * Array of order ids with their last transitioned status as key value pairs.
+	 *
+	 * @var array
+	 */
+	private $order_statuses = array();
+
+	/**
+	 * Array of order ids with their initial status as key value pairs.
+	 *
+	 * @var array
+	 */
+	private $initial_order_statuses = array();
 
 	/**
 	 * Class initialization, invoked by the DI container.
@@ -44,6 +60,18 @@ class OrderCountCacheService {
 			return;
 		}
 
+		// If the order status was updated, we need to increment the order count cache for the
+		// initial status that was errantly decremented on order status change.
+		if ( isset( $this->initial_order_statuses[ $order_id ] ) ) {
+			$this->order_count_cache->increment( $order->get_type(), $this->get_prefixed_status( $this->initial_order_statuses[ $order_id ] ) );
+		}
+
+		// If the order status count has already been incremented, we can skip incrementing it again.
+		if ( isset( $this->order_statuses[ $order->get_id() ] ) && $this->order_statuses[ $order->get_id() ] === $order->get_status() ) {
+			return;
+		}
+
+		$this->order_statuses[ $order_id ] = $order->get_status();
 		$this->order_count_cache->increment( $order->get_type(), $this->get_prefixed_status( $order->get_status() ) );
 	}
 
@@ -94,6 +122,15 @@ class OrderCountCacheService {
 			return;
 		}
 
+		if ( isset( $this->order_statuses[ $order_id ] ) && $this->order_statuses[ $order_id ] === $next_status ) {
+			return;
+		}
+
+		if ( ! isset( $this->initial_order_statuses[ $order_id ] ) ) {
+			$this->initial_order_statuses[ $order_id ] = $previous_status;
+		}
+
+		$this->order_statuses[ $order_id ] = $next_status;
 		$this->order_count_cache->decrement( $order->get_type(), $this->get_prefixed_status( $previous_status ) );
 		$this->order_count_cache->increment( $order->get_type(), $this->get_prefixed_status( $next_status ) );
 	}

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -122,10 +122,12 @@ class OrderCountCacheService {
 			return;
 		}
 
+		// If the order status count has already been incremented, we can skip incrementing it again.
 		if ( isset( $this->order_statuses[ $order_id ] ) && $this->order_statuses[ $order_id ] === $next_status ) {
 			return;
 		}
 
+		// Set the initial order status in case this is a new order and the previous status should not be decremented.
 		if ( ! isset( $this->initial_order_statuses[ $order_id ] ) ) {
 			$this->initial_order_statuses[ $order_id ] = $previous_status;
 		}

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -128,7 +128,7 @@ class OrderCountCacheService {
 		}
 
 		$this->order_statuses[ $order_id ] = $next_status;
-		$was_decremented = $this->order_count_cache->decrement( $order->get_type(), $this->get_prefixed_status( $previous_status ) );
+		$was_decremented                   = $this->order_count_cache->decrement( $order->get_type(), $this->get_prefixed_status( $previous_status ) );
 		$this->order_count_cache->increment( $order->get_type(), $this->get_prefixed_status( $next_status ) );
 
 		// Set the initial order status in case this is a new order and the previous status should not be decremented.

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -127,14 +127,14 @@ class OrderCountCacheService {
 			return;
 		}
 
+		$this->order_statuses[ $order_id ] = $next_status;
+		$was_decremented = $this->order_count_cache->decrement( $order->get_type(), $this->get_prefixed_status( $previous_status ) );
+		$this->order_count_cache->increment( $order->get_type(), $this->get_prefixed_status( $next_status ) );
+
 		// Set the initial order status in case this is a new order and the previous status should not be decremented.
-		if ( ! isset( $this->initial_order_statuses[ $order_id ] ) ) {
+		if ( ! isset( $this->initial_order_statuses[ $order_id ] ) && $was_decremented ) {
 			$this->initial_order_statuses[ $order_id ] = $previous_status;
 		}
-
-		$this->order_statuses[ $order_id ] = $next_status;
-		$this->order_count_cache->decrement( $order->get_type(), $this->get_prefixed_status( $previous_status ) );
-		$this->order_count_cache->increment( $order->get_type(), $this->get_prefixed_status( $next_status ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -4,8 +4,10 @@ declare( strict_types = 1);
 namespace Automattic\WooCommerce\Tests\Caching;
 
 use WC_Helper_Order;
+use WC_Order;
 use Automattic\WooCommerce\Caches\OrderCountCache;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
@@ -78,5 +80,57 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( $initial_count[ OrderInternalStatus::PENDING ] - 1, $count[ OrderInternalStatus::PENDING ] );
 		$this->assertEquals( $initial_count[ OrderInternalStatus::COMPLETED ] + 1, $count[ OrderInternalStatus::COMPLETED ] );
+	}
+
+	/**
+	 * Test that count gets incremented on new orders with initial status and does not incorrectly decrement the pending count.
+	 */
+	public function test_count_on_new_order_with_initial_status() {
+		$initial_count = OrderUtil::get_count_for_type( 'shop_order' );
+		$order_data    = array(
+			'status'        => OrderStatus::COMPLETED,
+			'customer_id'   => $customer_id,
+			'customer_note' => '',
+			'total'         => '',
+		);
+
+		$order = wc_create_order( $order_data );
+
+		$count = OrderUtil::get_count_for_type( 'shop_order' );
+
+		$this->assertEquals( $initial_count[ OrderInternalStatus::PENDING ], $count[ OrderInternalStatus::PENDING ] );
+		$this->assertEquals( $initial_count[ OrderInternalStatus::COMPLETED ] + 1, $count[ OrderInternalStatus::COMPLETED ] );
+	}
+
+	/**
+	 * Test that count works when status change hook is triggered on new orders.
+	 */
+	public function test_count_on_new_order_with_status_change() {
+		$initial_count = OrderUtil::get_count_for_type( 'shop_order' );
+
+		$order = new WC_Order();
+		$order->set_status( OrderStatus::CANCELLED );
+		$order->save();
+
+		$count = OrderUtil::get_count_for_type( 'shop_order' );
+
+		$this->assertEquals( $initial_count[ OrderInternalStatus::CANCELLED ] + 1, $count[ OrderInternalStatus::CANCELLED ] );
+		$this->assertEquals( $initial_count[ OrderInternalStatus::PENDING ], $count[ OrderInternalStatus::PENDING ] );
+	}
+
+	/**
+	 * Test that count works when status change hook is triggered on multiple status changes.
+	 */
+	public function test_count_on_multiple_status_changes() {
+		$order = new WC_Order();
+		$order->set_status( OrderInternalStatus::COMPLETED );
+		$order->set_status( OrderInternalStatus::CANCELLED );
+		$order->save();
+
+		$count = OrderUtil::get_count_for_type( 'shop_order' );
+
+		$this->assertEquals( $initial_count[ OrderInternalStatus::PENDING ], $count[ OrderInternalStatus::PENDING ] );
+		$this->assertEquals( $initial_count[ OrderInternalStatus::COMPLETED ], $count[ OrderInternalStatus::COMPLETED ] );
+		$this->assertEquals( $initial_count[ OrderInternalStatus::CANCELLED ] + 1, $count[ OrderInternalStatus::CANCELLED ] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -122,6 +122,8 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 	 * Test that count works when status change hook is triggered on multiple status changes.
 	 */
 	public function test_count_on_multiple_status_changes() {
+		$initial_count = OrderUtil::get_count_for_type( 'shop_order' );
+
 		$order = new WC_Order();
 		$order->set_status( OrderInternalStatus::COMPLETED );
 		$order->set_status( OrderInternalStatus::CANCELLED );

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -89,7 +89,7 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 		$initial_count = OrderUtil::get_count_for_type( 'shop_order' );
 		$order_data    = array(
 			'status'        => OrderStatus::COMPLETED,
-			'customer_id'   => $customer_id,
+			'customer_id'   => 1,
 			'customer_note' => '',
 			'total'         => '',
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the order count becoming out of sync as order hooks fire in different orders and potentially multiple times.

Closes #56650 .

(For Bug Fixes) Bug introduced in PR #54034.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="483" alt="Screenshot 2025-03-24 at 3 22 34 PM" src="https://github.com/user-attachments/assets/52d79720-6c18-48b9-968d-277ff7115dd2" />  |   <img width="456" alt="Screenshot 2025-03-24 at 3 22 25 PM" src="https://github.com/user-attachments/assets/ef5835fe-8c53-42ee-96b1-396eda0af667" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

For all tests, install an object persistent cache plugin like [Docket Cache](https://wordpress.org/plugins/docket-cache/).

**Admin orders without status changes**
1. Go to WooCommerce -> Orders
2. Take note of the order counts
3. Click "Add order"
4. Keep the order status as "Pending"
5. Click "Create"
6. Make sure that "Pending" has increased by 1 and no other order counts have

**Admin orders with status changes**
1. Go to WooCommerce -> Orders
2. Take note of the order counts
3. Click "Add order"
4. Set the status to "Complete" or any non-pending status
5. Click "Create"
6. Make sure that "Complete" has increased by 1 and no other order counts have increased or decreased

**Customer placed order**
1. Add various payment gateways from as a merchant that have different initial order statuses
2. Take note of the order counts
3. As a customer, add an item to the cart
4. Checkout as a customer
5. In the admin, make sure order counts are reflected correctly

**Programmatically placed order (dev only)**
1. Make sure tests pass
6. Attempt to create orders without status changes and persist
7. Make sure that order counts are correctly reflected
8. Attempt to create an order and set a status one or more times before persisting
9. Make sure that order counts are correctly reflected

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
