### PR TITLE
Update override-loop-template-show-quantities-next-add-cart.md

### DIFF
--- a/docs/code-snippets/override-loop-template-show-quantities-next-add-cart.md
+++ b/docs/code-snippets/override-loop-template-show-quantities-next-add-cart.md
@@ -3,7 +3,7 @@ post_title: Override loop template and show quantities next to add to cart butto
 tags: code-snippet
 ---
 
-Add this code to your child theme’s `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme’s functions.php file, as this will be wiped entirely when you update the theme.
+Add this code to your child theme's `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme's functions.php file, as this will be wiped entirely when you update the theme.
 
 ```php
 if ( ! function_exists( 'YOUR_PREFIX_quantity_inputs_for_woocommerce_loop_add_to_cart_link' ) ) {


### PR DESCRIPTION
We are using the wrong apostrophe throughout several docs which is rendering incorrectly in the front end

![CleanShot 2025-03-24 at 15 07 38@2x](https://github.com/user-attachments/assets/31339d30-b6a8-45d3-a3c4-f79a8c2292e7)

Just changed the text to  `theme's`
