### PR TITLE
Remove calls to disable third party shipping plugin in shipping E2E tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-failing-e2e-shipping-test
+++ b/plugins/woocommerce/changelog/fix-failing-e2e-shipping-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Test update only
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -45,8 +45,7 @@ test.describe( 'Shopper → Shipping', () => {
 		await shippingUtils.enableShippingCostsRequireAddress();
 	} );
 
-	test.beforeEach( async ( { admin, requestUtils } ) => {
-		await requestUtils.deactivatePlugin( 'woocommerce-blocks-test-helper' );
+	test.beforeEach( async ( { admin } ) => {
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=general' );
 		await admin.page
 			.getByLabel( 'Default customer location' )

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -45,7 +45,10 @@ test.describe( 'Shopper → Shipping', () => {
 		await shippingUtils.enableShippingCostsRequireAddress();
 	} );
 
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'woocommerce-blocks-test-helper'
+		);
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=general' );
 		await admin.page
 			.getByLabel( 'Default customer location' )
@@ -115,16 +118,7 @@ test.describe( 'Shopper → Shipping', () => {
 	test( '1. With shipping methods for the default location, shipping methods for _any_ location, and local pickup enabled, the shopper sees shipping rates and pickup options - rates are selected default', async ( {
 		localPickupUtils,
 		frontendUtils,
-		page,
 	} ) => {
-		await page.goto(
-			'/?disable_third_party_local_pickup_method_registration'
-		);
-		await expect(
-			page.getByText(
-				'Third party local pickup method registration disabled.'
-			)
-		).toBeVisible();
 		await localPickupUtils.enableLocalPickup();
 		await localPickupUtils.addPickupLocation( {
 			location: {
@@ -268,16 +262,7 @@ test.describe( 'Shopper → Shipping', () => {
 		frontendUtils,
 		checkoutPageObject,
 		shippingUtils,
-		page,
 	} ) => {
-		await page.goto(
-			'/?disable_third_party_local_pickup_method_registration'
-		);
-		await expect(
-			page.getByText(
-				'Third party local pickup method registration disabled.'
-			)
-		).toBeVisible();
 		await localPickupUtils.disableLocalPickup();
 		await shippingUtils.disableShippingCostsRequireAddress();
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=general' );
@@ -351,17 +336,7 @@ test.describe( 'Shopper → Shipping', () => {
 		localPickupUtils,
 		admin,
 		frontendUtils,
-		page,
 	} ) => {
-		await page.goto(
-			'/?disable_third_party_local_pickup_method_registration'
-		);
-		await expect(
-			page.getByText(
-				'Third party local pickup method registration disabled.'
-			)
-		).toBeVisible();
-
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=shipping' );
 		// Accept the delete dialog, then remove the listener;
 		const acceptDialog = ( dialog: Dialog ) => dialog.accept();
@@ -433,16 +408,7 @@ test.describe( 'Shopper → Shipping', () => {
 		localPickupUtils,
 		admin,
 		frontendUtils,
-		page,
 	} ) => {
-		await page.goto(
-			'/?disable_third_party_local_pickup_method_registration'
-		);
-		await expect(
-			page.getByText(
-				'Third party local pickup method registration disabled.'
-			)
-		).toBeVisible();
 
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=shipping' );
 		// Accept the delete dialog, then remove the listener;
@@ -492,18 +458,8 @@ test.describe( 'Shopper → Shipping', () => {
 		localPickupUtils,
 		frontendUtils,
 		shippingUtils,
-		page,
 		checkoutPageObject,
 	} ) => {
-		await page.goto(
-			'/?disable_third_party_local_pickup_method_registration'
-		);
-		await expect(
-			page.getByText(
-				'Third party local pickup method registration disabled.'
-			)
-		).toBeVisible();
-
 		await localPickupUtils.disableLocalPickup();
 		await shippingUtils.enableShippingCostsRequireAddress();
 
@@ -598,18 +554,8 @@ test.describe( 'Shopper → Shipping', () => {
 		localPickupUtils,
 		admin,
 		frontendUtils,
-		page,
 		shippingUtils,
 	} ) => {
-		await page.goto(
-			'/?disable_third_party_local_pickup_method_registration'
-		);
-		await expect(
-			page.getByText(
-				'Third party local pickup method registration disabled.'
-			)
-		).toBeVisible();
-
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=shipping' );
 		// Accept the delete dialog, then remove the listener;
 		const acceptDialog = ( dialog: Dialog ) => dialog.accept();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -46,9 +46,7 @@ test.describe( 'Shopper → Shipping', () => {
 	} );
 
 	test.beforeEach( async ( { admin, requestUtils } ) => {
-		await requestUtils.deactivatePlugin(
-			'woocommerce-blocks-test-helper'
-		);
+		await requestUtils.deactivatePlugin( 'woocommerce-blocks-test-helper' );
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=general' );
 		await admin.page
 			.getByLabel( 'Default customer location' )
@@ -409,7 +407,6 @@ test.describe( 'Shopper → Shipping', () => {
 		admin,
 		frontendUtils,
 	} ) => {
-
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=shipping' );
 		// Accept the delete dialog, then remove the listener;
 		const acceptDialog = ( dialog: Dialog ) => dialog.accept();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/56460 added many E2E tests, some of which disabled the third party "Woo Collection" shipping method. This PR disables the test helper plugin as a whole so this is no longer necessary. The plugin is not needed for these tests. If another test needs the helper plugin it can be enabled, like so: https://github.com/woocommerce/woocommerce/blob/6a7d3f4d6d7570978dd5380bc3f05fc12c1912de/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts#L104-L106

Note, I created a follow up issue as this test plugin may not be needed. https://github.com/woocommerce/woocommerce/issues/56664

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/56460

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check E2E tests in CI pass.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
